### PR TITLE
fix: Update execution object to have up to date result status before incrementing metrics on it

### DIFF
--- a/pkg/jobs/jobclient.go
+++ b/pkg/jobs/jobclient.go
@@ -178,6 +178,7 @@ func (c *JobClient) LaunchK8sJobSync(repo result.Repository, execution testkube.
 			}
 
 			// metrics increase
+			execution.ExecutionResult = &result
 			c.metrics.IncExecution(execution)
 
 			l.Infow("execution completed saving result", "executionId", execution.Id, "status", result.Status)
@@ -282,6 +283,7 @@ func (c *JobClient) LaunchK8sJob(repo result.Repository, execution testkube.Exec
 				}
 
 				// metrics increase
+				execution.ExecutionResult = &result
 				c.metrics.IncExecution(execution)
 
 				l.Infow("execution completed saving result", "status", result.Status)


### PR DESCRIPTION
## Pull request description
* Issue is that the status of a test run continues to hold the original status of "running" because execution object never gets pass/fail status assigned before incrementing metrics on it.
* So, this change will fix that issue by updating execution object to have up to date result status before incrementing metrics on it.
* The result is that instead of metrics being stuck as "running" regardless of whether the corresponding test passed or failed as shown below:
`testkube_executions_count{name="kubeshop-site",result="running",type="postman/collection"} `
now we have the following when the corresponding test fails:
`testkube_executions_count{name="kubeshop-site",result="failed",type="postman/collection"}`
and the following when the corresponding test passes:
`testkube_executions_count{name="kubeshop-site",result="passed",type="postman/collection"}`

## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [ ] tested locally
- [ ] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Breaking changes

-

## Changes

-

## Fixes

-