### PR TITLE
Add fiber.Config to Config of API Server

### DIFF
--- a/pkg/server/config.go
+++ b/pkg/server/config.go
@@ -14,11 +14,6 @@ type Config struct {
 	Http      fiber.Config
 }
 
-type HttpConfig struct {
-	ReadBufferSize  int
-	WriteBufferSize int
-}
-
 // Addr returns port based address
 func (c Config) Addr() string {
 	return fmt.Sprintf(":%d", c.Port)

--- a/pkg/server/config.go
+++ b/pkg/server/config.go
@@ -1,12 +1,22 @@
 package server
 
-import "fmt"
+import (
+	"fmt"
+
+	"github.com/gofiber/fiber/v2"
+)
 
 // Config for HTTP server
 type Config struct {
 	Port      int
 	Fullname  string
 	ClusterID string
+	Http      fiber.Config
+}
+
+type HttpConfig struct {
+	ReadBufferSize  int
+	WriteBufferSize int
 }
 
 // Addr returns port based address

--- a/pkg/server/httpserver.go
+++ b/pkg/server/httpserver.go
@@ -15,11 +15,15 @@ import (
 
 // NewServer returns new HTTP server instance, initializes logger and metrics
 func NewServer(config Config) HTTPServer {
+  config.Http.DisableStartupMessage = true;
+
 	s := HTTPServer{
-		Mux:    fiber.New(fiber.Config{DisableStartupMessage: true}),
+		Mux:    fiber.New(config.Http),
 		Log:    log.DefaultLogger,
 		Config: config,
 	}
+
+  s.Log.Error("hi");
 
 	s.Init()
 	return s


### PR DESCRIPTION
## Pull request description 

This pull requests adds the possibility to configure the underlying HTTP Server through the API Server configuration via environment variables.

## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [ ] tested locally
- [ ] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Fixes

#2870 