### PR TITLE
fix: `a` is placed at correct position

### DIFF
--- a/docs/tests-getting-results.md
+++ b/docs/tests-getting-results.md
@@ -4,7 +4,7 @@ We saw how simple it is to create and run Testkube tests execution. Obtaining te
 
 ## **Getting Test Executions After Test is Executed**
 
-After each run, Testkube informs you that you can get results a of given test execution.
+After each run, Testkube informs you that you can get results of a given test execution.
 
 ```sh
 kubectl testkube run test api-incluster-test


### PR DESCRIPTION
## Pull request description 
a is placed at the correct position according to the issue


## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [ ] tested locally
- [ ] tested on cluster
- [ ] added new dependencies
- [x] updated the docs
- [ ] added a test

## Fixes #1929 
