### PR TITLE
fix: slack update message will fail if the end events are configured to a different channel

### DIFF
--- a/pkg/slack/slack.go
+++ b/pkg/slack/slack.go
@@ -83,7 +83,9 @@ func (s *Notifier) SendEvent(event *testkube.Event) error {
 
 			if ok {
 				_, timestamp, _, err = s.client.UpdateMessage(channelID, prevTimestamp, slack.MsgOptionBlocks(message.Blocks.BlockSet...))
-			} else {
+			}
+
+			if !ok || err != nil {
 				_, timestamp, err = s.client.PostMessage(channelID, slack.MsgOptionBlocks(message.Blocks.BlockSet...))
 			}
 


### PR DESCRIPTION


## Pull request description 



## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [ ] tested locally
- [ ] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Breaking changes

-

## Changes

-

## Fixes

-