### PR TITLE
fix: open api spec enum type

### DIFF
--- a/api/v1/testkube.yaml
+++ b/api/v1/testkube.yaml
@@ -4069,6 +4069,7 @@ components:
                   type: string
                   example: "test-1"
                 parentType:
+                  type: string
                   enum:
                    - test
                    - execution


### PR DESCRIPTION
## Pull request description 

Fix:
```
parse enum values: parse value "\"test\"": unexpected type: ""
```

## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [ ] tested locally
- [ ] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Breaking changes

-

## Changes

-

## Fixes

-