### PR TITLE
ci: add manual flow to trigger formula bump

### DIFF
--- a/.github/workflows/manual-bump-formula.yaml
+++ b/.github/workflows/manual-bump-formula.yaml
@@ -1,0 +1,50 @@
+name: Manual trigger for Homebrew Formula Bump
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag-name:
+        description: 'The git tag to bump the formula to'
+        required: false
+  schedule:
+    - cron: "0 0 * * 0"
+
+jobs:
+  homebrew:
+    name: Bump Homebrew formula
+    runs-on: ubuntu-latest
+    steps:
+      #If the tag was not provided during workflow run, then the latest will be used
+      - name: Get latest release tag
+        if: ${{ github.event.inputs.tag-name == '' }}
+        id: tag
+        run: |
+          #Get latest release tag
+          curl -s -f --output /dev/null --connect-timeout 5 https://api.github.com/repos/kubeshop/testkube/releases/latest
+
+          export VERSION=$(curl -s -f https://api.github.com/repos/kubeshop/testkube/releases/latest | jq -r .tag_name | cut -c2-)
+          echo "::set-output name=VERSION::${VERSION}"
+
+      - name: Setup Homebrew
+        uses: Homebrew/actions/setup-homebrew@master
+
+      - name: Update brew
+        run: brew update
+      # Run if no tag was provided as an input, latest will be used.
+      - name: Update Homebrew formula
+        if: ${{ github.event.inputs.tag-name == '' }}
+        uses: dawidd6/action-homebrew-bump-formula@v3
+        with:
+          token: ${{ secrets.CI_BOT_TOKEN }}
+          formula: Testkube
+          tag: ${{ steps.tag.outputs.VERSION }}
+          force: true
+      # Run if a tag was provided as an input.
+      - name: Update Homebrew formula
+        if: ${{ github.event.inputs.tag-name != '' }}
+        uses: dawidd6/action-homebrew-bump-formula@v3
+        with:
+          token: ${{ secrets.CI_BOT_TOKEN }}
+          formula: Testkube
+          tag: ${{ github.event.inputs.tag-name }}
+          force: true


### PR DESCRIPTION
## Pull request description 
This PR adds a workflow that can be run manually, passing a needed tag release number as an input, to bump `homebrew` formula. If a tag is not passed, then the latest one will be used. 
There is also a cron expression that is scheduled to run once a week. 

The caveat: https://upptime.js.org/blog/2021/01/22/github-actions-schedule-not-working/

**Downgrade of versions cannot be done!**

I have tested this on my own repo for now, however, in a few days we can release to `homebrew-core`. 


## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [x] tested locally
- [ ] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Breaking changes

-

## Changes

-

## Fixes

-