### PR TITLE
fix: use dll to open windows browser

### DIFF
--- a/cmd/kubectl-testkube/commands/dashboard.go
+++ b/cmd/kubectl-testkube/commands/dashboard.go
@@ -11,6 +11,7 @@ import (
 	"github.com/kubeshop/testkube/pkg/http"
 	"github.com/kubeshop/testkube/pkg/process"
 	"github.com/kubeshop/testkube/pkg/ui"
+	"github.com/skratchdot/open-golang/open"
 	"github.com/spf13/cobra"
 )
 
@@ -69,11 +70,9 @@ func NewDashboardCmd() *cobra.Command {
 			ui.Debug("Endpoints readiness", fmt.Sprintf("%v", ready))
 
 			// open browser
-			openCmd, err := getOpenCommand()
-			if err == nil {
-				_, err = process.Execute(openCmd, dashboardAddress)
-				ui.PrintOnError("openning dashboard", err)
-			}
+			// open browser
+			err = open.Run(dashboardAddress)
+			ui.PrintOnError("openning dashboard", err)
 
 			// wait for Ctrl/Cmd + c signal to clear everything
 			c := make(chan os.Signal, 1)


### PR DESCRIPTION
## Pull request description 

Use dll to open windows browser

## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [x] tested locally
- [ ] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Breaking changes

-

## Changes

-

## Fixes

-