### PR TITLE
fix: envManager as interface not pointer in executor.Run

### DIFF
--- a/pkg/executor/process.go
+++ b/pkg/executor/process.go
@@ -13,6 +13,6 @@ import (
 // stdin <- testkube.Execution, stdout <- stream of json logs
 // LoggedExecuteInDir will put wrapped JSON output to stdout AND get RAW output into out var
 // json logs can be processed later on watch of pod logs
-func Run(dir string, command string, envMngr *secret.EnvManager, arguments ...string) (out []byte, err error) {
+func Run(dir string, command string, envMngr secret.Manager, arguments ...string) (out []byte, err error) {
 	return process.LoggedExecuteInDir(dir, output.NewJSONWrapWriter(os.Stdout, envMngr), command, arguments...)
 }


### PR DESCRIPTION
## Pull request description 



## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [ ] tested locally
- [ ] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Breaking changes

-

## Changes

-

## Fixes

-