### PR TITLE
fix: replace homebrew formulae

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -118,10 +118,10 @@ jobs:
           name: bin-artifacts
           path: dist
           retention-days: 1
-      - name: Setup Homebrew
-        uses: Homebrew/actions/setup-homebrew@master
-      - name: Update brew
-        run: brew update
+#      - name: Setup Homebrew
+#        uses: Homebrew/actions/setup-homebrew@master
+#      - name: Update brew
+#        run: brew update
       - name: Setup git email
         run: git config --global user.email "brewbot@kubeshop.io"
       - name: Setup git name

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -118,26 +118,13 @@ jobs:
           name: bin-artifacts
           path: dist
           retention-days: 1
-#      - name: Setup Homebrew
-#        uses: Homebrew/actions/setup-homebrew@master
-#      - name: Update brew
-#        run: brew update
       - name: Setup git email
         run: git config --global user.email "brewbot@kubeshop.io"
       - name: Setup git name
         run: git config --global user.name "Brew Bot"
-#      - name: Bump formulae
-#        uses: Homebrew/actions/bump-formulae@master
-#        with:
-#          # Custom GitHub access token with only the 'public_repo' scope enabled
-#          token: ${{ secrets.CI_BOT_TOKEN }}
-#          # Bump only these formulae if outdated
-#          formulae: testkube
       - name: Bump formulae
         uses: mislav/bump-homebrew-formula-action@v2
         with:
-          # Custom GitHub access token with only the 'public_repo' scope enabled
-          # Bump only these formulae if outdated
           formula-name: testkube
         env:
           COMMITTER_TOKEN: ${{ secrets.CI_BOT_TOKEN }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -126,13 +126,21 @@ jobs:
         run: git config --global user.email "brewbot@kubeshop.io"
       - name: Setup git name
         run: git config --global user.name "Brew Bot"
+#      - name: Bump formulae
+#        uses: Homebrew/actions/bump-formulae@master
+#        with:
+#          # Custom GitHub access token with only the 'public_repo' scope enabled
+#          token: ${{ secrets.CI_BOT_TOKEN }}
+#          # Bump only these formulae if outdated
+#          formulae: testkube
       - name: Bump formulae
-        uses: Homebrew/actions/bump-formulae@master
+        uses: dawidd6/action-homebrew-bump-formula@v3
         with:
           # Custom GitHub access token with only the 'public_repo' scope enabled
           token: ${{ secrets.CI_BOT_TOKEN }}
           # Bump only these formulae if outdated
           formulae: testkube
+          livecheck: true
 
   build-and-publish-windows-installer:
     needs: release

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -139,7 +139,7 @@ jobs:
           # Custom GitHub access token with only the 'public_repo' scope enabled
           token: ${{ secrets.CI_BOT_TOKEN }}
           # Bump only these formulae if outdated
-          formulae: testkube
+          formula: testkube
           livecheck: true
 
   build-and-publish-windows-installer:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -134,13 +134,12 @@ jobs:
 #          # Bump only these formulae if outdated
 #          formulae: testkube
       - name: Bump formulae
-        uses: dawidd6/action-homebrew-bump-formula@v3
+        uses: mislav/bump-homebrew-formula-action@v2
         with:
           # Custom GitHub access token with only the 'public_repo' scope enabled
           token: ${{ secrets.CI_BOT_TOKEN }}
           # Bump only these formulae if outdated
           formula: testkube
-          livecheck: true
 
   build-and-publish-windows-installer:
     needs: release

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -137,9 +137,10 @@ jobs:
         uses: mislav/bump-homebrew-formula-action@v2
         with:
           # Custom GitHub access token with only the 'public_repo' scope enabled
-          token: ${{ secrets.CI_BOT_TOKEN }}
           # Bump only these formulae if outdated
-          formula: testkube
+          formula-name: testkube
+        env:
+          COMMITTER_TOKEN: ${{ secrets.CI_BOT_TOKEN }}
 
   build-and-publish-windows-installer:
     needs: release


### PR DESCRIPTION
## Pull request description 
Changed GH action to a new `bump formula` step.
The PR in homebrew repo was created for a new version.

## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [ ] tested locally
- [ ] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Breaking changes

-

## Changes

-

## Fixes

-