### PR TITLE
feat: added dashboard install option as default to install command

### DIFF
--- a/cmd/kubectl-testkube/commands/install.go
+++ b/cmd/kubectl-testkube/commands/install.go
@@ -1,6 +1,7 @@
 package commands
 
 import (
+	"fmt"
 	"os/exec"
 
 	"github.com/kubeshop/testkube/pkg/process"
@@ -37,12 +38,8 @@ func NewInstallCmd() *cobra.Command {
 			ui.ExitOnError("updating helm repositories", err)
 
 			command := []string{"upgrade", "--install", "--create-namespace", "--namespace", namespace}
-			if !noDashboard {
-				command = append(command, "--set", "api-server.minio.enabled=true")
-			}
-			if !noMinio {
-				command = append(command, "--set", "testkube-dashboard.enabled=true")
-			}
+			command = append(command, "--set", fmt.Sprintf("api-server.minio.enabled=%t", !noDashboard))
+			command = append(command, "--set", fmt.Sprintf("testkube-dashboard.enabled=%t", !noMinio))
 			command = append(command, name, chart)
 
 			out, err := process.Execute(helmPath, command...)

--- a/docs/installing.md
+++ b/docs/installing.md
@@ -57,26 +57,35 @@ The above command will install the following components in your Kubernetes clust
 2. `testkube` namespace
 3. CRD for scripts 
 4. MongoDB
-5. Minio - optional
+5. Minio - default (can be disabled with `--no-minio` flag if you want to use S3 buckets)
+6. Dashboard - default (can be disabled with `--no-dasboard` flag)
 
 You can confirm it by running:
 ```
-$ kubectl get all -n testkube
-NAME                                       READY   STATUS    RESTARTS   AGE
-pod/testkube-api-server-5478577b5b-jnnv6   1/1     Running   0          64s
-pod/testkube-mongodb-5d95f44fdd-8wkwh      1/1     Running   0          64s
+➜  kubectl get all -n testkube
+NAME                                           READY   STATUS    RESTARTS   AGE
+pod/testkube-dashboard-748cbcbb66-q8zzp        1/1     Running   0          4m51s
+pod/testkube-api-server-546777c9f7-7g4kg       1/1     Running   0          4m51s
+pod/testkube-mongodb-5d95f44fdd-cxqz6          1/1     Running   0          4m51s
+pod/testkube-minio-testkube-64cd475b94-562hz   1/1     Running   0          4m51s
 
-NAME                          TYPE        CLUSTER-IP     EXTERNAL-IP   PORT(S)          AGE
-service/testkube-mongodb      ClusterIP   10.43.192.11   <none>        27017/TCP        64s
-service/testkube-api-server   NodePort    10.43.32.229   <none>        8088:31868/TCP   64s
+NAME                                      TYPE        CLUSTER-IP      EXTERNAL-IP   PORT(S)                                        AGE
+service/testkube-minio-service-testkube   NodePort    10.43.121.107   <none>        9000:31222/TCP,9090:32002/TCP,9443:32586/TCP   4m51s
+service/testkube-api-server               NodePort    10.43.66.13     <none>        8088:32203/TCP                                 4m51s
+service/testkube-mongodb                  ClusterIP   10.43.126.230   <none>        27017/TCP                                      4m51s
+service/testkube-dashboard                NodePort    10.43.136.34    <none>        80:31991/TCP                                   4m51s
 
-NAME                                  READY   UP-TO-DATE   AVAILABLE   AGE
-deployment.apps/testkube-api-server   1/1     1            1           64s
-deployment.apps/testkube-mongodb      1/1     1            1           64s
+NAME                                      READY   UP-TO-DATE   AVAILABLE   AGE
+deployment.apps/testkube-dashboard        1/1     1            1           4m51s
+deployment.apps/testkube-api-server       1/1     1            1           4m51s
+deployment.apps/testkube-mongodb          1/1     1            1           4m51s
+deployment.apps/testkube-minio-testkube   1/1     1            1           4m51s
 
-NAME                                             DESIRED   CURRENT   READY   AGE
-replicaset.apps/testkube-api-server-5478577b5b   1         1         1       64s
-replicaset.apps/testkube-mongodb-5d95f44fdd      1         1         1       64s
+NAME                                                 DESIRED   CURRENT   READY   AGE
+replicaset.apps/testkube-dashboard-748cbcbb66        1         1         1       4m51s
+replicaset.apps/testkube-api-server-546777c9f7       1         1         1       4m51s
+replicaset.apps/testkube-mongodb-5d95f44fdd          1         1         1       4m51s
+replicaset.apps/testkube-minio-testkube-64cd475b94   1         1         1       4m51s
 ```
 
 By default testkube is installed in the `testkube` namespace.


### PR DESCRIPTION
## Pull request description 

Updated installation command with minio and dasboard options
Dashboard is installed by default now.

colses #536

## Checklist (choose whats happened)

- [x] breaking change! (describe)
- [x] tested locally
- [x] tested on cluster
- [ ] added new dependencies
- [x] updated the docs
- [ ] added a test

## Breaking changes

-

## Changes

-

## Fixes

-