### PR TITLE
feat: Cypress tests - default switched to Cypress 11, Staging and Demo testsuites updated

### DIFF
--- a/test/cypress/executor-tests/crd/crd.yaml
+++ b/test/cypress/executor-tests/crd/crd.yaml
@@ -96,7 +96,7 @@ spec:
       type: git
       uri: https://github.com/kubeshop/testkube
       branch: main
-      path: test/cypress/executor-tests/cypress-10
+      path: test/cypress/executor-tests/cypress-11
   executionRequest:
     variables:
       CYPRESS_CUSTOM_ENV:
@@ -119,7 +119,7 @@ spec:
     type: git
     uri: https://github.com/kubeshop/testkube.git
     branch: main
-    path: test/cypress/executor-tests/cypress-10
+    path: test/cypress/executor-tests/cypress-11
 ---
 # cypress-default-executor-smoke-electron-testsource-git-dir - Test
 apiVersion: tests.testkube.io/v3
@@ -131,7 +131,7 @@ spec:
   type: cypress/project
   content:
     repository:
-      path: test/cypress/executor-tests/cypress-10
+      path: test/cypress/executor-tests/cypress-11
   source: testsource-cypress-default-executor-smoke-electron-testsource-git-dir
   executionRequest:
     variables:

--- a/test/suites/demo-testsuite.json
+++ b/test/suites/demo-testsuite.json
@@ -6,6 +6,7 @@
         {"execute": {"name": "postman-executor-smoke-testsource-git-file"}},
         {"execute": {"name": "k6-executor-smoke"}},
         {"execute": {"name": "container-executor-curl-smoke"}},
-        {"execute": {"name": "dashboard-e2e-tests"}}
+        {"execute" :{"name": "cypress-11-executor-smoke-chrome"}},
+        {"execute" :{"name": "cypress-default-executor-smoke-electron-testsource-git-dir"}}
     ]
 }

--- a/test/suites/staging-testsuite.json
+++ b/test/suites/staging-testsuite.json
@@ -5,6 +5,8 @@
         {"execute": {"name": "postman-executor-smoke"}},
         {"execute": {"name": "postman-executor-smoke-testsource-git-file"}},
         {"execute": {"name": "k6-executor-smoke"}},
-        {"execute": {"name": "container-executor-curl-smoke"}}
+        {"execute": {"name": "container-executor-curl-smoke"}},
+        {"execute" :{"name": "cypress-11-executor-smoke-chrome"}},
+        {"execute" :{"name": "cypress-default-executor-smoke-electron-testsource-git-dir"}}
     ]
 }


### PR DESCRIPTION
- Cypress tests - default switched to Cypress 11
- Staging and Demo testsuites updated (testsuites updated with Cypress tests, Dashboard E2E tests temporary removed because of stability problems)
