### PR TITLE
fix: duplicated patch in openapi yaml

### DIFF
--- a/api/v1/testkube.yaml
+++ b/api/v1/testkube.yaml
@@ -174,51 +174,6 @@ paths:
                 items:
                   $ref: "#/components/schemas/Problem"
 
-    patch:
-      tags:
-        - test-triggers
-        - api
-      summary: "Bulk update test triggers"
-      description: "Updates test triggers provided as an array in the request body"
-      operationId: bulkUpdateTestTriggers
-      requestBody:
-        description: array of test trigger upsert requests
-        required: true
-        content:
-          application/json:
-            schema:
-              type: array
-              items:
-                $ref: "#/components/schemas/TestTriggerUpsertRequest"
-      responses:
-        200:
-          description: "successful operation"
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: "#/components/schemas/TestTrigger"
-            text/yaml:
-              schema:
-                type: string
-        400:
-          description: "problem with test trigger definition - probably some bad input occurs (invalid JSON body or similar)"
-          content:
-            application/problem+json:
-              schema:
-                type: object
-                items:
-                  $ref: "#/components/schemas/Problem"
-        502:
-          description: problem communicating with kubernetes cluster
-          content:
-            application/problem+json:
-              schema:
-                type: object
-                items:
-                  $ref: "#/components/schemas/Problem"
-
     delete:
       tags:
         - test-triggers

--- a/pkg/api/v1/testkube/model_test_trigger_upsert_request.go
+++ b/pkg/api/v1/testkube/model_test_trigger_upsert_request.go
@@ -12,7 +12,7 @@ package testkube
 // test trigger create or update request body
 type TestTriggerUpsertRequest struct {
 	// object kubernetes namespace
-	Namespace string `json:"namespace"`
+	Namespace string `json:"namespace,omitempty"`
 	// object name
 	Name string `json:"name"`
 	// test trigger labels


### PR DESCRIPTION
## Pull request description 

Swagger was complaining about duplicated IDs, this `patch` entry is the same as the one above it. This change does not affect the generated code.

## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [ ] tested locally
- [ ] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Breaking changes

-

## Changes

-

## Fixes

-