### PR TITLE
fix: get from queue only for given concurrent worker goroutines

### DIFF
--- a/pkg/worker/worker.go
+++ b/pkg/worker/worker.go
@@ -14,13 +14,13 @@ import (
 )
 
 const EmptyQueueWaitTime = 2 * time.Second
-const WorkerQueueBufferSize = 10000
+const Concurrency = 4
 
 // NewWorker returns new worker instance with data repository and runner
 func NewWorker(resultsRepository result.Repository, runner runner.Runner) Worker {
 	return Worker{
-		Concurrency: 4,
-		BufferSize:  WorkerQueueBufferSize,
+		Concurrency: Concurrency,
+		BufferSize:  Concurrency,
 		Repository:  resultsRepository,
 		// TODO implement runner for new executor
 		Runner: runner,


### PR DESCRIPTION
## Pull request description 

There was BufferSize variable set for 10000 which simply allows queue to get 10000 rows from DB and set pending status for them. and from then they was stored in channel on given executor node. 


closes #431


## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [ ] tested locally
- [ ] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Breaking changes

-

## Changes

-

## Fixes

-