### PR TITLE
fix: move log closing channel back to goroutine

### DIFF
--- a/pkg/executor/client/job.go
+++ b/pkg/executor/client/job.go
@@ -77,7 +77,6 @@ func (c JobExecutor) Logs(id string) (out chan output.Output, err error) {
 	go func() {
 		defer func() {
 			c.Log.Debug("closing JobExecutor.Logs out log")
-			close(logs)
 			close(out)
 		}()
 


### PR DESCRIPTION
## Pull request description 

Move log closing channel back to goroutine (kubectl-testkube was waiting forever for channel closing)

## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [ ] tested locally
- [x] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Breaking changes

-

## Changes

-

## Fixes

-