### PR TITLE
fix: [WIP] Executor tests - run script - Kubectl replace

### DIFF
--- a/test/scripts/executor-tests/run.sh
+++ b/test/scripts/executor-tests/run.sh
@@ -79,10 +79,12 @@ common_run() { # name, test_crd_file, testsuite_name, testsuite_file, custom_exe
     if [ ! -z "$custom_executor_crd_file" ] ; then
       # Executors (not created by default)
       kubectl apply -f $custom_executor_crd_file
+      kubectl replace -f $custom_executor_crd_file
     fi
     
     # Tests
     kubectl apply -f $test_crd_file
+    kubectl replace -f $test_crd_file # `apply` doesn't guarantee the resource will match the definition (PATCH) - `replace` is needed (which won't create resource)
 
     # TestsSuites
     create_update_testsuite "$testsuite_name" "$testsuite_file"


### PR DESCRIPTION
Probably some additional logic will be needed here - to check if the tests is created, and then use `replace`, and to use `apply` in other cases. `apply` and `replace` can't be mixed:
```
Warning: resource tests/cypress-8-executor-smoke-firefox is missing the kubectl.kubernetes.io/last-applied-configuration annotation which is required by kubectl apply. kubectl apply should only be used on resources created declaratively by either kubectl create --save-config or kubectl apply. The missing annotation will be patched automatically.
test.tests.testkube.io/cypress-8-executor-smoke-firefox configured
```