### PR TITLE
feat: Pass workingDir to container executor

### DIFF
--- a/pkg/executor/containerexecutor/templates/job.tmpl
+++ b/pkg/executor/containerexecutor/templates/job.tmpl
@@ -38,6 +38,9 @@ spec:
         - {{ $arg -}}
 		{{- end}}
 		{{- end}}
+    {{- if .WorkingDir }}
+        workingDir: {{ .WorkingDir }}
+    {{- end}}
         volumeMounts:
         - name: data-volume
           mountPath: /data


### PR DESCRIPTION
## Pull request description 

Pass workingDir to container executor as stated in #2683 

When workingDir is containing a relative path it is added on top of container executor repository path (/data/repo) and when the path is absolute it is used as it is.

## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [x] tested locally
- [ ] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [x] added a test

## Breaking changes

-

## Changes

-

## Fixes

-