### PR TITLE
[docs] testkube-api.service.type now defaults to ClusterIP

### DIFF
--- a/docs/installing.md
+++ b/docs/installing.md
@@ -196,7 +196,7 @@ The following Helm defaults are used in the `testkube` chart:
 | testkube-api.image.repository        | yes         | "kubeshop/testkube-api-server"       |
 | testkube-api.image.pullPolicy        | yes         | "Always"                             |
 | testkube-api.image.tag               | yes         | "latest"                             |
-| testkube-api.service.type            | yes         | "NodePort"                           |
+| testkube-api.service.type            | yes         | "ClusterIP"                           |
 | testkube-api.service.port            | yes         | 8088                                 |
 | testkube-api.mongoDSN                | yes         | "mongodb://testkube-mongodb:27017"   |
 | testkube-api.telemetryEnabled        | yes         | true                                 |


### PR DESCRIPTION
testkube-api.service.type now defaults to ClusterIP
https://github.com/kubeshop/helm-charts/blob/main/charts/testkube-api/values.yaml#L52

## Pull request description 



## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [ ] tested locally
- [ ] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Breaking changes

-

## Changes

-

## Fixes

-