### PR TITLE
fix: issue with generating trigger name from spec

### DIFF
--- a/internal/app/api/config/defaults.go
+++ b/internal/app/api/config/defaults.go
@@ -1,0 +1,4 @@
+package config
+
+// DefaultConcurrencyLevel is a default concurrency level for worker pool
+const DefaultConcurrencyLevel = "10"

--- a/internal/app/api/v1/executions.go
+++ b/internal/app/api/v1/executions.go
@@ -10,6 +10,8 @@ import (
 	"os"
 	"strconv"
 
+	"github.com/kubeshop/testkube/internal/app/api/config"
+
 	"github.com/gofiber/fiber/v2"
 	"github.com/gofiber/websocket/v2"
 	"github.com/valyala/fasthttp"
@@ -25,8 +27,6 @@ import (
 )
 
 const (
-	// DefaultConcurrencyLevel is a default concurrency level for worker pool
-	DefaultConcurrencyLevel = "10"
 	// latestExecutionNo defines the number of relevant latest executions
 	latestExecutions = 5
 
@@ -72,7 +72,7 @@ func (s TestkubeAPI) ExecuteTestsHandler() fiber.Handler {
 
 		var results []testkube.Execution
 		if len(tests) != 0 {
-			concurrencyLevel, err := strconv.Atoi(c.Query("concurrency", DefaultConcurrencyLevel))
+			concurrencyLevel, err := strconv.Atoi(c.Query("concurrency", config.DefaultConcurrencyLevel))
 			if err != nil {
 				return s.Error(c, http.StatusBadRequest, fmt.Errorf("can't detect concurrency level: %w", err))
 			}

--- a/internal/app/api/v1/testsuites.go
+++ b/internal/app/api/v1/testsuites.go
@@ -8,6 +8,8 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/kubeshop/testkube/internal/app/api/config"
+
 	"github.com/gofiber/fiber/v2"
 	"go.mongodb.org/mongo-driver/mongo"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -510,7 +512,7 @@ func (s TestkubeAPI) ExecuteTestSuitesHandler() fiber.Handler {
 
 		var results []testkube.TestSuiteExecution
 		if len(testSuites) != 0 {
-			concurrencyLevel, err := strconv.Atoi(c.Query("concurrency", DefaultConcurrencyLevel))
+			concurrencyLevel, err := strconv.Atoi(c.Query("concurrency", config.DefaultConcurrencyLevel))
 			if err != nil {
 				return s.Error(c, http.StatusBadRequest, fmt.Errorf("can't detect concurrency level: %w", err))
 			}

--- a/pkg/triggers/executor.go
+++ b/pkg/triggers/executor.go
@@ -4,12 +4,13 @@ import (
 	"context"
 	"strconv"
 
+	"github.com/kubeshop/testkube/internal/app/api/config"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	testsv3 "github.com/kubeshop/testkube-operator/apis/tests/v3"
 	testsuitesv2 "github.com/kubeshop/testkube-operator/apis/testsuite/v2"
 	testtriggersv1 "github.com/kubeshop/testkube-operator/apis/testtriggers/v1"
-	v1 "github.com/kubeshop/testkube/internal/app/api/v1"
 	"github.com/kubeshop/testkube/pkg/api/v1/testkube"
 	"github.com/kubeshop/testkube/pkg/workerpool"
 	"github.com/pkg/errors"
@@ -27,7 +28,7 @@ type ExecutorF func(context.Context, *testtriggersv1.TestTrigger) error
 func (s *Service) execute(ctx context.Context, t *testtriggersv1.TestTrigger) error {
 	status := s.getStatusForTrigger(t)
 
-	concurrencyLevel, err := strconv.Atoi(v1.DefaultConcurrencyLevel)
+	concurrencyLevel, err := strconv.Atoi(config.DefaultConcurrencyLevel)
 	if err != nil {
 		return errors.Wrap(err, "error parsing default concurrency level")
 	}

--- a/pkg/triggers/util.go
+++ b/pkg/triggers/util.go
@@ -1,10 +1,17 @@
 package triggers
 
 import (
+	"fmt"
+	"strings"
 	"time"
+
+	testtriggersv1 "github.com/kubeshop/testkube-operator/apis/testtriggers/v1"
+	"github.com/kubeshop/testkube/pkg/utils"
 
 	core_v1 "k8s.io/api/core/v1"
 )
+
+const testTriggerMaxNameLength = 57
 
 func findContainer(containers []core_v1.Container, target string) *core_v1.Container {
 	for _, c := range containers {
@@ -17,4 +24,22 @@ func findContainer(containers []core_v1.Container, target string) *core_v1.Conta
 
 func inPast(t1, t2 time.Time) bool {
 	return t1.Before(t2)
+}
+
+// GenerateTestTriggerName function generates a trigger name from the TestTrigger spec
+// function also takes care of name collisions, not exceeding k8s max object name (63 characters) and not ending with a hyphen '-'
+func GenerateTestTriggerName(t *testtriggersv1.TestTrigger) string {
+	if t == nil {
+		return ""
+	}
+	name := fmt.Sprintf("trigger-%s-%s-%s-%s", t.Spec.Resource, t.Spec.Event, t.Spec.Action, t.Spec.Execution)
+	if len(name) > testTriggerMaxNameLength {
+		name = name[:testTriggerMaxNameLength]
+	}
+	// RFC 1123 compliant names cannot end with a dash
+	name = strings.TrimSuffix(name, "-")
+	// RFC 1123 compliant names cannot have underscores
+	name = strings.ReplaceAll(name, "_", "-")
+	name = fmt.Sprintf("%s-%s", name, utils.RandAlphanum(5))
+	return name
 }

--- a/pkg/triggers/util_test.go
+++ b/pkg/triggers/util_test.go
@@ -1,0 +1,45 @@
+package triggers
+
+import (
+	"testing"
+
+	v1 "github.com/kubeshop/testkube-operator/apis/testtriggers/v1"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGenerateTestTriggerName(t *testing.T) {
+	testTrigger1 := v1.TestTrigger{
+		Spec: v1.TestTriggerSpec{
+			Resource:  "deployment",
+			Event:     "deployment_scale_modified",
+			Action:    "run",
+			Execution: "test",
+		}}
+	expected1 := "trigger-deployment-deployment-scale-modified-run-test-"
+	actual1 := GenerateTestTriggerName(&testTrigger1)
+	assert.Contains(t, actual1, expected1)
+
+	testTrigger2 := v1.TestTrigger{
+		Spec: v1.TestTriggerSpec{
+			Resource:  "pod",
+			Event:     "some-really-really-really-really-really-really-really-really-really-really-really-really-really-really-really-long-event",
+			Action:    "run",
+			Execution: "test",
+		}}
+	actual2 := GenerateTestTriggerName(&testTrigger2)
+	assert.Len(t, actual2, 63)
+
+	testTrigger3 := v1.TestTrigger{
+		Spec: v1.TestTriggerSpec{
+			Resource:  "service",
+			Event:     "created",
+			Action:    "run",
+			Execution: "test",
+		}}
+	expected3 := "trigger-service-created-run-test-"
+	actual3 := GenerateTestTriggerName(&testTrigger3)
+	assert.Contains(t, actual3, expected3)
+
+	actual4 := GenerateTestTriggerName(nil)
+	assert.Empty(t, actual4)
+}


### PR DESCRIPTION
## Pull request description 

Fix an issue where generating trigger names when name is not provided in a request contains `_` which is not RFC 1123 compliant

## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [x] tested locally
- [ ] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [x] added a test

## Breaking changes

-

## Changes

-

## Fixes

- issue when a test trigger generated name is not RFC 1123 compliant