### PR TITLE
fix: set logs storage to mongo when minio is not enabled

### DIFF
--- a/cmd/kubectl-testkube/commands/common.go
+++ b/cmd/kubectl-testkube/commands/common.go
@@ -58,6 +58,11 @@ func HelmUpgradeOrInstalTestkube(options HelmUpgradeOrInstalTestkubeOptions) err
 
 	command := []string{"upgrade", "--install", "--create-namespace", "--namespace", options.Namespace}
 	command = append(command, "--set", fmt.Sprintf("testkube-api.minio.enabled=%t", !options.NoMinio))
+	if options.NoMinio {
+		command = append(command, "--set", "testkube-api.logs.storage=mongo")
+	} else {
+		command = append(command, "--set", "testkube-api.logs.storage=minio")
+	}
 	command = append(command, "--set", fmt.Sprintf("testkube-dashboard.enabled=%t", !options.NoDashboard))
 	command = append(command, "--set", fmt.Sprintf("mongodb.enabled=%t", !options.NoMongo))
 	command = append(command, options.Name, options.Chart)


### PR DESCRIPTION
## Pull request description 

Fixes https://github.com/kubeshop/testkube/issues/3036 and addresses comments on https://github.com/kubeshop/testkube/issues/2906

## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [x] tested locally
- [ ] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Breaking changes

-

## Changes

-

## Fixes

-