### PR TITLE
docs: update parameter casing in docs

### DIFF
--- a/docs/executor-custom.md
+++ b/docs/executor-custom.md
@@ -142,7 +142,7 @@ spec:
   - example/test      
   # your custom type registered (used when creating and running your testkube tests)
 
-  contentTypes:
+  content_types:
   - string             # test content as string 
   - file-uri           # http based file content
   - git-file           # file stored in Git
@@ -152,7 +152,7 @@ spec:
   - artifacts          # executor can have artifacts after test run (e.g. videos, screenshots)
   - junit-report       # executor can have junit xml based results
 
-# Remove any contentTypes and features which will be not implemented by your executor.
+# Remove any content_types and features which will be not implemented by your executor.
 
 ```
 


### PR DESCRIPTION
## Pull request description 
When creating a new executor, the docs suggested to use contentTypes, despite all other params using snake case. This PR fixes that.

## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [x] tested locally - tested that the parameter is indeed content_types, not the docs themselves
- [ ] tested on cluster
- [ ] added new dependencies
- [x] updated the docs
- [ ] added a test

## Breaking changes

- none

## Changes

- just the docs

## Fixes

- just the docs