### PR TITLE
fix: invalid statuses on unordered logs

### DIFF
--- a/pkg/executor/client/job.go
+++ b/pkg/executor/client/job.go
@@ -309,7 +309,7 @@ func (c JobExecutor) updateResultsFromPod(ctx context.Context, pod corev1.Pod, l
 	// parse job output log (JSON stream)
 	result, _, err = output.ParseRunnerOutput(logs)
 	if err != nil {
-		l.Errorw("parse ouput error", "error", err)
+		l.Errorw("parse output error", "error", err)
 		return result, err
 	}
 	// saving result in the defer function


### PR DESCRIPTION
## Pull request description 

Relates to https://github.com/kubeshop/testkube/issues/3023

When getting the result of an execution, Testkube checks the last log line to see if it was either an error or a log of type Result. The purpose of this PR is to check for the last log line by timestamp.

## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [x] tested locally
- [ ] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [x] added a test

## Breaking changes

-

## Changes

-

## Fixes

-