### PR TITLE
docs: updating the apt install command in the docs as sudo was in the wrong place

### DIFF
--- a/docs/installing.md
+++ b/docs/installing.md
@@ -42,7 +42,7 @@ wget -qO - https://repo.testkube.io/key.pub | sudo apt-key add -
 
 Add our repository to your apt sources:
 ```sh
-sudo echo "deb https://repo.testkube.io/linux linux main" >> /etc/apt/sources.list
+echo "deb https://repo.testkube.io/linux linux main" | sudo tee -a /etc/apt/sources.list
 ```
 
 Make sure to get the updates:


### PR DESCRIPTION
Apparently, the >> is run by the shell and sudo didn't apply to it.

## Pull request description 



## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [ ] tested locally
- [ ] tested on cluster
- [ ] added new dependencies
- [x] updated the docs
- [ ] added a test

## Breaking changes

-

## Changes

-

## Fixes

-