### PR TITLE
feat: remove io/ioutil pkg

### DIFF
--- a/cmd/kubectl-testkube/commands/crds/tests_crds.go
+++ b/cmd/kubectl-testkube/commands/crds/tests_crds.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"io/fs"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"regexp"
 	"strings"
@@ -75,7 +75,7 @@ var ErrTypeNotDetected = fmt.Errorf("type not detected")
 func GenerateCRD(namespace, path string) (string, error) {
 	var testType string
 
-	content, err := ioutil.ReadFile(path)
+	content, err := os.ReadFile(path)
 	if err != nil {
 		return "", err
 	}

--- a/cmd/kubectl-testkube/commands/executors/create.go
+++ b/cmd/kubectl-testkube/commands/executors/create.go
@@ -2,7 +2,7 @@ package executors
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"strconv"
 
 	"github.com/kubeshop/testkube/cmd/kubectl-testkube/commands/common"
@@ -45,7 +45,7 @@ func NewCreateExecutorCmd() *cobra.Command {
 
 			jobTemplateContent := ""
 			if jobTemplate != "" {
-				b, err := ioutil.ReadFile(jobTemplate)
+				b, err := os.ReadFile(jobTemplate)
 				ui.ExitOnError("reading job template", err)
 				jobTemplateContent = string(b)
 			}

--- a/cmd/kubectl-testkube/commands/tests/common.go
+++ b/cmd/kubectl-testkube/commands/tests/common.go
@@ -2,7 +2,7 @@ package tests
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"reflect"
 	"time"
@@ -112,12 +112,12 @@ func newContentFromFlags(cmd *cobra.Command) (content *testkube.TestContent, err
 
 	// get file content
 	if file != "" {
-		fileContent, err = ioutil.ReadFile(file)
+		fileContent, err = os.ReadFile(file)
 		if err != nil {
 			return content, fmt.Errorf("reading file "+file+" error: %w", err)
 		}
 	} else if stat, _ := os.Stdin.Stat(); (stat.Mode() & os.ModeCharDevice) == 0 {
-		fileContent, err = ioutil.ReadAll(os.Stdin)
+		fileContent, err = io.ReadAll(os.Stdin)
 		if err != nil {
 			return content, fmt.Errorf("reading stdin error: %w", err)
 		}

--- a/cmd/kubectl-testkube/commands/tests/run.go
+++ b/cmd/kubectl-testkube/commands/tests/run.go
@@ -2,7 +2,6 @@ package tests
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"strings"
 	"time"
@@ -42,7 +41,7 @@ func NewRunTestCmd() *cobra.Command {
 
 			paramsFileContent := ""
 			if variablesFile != "" {
-				b, err := ioutil.ReadFile(variablesFile)
+				b, err := os.ReadFile(variablesFile)
 				ui.ExitOnError("reading variables file", err)
 				paramsFileContent = string(b)
 			}

--- a/cmd/kubectl-testkube/commands/testsuites/create.go
+++ b/cmd/kubectl-testkube/commands/testsuites/create.go
@@ -3,7 +3,7 @@ package testsuites
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"strconv"
 
@@ -39,10 +39,10 @@ func NewCreateTestSuitesCmd() *cobra.Command {
 
 			if file != "" {
 				// read test content
-				content, err = ioutil.ReadFile(file)
+				content, err = os.ReadFile(file)
 				ui.ExitOnError("reading file"+file, err)
 			} else if stat, _ := os.Stdin.Stat(); (stat.Mode() & os.ModeCharDevice) == 0 {
-				content, err = ioutil.ReadAll(os.Stdin)
+				content, err = io.ReadAll(os.Stdin)
 				ui.ExitOnError("reading stdin", err)
 			}
 

--- a/cmd/kubectl-testkube/commands/testsuites/update.go
+++ b/cmd/kubectl-testkube/commands/testsuites/update.go
@@ -2,7 +2,7 @@ package testsuites
 
 import (
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"os"
 	"reflect"
 
@@ -32,10 +32,10 @@ func NewUpdateTestSuitesCmd() *cobra.Command {
 
 			if file != "" {
 				// read test content
-				content, err = ioutil.ReadFile(file)
+				content, err = os.ReadFile(file)
 				ui.ExitOnError("reading file"+file, err)
 			} else if stat, _ := os.Stdin.Stat(); (stat.Mode() & os.ModeCharDevice) == 0 {
-				content, err = ioutil.ReadAll(os.Stdin)
+				content, err = io.ReadAll(os.Stdin)
 				ui.ExitOnError("reading stdin", err)
 			}
 

--- a/cmd/kubectl-testkube/config/config_test.go
+++ b/cmd/kubectl-testkube/config/config_test.go
@@ -1,7 +1,7 @@
 package config
 
 import (
-	"io/ioutil"
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -9,7 +9,7 @@ import (
 
 func TestSaveAnalyticsEnabled(t *testing.T) {
 
-	dir, err := ioutil.TempDir("", "test-config-save")
+	dir, err := os.MkdirTemp("", "test-config-save")
 	assert.NoError(t, err)
 
 	// create homedir config file

--- a/cmd/kubectl-testkube/config/storage.go
+++ b/cmd/kubectl-testkube/config/storage.go
@@ -2,7 +2,6 @@ package config
 
 import (
 	"encoding/json"
-	"io/ioutil"
 	"os"
 	"path"
 
@@ -29,7 +28,7 @@ func (c *Storage) Load() (data Data, err error) {
 	if err != nil {
 		return data, err
 	}
-	d, err := ioutil.ReadFile(path)
+	d, err := os.ReadFile(path)
 	if err != nil {
 		return data, err
 	}
@@ -46,7 +45,7 @@ func (c *Storage) Save(data Data) error {
 	if err != nil {
 		return err
 	}
-	return ioutil.WriteFile(path, d, 0700)
+	return os.WriteFile(path, d, 0700)
 }
 
 func (c *Storage) Init() error {

--- a/cmd/proxy/main.go
+++ b/cmd/proxy/main.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"flag"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httputil"
 	"net/url"
@@ -44,14 +44,14 @@ func (DebugTransport) RoundTrip(r *http.Request) (*http.Response, error) {
 
 func proxyPass(res http.ResponseWriter, req *http.Request) {
 	fmt.Printf("\n-------------\n")
-	body, _ := ioutil.ReadAll(req.Body)
+	body, _ := io.ReadAll(req.Body)
 	fmt.Printf("%s\n", body)
 
 	prefix := fmt.Sprintf("/api/v1/namespaces/%s/services/testkube-api-server:%d/proxy", *namespace, *apiPort)
 	req.URL.Path = strings.Replace(req.URL.Path, prefix, "", -1)
 
 	newReq := req.Clone(req.Context())
-	newReq.Body = ioutil.NopCloser(bytes.NewReader(body))
+	newReq.Body = io.NopCloser(bytes.NewReader(body))
 
 	url, _ := url.Parse(fmt.Sprintf("http://127.0.0.1:%d", *apiPort))
 	proxy := httputil.NewSingleHostReverseProxy(url)

--- a/internal/app/api/v1/slack_oauth.go
+++ b/internal/app/api/v1/slack_oauth.go
@@ -3,11 +3,10 @@ package v1
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 
 	"github.com/gofiber/fiber/v2"
-
 	thttp "github.com/kubeshop/testkube/pkg/http"
 )
 
@@ -74,7 +73,7 @@ func (s TestkubeAPI) OauthHandler() fiber.Handler {
 		}
 		defer resp.Body.Close()
 
-		body, err := ioutil.ReadAll(resp.Body)
+		body, err := io.ReadAll(resp.Body)
 
 		if err != nil {
 			return s.Error(c, http.StatusInternalServerError, fmt.Errorf("\nInvalid format for access token: %+v", err))

--- a/pkg/analytics/analytics.go
+++ b/pkg/analytics/analytics.go
@@ -6,7 +6,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"os"
 	"runtime"
@@ -208,7 +208,7 @@ func sendDataToGA(payload Payload) (out string, err error) {
 		return out, err
 	}
 	defer resp.Body.Close()
-	b, err := ioutil.ReadAll(resp.Body)
+	b, err := io.ReadAll(resp.Body)
 
 	if resp.StatusCode > 300 {
 		return out, fmt.Errorf("could not POST, statusCode: %d", resp.StatusCode)
@@ -238,7 +238,7 @@ func sendValidationRequest(payload Payload) (out string, err error) {
 		return out, err
 	}
 	defer resp.Body.Close()
-	b, err := ioutil.ReadAll(resp.Body)
+	b, err := io.ReadAll(resp.Body)
 
 	if resp.StatusCode > 300 {
 		return out, fmt.Errorf("could not POST, statusCode: %d", resp.StatusCode)

--- a/pkg/api/v1/client/direct_client.go
+++ b/pkg/api/v1/client/direct_client.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -126,7 +125,7 @@ func (t DirectClient[A]) Delete(uri, selector string, isContentExpected bool) er
 	defer resp.Body.Close()
 
 	if isContentExpected && resp.StatusCode != http.StatusNoContent {
-		respBody, err := ioutil.ReadAll(resp.Body)
+		respBody, err := io.ReadAll(resp.Body)
 		if err != nil {
 			return err
 		}
@@ -210,7 +209,7 @@ func (t DirectClient[A]) responseError(resp *http.Response) error {
 	if resp.StatusCode >= 400 {
 		var pr problem.Problem
 
-		bytes, err := ioutil.ReadAll(resp.Body)
+		bytes, err := io.ReadAll(resp.Body)
 		if err != nil {
 			return fmt.Errorf("can't get problem from api response: can't read response body %w", err)
 		}

--- a/pkg/executor/agent/agent.go
+++ b/pkg/executor/agent/agent.go
@@ -3,7 +3,7 @@ package agent
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 
 	"github.com/kubeshop/testkube/pkg/api/v1/testkube"
@@ -22,7 +22,7 @@ func Run(r runner.Runner, args []string) {
 
 	stat, _ := os.Stdin.Stat()
 	if (stat.Mode() & os.ModeCharDevice) == 0 {
-		test, err = ioutil.ReadAll(os.Stdin)
+		test, err = io.ReadAll(os.Stdin)
 		if err != nil {
 			output.PrintError(os.Stderr, fmt.Errorf("can't read stind input: %w", err))
 			os.Exit(1)

--- a/pkg/executor/content/fetcher.go
+++ b/pkg/executor/content/fetcher.go
@@ -3,7 +3,6 @@ package content
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -110,7 +109,7 @@ func (f Fetcher) saveTempFile(reader io.Reader) (path string, err error) {
 	var tmpFile *os.File
 	filename := "test-content"
 	if f.path == "" {
-		tmpFile, err = ioutil.TempFile("", filename)
+		tmpFile, err = os.CreateTemp("", filename)
 	} else {
 		tmpFile, err = os.Create(filepath.Join(f.path, filename))
 	}

--- a/pkg/executor/content/fetcher_test.go
+++ b/pkg/executor/content/fetcher_test.go
@@ -4,7 +4,7 @@
 package content
 
 import (
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -32,7 +32,7 @@ func TestFetcher(t *testing.T) {
 		assert.NoError(t, err)
 		assert.FileExists(t, path)
 
-		d, err := ioutil.ReadFile(path)
+		d, err := os.ReadFile(path)
 		assert.NoError(t, err)
 		assert.Equal(t, string(fileContent), string(d))
 	})
@@ -48,7 +48,7 @@ func TestFetcher(t *testing.T) {
 		assert.NoError(t, err)
 		assert.FileExists(t, path)
 
-		d, err := ioutil.ReadFile(path)
+		d, err := os.ReadFile(path)
 		assert.NoError(t, err)
 		assert.Equal(t, string(fileContent), string(d))
 	})

--- a/pkg/git/checkout.go
+++ b/pkg/git/checkout.go
@@ -4,7 +4,7 @@
 package git
 
 import (
-	"io/ioutil"
+	"os"
 
 	"github.com/kubeshop/testkube/pkg/process"
 )
@@ -13,7 +13,7 @@ import (
 func Checkout(uri, branch, dir string) (outputDir string, err error) {
 	tmpDir := dir
 	if tmpDir == "" {
-		tmpDir, err = ioutil.TempDir("", "git-checkout")
+		tmpDir, err = os.MkdirTemp("", "git-checkout")
 		if err != nil {
 			return "", err
 		}
@@ -38,7 +38,7 @@ func Checkout(uri, branch, dir string) (outputDir string, err error) {
 func PartialCheckout(uri, path, branch, dir string) (outputDir string, err error) {
 	tmpDir := dir
 	if tmpDir == "" {
-		tmpDir, err = ioutil.TempDir("", "git-sparse-checkout")
+		tmpDir, err = os.MkdirTemp("", "git-sparse-checkout")
 		if err != nil {
 			return "", err
 		}

--- a/pkg/helm/chart.go
+++ b/pkg/helm/chart.go
@@ -2,7 +2,6 @@ package helm
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -15,7 +14,7 @@ type HelmChart yaml.MapSlice
 
 // Read reads helm chart based on path
 func Read(filePath string) (helmChart HelmChart, err error) {
-	content, err := ioutil.ReadFile(filePath)
+	content, err := os.ReadFile(filePath)
 	if err != nil {
 		return helmChart, err
 	}
@@ -31,7 +30,7 @@ func Write(filePath string, helmChart HelmChart) (err error) {
 	if err != nil {
 		return err
 	}
-	return ioutil.WriteFile(filePath, content, 0644)
+	return os.WriteFile(filePath, content, 0644)
 }
 
 // UpdateDependencyVersion updates version in HelmChart
@@ -164,7 +163,7 @@ func Find(dir string) (chartPath string, err error) {
 
 // UpdateValuesImageTag updates values.yaml image tag field
 func UpdateValuesImageTag(path, tag string) error {
-	input, err := ioutil.ReadFile(path)
+	input, err := os.ReadFile(path)
 	if err != nil {
 		return err
 	}
@@ -172,5 +171,5 @@ func UpdateValuesImageTag(path, tag string) error {
 	r := regexp.MustCompile(`tag: "[^"]+"`)
 	output := r.ReplaceAll(input, []byte(fmt.Sprintf(`tag: "%s"`, tag)))
 
-	return ioutil.WriteFile(path, output, 0644)
+	return os.WriteFile(path, output, 0644)
 }

--- a/pkg/oauth/github.go
+++ b/pkg/oauth/github.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"time"
@@ -64,7 +64,7 @@ func (v GithubValidator) Validate(accessToken string) error {
 		return fmt.Errorf("status: %s", resp.Status)
 	}
 
-	result, err := ioutil.ReadAll(resp.Body)
+	result, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return err
 	}

--- a/pkg/tmp/files.go
+++ b/pkg/tmp/files.go
@@ -2,12 +2,12 @@ package tmp
 
 import (
 	"io"
-	"io/ioutil"
+	"os"
 )
 
 // ReaderToTmpfile converts io.Reader to tmp file returns saved file path
 func ReaderToTmpfile(input io.Reader) (path string, err error) {
-	tmpfile, err := ioutil.TempFile("", "testkube-tmp")
+	tmpfile, err := os.CreateTemp("", "testkube-tmp")
 	path = tmpfile.Name()
 	if _, err := io.Copy(tmpfile, input); err != nil {
 		return path, err
@@ -22,6 +22,6 @@ func ReaderToTmpfile(input io.Reader) (path string, err error) {
 
 // Name generate new temp file and returns file path
 func Name() string {
-	tmpfile, _ := ioutil.TempFile("", "testkube-tmp")
+	tmpfile, _ := os.CreateTemp("", "testkube-tmp")
 	return tmpfile.Name()
 }

--- a/pkg/tmp/files_test.go
+++ b/pkg/tmp/files_test.go
@@ -1,7 +1,6 @@
 package tmp
 
 import (
-	"io/ioutil"
 	"os"
 	"strings"
 	"testing"
@@ -20,7 +19,7 @@ func TestReaderToTmpfile(t *testing.T) {
 	assert.NoError(t, err)
 	defer os.Remove(path) // clean up
 
-	contentBytes, err := ioutil.ReadFile(path)
+	contentBytes, err := os.ReadFile(path)
 	if err != nil {
 		panic(err)
 	}

--- a/pkg/webhook/emitter.go
+++ b/pkg/webhook/emitter.go
@@ -3,7 +3,7 @@ package webhook
 import (
 	"bytes"
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"net/http"
 
 	"github.com/kubeshop/testkube/pkg/api/v1/testkube"
@@ -92,7 +92,7 @@ func (s *Emitter) Send(event testkube.WebhookEvent) {
 		return
 	}
 
-	d, err := ioutil.ReadAll(resp.Body)
+	d, err := io.ReadAll(resp.Body)
 	if err != nil {
 		l.Errorw("webhook read response error", "error", err)
 		s.Responses <- WebhookResult{Error: err, Event: event}


### PR DESCRIPTION
Signed-off-by: Fahed DORGAA <fahed.dorgaa@gmail.com>

## Pull request description 

Deprecation of `io/ioutil` (https://go.dev/doc/go1.16#:~:text=FS%20implementations.-,Deprecation%20of%20io%2Fioutil,been%20moved%20to%20other%20packages.)


## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [ ] tested locally
- [ ] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Breaking changes

- N/A

## Changes

- switch to `os` and  `io` package

## Fixes

- switch to `os` and  `io` package