### PR TITLE
fix: test transport with SSE client

### DIFF
--- a/internal/app/api/v1/executions.go
+++ b/internal/app/api/v1/executions.go
@@ -321,7 +321,7 @@ func (s *TestkubeAPI) ExecutionLogsHandler() fiber.Handler {
 		ctx.Response.Header.Set("Transfer-Encoding", "chunked")
 
 		ctx.SetBodyStreamWriter(fasthttp.StreamWriter(func(w *bufio.Writer) {
-			s.Log.Debug("starting stream writer")
+			s.Log.Debug("start streaming logs")
 			w.Flush()
 
 			execution, err := s.ExecutionResults.Get(ctx, executionID)
@@ -558,7 +558,7 @@ func (s *TestkubeAPI) streamLogsFromResult(executionResult *testkube.ExecutionRe
 // streamLogsFromJob streams logs in chunks to writer from the running execution
 func (s *TestkubeAPI) streamLogsFromJob(executionID string, w *bufio.Writer) {
 	enc := json.NewEncoder(w)
-	s.Log.Debug("getting logs from Kubernetes job")
+	s.Log.Infow("getting logs from Kubernetes job")
 
 	logs, err := s.Executor.Logs(executionID)
 	s.Log.Debugw("waiting for jobs channel", "channelSize", len(logs))
@@ -569,10 +569,11 @@ func (s *TestkubeAPI) streamLogsFromJob(executionID string, w *bufio.Writer) {
 		return
 	}
 
+	s.Log.Infow("looping through logs channel")
 	// loop through pods log lines - it's blocking channel
 	// and pass single log output as sse data chunk
 	for out := range logs {
-		s.Log.Debugw("got log", "out", out)
+		s.Log.Debugw("got log line from pod", "out", out)
 		fmt.Fprintf(w, "data: ")
 		err = enc.Encode(out)
 		if err != nil {

--- a/pkg/api/v1/client/api.go
+++ b/pkg/api/v1/client/api.go
@@ -36,10 +36,10 @@ func NewProxyAPIClient(client kubernetes.Interface, config APIConfig) APIClient 
 }
 
 // NewDirectAPIClient returns direct api client
-func NewDirectAPIClient(httpClient *http.Client, apiURI string) APIClient {
+func NewDirectAPIClient(httpClient *http.Client, sseClient *http.Client, apiURI string) APIClient {
 	return APIClient{
 		TestClient: NewTestClient(
-			NewDirectClient[testkube.Test](httpClient, apiURI),
+			NewDirectClient[testkube.Test](httpClient, apiURI).WithSSEClient(sseClient),
 			NewDirectClient[testkube.Execution](httpClient, apiURI),
 			NewDirectClient[testkube.TestWithExecution](httpClient, apiURI),
 			NewDirectClient[testkube.ExecutionsResult](httpClient, apiURI),

--- a/pkg/api/v1/client/factory.go
+++ b/pkg/api/v1/client/factory.go
@@ -42,7 +42,12 @@ func GetClient(clientType ClientType, options Options) (client Client, err error
 			return client, err
 		}
 
-		client = NewDirectAPIClient(httpClient, options.APIURI)
+		httpSSEClient, err := GetHTTTPSSEClient(token)
+		if err != nil {
+			return client, err
+		}
+
+		client = NewDirectAPIClient(httpClient, httpSSEClient, options.APIURI)
 	case ClientProxy:
 		clientset, err := GetClientSet("")
 		if err != nil {

--- a/pkg/event/kind/slack/loader.go
+++ b/pkg/event/kind/slack/loader.go
@@ -31,6 +31,6 @@ func (r *SlackLoader) Load() (listeners common.Listeners, err error) {
 	if slacknotifier.Ready {
 		return common.Listeners{NewSlackListener("slack", "", testkube.AllEventTypes)}, nil
 	}
-	r.Log.Infow("Slack notifier is not ready or not configured properly", "kind", r.Kind())
+	r.Log.Debugw("Slack notifier is not ready or not configured properly, omiting", "kind", r.Kind())
 	return common.Listeners{}, nil
 }

--- a/pkg/executor/client/job.go
+++ b/pkg/executor/client/job.go
@@ -269,7 +269,7 @@ func (c JobExecutor) updateResultsFromPod(ctx context.Context, pod corev1.Pod, l
 
 	// wait for complete
 	l.Debug("poll immediate waiting for pod to succeed")
-	if err = wait.PollImmediate(pollInterval, pollTimeout, IsPodReady(c.ClientSet, pod.Name, c.Namespace)); err != nil {
+	if err = wait.PollImmediate(pollInterval, pollTimeout, IsPodCompleted(c.ClientSet, pod.Name, c.Namespace)); err != nil {
 		// continue on poll err and try to get logs later
 		l.Errorw("waiting for pod complete error", "error", err)
 	}
@@ -383,8 +383,8 @@ func (c *JobExecutor) TailJobLogs(id string, logs chan []byte) (err error) {
 				return c.GetLastLogLineError(ctx, pod)
 
 			default:
-				l.Debugw("tailing job logs: waiting for pod to be ready")
-				if err = wait.PollImmediate(pollInterval, pollTimeout, IsPodReady(c.ClientSet, pod.Name, c.Namespace)); err != nil {
+				l.Debug("tailing job logs: waiting for pod to be ready")
+				if err = wait.PollImmediate(pollInterval, pollTimeout, IsPodReadyForLogs(c.ClientSet, pod.Name, c.Namespace)); err != nil {
 					l.Errorw("poll immediate error when tailing logs", "error", err)
 					return c.GetLastLogLineError(ctx, pod)
 				}
@@ -596,8 +596,26 @@ func NewJobSpec(log *zap.SugaredLogger, options JobOptions) (*batchv1.Job, error
 	return &job, nil
 }
 
-// IsPodReady defines if pod is ready or failed for logs scrapping
-func IsPodReady(c *kubernetes.Clientset, podName, namespace string) wait.ConditionFunc {
+// IsPodReadyForLogs defines if pod is ready or failed for logs scrapping
+func IsPodReadyForLogs(c *kubernetes.Clientset, podName, namespace string) wait.ConditionFunc {
+	return func() (bool, error) {
+		pod, err := c.CoreV1().Pods(namespace).Get(context.Background(), podName, metav1.GetOptions{})
+		if err != nil {
+			return false, err
+		}
+
+		switch pod.Status.Phase {
+		case corev1.PodRunning, corev1.PodSucceeded:
+			return true, nil
+		case corev1.PodFailed:
+			return true, fmt.Errorf("pod %s/%s failed", pod.Namespace, pod.Name)
+		}
+		return false, nil
+	}
+}
+
+// IsPodCompleted defines if pod is ready or failed for logs scrapping
+func IsPodCompleted(c *kubernetes.Clientset, podName, namespace string) wait.ConditionFunc {
 	return func() (bool, error) {
 		pod, err := c.CoreV1().Pods(namespace).Get(context.Background(), podName, metav1.GetOptions{})
 		if err != nil {

--- a/pkg/executor/client/job.go
+++ b/pkg/executor/client/job.go
@@ -614,7 +614,7 @@ func IsPodReadyForLogs(c *kubernetes.Clientset, podName, namespace string) wait.
 	}
 }
 
-// IsPodCompleted defines if pod is ready or failed for logs scrapping
+// IsPodCompleted defines if pod is completed or failed
 func IsPodCompleted(c *kubernetes.Clientset, podName, namespace string) wait.ConditionFunc {
 	return func() (bool, error) {
 		pod, err := c.CoreV1().Pods(namespace).Get(context.Background(), podName, metav1.GetOptions{})

--- a/pkg/http/client.go
+++ b/pkg/http/client.go
@@ -25,6 +25,7 @@ func NewClient() *http.Client {
 	}
 }
 
+// NewSSEClient is HTTP client with long timeout to be able to read SSE endpoints
 func NewSSEClient() *http.Client {
 	return &http.Client{
 		Timeout: time.Hour,

--- a/pkg/http/client.go
+++ b/pkg/http/client.go
@@ -24,3 +24,9 @@ func NewClient() *http.Client {
 		Transport: netTransport,
 	}
 }
+
+func NewSSEClient() *http.Client {
+	return &http.Client{
+		Timeout: time.Hour,
+	}
+}

--- a/pkg/http/client_test.go
+++ b/pkg/http/client_test.go
@@ -3,6 +3,7 @@ package http
 import (
 	"net/http"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -18,4 +19,11 @@ func TestNewClient(t *testing.T) {
 		assert.Equal(t, TLSHandshakeTimeout, c.Transport.(*http.Transport).TLSHandshakeTimeout)
 	})
 
+	t.Run("returns new SSE client with a hour timeout", func(t *testing.T) {
+		// given / when
+		c := NewSSEClient()
+
+		// then
+		assert.Equal(t, time.Hour, c.Timeout)
+	})
 }


### PR DESCRIPTION
## Pull request description 

Looks like during the rewrite  of our clients we've started using a configured client with valid timeouts, it's good for most endpoints, but not for SSE like ;) 

I've introduced an additional client who is able to wait for the SSE stream. 

## Checklist (choose what happened)

- [ ] breaking change! (describe)
- [ ] tested locally
- [ ] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Breaking changes

-

## Changes

-

## Fixes

-