### PR TITLE
fix: Cypress executor logs broken

### DIFF
--- a/cmd/kubectl-testkube/commands/artifacts.go
+++ b/cmd/kubectl-testkube/commands/artifacts.go
@@ -13,6 +13,7 @@ var (
 	executionID string
 	filename    string
 	destination string
+	downloadDir string
 )
 
 func NewArtifactsCmd() *cobra.Command {
@@ -31,7 +32,8 @@ func NewArtifactsCmd() *cobra.Command {
 	cmd.PersistentFlags().StringVarP(&executionID, "execution-id", "e", "", "ID of the execution")
 
 	cmd.AddCommand(NewListArtifactsCmd())
-	cmd.AddCommand(NewDownloadArtifactsCmd())
+	cmd.AddCommand(NewDownloadSingleArtifactsCmd())
+	cmd.AddCommand(NewDownloadAllArtifactsCmd())
 	// output renderer flags
 	return cmd
 }
@@ -67,9 +69,9 @@ func NewListArtifactsCmd() *cobra.Command {
 	return cmd
 }
 
-func NewDownloadArtifactsCmd() *cobra.Command {
+func NewDownloadSingleArtifactsCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "download",
+		Use:   "download-one",
 		Short: "download artifact",
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			if executionID == "" {
@@ -104,6 +106,35 @@ func NewDownloadArtifactsCmd() *cobra.Command {
 	cmd.PersistentFlags().StringVarP(&executionID, "execution-id", "e", "", "ID of the execution")
 	cmd.PersistentFlags().StringVarP(&filename, "filename", "f", "", "name of the file")
 	cmd.PersistentFlags().StringVarP(&destination, "destination", "d", "", "name of the file")
+
+	// output renderer flags
+	return cmd
+}
+
+func NewDownloadAllArtifactsCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "download",
+		Short: "download artifact",
+		PreRunE: func(cmd *cobra.Command, args []string) error {
+			if executionID == "" {
+				cmd.SilenceUsage = true
+				return fmt.Errorf("execution-id is a required parameter")
+			}
+
+			return nil
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			client, _ := scripts.GetClient(cmd)
+			scripts.DownloadArtifacts(executionID, downloadDir, client)
+			return nil
+		},
+	}
+
+	cmd.PersistentFlags().StringVarP(&client, "client", "c", "proxy", "Client used for connecting to testkube API one of proxy|direct")
+	cmd.PersistentFlags().BoolVarP(&verbose, "verbose", "v", false, "should I show additional debug messages")
+
+	cmd.PersistentFlags().StringVarP(&executionID, "execution-id", "e", "", "ID of the execution")
+	cmd.Flags().StringVar(&downloadDir, "download-dir", "artifacts", "download dir")
 
 	// output renderer flags
 	return cmd

--- a/cmd/kubectl-testkube/commands/install.go
+++ b/cmd/kubectl-testkube/commands/install.go
@@ -15,9 +15,10 @@ func init() {
 func NewInstallCmd() *cobra.Command {
 	var chart, name, namespace string
 	cmd := &cobra.Command{
-		Use:   "install",
-		Short: "Install Helm chart registry in current kubectl context",
-		Long:  `Install can be configured with use of particular `,
+		Use:     "install",
+		Short:   "Install Helm chart registry in current kubectl context",
+		Long:    `Install can be configured with use of particular `,
+		Aliases: []string{"update", "upgrade"},
 		Run: func(cmd *cobra.Command, args []string) {
 
 			ui.Verbose = true

--- a/cmd/kubectl-testkube/commands/root.go
+++ b/cmd/kubectl-testkube/commands/root.go
@@ -76,6 +76,7 @@ func ValidateVersions(c apiclient.Client) error {
 		ui.Info("Testkube API version", serverVersion.String())
 		ui.Info("Testkube kubectl plugin client", clientVersion.String())
 		ui.Info("It's recommended to upgrade client to version close to API server version")
+		ui.NL()
 	}
 
 	return nil

--- a/cmd/kubectl-testkube/commands/scripts/common.go
+++ b/cmd/kubectl-testkube/commands/scripts/common.go
@@ -31,7 +31,7 @@ func printExecutionDetails(execution testkube.Execution) {
 	ui.NL()
 }
 
-func downloadArtifacts(id, dir string, client client.Client) {
+func DownloadArtifacts(id, dir string, client client.Client) {
 	artifacts, err := client.GetExecutionArtifacts(id)
 	ui.ExitOnError("getting artifacts ", err)
 
@@ -39,12 +39,12 @@ func downloadArtifacts(id, dir string, client client.Client) {
 	ui.ExitOnError("creating dir "+dir, err)
 
 	if len(artifacts) > 0 {
-		ui.Info("Getting artifacts", fmt.Sprintf("count = %d", len(artifacts)))
+		ui.Info("Getting artifacts", fmt.Sprintf("count = %d", len(artifacts)), "\n")
 	}
 	for _, artifact := range artifacts {
 		f, err := client.DownloadFile(id, artifact.Name, dir)
 		ui.ExitOnError("downloading file: "+f, err)
-		ui.Info("- downloading file " + f)
+		ui.Warn(" - downloading file ", f)
 	}
 
 	ui.NL()

--- a/cmd/kubectl-testkube/commands/scripts/start_script.go
+++ b/cmd/kubectl-testkube/commands/scripts/start_script.go
@@ -63,7 +63,7 @@ func NewStartScriptCmd() *cobra.Command {
 	cmd.Flags().StringToStringVarP(&params, "param", "p", map[string]string{}, "execution envs passed to executor")
 	cmd.Flags().BoolVarP(&watchEnabled, "watch", "f", false, "watch for changes after start")
 	cmd.Flags().StringVar(&downloadDir, "download-dir", "artifacts", "download dir")
-	cmd.Flags().BoolVar(&downloadArtifactsEnabled, "download-artifacts", true, "downlaod artifacts automatically")
+	cmd.Flags().BoolVarP(&downloadArtifactsEnabled, "download-artifacts", "a", false, "downlaod artifacts automatically")
 
 	return cmd
 }

--- a/cmd/kubectl-testkube/commands/scripts/start_script.go
+++ b/cmd/kubectl-testkube/commands/scripts/start_script.go
@@ -52,7 +52,7 @@ func NewStartScriptCmd() *cobra.Command {
 			uiPrintStatus(execution)
 
 			if downloadArtifactsEnabled {
-				downloadArtifacts(execution.Id, downloadDir, client)
+				DownloadArtifacts(execution.Id, downloadDir, client)
 			}
 
 			uiShellCommandBlock(execution.Id)

--- a/internal/app/api/v1/scripts.go
+++ b/internal/app/api/v1/scripts.go
@@ -265,6 +265,7 @@ func (s testkubeAPI) ExecutionLogs() fiber.Handler {
 			logs, err = s.Executor.Logs(executionID)
 			s.Log.Debugw("waiting for jobs channel", "channelSize", len(logs))
 			if err != nil {
+				// TODO convert to some library for common output
 				fmt.Fprintf(w, `data: {"type": "error","message": "%s"}\n\n`, err.Error())
 				s.Log.Errorw("getting logs error", "error", err)
 				w.Flush()
@@ -277,7 +278,8 @@ func (s testkubeAPI) ExecutionLogs() fiber.Handler {
 				s.Log.Debugw("got log", "out", out)
 				fmt.Fprintf(w, "data: ")
 				enc.Encode(out)
-				fmt.Fprintf(w, "\n\n")
+				// enc.Encode adds \n and we need \n\n after `data: {}` chunk
+				fmt.Fprintf(w, "\n")
 				w.Flush()
 			}
 		}))

--- a/pkg/api/v1/client/common.go
+++ b/pkg/api/v1/client/common.go
@@ -44,7 +44,5 @@ func trimDataChunk(in []byte) []byte {
 	chunk := bytes.Replace(in, prefix, []byte{}, 1)
 	chunk = bytes.Replace(chunk, postfix, []byte{}, 1)
 
-	// chunk = chunk[:len(chunk)-4]
-
 	return chunk
 }

--- a/pkg/api/v1/client/direct.go
+++ b/pkg/api/v1/client/direct.go
@@ -166,7 +166,7 @@ func (c DirectScriptsAPI) ExecuteScript(id, namespace, executionName string, exe
 
 // Logs reads logs from API SSE endpoint asynchronously
 func (c DirectScriptsAPI) Logs(id string) (logs chan output.Output, err error) {
-	logs = make(chan output.Output, 1000)
+	logs = make(chan output.Output)
 	uri := c.getURI("/executions/%s/logs", id)
 
 	req, err := http.NewRequest("GET", uri, nil)

--- a/pkg/api/v1/client/proxy.go
+++ b/pkg/api/v1/client/proxy.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"net/url"
 	"os"
@@ -175,6 +176,17 @@ func (c ProxyScriptsAPI) Logs(id string) (logs chan output.Output, err error) {
 		Suffix(uri).
 		SetHeader("Accept", "text/event-stream").
 		Stream(context.Background())
+
+	b := make([]byte, 1000)
+	for {
+		n, err := resp.Read(b)
+		fmt.Printf("n = %v err = %v b = %v\n", n, err, b)
+		fmt.Printf("b[:n] = %q\n", b[:n])
+		if err == io.EOF {
+			break
+		}
+
+	}
 
 	go func() {
 		defer close(logs)

--- a/pkg/api/v1/client/proxy.go
+++ b/pkg/api/v1/client/proxy.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io"
 	"net/http"
 	"net/url"
 	"os"
@@ -176,17 +175,6 @@ func (c ProxyScriptsAPI) Logs(id string) (logs chan output.Output, err error) {
 		Suffix(uri).
 		SetHeader("Accept", "text/event-stream").
 		Stream(context.Background())
-
-	b := make([]byte, 1000)
-	for {
-		n, err := resp.Read(b)
-		fmt.Printf("n = %v err = %v b = %v\n", n, err, b)
-		fmt.Printf("b[:n] = %q\n", b[:n])
-		if err == io.EOF {
-			break
-		}
-
-	}
 
 	go func() {
 		defer close(logs)

--- a/pkg/executor/client/job.go
+++ b/pkg/executor/client/job.go
@@ -67,8 +67,9 @@ func (c JobExecutor) Get(id string) (execution testkube.ExecutionResult, err err
 // TODO too many goroutines - need to be simplified
 func (c JobExecutor) Logs(id string) (out chan output.Output, err error) {
 	out = make(chan output.Output)
-	logs, err := c.Client.TailJobLogs(id)
-	if err != nil {
+	logs := make(chan []byte)
+
+	if err := c.Client.TailJobLogs(id, logs); err != nil {
 		return out, err
 	}
 
@@ -78,11 +79,11 @@ func (c JobExecutor) Logs(id string) (out chan output.Output, err error) {
 			close(out)
 		}()
 		for l := range logs {
-			output, err := output.GetLogEntry(l)
+			entry, err := output.GetLogEntry(l)
 			if err != nil {
 				return
 			}
-			out <- output
+			out <- entry
 		}
 	}()
 

--- a/pkg/executor/client/job.go
+++ b/pkg/executor/client/job.go
@@ -8,7 +8,9 @@ import (
 	"github.com/kubeshop/testkube/internal/pkg/api/repository/result"
 	"github.com/kubeshop/testkube/pkg/api/v1/testkube"
 	"github.com/kubeshop/testkube/pkg/jobs"
+	"github.com/kubeshop/testkube/pkg/log"
 	"github.com/kubeshop/testkube/pkg/runner/output"
+	"go.uber.org/zap"
 )
 
 func NewJobExecutor(repo result.Repository) (client JobExecutor, err error) {
@@ -20,12 +22,14 @@ func NewJobExecutor(repo result.Repository) (client JobExecutor, err error) {
 	return JobExecutor{
 		Client:     jobClient,
 		Repository: repo,
+		Log:        log.DefaultLogger,
 	}, nil
 }
 
 type JobExecutor struct {
 	Client     *jobs.JobClient
 	Repository result.Repository
+	Log        *zap.SugaredLogger
 }
 
 // Watch will get valid execution after async Execute, execution will be returned when success or error occurs
@@ -75,7 +79,7 @@ func (c JobExecutor) Logs(id string) (out chan output.Output, err error) {
 
 	go func() {
 		defer func() {
-			fmt.Printf("%+v\n", "closing JobExecutor.Logs out log")
+			c.Log.Debug("closing JobExecutor.Logs out log")
 			close(out)
 		}()
 		for l := range logs {

--- a/pkg/executor/client/job.go
+++ b/pkg/executor/client/job.go
@@ -66,14 +66,17 @@ func (c JobExecutor) Get(id string) (execution testkube.ExecutionResult, err err
 // Logs returns job logs
 // TODO too many goroutines - need to be simplified
 func (c JobExecutor) Logs(id string) (out chan output.Output, err error) {
-	out = make(chan output.Output, 10000)
+	out = make(chan output.Output)
 	logs, err := c.Client.TailJobLogs(id)
 	if err != nil {
 		return out, err
 	}
 
 	go func() {
-		defer close(out)
+		defer func() {
+			fmt.Printf("%+v\n", "closing JobExecutor.Logs out log")
+			close(out)
+		}()
 		for l := range logs {
 			output, err := output.GetLogEntry(l)
 			if err != nil {

--- a/pkg/jobs/jobclient.go
+++ b/pkg/jobs/jobclient.go
@@ -216,24 +216,6 @@ func (c *JobClient) TailPodLogs(ctx context.Context, podName string, logs chan [
 		if scanner.Err() != nil {
 			c.Log.Errorw("scanner error", "error", scanner.Err())
 		}
-
-		// for {
-		// 	// TODO is it bulletprof for huge messages ?
-		// 	// we need to parse output.Output struct
-		// 	buf := make([]byte, 20000)
-		// 	numBytes, err := stream.Read(buf)
-		// 	if numBytes == 0 || err == io.EOF {
-		// 		c.Log.Debug("no more logs", "error", err)
-		// 		break
-		// 	}
-
-		// 	if err != nil {
-		// 		c.Log.Errorw("error when tailing logs stream", "error", err)
-		// 		return
-		// 	}
-
-		// 	logs <- buf[:numBytes]
-		// }
 	}()
 	return
 }

--- a/pkg/jobs/jobclient.go
+++ b/pkg/jobs/jobclient.go
@@ -1,6 +1,7 @@
 package jobs
 
 import (
+	"bufio"
 	"bytes"
 	"context"
 	"encoding/json"
@@ -128,29 +129,30 @@ func (c *JobClient) GetJobPods(podsClient pods.PodInterface, jobName string, ret
 }
 
 // TailJobLogs - locates logs for job pod(s)
-func (c *JobClient) TailJobLogs(id string) (logs chan []byte, err error) {
+func (c *JobClient) TailJobLogs(id string, logs chan []byte) (err error) {
 	podsClient := c.ClientSet.CoreV1().Pods(c.Namespace)
 	ctx := context.Background()
 	pods, err := c.GetJobPods(podsClient, id, 1, 10)
-	logs = make(chan []byte)
 
 	if err != nil {
 		close(logs)
-		return logs, err
+		return err
 	}
 
 	for _, pod := range pods.Items {
-		if pod.Status.Phase != v1.PodRunning && pod.Labels["job-name"] == id {
-			c.Log.Debugw("Waiting for pod to be ready", "pod", pod.Name)
-			if err = wait.PollImmediate(100*time.Millisecond, time.Duration(0)*time.Second, k8sclient.IsPodReady(c.ClientSet, pod.Name, c.Namespace)); err != nil {
-				c.Log.Errorw("poll immediate error when tailing logs", "error", err)
-				close(logs)
-				return logs, err
+		if pod.Labels["job-name"] == id {
+			if pod.Status.Phase != v1.PodRunning {
+				c.Log.Debugw("Waiting for pod to be ready", "pod", pod.Name)
+				if err = wait.PollImmediate(100*time.Millisecond, time.Duration(0)*time.Second, k8sclient.IsPodReady(c.ClientSet, pod.Name, c.Namespace)); err != nil {
+					c.Log.Errorw("poll immediate error when tailing logs", "error", err)
+					close(logs)
+					return err
+				}
+				c.Log.Debug("Tailing pod logs")
+				return c.TailPodLogs(ctx, pod.Name, logs)
+			} else if pod.Status.Phase == v1.PodRunning {
+				return c.TailPodLogs(ctx, pod.Name, logs)
 			}
-			c.Log.Debug("Tailing pod logs")
-			return c.TailPodLogs(ctx, pod.Name)
-		} else if pod.Status.Phase == v1.PodRunning {
-			return c.TailPodLogs(ctx, pod.Name)
 		}
 	}
 
@@ -185,8 +187,7 @@ func (c *JobClient) GetPodLogs(podName string) (logs []byte, err error) {
 	return buf.Bytes(), nil
 }
 
-func (c *JobClient) TailPodLogs(ctx context.Context, podName string) (logs chan []byte, err error) {
-	logs = make(chan []byte)
+func (c *JobClient) TailPodLogs(ctx context.Context, podName string, logs chan []byte) (err error) {
 	count := int64(1)
 
 	podLogOptions := v1.PodLogOptions{
@@ -200,30 +201,39 @@ func (c *JobClient) TailPodLogs(ctx context.Context, podName string) (logs chan 
 
 	stream, err := podLogRequest.Stream(ctx)
 	if err != nil {
-		return logs, err
+		return err
 	}
 
 	go func() {
-		defer stream.Close()
 		defer close(logs)
 
-		for {
-			// TODO is it bulletprof for huge messages ?
-			// we need to parse output.Output struct
-			buf := make([]byte, 20000)
-			numBytes, err := stream.Read(buf)
-			if numBytes == 0 || err == io.EOF {
-				c.Log.Debug("no more logs", "error", err)
-				break
-			}
-
-			if err != nil {
-				c.Log.Errorw("error when tailing logs stream", "error", err)
-				return
-			}
-
-			logs <- buf[:numBytes]
+		scanner := bufio.NewScanner(stream)
+		for scanner.Scan() {
+			c.Log.Debug("TailPodLogs stream scan", "out", scanner.Text(), "pod", podName)
+			logs <- scanner.Bytes()
 		}
+
+		if scanner.Err() != nil {
+			c.Log.Errorw("scanner error", "error", scanner.Err())
+		}
+
+		// for {
+		// 	// TODO is it bulletprof for huge messages ?
+		// 	// we need to parse output.Output struct
+		// 	buf := make([]byte, 20000)
+		// 	numBytes, err := stream.Read(buf)
+		// 	if numBytes == 0 || err == io.EOF {
+		// 		c.Log.Debug("no more logs", "error", err)
+		// 		break
+		// 	}
+
+		// 	if err != nil {
+		// 		c.Log.Errorw("error when tailing logs stream", "error", err)
+		// 		return
+		// 	}
+
+		// 	logs <- buf[:numBytes]
+		// }
 	}()
 	return
 }

--- a/pkg/jobs/jobclient.go
+++ b/pkg/jobs/jobclient.go
@@ -186,7 +186,7 @@ func (c *JobClient) GetPodLogs(podName string) (logs []byte, err error) {
 }
 
 func (c *JobClient) TailPodLogs(ctx context.Context, podName string) (logs chan []byte, err error) {
-	logs = make(chan []byte, 10000)
+	logs = make(chan []byte)
 	count := int64(1)
 
 	podLogOptions := v1.PodLogOptions{


### PR DESCRIPTION
## Pull request description 

- added download all artifacts by default download is now download-one
- fix for Cypress logs on GKE 
- simplified passing/closing channel to logs stream
- simplified reading streams
- kubectl plugin UI fixes
- closes #533 
- closes #560 


## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [x] tested locally
- [ ] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Breaking changes

-

## Changes

-

## Fixes

-