### PR TITLE
fix: stripping root dir from filename before storing it inminio's bucket

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/go-ini/ini v1.64.0 // indirect
 	github.com/gofiber/adaptor/v2 v2.1.14
 	github.com/gofiber/fiber/v2 v2.22.0
+	github.com/gofrs/uuid v4.1.0+incompatible // indirect
 	github.com/kelseyhightower/envconfig v1.4.0
 	github.com/kubeshop/testkube-operator v0.6.0
 	github.com/minio/minio-go v6.0.14+incompatible // indirect

--- a/go.sum
+++ b/go.sum
@@ -207,6 +207,8 @@ github.com/gofiber/fiber/v2 v2.22.0 h1:+iyKK4ooDH6z0lAHdaWO1AFIB/DZ9AVo6vz8VZIA0
 github.com/gofiber/fiber/v2 v2.22.0/go.mod h1:MR1usVH3JHYRyQwMe2eZXRSZHRX38fkV+A7CPB+DlDQ=
 github.com/gofiber/utils v0.1.2 h1:1SH2YEz4RlNS0tJlMJ0bGwO0JkqPqvq6TbHK9tXZKtk=
 github.com/gofiber/utils v0.1.2/go.mod h1:pacRFtghAE3UoknMOUiXh2Io/nLWSUHtQCi/3QASsOc=
+github.com/gofrs/uuid v4.1.0+incompatible h1:sIa2eCvUTwgjbqXrPLfNwUf9S3i3mpH1O1atV+iL/Wk=
+github.com/gofrs/uuid v4.1.0+incompatible/go.mod h1:b2aQJv3Z4Fp6yNu3cdSllBxTCLRxnplIgP/c0N/04lM=
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
 github.com/gogo/protobuf v1.2.1/go.mod h1:hp+jE20tsWTFYpLwKvXlhS1hjn+gTNwPg2I6zVXpSg4=
 github.com/gogo/protobuf v1.3.2 h1:Ov1cvc58UF3b5XjBnZv7+opcTcQFZebYjWzi34vdm4Q=

--- a/pkg/storage/minio/minio.go
+++ b/pkg/storage/minio/minio.go
@@ -110,13 +110,23 @@ func (c *Client) SaveFile(bucket, filePath string) error {
 	if err != nil {
 		return err
 	}
+
 	var fileName string
 	if strings.Contains(filePath, "/") {
-		fileName = filePath
+		// fileName = filePath
+
+		// strip the filename if the path is longer than 3 subdirectories /dir/sub1/sub2/ -> /sub1/sub2
+		split := strings.Split(filePath, "/")
+		length := len(split)
+		if length > 2 {
+			fileName = filepath.Join(split[length-2], split[length-1])
+		}
+
 	} else {
 		fileName = objectStat.Name()
 	}
 
+	fmt.Println(fileName)
 	_, err = c.minioclient.PutObject(context.Background(), bucket, fileName, object, objectStat.Size(), minio.PutObjectOptions{ContentType: "application/octet-stream"})
 	if err != nil {
 		return err

--- a/pkg/storage/minio/minio.go
+++ b/pkg/storage/minio/minio.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"path"
 	"path/filepath"
 	"strings"
 
@@ -113,15 +114,7 @@ func (c *Client) SaveFile(bucket, filePath string) error {
 
 	var fileName string
 	if strings.Contains(filePath, "/") {
-		// fileName = filePath
-
-		// strip the filename if the path is longer than 3 subdirectories /dir/sub1/sub2/ -> /sub1/sub2
-		split := strings.Split(filePath, "/")
-		length := len(split)
-		if length > 2 {
-			fileName = filepath.Join(split[length-2], split[length-1])
-		}
-
+		_, fileName = path.Split("/")
 	} else {
 		fileName = objectStat.Name()
 	}


### PR DESCRIPTION
Signed-off-by: Jasmin Gacic <jasmin.gacic@gmail.com>

## Pull request description 

Strips the filename if the path is longer than 3 subdirectories /dir/sub1/sub2/ -> /sub1/sub2

## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [ x] tested locally
- [ x] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test


## Changes

-

## Fixes

-