### PR TITLE
fix: Dashboard E2E tests - Cypress video recording disabled

### DIFF
--- a/test/dashboard-e2e/cypress.config.js
+++ b/test/dashboard-e2e/cypress.config.js
@@ -9,6 +9,7 @@ module.exports = defineConfig({
     baseUrl: 'http://localhost:8080',
     env: {
       API_URL: 'http://localhost:8088/v1'
-    }
+    },
+    video: false //disabled because of this issue: https://github.com/kubeshop/testkube/issues/1540#issuecomment-1304850859
   },
 });


### PR DESCRIPTION
Video recording disabled for Dashboard E2E tests because of this issue: https://github.com/kubeshop/testkube/issues/1540#issuecomment-1304850859