### PR TITLE
fix: display slack message info only if not empty

### DIFF
--- a/pkg/slacknotifier/slack.go
+++ b/pkg/slacknotifier/slack.go
@@ -18,7 +18,7 @@ const messageTemplate string = `{
 			"type": "header",
 			"text": {
 				"type": "plain_text",
-				"text": "New Event",
+				"text": "Teskube activity",
 				"emoji": true
 			}
 		},
@@ -28,11 +28,14 @@ const messageTemplate string = `{
 				{
 					"type": "mrkdwn",
 					"text": "*Event Type:*\n{{ .EventType }}"
-				},
+				}
+				{{ if .Namespace }}
+				,
 				{
 					"type": "mrkdwn",
 					"text": "*Namespace:*\n{{ .Namespace }}"
 				}
+				{{ end }}
 			]
 		},
 		{
@@ -69,7 +72,9 @@ const messageTemplate string = `{
 					"text": "*End Time:*\n{{ .EndTime }}"
 				}
 			]
-		},
+		}
+		{{ if .Duration }}
+		,
 		{
 			"type": "section",
 			"fields": [
@@ -78,7 +83,10 @@ const messageTemplate string = `{
 					"text": "*Duration:*\n{{ .Duration }}"
 				}
 			]
-		},
+		}
+		{{ end }}
+		{{ if .Output }}
+		,
 		{
 			"type": "section",
 			"fields": [
@@ -88,6 +96,7 @@ const messageTemplate string = `{
 				}
 			]
 		}
+		{{ end }}
 	]
 }`
 


### PR DESCRIPTION
## Pull request description 



## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [ ] tested locally
- [ ] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Breaking changes

-

## Changes

-

## Fixes

-