### PR TITLE
fix: Increase counter after an execution

### DIFF
--- a/internal/app/api/v1/server.go
+++ b/internal/app/api/v1/server.go
@@ -81,7 +81,7 @@ func NewTestkubeAPI(
 		panic(err)
 	}
 
-	if s.Executor, err = client.NewJobExecutor(executionsResults, s.Namespace, initImage, s.jobTemplates.Job); err != nil {
+	if s.Executor, err = client.NewJobExecutor(executionsResults, s.Namespace, initImage, s.jobTemplates.Job, s.Metrics); err != nil {
 		panic(err)
 	}
 

--- a/pkg/executor/client/job.go
+++ b/pkg/executor/client/job.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"time"
 
-	apiv1 "github.com/kubeshop/testkube/internal/app/api/v1"
 	"github.com/kubeshop/testkube/internal/pkg/api/repository/result"
 	"github.com/kubeshop/testkube/pkg/api/v1/testkube"
 	"github.com/kubeshop/testkube/pkg/executor/output"
@@ -15,7 +14,7 @@ import (
 )
 
 // NewJobExecutor creates new job executor
-func NewJobExecutor(repo result.Repository, namespace, initImage, jobTemplate string, metrics apiv1.Metrics) (client JobExecutor, err error) {
+func NewJobExecutor(repo result.Repository, namespace, initImage, jobTemplate string, metrics jobs.ExecutionCounter) (client JobExecutor, err error) {
 	jobClient, err := jobs.NewJobClient(namespace, initImage, jobTemplate, metrics)
 	if err != nil {
 		return client, fmt.Errorf("can't get k8s jobs client: %w", err)

--- a/pkg/executor/client/job.go
+++ b/pkg/executor/client/job.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"time"
 
+	apiv1 "github.com/kubeshop/testkube/internal/app/api/v1"
 	"github.com/kubeshop/testkube/internal/pkg/api/repository/result"
 	"github.com/kubeshop/testkube/pkg/api/v1/testkube"
 	"github.com/kubeshop/testkube/pkg/executor/output"
@@ -14,8 +15,8 @@ import (
 )
 
 // NewJobExecutor creates new job executor
-func NewJobExecutor(repo result.Repository, namespace, initImage, jobTemplate string) (client JobExecutor, err error) {
-	jobClient, err := jobs.NewJobClient(namespace, initImage, jobTemplate)
+func NewJobExecutor(repo result.Repository, namespace, initImage, jobTemplate string, metrics apiv1.Metrics) (client JobExecutor, err error) {
+	jobClient, err := jobs.NewJobClient(namespace, initImage, jobTemplate, metrics)
 	if err != nil {
 		return client, fmt.Errorf("can't get k8s jobs client: %w", err)
 	}

--- a/pkg/jobs/jobclient.go
+++ b/pkg/jobs/jobclient.go
@@ -174,6 +174,9 @@ func (c *JobClient) LaunchK8sJobSync(repo result.Repository, execution testkube.
 				return result, err
 			}
 
+			// metrics increase
+			c.metrics.IncExecution(execution)
+
 			l.Infow("execution completed saving result", "executionId", execution.Id, "status", result.Status)
 			err = repo.UpdateResult(ctx, execution.Id, result)
 			if err != nil {

--- a/pkg/jobs/jobclient.go
+++ b/pkg/jobs/jobclient.go
@@ -22,7 +22,6 @@ import (
 	"k8s.io/client-go/kubernetes"
 	tcorev1 "k8s.io/client-go/kubernetes/typed/core/v1"
 
-	apiv1 "github.com/kubeshop/testkube/internal/app/api/v1"
 	"github.com/kubeshop/testkube/internal/pkg/api/repository/result"
 	"github.com/kubeshop/testkube/pkg/api/v1/testkube"
 	"github.com/kubeshop/testkube/pkg/executor/output"
@@ -46,6 +45,10 @@ const (
 	volumeDir    = "/data"
 )
 
+type ExecutionCounter interface {
+	IncExecution(execution testkube.Execution)
+}
+
 // JobClient data struct for managing running jobs
 type JobClient struct {
 	ClientSet   *kubernetes.Clientset
@@ -55,7 +58,7 @@ type JobClient struct {
 	Log         *zap.SugaredLogger
 	initImage   string
 	jobTemplate string
-	metrics     apiv1.Metrics
+	metrics     ExecutionCounter
 }
 
 // JobOptions is for configuring JobOptions
@@ -74,7 +77,7 @@ type JobOptions struct {
 }
 
 // NewJobClient returns new JobClient instance
-func NewJobClient(namespace, initImage, jobTemplate string, metrics apiv1.Metrics) (*JobClient, error) {
+func NewJobClient(namespace, initImage, jobTemplate string, metrics ExecutionCounter) (*JobClient, error) {
 	clientSet, err := k8sclient.ConnectToK8s()
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
## Pull request description 

Test execution counter is not increased after execution finishes, i.e. the result is stuck at `running` even after the execution succeeded or failed. This change fixes that.

```
testkube_executions_count{name="xyz",result="running",type="universal-package-test"} 1
```

## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [ ] tested locally
- [ ] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Breaking changes

-

## Changes

-

## Fixes

-