### PR TITLE
fix: use secret envs with their name and also with numbers

### DIFF
--- a/pkg/executor/secret/manager.go
+++ b/pkg/executor/secret/manager.go
@@ -9,10 +9,19 @@ import (
 	corev1 "k8s.io/api/core/v1"
 )
 
+const (
+	// SecretEnvVarPrefix is a prefix for secret env vars
+	SecretEnvVarPrefix = "RUNNER_SECRET_ENV"
+	// SecretVarPrefix is a prefix for secret vars
+	SecretVarPrefix = "RUNNER_SECRET_VAR_"
+)
+
 // Manager is responsible for exchanging secrets with executor pod
 type Manager interface {
 	// Prepare prepares secret env vars based on secret envs and variables
 	Prepare(secretEnvs map[string]string, variables map[string]testkube.Variable) (secretEnvVars []corev1.EnvVar)
+	// GetEnvs get secret envs
+	GetEnvs() (secretEnvs []string)
 	// GetVars gets secret vars
 	GetVars(variables map[string]testkube.Variable)
 	// Obfuscate obfuscates secret values
@@ -38,7 +47,10 @@ type EnvManager struct {
 // Prepare prepares secret env vars based on secret envs and variables
 func (m EnvManager) Prepare(secretEnvs map[string]string, variables map[string]testkube.Variable) (secretEnvVars []corev1.EnvVar) {
 	// preparet secret envs
+	i := 1
 	for secretName, secretVar := range secretEnvs {
+		// TODO: these are duplicated because Postman executor is expecting it as json string
+		// and gets unmarshalled and the name and the value are taken from there, for other executors it will be like a normal env var.
 		secretEnvVars = append(secretEnvVars, corev1.EnvVar{
 			Name: secretVar,
 			ValueFrom: &corev1.EnvVarSource{
@@ -50,6 +62,18 @@ func (m EnvManager) Prepare(secretEnvs map[string]string, variables map[string]t
 				},
 			},
 		})
+		secretEnvVars = append(secretEnvVars, corev1.EnvVar{
+			Name: fmt.Sprintf("%s%d", SecretEnvVarPrefix, i),
+			ValueFrom: &corev1.EnvVarSource{
+				SecretKeyRef: &corev1.SecretKeySelector{
+					LocalObjectReference: corev1.LocalObjectReference{
+						Name: secretName,
+					},
+					Key: secretVar,
+				},
+			},
+		})
+		i++
 	}
 
 	// prepare secret vars
@@ -59,7 +83,7 @@ func (m EnvManager) Prepare(secretEnvs map[string]string, variables map[string]t
 		}
 
 		secretEnvVars = append(secretEnvVars, corev1.EnvVar{
-			Name: fmt.Sprintf("RUNNER_SECRET_VAR_%s", name),
+			Name: fmt.Sprintf("%s%s", SecretVarPrefix, name),
 			ValueFrom: &corev1.EnvVarSource{
 				SecretKeyRef: &corev1.SecretKeySelector{
 					LocalObjectReference: corev1.LocalObjectReference{
@@ -74,6 +98,22 @@ func (m EnvManager) Prepare(secretEnvs map[string]string, variables map[string]t
 	return secretEnvVars
 }
 
+// GetEnvs gets secret envs
+func (m EnvManager) GetEnvs() (secretEnvs []string) {
+	i := 1
+	for {
+		secretEnv, ok := os.LookupEnv(fmt.Sprintf("%s%d", SecretEnvVarPrefix, i))
+		if !ok {
+			break
+		}
+
+		secretEnvs = append(secretEnvs, secretEnv)
+		i++
+	}
+
+	return secretEnvs
+}
+
 // GetVars gets secret vars
 func (m EnvManager) GetVars(variables map[string]testkube.Variable) {
 	for name, variable := range variables {
@@ -81,7 +121,7 @@ func (m EnvManager) GetVars(variables map[string]testkube.Variable) {
 			continue
 		}
 
-		value, ok := os.LookupEnv(fmt.Sprintf("RUNNER_SECRET_VAR_%s", name))
+		value, ok := os.LookupEnv(fmt.Sprintf("%s%s", SecretVarPrefix, name))
 		if !ok {
 			continue
 		}


### PR DESCRIPTION
## Pull request description 
The implementation that we have was specialised for Postman that expects the value of the secret env to be a json string that contains name and secret in it, but it will not be the same for the rest of the executors.
For now two variants will be provided, the env var with the secret key as the var name and the one with the name lwith RUNNER_SECRET_ENV%d format that can be parsed in a loop(this is how Postman is processing them)


## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [ ] tested locally
- [ ] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Breaking changes

-

## Changes

-

## Fixes

-