### PR TITLE
fix: add warning about skipping cert manager installation

### DIFF
--- a/cmd/kubectl-testkube/commands/common.go
+++ b/cmd/kubectl-testkube/commands/common.go
@@ -74,6 +74,9 @@ func HelmUpgradeOrInstalTestkube(name, namespace, chart string, noDashboard, noM
 			}
 
 			ui.Info("Helm install jetstack output", string(out))
+		} else {
+			ui.Info("Found existing crd certificates.cert-manager.io. Assume that jetstack cert manager is already installed. " +
+				"Skip its installation")
 		}
 	}
 


### PR DESCRIPTION
## Pull request description 

add warning about skipping cert manager installation

## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [ ] tested locally
- [ ] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Breaking changes

-

## Changes

-

## Fixes

-