### PR TITLE
fix: dependabot prefix are build

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,7 +11,7 @@ updates:
     allow:
       - dependency-type: "all"
     commit-message:
-      prefix: "dep: "
+      prefix: "build: "
     reviewers:
       - "exu"
     


### PR DESCRIPTION
## Pull request description 



## Checklist

- [ ] tested on cluster
- [x] minor fix changes

## Fixes

- update dependabot PR prefix to match linter as we have issue within external dependency that blocking us to customize linter settings

https://github.com/amannn/action-semantic-pull-request/issues/161
and this is our limited possibilities 
https://github.com/commitizen/conventional-commit-types/blob/master/index.json