### PR TITLE
feat: duration for testexecutions and for executions + small fixes

### DIFF
--- a/api/v1/testkube.yaml
+++ b/api/v1/testkube.yaml
@@ -969,6 +969,9 @@ components:
           type: string
           description: "test end time"
           format: date-time
+        duration:
+          type: string
+          description: "test duration"
         stepResults:
           type: array
           description: "steps execution restults"
@@ -1049,6 +1052,9 @@ components:
           type: string
           description: "test execution end time"
           format: date-time
+        duration:
+          type: string
+          description: "test execution duration"
         execution:
           type: array
           items:
@@ -1150,6 +1156,9 @@ components:
           type: string
           description: "test end time"
           format: date-time
+        duration:
+          type: string
+          description: "test duration"
         executionResult:
           required: true
           description: result get from executor

--- a/cmd/kubectl-testkube/commands/scripts/execution_renderer.go
+++ b/cmd/kubectl-testkube/commands/scripts/execution_renderer.go
@@ -71,7 +71,7 @@ func (r ExecutionRawRenderer) Render(execution testkube.Execution, writer io.Wri
 func (r ExecutionRawRenderer) Watch(execution testkube.Execution, writer io.Writer) error {
 	_, err := fmt.Fprintf(writer, "Status: %s, Duration: %s\n",
 		*execution.ExecutionResult.Status,
-		execution.Duration(),
+		execution.CalculateDuration(),
 	)
 
 	return err
@@ -81,7 +81,7 @@ func (r ExecutionRawRenderer) renderDetails(execution testkube.Execution, writer
 	_, err := fmt.Fprintf(writer, "Name: %s, Status: %s, Duration: %s\n",
 		execution.Name,
 		*execution.ExecutionResult.Status,
-		execution.Duration(),
+		execution.CalculateDuration(),
 	)
 
 	return err

--- a/cmd/kubectl-testkube/commands/tests/common.go
+++ b/cmd/kubectl-testkube/commands/tests/common.go
@@ -2,6 +2,7 @@ package tests
 
 import (
 	"os"
+	"time"
 
 	"github.com/kubeshop/testkube/pkg/api/v1/client"
 	"github.com/kubeshop/testkube/pkg/api/v1/testkube"
@@ -19,9 +20,12 @@ func GetClient(cmd *cobra.Command) (client.Client, string) {
 	return client, namespace
 }
 
-func printTestExecutionDetails(execution testkube.TestExecution) {
+func printTestExecutionDetails(execution testkube.TestExecution, startTime time.Time) {
 	ui.Warn("Name:", execution.Name)
-	ui.Warn("Status:", string(*execution.Status)+"\n")
+	if execution.Status != nil {
+		ui.Warn("Status:", string(*execution.Status))
+	}
+	ui.Warn("Duration", execution.CalculateDuration().String()+"\n")
 	ui.Table(execution, os.Stdout)
 
 	ui.NL()
@@ -37,8 +41,7 @@ func uiPrintTestStatus(execution testkube.TestExecution) {
 		ui.Warn("Test execution started")
 
 	case testkube.TestStatusSuccess:
-		duration := execution.EndTime.Sub(execution.StartTime)
-		ui.Success("Test execution completed with sucess in " + duration.String())
+		ui.Success("Test execution completed with sucess in " + execution.Duration)
 
 	case testkube.TestStatusError:
 		ui.Errf("Test execution failed")

--- a/cmd/kubectl-testkube/commands/tests/execution.go
+++ b/cmd/kubectl-testkube/commands/tests/execution.go
@@ -2,6 +2,7 @@ package tests
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/kubeshop/testkube/pkg/ui"
 	"github.com/spf13/cobra"
@@ -20,13 +21,14 @@ func NewTestExecutionCmd() *cobra.Command {
 				ui.ExitOnError("Invalid arguments", fmt.Errorf("please pass execution ID"))
 			}
 
+			startTime := time.Now()
 			client, _ := GetClient(cmd)
 
 			executionID := args[0]
 			execution, err := client.GetTestExecution(executionID)
 			ui.ExitOnError("getting recent execution data id:"+execution.Id, err)
 
-			printTestExecutionDetails(execution)
+			printTestExecutionDetails(execution, startTime)
 
 			uiPrintTestStatus(execution)
 

--- a/cmd/kubectl-testkube/commands/tests/start.go
+++ b/cmd/kubectl-testkube/commands/tests/start.go
@@ -32,6 +32,7 @@ func NewStartTestCmd() *cobra.Command {
 			}
 
 			testID := args[0]
+			startTime := time.Now()
 
 			client, namespace := GetClient(cmd)
 			namespacedName := fmt.Sprintf("%s/%s", namespace, testID)
@@ -43,12 +44,12 @@ func NewStartTestCmd() *cobra.Command {
 				executionCh, err := client.WatchTestExecution(execution.Id)
 				for execution := range executionCh {
 					ui.ExitOnError("watching test execution", err)
-					printTestExecutionDetails(execution)
+					printTestExecutionDetails(execution, startTime)
 				}
 			}
 
 			execution, err = client.GetTestExecution(execution.Id)
-			printTestExecutionDetails(execution)
+			printTestExecutionDetails(execution, startTime)
 			ui.ExitOnError("getting recent execution data id:"+execution.Id, err)
 
 			uiPrintTestStatus(execution)

--- a/cmd/kubectl-testkube/commands/tests/watch.go
+++ b/cmd/kubectl-testkube/commands/tests/watch.go
@@ -2,6 +2,7 @@ package tests
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/kubeshop/testkube/pkg/ui"
 	"github.com/spf13/cobra"
@@ -29,17 +30,18 @@ func NewWatchTestExecutionCmd() *cobra.Command {
 			}
 
 			client, _ := GetClient(cmd)
+			startTime := time.Now()
 
 			executionID := args[0]
 			executionCh, err := client.WatchTestExecution(executionID)
 			for execution := range executionCh {
 				ui.ExitOnError("watching test execution", err)
-				printTestExecutionDetails(execution)
+				printTestExecutionDetails(execution, startTime)
 			}
 
 			execution, err := client.GetTestExecution(executionID)
 			ui.ExitOnError("getting test excecution", err)
-			printTestExecutionDetails(execution)
+			printTestExecutionDetails(execution, startTime)
 			ui.ExitOnError("getting recent execution data id:"+execution.Id, err)
 
 			uiPrintTestStatus(execution)

--- a/docs/installing.md
+++ b/docs/installing.md
@@ -14,7 +14,7 @@ We're building Homebew tap for each release, so you can easily install TestKube 
 
 ```sh
 brew tap kubeshop/homebrew-testkube
-brew install kubeshop/testkube
+brew install kubeshop/testkube/testkube
 ```
 
 If you want to upgrade testkube please run following command

--- a/internal/app/api/v1/executions.go
+++ b/internal/app/api/v1/executions.go
@@ -298,7 +298,7 @@ func newExecutionFromExecutionOptions(options client.ExecuteOptions) testkube.Ex
 		options.Request.Name,
 		options.ScriptSpec.Type_,
 		options.ScriptSpec.Content,
-		testkube.NewQueuedExecutionResult(),
+		testkube.NewPendingExecutionResult(),
 		options.Request.Params,
 		options.Request.Tags,
 	)

--- a/internal/pkg/api/repository/result/interface.go
+++ b/internal/pkg/api/repository/result/interface.go
@@ -44,7 +44,7 @@ type Repository interface {
 	// StartExecution updates execution start time
 	StartExecution(ctx context.Context, id string, startTime time.Time) error
 	// EndExecution updates execution end time
-	EndExecution(ctx context.Context, id string, endTime time.Time) error
+	EndExecution(ctx context.Context, id string, endTime time.Time, duration time.Duration) error
 	// GetTags get all available tags
 	GetTags(ctx context.Context) (tags []string, err error)
 }

--- a/internal/pkg/api/repository/result/mongo.go
+++ b/internal/pkg/api/repository/result/mongo.go
@@ -146,8 +146,8 @@ func (r *MongoRepository) StartExecution(ctx context.Context, id string, startTi
 }
 
 // EndExecution updates execution end time
-func (r *MongoRepository) EndExecution(ctx context.Context, id string, endTime time.Time) (err error) {
-	_, err = r.Coll.UpdateOne(ctx, bson.M{"id": id}, bson.M{"$set": bson.M{"endtime": endTime}})
+func (r *MongoRepository) EndExecution(ctx context.Context, id string, endTime time.Time, duration time.Duration) (err error) {
+	_, err = r.Coll.UpdateOne(ctx, bson.M{"id": id}, bson.M{"$set": bson.M{"endtime": endTime, "duration": duration.String()}})
 	return
 }
 

--- a/internal/pkg/api/repository/testresult/interface.go
+++ b/internal/pkg/api/repository/testresult/interface.go
@@ -39,5 +39,5 @@ type Repository interface {
 	// StartExecution updates execution start time
 	StartExecution(ctx context.Context, id string, startTime time.Time) error
 	// EndExecution updates execution end time
-	EndExecution(ctx context.Context, id string, endTime time.Time) error
+	EndExecution(ctx context.Context, id string, endTime time.Time, duration time.Duration) error
 }

--- a/internal/pkg/api/repository/testresult/mongo.go
+++ b/internal/pkg/api/repository/testresult/mongo.go
@@ -116,8 +116,8 @@ func (r *MongoRepository) StartExecution(ctx context.Context, id string, startTi
 }
 
 // EndExecution updates execution end time
-func (r *MongoRepository) EndExecution(ctx context.Context, id string, endTime time.Time) (err error) {
-	_, err = r.Coll.UpdateOne(ctx, bson.M{"id": id}, bson.M{"$set": bson.M{"endtime": endTime}})
+func (r *MongoRepository) EndExecution(ctx context.Context, id string, endTime time.Time, duration time.Duration) (err error) {
+	_, err = r.Coll.UpdateOne(ctx, bson.M{"id": id}, bson.M{"$set": bson.M{"endtime": endTime, "duration": duration.String()}})
 	return
 }
 

--- a/pkg/api/v1/testkube/model_execution.go
+++ b/pkg/api/v1/testkube/model_execution.go
@@ -35,7 +35,9 @@ type Execution struct {
 	// test start time
 	StartTime time.Time `json:"startTime,omitempty"`
 	// test end time
-	EndTime         time.Time        `json:"endTime,omitempty"`
+	EndTime time.Time `json:"endTime,omitempty"`
+	// test duration
+	Duration        string           `json:"duration,omitempty"`
 	ExecutionResult *ExecutionResult `json:"executionResult,omitempty"`
 	// execution tags
 	Tags []string `json:"tags,omitempty"`

--- a/pkg/api/v1/testkube/model_execution_extended.go
+++ b/pkg/api/v1/testkube/model_execution_extended.go
@@ -97,12 +97,16 @@ func (e Execution) Errw(msg string, err error) Execution {
 
 func (e *Execution) Start() {
 	e.StartTime = time.Now()
+	if e.ExecutionResult != nil {
+		e.ExecutionResult.Status = ExecutionStatusPending
+	}
 }
 
 func (e *Execution) Stop() {
 	e.EndTime = time.Now()
+	e.Duration = e.CalculateDuration().String()
 }
-func (e *Execution) Duration() time.Duration {
+func (e *Execution) CalculateDuration() time.Duration {
 
 	end := e.EndTime
 	start := e.StartTime

--- a/pkg/api/v1/testkube/model_execution_result_extended.go
+++ b/pkg/api/v1/testkube/model_execution_result_extended.go
@@ -6,12 +6,6 @@ func NewPendingExecutionResult() ExecutionResult {
 	}
 }
 
-func NewQueuedExecutionResult() ExecutionResult {
-	return ExecutionResult{
-		Status: StatusPtr(QUEUED_ExecutionStatus),
-	}
-}
-
 func NewErrorExecutionResult(err error) ExecutionResult {
 	return ExecutionResult{
 		Status:       StatusPtr(ERROR__ExecutionStatus),

--- a/pkg/api/v1/testkube/model_test_execution.go
+++ b/pkg/api/v1/testkube/model_test_execution.go
@@ -29,6 +29,8 @@ type TestExecution struct {
 	StartTime time.Time `json:"startTime,omitempty"`
 	// test end time
 	EndTime time.Time `json:"endTime,omitempty"`
+	// test duration
+	Duration string `json:"duration,omitempty"`
 	// steps execution restults
 	StepResults []TestStepExecutionResult `json:"stepResults,omitempty"`
 	// test execution tags

--- a/pkg/api/v1/testkube/model_test_execution_extended.go
+++ b/pkg/api/v1/testkube/model_test_execution_extended.go
@@ -19,6 +19,22 @@ func (e TestExecution) IsCompleted() bool {
 	return *e.Status == *TestStatusError || *e.Status == *TestStatusSuccess
 }
 
+func (e *TestExecution) CalculateDuration() time.Duration {
+
+	end := e.EndTime
+	start := e.StartTime
+
+	if start.UnixNano() <= 0 && end.UnixNano() <= 0 {
+		return time.Duration(0)
+	}
+
+	if end.UnixNano() <= 0 {
+		end = time.Now()
+	}
+
+	return end.Sub(e.StartTime)
+}
+
 func (e TestExecution) Table() (header []string, output [][]string) {
 	header = []string{"Step", "Status", "ID", "Error"}
 	output = make([][]string, 0)

--- a/pkg/api/v1/testkube/model_test_execution_summary.go
+++ b/pkg/api/v1/testkube/model_test_execution_summary.go
@@ -25,6 +25,8 @@ type TestExecutionSummary struct {
 	// test execution start time
 	StartTime time.Time `json:"startTime,omitempty"`
 	// test execution end time
-	EndTime   time.Time                  `json:"endTime,omitempty"`
+	EndTime time.Time `json:"endTime,omitempty"`
+	// test execution duration
+	Duration  string                     `json:"duration,omitempty"`
 	Execution []TestStepExecutionSummary `json:"execution,omitempty"`
 }

--- a/pkg/jobs/jobclient.go
+++ b/pkg/jobs/jobclient.go
@@ -80,7 +80,7 @@ func (c *JobClient) LaunchK8sJobSync(image string, repo result.Repository, execu
 			// save stop time
 			defer func() {
 				execution.Stop()
-				repo.EndExecution(ctx, execution.Id, execution.EndTime)
+				repo.EndExecution(ctx, execution.Id, execution.EndTime, execution.CalculateDuration())
 			}()
 
 			// wait for complete
@@ -149,7 +149,7 @@ func (c *JobClient) LaunchK8sJob(image string, repo result.Repository, execution
 				// save stop time
 				defer func() {
 					execution.Stop()
-					repo.EndExecution(ctx, execution.Id, execution.EndTime)
+					repo.EndExecution(ctx, execution.Id, execution.EndTime, execution.CalculateDuration())
 				}()
 				// wait for complete
 				if err := wait.PollImmediate(time.Second, time.Duration(0)*time.Second, k8sclient.HasPodSucceeded(c.ClientSet, pod.Name, c.Namespace)); err != nil {

--- a/pkg/rand/common.go
+++ b/pkg/rand/common.go
@@ -1,0 +1,10 @@
+package rand
+
+import (
+	"math/rand"
+	"time"
+)
+
+func init() {
+	rand.Seed(time.Now().UnixNano())
+}

--- a/pkg/rand/names.go
+++ b/pkg/rand/names.go
@@ -1,15 +1,8 @@
 package rand
 
 import (
-	"math/rand"
-	"time"
-
 	petname "github.com/dustinkirkland/golang-petname"
 )
-
-func init() {
-	rand.Seed(time.Now().UnixNano())
-}
 
 func Name() string {
 	return petname.Generate(3, "-")

--- a/pkg/rand/string.go
+++ b/pkg/rand/string.go
@@ -1,0 +1,13 @@
+package rand
+
+import "math/rand"
+
+var letters = []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ")
+
+func String(n int) string {
+	b := make([]rune, n)
+	for i := range b {
+		b[i] = letters[rand.Intn(len(letters))]
+	}
+	return string(b)
+}

--- a/pkg/server/httpserver.go
+++ b/pkg/server/httpserver.go
@@ -33,6 +33,13 @@ type HTTPServer struct {
 
 // Init initializes router and setting up basic routes for health and metrics
 func (s *HTTPServer) Init() {
+
+	// global log for requests
+	s.Mux.Use(func(c *fiber.Ctx) error {
+		s.Log.Debugw("request", "method", string(c.Request().Header.Method()), "path", c.Request().URI().String())
+		return c.Next()
+	})
+
 	// server generic endpoints
 	s.Mux.Get("/health", s.HealthEndpoint())
 	s.Mux.Get("/metrics", adaptor.HTTPHandler(promhttp.Handler()))


### PR DESCRIPTION
## Pull request description 

As api client I want to have duration calculated on backend.

closes #781 
closes #784
closes #785

## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [x] tested locally
- [ ] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Breaking changes

-

## Changes

-

## Fixes

-