### PR TITLE
fix: remove docker libssl upgrade

### DIFF
--- a/build/api-server/Dockerfile
+++ b/build/api-server/Dockerfile
@@ -12,8 +12,6 @@ RUN cd cmd/api-server;go build -ldflags "-X github.com/kubeshop/testkube/interna
 
 FROM alpine:latest  
 RUN apk --no-cache add ca-certificates libssl1.1
-# TODO remove when alpine will get it - We need upgrade libssl to fix 
-RUN apk upgrade libssl1.1
 WORKDIR /root/
 COPY --from=0 /app /bin/app
 EXPOSE 8088


### PR DESCRIPTION
## Pull request description 

Remove libssl upgrade for latest alpine Docker image, because it alreday contains libssl1.1
It fixes issue #699

Proof:
```
docker run -it --rm alpine:latest ash
/ # apk --no-cache add ca-certificates libssl1.1
fetch https://dl-cdn.alpinelinux.org/alpine/v3.15/main/x86_64/APKINDEX.tar.gz
fetch https://dl-cdn.alpinelinux.org/alpine/v3.15/community/x86_64/APKINDEX.tar.gz
(1/1) Installing ca-certificates (20191127-r7)
Executing busybox-1.34.1-r3.trigger
Executing ca-certificates-20191127-r7.trigger
OK: 6 MiB in 15 packages
/ # cd /lib
/lib # ls
apk                    libapk.so.3.12.0       libssl.so.1.1          mdev
firmware               libc.musl-x86_64.so.1  libz.so.1              modules-load.d
ld-musl-x86_64.so.1    libcrypto.so.1.1       libz.so.1.2.11         sysctl.d
/lib # strings /lib/libssl.so.1.1  | grep "OpenSSL 1.1.1"
OpenSSL 1.1.1l  24 Aug 2021
```
## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [x] tested locally
- [ ] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Breaking changes

-

## Changes

-

## Fixes
Remove libssl upgrade for Docker alpine image to libssl1.1
-