### PR TITLE
fix: byte is unrecognized

### DIFF
--- a/api/v1/testkube.yaml
+++ b/api/v1/testkube.yaml
@@ -2616,9 +2616,7 @@ components:
         copyFiles:
           type: object
           additionalProperties:
-            type: array
-            items:
-              type: byte
+            type: string
           description: map of files with target location as key and contents as value
 
 
@@ -2972,9 +2970,7 @@ components:
         copyFiles:
           type: object
           additionalProperties:
-            type: array
-            items:
-              type: byte
+            type: string
           description: map of files with target location as key and contents as value
 
     TestSuiteExecutionRequest:

--- a/cmd/kubectl-testkube/commands/tests/common.go
+++ b/cmd/kubectl-testkube/commands/tests/common.go
@@ -357,8 +357,8 @@ func prepareExecutorArgs(binaryArgs []string) ([]string, error) {
 }
 
 // readCopyFiles reads files
-func readCopyFiles(copyFiles []string) (map[string][]byte, error) {
-	files := map[string][]byte{}
+func readCopyFiles(copyFiles []string) (map[string]string, error) {
+	files := map[string]string{}
 	for _, f := range copyFiles {
 		paths := strings.Split(f, ":")
 		if len(paths) != 2 {
@@ -368,7 +368,7 @@ func readCopyFiles(copyFiles []string) (map[string][]byte, error) {
 		if err != nil {
 			return nil, fmt.Errorf("could not read executor copy file: %w", err)
 		}
-		files[paths[1]] = contents
+		files[paths[1]] = string(contents)
 	}
 	return files, nil
 }

--- a/cmd/kubectl-testkube/commands/tests/common_test.go
+++ b/cmd/kubectl-testkube/commands/tests/common_test.go
@@ -22,7 +22,7 @@ func Test_readCopyFiles(t *testing.T) {
 		assert.NoError(t, err)
 
 		for _, f := range gotFiles {
-			assert.Contains(t, string(f), "config file #")
+			assert.Contains(t, f, "config file #")
 		}
 
 		err = cleanup(files)

--- a/pkg/api/v1/client/interface.go
+++ b/pkg/api/v1/client/interface.go
@@ -134,7 +134,7 @@ type ExecuteTestOptions struct {
 	HTTPProxy                     string
 	HTTPSProxy                    string
 	Image                         string
-	CopyFiles                     map[string][]byte
+	CopyFiles                     map[string]string
 }
 
 // ExecuteTestSuiteOptions contains test suite run options

--- a/pkg/api/v1/testkube/model_execution.go
+++ b/pkg/api/v1/testkube/model_execution.go
@@ -53,5 +53,5 @@ type Execution struct {
 	// test and execution labels
 	Labels map[string]string `json:"labels,omitempty"`
 	// map of files with target location as key and contents as value
-	CopyFiles map[string][]byte `json:"copyFiles,omitempty"`
+	CopyFiles map[string]string `json:"copyFiles,omitempty"`
 }

--- a/pkg/api/v1/testkube/model_execution_request.go
+++ b/pkg/api/v1/testkube/model_execution_request.go
@@ -49,5 +49,5 @@ type ExecutionRequest struct {
 	// duration in seconds the test may be active, until its stopped
 	ActiveDeadlineSeconds int64 `json:"activeDeadlineSeconds,omitempty"`
 	// map of files with target location as key and contents as value
-	CopyFiles map[string][]byte `json:"copyFiles,omitempty"`
+	CopyFiles map[string]string `json:"copyFiles,omitempty"`
 }

--- a/pkg/scheduler/test_scheduler_test.go
+++ b/pkg/scheduler/test_scheduler_test.go
@@ -112,8 +112,8 @@ func TestGetExecuteOptions(t *testing.T) {
 		Sync:       false,
 		HttpProxy:  "",
 		HttpsProxy: "",
-		CopyFiles: map[string][]byte{
-			"": {},
+		CopyFiles: map[string]string{
+			"": "",
 		},
 		ActiveDeadlineSeconds: 10,
 	}


### PR DESCRIPTION
## Pull request description 

This PR fixes the
```
Structural error at components.schemas.ExecutionRequest.properties.copyFiles.additionalProperties.items.type
should be equal to one of the allowed values
allowedValues: array, boolean, integer, number, object, string
```

swagger error

## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [x] tested locally
- [ ] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Breaking changes

-

## Changes

-

## Fixes

-