### PR TITLE
fix: mark test failed if one of the steps fails and record step if it stops on failure

### DIFF
--- a/internal/app/api/v1/tests.go
+++ b/internal/app/api/v1/tests.go
@@ -239,8 +239,7 @@ func (s TestKubeAPI) executeTest(ctx context.Context, request testkube.TestExecu
 			if stepResult.IsFailed() {
 				hasFailedSteps = true
 				if steps[i].StopTestOnFailure {
-					testExecution.Status = testkube.TestStatusError
-					return
+					break
 				}
 			}
 

--- a/internal/app/api/v1/tests.go
+++ b/internal/app/api/v1/tests.go
@@ -231,16 +231,14 @@ func (s TestKubeAPI) executeTest(ctx context.Context, request testkube.TestExecu
 		steps = append(steps, test.After...)
 
 		hasFailedSteps := false
-		for _, step := range steps {
-			// we need to pass pointer to value - so we need to copy it
-			stepCopy := step
-			stepResult := s.executeTestStep(ctx, testExecution, step)
-			stepResult.Step = &stepCopy
+		for i := range steps {
+			stepResult := s.executeTestStep(ctx, testExecution, steps[i])
+			stepResult.Step = &steps[i]
 			// TODO load script details to stepResult
 			testExecution.StepResults = append(testExecution.StepResults, stepResult)
 			if stepResult.IsFailed() {
 				hasFailedSteps = true
-				if step.StopTestOnFailure {
+				if steps[i].StopTestOnFailure {
 					testExecution.Status = testkube.TestStatusError
 					return
 				}
@@ -251,7 +249,7 @@ func (s TestKubeAPI) executeTest(ctx context.Context, request testkube.TestExecu
 
 		testExecution.Status = testkube.TestStatusSuccess
 		if hasFailedSteps {
-			testExecution.Status = testkube.TestStatusSuccess
+			testExecution.Status = testkube.TestStatusError
 		}
 
 		s.TestExecutionResults.Update(ctx, testExecution)

--- a/internal/app/api/v1/tests.go
+++ b/internal/app/api/v1/tests.go
@@ -290,6 +290,7 @@ func (s TestKubeAPI) executeTestStep(ctx context.Context, testExecution testkube
 	case testkube.TestStepTypeDelay:
 		l.Debug("delaying execution")
 		time.Sleep(time.Millisecond * time.Duration(step.Delay.Duration))
+		return newTestStepDelayResult()
 
 	default:
 		result.Err(fmt.Errorf("can't find handler for execution step type: '%v'", step.Type()))
@@ -301,6 +302,12 @@ func (s TestKubeAPI) executeTestStep(ctx context.Context, testExecution testkube
 func newTestStepExecutionResult(execution testkube.Execution, step *testkube.TestStepExecuteScript) (result testkube.TestStepExecutionResult) {
 	result.Execution = &execution
 	result.Script = &testkube.ObjectRef{Name: step.Name, Namespace: step.Namespace}
+
+	return
+}
+
+func newTestStepDelayResult() (result testkube.TestStepExecutionResult) {
+	result.Execution = &testkube.Execution{ExecutionResult: &testkube.ExecutionResult{Status: testkube.ExecutionStatusSuccess}}
 
 	return
 }


### PR DESCRIPTION
## Pull request description 

Mark test as failed if one of the steps fails and record step if it stops on fialure
Closed #867, #866

## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [ ] tested locally
- [x] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Breaking changes

-

## Changes

-

## Fixes

- Refactor step execution loop to break on failure and mark test as failed for any failed steps