### PR TITLE
refactor: reuse existing output method for printing errors

### DIFF
--- a/internal/app/api/v1/executions.go
+++ b/internal/app/api/v1/executions.go
@@ -167,8 +167,7 @@ func (s TestKubeAPI) ExecutionLogsHandler() fiber.Handler {
 			logs, err = s.Executor.Logs(executionID)
 			s.Log.Debugw("waiting for jobs channel", "channelSize", len(logs))
 			if err != nil {
-				// TODO convert to some library for common output
-				fmt.Fprintf(w, `data: {"type": "error","message": "%s"}\n\n`, err.Error())
+				output.PrintError(err)
 				s.Log.Errorw("getting logs error", "error", err)
 				w.Flush()
 				return


### PR DESCRIPTION
## Pull request description 

Reuse existing output method for printing errors
Closes #704 

## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [x] tested locally
- [ ] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Breaking changes

-

## Changes

-

## Fixes

Update method to print error output
