### PR TITLE
fix: check if the os.Args have more than one element before cutting down the first element

### DIFF
--- a/pkg/analytics/analytics.go
+++ b/pkg/analytics/analytics.go
@@ -45,6 +45,10 @@ func SendAnonymousInfo() {
 
 func SendAnonymouscmdInfo() {
 	client := v1.NewClient(testkubeTrackingID, "golang")
+	command := []string{}
+	if len(os.Args) > 1 {
+		command = os.Args[1:]
+	}
 	payload := &gatypes.Payload{
 		HitType:                           "event",
 		DataSource:                        "CLI",
@@ -60,7 +64,7 @@ func SendAnonymouscmdInfo() {
 			ApplicationName:    "testkube",
 			ApplicationVersion: commands.Version,
 		},
-		CustomDimensions: gatypes.StringList(os.Args[1:]),
+		CustomDimensions: gatypes.StringList(command),
 	}
 	client.SendPost(payload)
 }


### PR DESCRIPTION


## Pull request description 



## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [ ] tested locally
- [ ] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Breaking changes

-

## Changes

-

## Fixes

-