### PR TITLE
fix: remove api double parameter unescaping

### DIFF
--- a/internal/app/api/v1/executions.go
+++ b/internal/app/api/v1/executions.go
@@ -239,19 +239,12 @@ func (s TestKubeAPI) GetArtifactHandler() fiber.Handler {
 		executionID := c.Params("executionID")
 		fileName := c.Params("filename")
 
-		// TODO fix this someday :) we don't know 15 mins before release why it's working this way
 		unescaped, err := url.QueryUnescape(fileName)
-		if err == nil {
-			fileName = unescaped
+		if err != nil {
+			return s.Error(c, http.StatusBadRequest, fmt.Errorf("can't unescape filename %s for execution %s with error %w", fileName, executionID, err))
 		}
 
-		unescaped, err = url.QueryUnescape(fileName)
-		if err == nil {
-			fileName = unescaped
-		}
-
-		//// quickfix end
-
+		fileName = unescaped
 		file, err := s.Storage.DownloadFile(executionID, fileName)
 		if err != nil {
 			return s.Error(c, http.StatusInternalServerError, err)

--- a/internal/app/api/v1/executions.go
+++ b/internal/app/api/v1/executions.go
@@ -140,6 +140,7 @@ func (s TestKubeAPI) ListExecutionsHandler() fiber.Handler {
 	}
 }
 
+// ExecutionLogsHandler returns execution logs for given execution id
 func (s TestKubeAPI) ExecutionLogsHandler() fiber.Handler {
 	return func(c *fiber.Ctx) error {
 		executionID := c.Params("executionID")
@@ -224,6 +225,7 @@ func (s TestKubeAPI) GetExecutionHandler() fiber.Handler {
 	}
 }
 
+// AbortExecutionHandler aborts script execution for given executor id
 func (s TestKubeAPI) AbortExecutionHandler() fiber.Handler {
 	return func(c *fiber.Ctx) error {
 		id := c.Params("id")
@@ -231,6 +233,7 @@ func (s TestKubeAPI) AbortExecutionHandler() fiber.Handler {
 	}
 }
 
+// GetArtifactHandler returns execution result file for given execution id and filename
 func (s TestKubeAPI) GetArtifactHandler() fiber.Handler {
 	return func(c *fiber.Ctx) error {
 		executionID := c.Params("executionID")
@@ -259,7 +262,7 @@ func (s TestKubeAPI) GetArtifactHandler() fiber.Handler {
 	}
 }
 
-// GetArtifacts returns list of files in the given bucket
+// ListArtifactsHandler returns list of files for the given execution id
 func (s TestKubeAPI) ListArtifactsHandler() fiber.Handler {
 	return func(c *fiber.Ctx) error {
 
@@ -273,6 +276,7 @@ func (s TestKubeAPI) ListArtifactsHandler() fiber.Handler {
 	}
 }
 
+// GetExecuteOptions returns execute options for given namespace, script id and request
 func (s TestKubeAPI) GetExecuteOptions(namespace, scriptID string, request testkube.ExecutionRequest) (options client.ExecuteOptions, err error) {
 	// get script content from kubernetes CRs
 	scriptCR, err := s.ScriptsClient.Get(namespace, scriptID)

--- a/pkg/api/v1/client/direct.go
+++ b/pkg/api/v1/client/direct.go
@@ -7,7 +7,6 @@ import (
 	"io"
 	"io/ioutil"
 	"net/http"
-	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
@@ -462,7 +461,7 @@ func (c DirectScriptsAPI) GetExecutionArtifacts(executionID string) (artifacts t
 }
 
 func (c DirectScriptsAPI) DownloadFile(executionID, fileName, destination string) (artifact string, err error) {
-	uri := c.getURI("/executions/%s/artifacts/%s", executionID, url.QueryEscape(fileName))
+	uri := c.getURI("/executions/%s/artifacts/%s", executionID, fileName)
 	resp, err := c.client.Get(uri)
 	if err != nil {
 		return artifact, err

--- a/pkg/api/v1/client/proxy.go
+++ b/pkg/api/v1/client/proxy.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
@@ -478,7 +477,7 @@ func (c ProxyScriptsAPI) GetExecutionArtifacts(executionID string) (artifacts te
 }
 
 func (c ProxyScriptsAPI) DownloadFile(executionID, fileName, destination string) (artifact string, err error) {
-	uri := c.getURI("/executions/%s/artifacts/%s", executionID, url.QueryEscape(fileName))
+	uri := c.getURI("/executions/%s/artifacts/%s", executionID, fileName)
 	req, err := c.GetProxy("GET").
 		Suffix(uri).
 		SetHeader("Accept", "text/event-stream").


### PR DESCRIPTION
## Pull request description 
We use url parameter escaping when we prepate url for http request. But net http client automatically escapes url parameter
Closes #740 

## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [x] tested locally
- [x] tested on cluster
- [ ] added new dependencies
- [x] updated the docs
- [ ] added a test

## Breaking changes

-

## Changes

-

## Fixes
 - Update comments for golint
 - Remove double escaping/unescaping for url parameters
-