### PR TITLE
fix: use right environment variable name

### DIFF
--- a/cmd/api-server/main.go
+++ b/cmd/api-server/main.go
@@ -54,7 +54,7 @@ import (
 type MongoConfig struct {
 	DSN          string `envconfig:"API_MONGO_DSN" default:"mongodb://localhost:27017"`
 	DB           string `envconfig:"API_MONGO_DB" default:"testkube"`
-	SSLSecretRef string `envconfig:"API_MONGO_SSL_SECRET_REF"`
+	SSLSecretRef string `envconfig:"API_MONGO_SSL_CERT"`
 }
 
 var Config MongoConfig


### PR DESCRIPTION
## Pull request description 

mongo ssl cert environment variable name was out of date with the docs, this pr fixes that

## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [ ] tested locally
- [ ] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Breaking changes

-

## Changes

-

## Fixes

-