### PR TITLE
fix: regular executors env

### DIFF
--- a/pkg/executor/client/job.go
+++ b/pkg/executor/client/job.go
@@ -91,7 +91,6 @@ type JobOptions struct {
 	InitImage             string
 	JobTemplate           string
 	SecretEnvs            map[string]string
-	Envs                  map[string]string
 	HTTPProxy             string
 	HTTPSProxy            string
 	UsernameSecret        *testkube.SecretRef
@@ -456,8 +455,6 @@ func NewJobSpec(log *zap.SugaredLogger, options JobOptions) (*batchv1.Job, error
 		env = append(env, corev1.EnvVar{Name: "HTTPS_PROXY", Value: options.HTTPSProxy})
 	}
 
-	env = append(env, executor.PrepareEnvs(options.Envs)...)
-
 	for i := range job.Spec.Template.Spec.InitContainers {
 		job.Spec.Template.Spec.InitContainers[i].Env = append(job.Spec.Template.Spec.InitContainers[i].Env, env...)
 	}
@@ -490,6 +487,5 @@ func NewJobOptions(initImage, jobTemplate string, execution testkube.Execution, 
 	}
 	jobOptions.Variables = execution.Variables
 	jobOptions.ImagePullSecrets = options.ImagePullSecretNames
-	jobOptions.Envs = options.Request.Envs
 	return
 }


### PR DESCRIPTION
## Pull request description 

In https://github.com/kubeshop/testkube/commit/4317706d4afd0e86a68f4db4882805dbc5ce3f0b mistakenly updated regular executors with envs, which turns out they are actually set in runners:
https://github.com/kubeshop/testkube-executor-k6/blob/main/pkg/runner/runner.go#L76-L85


## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [ ] tested locally
- [ ] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Breaking changes

-

## Changes

-

## Fixes

-