### PR TITLE
fix: goreleaser prebuilt config

### DIFF
--- a/.builds-darwin.goreleaser-dev.yml
+++ b/.builds-darwin.goreleaser-dev.yml
@@ -19,3 +19,5 @@ builds:
       - -X main.builtBy=goreleaser
       - -X github.com/kubeshop/testkube/pkg/analytics.TestkubeMeasurementID={{.Env.ANALYTICS_TRACKING_ID}}
       - -X github.com/kubeshop/testkube/pkg/analytics.TestkubeMeasurementSecret={{.Env.ANALYTICS_API_KEY}}
+archives:
+  - format: binary

--- a/.builds-linux.goreleaser-dev.yml
+++ b/.builds-linux.goreleaser-dev.yml
@@ -20,3 +20,5 @@ builds:
       - -X main.builtBy=goreleaser
       - -X github.com/kubeshop/testkube/pkg/analytics.TestkubeMeasurementID={{.Env.ANALYTICS_TRACKING_ID}}
       - -X github.com/kubeshop/testkube/pkg/analytics.TestkubeMeasurementSecret={{.Env.ANALYTICS_API_KEY}}
+archives:
+  - format: binary

--- a/.builds-windows.goreleaser-dev.yml
+++ b/.builds-windows.goreleaser-dev.yml
@@ -20,3 +20,5 @@ builds:
       - -X main.builtBy=goreleaser
       - -X github.com/kubeshop/testkube/pkg/analytics.TestkubeMeasurementID={{.Env.ANALYTICS_TRACKING_ID}}
       - -X github.com/kubeshop/testkube/pkg/analytics.TestkubeMeasurementSecret={{.Env.ANALYTICS_API_KEY}}
+archives:
+  - format: binary

--- a/.goreleaser-dev.yml
+++ b/.goreleaser-dev.yml
@@ -1,6 +1,3 @@
-#before:
-#  hooks:
-#    - go mod tidy
 builds:
   - builder: prebuilt
     goos:
@@ -14,15 +11,10 @@ builds:
     goamd64:
       - v1
     prebuilt:
-      path: ./tmp
+      path: '{{ .Os }}/kubectl-testkube_{{ .Os }}_{{ .Arch }}{{ with .Amd64 }}_{{ . }}{{ end }}/kubectl-testkube{{ .Ext }}'
     binary: kubectl-testkube
-#    env:
-#      - CGO_ENABLED=0
-    ldflags:
-      - -s -w -X main.version={{.Version}}
-      - -X main.commit={{.Commit}}
-      - -X main.date={{.Date}}
-      - -X main.builtBy=goreleaser
+    hooks:
+      pre: 'du -hs {{ .Os }}/kubectl-testkube_{{ .Os }}_{{ .Arch }}{{ with .Amd64 }}_{{ . }}{{ end }}/kubectl-testkube{{ .Ext }}'
 archives:
   - replacements:
       darwin: macOS


### PR DESCRIPTION
- speed up children builds by skipping archiving
- fixed paths