### PR TITLE
fix: refactor execution logs parsing

### DIFF
--- a/pkg/api/v1/testkube/model_execution_result_extended.go
+++ b/pkg/api/v1/testkube/model_execution_result_extended.go
@@ -71,7 +71,6 @@ func (e *ExecutionResult) IsTimeout() bool {
 func (e *ExecutionResult) Err(err error) ExecutionResult {
 	e.Status = ExecutionStatusFailed
 	e.ErrorMessage = err.Error()
-	e.Output = e.Output + "\n" + err.Error()
 	return *e
 }
 

--- a/pkg/executor/client/job.go
+++ b/pkg/executor/client/job.go
@@ -308,7 +308,7 @@ func (c JobExecutor) updateResultsFromPod(ctx context.Context, pod corev1.Pod, l
 	}
 
 	// parse job output log (JSON stream)
-	result, _, err = output.ParseRunnerOutput(logs)
+	result, err = output.ParseRunnerOutput(logs)
 	if err != nil {
 		l.Errorw("parse output error", "error", err)
 		return result, err

--- a/pkg/executor/output/parser.go
+++ b/pkg/executor/output/parser.go
@@ -4,8 +4,10 @@ import (
 	"bufio"
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
+	"strings"
 	"time"
 
 	"github.com/kubeshop/testkube/pkg/api/v1/testkube"
@@ -17,33 +19,71 @@ func GetLogEntry(b []byte) (out Output, err error) {
 	return out, err
 }
 
-// GetExecutionResult tries to unmarshal execution result
-func GetExecutionResult(b []byte) (is bool, result testkube.ExecutionResult) {
-	err := json.Unmarshal(b, &result)
-	return err == nil, result
-}
-
-// ParseRunnerOutput try to parse possible runner output which is some bunch
-// of json stream like
-// {"type": "line", "message": "runner execution started  ------------"}
-// {"type": "line", "message": "GET /results"}
-// {"type": "result", "result": {"id": "2323", "output": "-----"}}
-func ParseRunnerOutput(b []byte) (result testkube.ExecutionResult, logs []string, err error) {
-	reader := bufio.NewReader(bytes.NewReader(b))
-	// The latest logline will contain either the Result or the last error
-	// See: pkg/executor/agent/agent.go: func Run(r runner.Runner, args []string)
-	lastLog := Output{
-		Time: time.Time{},
+// ParseRunnerOutput goes over the raw logs in b and parses possible runner output
+// The input is a json stream of the form
+// {"type": "line", "message": "runner execution started  ------------", "time": "..."}
+// {"type": "line", "message": "GET /results", "time": "..."}
+// {"type": "result", "result": {"id": "2323", "output": "-----"}, "time": "..."}
+func ParseRunnerOutput(b []byte) (testkube.ExecutionResult, error) {
+	result := testkube.ExecutionResult{}
+	if len(b) == 0 {
+		errMessage := "no logs found"
+		result.Output = errMessage
+		return result.Err(errors.New(errMessage)), nil
+	}
+	logs, err := parseLogs(b)
+	if err != nil {
+		err := fmt.Errorf("could not parse logs \"%s\": %v", b, err.Error())
+		result.Output = err.Error()
+		result.Err(err)
+		return result.Err(err), err
 	}
 
-	result.Status = testkube.ExecutionStatusFailed
+	log := getDecidingLogLine(logs)
+	if log == nil {
+		result.Err(errors.New("no logs found"))
+		return result, nil
+	}
+
+	switch log.Type_ {
+	case TypeResult:
+		if log.Result != nil {
+			result = *log.Result
+			break
+		}
+		result.Err(errors.New("found result log with no content"))
+	case TypeError:
+		result.Err(fmt.Errorf(log.Content))
+	default:
+		result.Err(fmt.Errorf("wrong log type was found as last log: %v", log))
+	}
+	result.Output = sanitizeLogs(logs)
+
+	return result, nil
+}
+
+// sanitizeLogs creates a human-readable string from a list of Outputs
+func sanitizeLogs(logs []Output) string {
+	var sb strings.Builder
+	for _, l := range logs {
+		sb.WriteString(fmt.Sprintf("%s\n", l.Content))
+	}
+	return sb.String()
+}
+
+// parseLogs gets a list of Outputs from raw logs
+func parseLogs(b []byte) ([]Output, error) {
+	logs := []Output{}
+	reader := bufio.NewReader(bytes.NewReader(b))
+
 	for {
 		b, err := utils.ReadLongLine(reader)
 		if err != nil {
 			if err == io.EOF {
 				err = nil
+				break
 			}
-			break
+			return logs, fmt.Errorf("could not read line: %w", err)
 		}
 		if len(b) < 2 || b[0] != byte('{') {
 			// empty or non json line
@@ -53,31 +93,104 @@ func ParseRunnerOutput(b []byte) (result testkube.ExecutionResult, logs []string
 		if err != nil {
 			// try to read in case of some lines which we couldn't parse
 			// sometimes we're not able to control all stdout messages from libs
-			logs = append(logs, fmt.Sprintf("ERROR can't get log entry: %s, (((%s)))", err, string(b)))
+			logs = append(logs, Output{
+				Type_:   TypeError,
+				Content: fmt.Sprintf("ERROR can't get log entry: %s, (((%s)))", err, string(b)),
+			})
 			continue
 		}
-		result.Status = testkube.ExecutionStatusPassed
-		if log.Type_ == TypeLogEvent || log.Type_ == TypeLogLine || log.Type_ == TypeError {
-			logs = append(logs, log.Content)
+		if log.Type_ == TypeResult {
+			if log.Result == nil {
+				logs = append(logs, Output{
+					Type_:   TypeError,
+					Content: fmt.Sprintf("ERROR empty result entry: %s, (((%s)))", err, string(b)),
+				})
+				continue
+			}
+			message := getResultMessage(*log.Result)
+			logs = append(logs, Output{
+				Type_:   TypeResult,
+				Content: message,
+				Result:  log.Result,
+			})
+			continue
 		}
-		if log.Time.After(lastLog.Time) {
-			lastLog = log
-		}
+		logs = append(logs, log)
+	}
+	return logs, nil
+}
+
+// getDecidingLogLine returns the log line of type result
+// if there is no log line of type result it will return the last log based on time
+// if there are no timestamps, it will return the last error log from the list,
+// if there are no errors, the last log line
+// The latest logline will contain either the Result, the last error or the last log
+// See: pkg/executor/agent/agent.go: func Run(r runner.Runner, args []string)
+func getDecidingLogLine(logs []Output) *Output {
+	if len(logs) == 0 {
+		return nil
+	}
+	resultLog := Output{
+		Type_: TypeLogLine,
+		Time:  time.Time{},
 	}
 
-	if lastLog.Time.IsZero() {
-		result.Err(fmt.Errorf("no usable logs were found, faulty logs: %v", logs))
-		return result, logs, nil
-	}
-
-	switch lastLog.Type_ {
-	case TypeResult:
-		if lastLog.Result != nil {
-			result = *lastLog.Result
+	for _, log := range logs {
+		if log.Type_ == TypeResult && log.Result.IsRunning() {
+			// this is the result of the init-container on success, let's ignore it
+			continue
 		}
-	case TypeError:
-		result = testkube.NewErrorExecutionResult(fmt.Errorf(lastLog.Content))
+
+		if moreSevere(log.Type_, resultLog.Type_) {
+			resultLog = log
+			continue
+		}
+
+		if sameSeverity(log.Type_, resultLog.Type_) {
+			if log.Time.Before(resultLog.Time) {
+				continue
+			}
+			resultLog = log
+		}
+	}
+	if resultLog.Content == "" {
+		resultLog = logs[len(logs)-1]
 	}
 
-	return result, logs, err
+	return &resultLog
+}
+
+// getResultMessage returns a message from the result regardless of its type
+func getResultMessage(result testkube.ExecutionResult) string {
+	if result.IsFailed() {
+		return result.ErrorMessage
+	}
+	if result.IsPassed() {
+		return result.Output
+	}
+
+	return fmt.Sprintf("%v", result.Status)
+}
+
+// sameSeverity decides if a and b are of the same severity type
+func sameSeverity(a string, b string) bool {
+	return a == b
+}
+
+// moreSevere decides if a is more severe than b
+func moreSevere(a string, b string) bool {
+	if sameSeverity(a, b) {
+		return false
+	}
+
+	if a == TypeResult {
+		return true
+	}
+
+	if a == TypeError {
+		return b != TypeResult
+	}
+
+	// a is either log or event
+	return !(b == TypeResult || b == TypeError)
 }

--- a/pkg/executor/output/parser_test.go
+++ b/pkg/executor/output/parser_test.go
@@ -7,20 +7,6 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-var exampleOutput = []byte(`
-{"type":"event","message":"running postman/collection from testkube.Execution","content":["{\n\t\"id\": \"blablablablabla\",\n\t\"name\": \"some-testing-exec\",\n\t\"scriptContent\": \"{\\n\\t\\\"info\\\": {\\n\\t\\t\\\"_postman_id\\\": \\\"97b67bfb-c1ca-4572-af46-06cab8f68998\\\",\\n\\t\\t\\\"name\\\": \\\"Local-API-Health\\\",\\n\\t\\t\\\"schema\\\": \\\"https://schema.getpostman.com/json/collection/v2.1.0/collection.json\\\"\\n\\t},\\n\\t\\\"item\\\": [\\n\\t\\t{\\n\\t\\t\\t\\\"name\\\": \\\"Health\\\",\\n\\t\\t\\t\\\"event\\\": [\\n\\t\\t\\t\\t{\\n\\t\\t\\t\\t\\t\\\"listen\\\": \\\"test\\\",\\n\\t\\t\\t\\t\\t\\\"script\\\": {\\n\\t\\t\\t\\t\\t\\t\\\"exec\\\": [\\n\\t\\t\\t\\t\\t\\t\\t\\\"pm.test(\\\\\\\"Status code is 200\\\\\\\", function () {\\\",\\n\\t\\t\\t\\t\\t\\t\\t\\\"    pm.response.to.have.status(200);\\\",\\n\\t\\t\\t\\t\\t\\t\\t\\\"});\\\"\\n\\t\\t\\t\\t\\t\\t],\\n\\t\\t\\t\\t\\t\\t\\\"type\\\": \\\"text/javascript\\\"\\n\\t\\t\\t\\t\\t}\\n\\t\\t\\t\\t}\\n\\t\\t\\t],\\n\\t\\t\\t\\\"request\\\": {\\n\\t\\t\\t\\t\\\"method\\\": \\\"GET\\\",\\n\\t\\t\\t\\t\\\"header\\\": [],\\n\\t\\t\\t\\t\\\"url\\\": {\\n\\t\\t\\t\\t\\t\\\"raw\\\": \\\"http://localhost:8088/health\\\",\\n\\t\\t\\t\\t\\t\\\"protocol\\\": \\\"http\\\",\\n\\t\\t\\t\\t\\t\\\"host\\\": [\\n\\t\\t\\t\\t\\t\\t\\\"localhost\\\"\\n\\t\\t\\t\\t\\t],\\n\\t\\t\\t\\t\\t\\\"port\\\": \\\"8088\\\",\\n\\t\\t\\t\\t\\t\\\"path\\\": [\\n\\t\\t\\t\\t\\t\\t\\\"health\\\"\\n\\t\\t\\t\\t\\t]\\n\\t\\t\\t\\t}\\n\\t\\t\\t},\\n\\t\\t\\t\\\"response\\\": []\\n\\t\\t}\\n\\t],\\n\\t\\\"event\\\": []\\n}\"\n}"]}
-{"type":"line","content":"newman\n\n"}
-{"type":"line","content":"Local-API-Health\n"}
-{"type":"line","content":"\n→ Health\n"}
-{"type":"line","content":"  GET http://localhost:8088/health "}
-{"type":"line","content":"[errored]\n"}
-{"type":"line","content":"     connect ECONNREFUSED 127.0.0.1:8088\n"}
-{"type":"line","content":"  2. Status code is 200\n"}
-{"type":"line","content":"\n┌─────────────────────────┬──────────┬──────────┐\n│                         │ executed │   failed │\n├─────────────────────────┼──────────┼──────────┤\n│              iterations │        1 │        0 │\n├─────────────────────────┼──────────┼──────────┤\n│                requests │        1 │        1 │\n├─────────────────────────┼──────────┼──────────┤\n│            test-scripts │        1 │        0 │\n├─────────────────────────┼──────────┼──────────┤\n│      prerequest-scripts │        0 │        0 │\n├─────────────────────────┼──────────┼──────────┤\n│              assertions │        1 │        1 │\n├─────────────────────────┴──────────┴──────────┤\n│ total run duration: 1012ms                    │\n├───────────────────────────────────────────────┤\n│ total data received: 0B (approx)              │\n└───────────────────────────────────────────────┘\n"}
-{"type":"line","content":"\n  #  failure         detail                                                          \n                                                                                     \n 1.  Error                                                                           \n                     connect ECONNREFUSED 127.0.0.1:8088                             \n                     at request                                                      \n                     inside \"Health\"                                                 \n                                                                                     \n 2.  AssertionError  Status code is 200                                              \n                     expected { Object (id, _details, ...) } to have property 'code' \n                     at assertion:0 in test-script                                   \n                     inside \"Health\"                                                 \n"}
-{"type":"result","result":{"status":"failed","startTime":"2021-10-29T11:35:35.759Z","endTime":"2021-10-29T11:35:36.771Z","output":"newman\n\nLocal-API-Health\n\n→ Health\n  GET http://localhost:8088/health [errored]\n     connect ECONNREFUSED 127.0.0.1:8088\n  2. Status code is 200\n\n┌─────────────────────────┬──────────┬──────────┐\n│                         │ executed │   failed │\n├─────────────────────────┼──────────┼──────────┤\n│              iterations │        1 │        0 │\n├─────────────────────────┼──────────┼──────────┤\n│                requests │        1 │        1 │\n├─────────────────────────┼──────────┼──────────┤\n│            test-scripts │        1 │        0 │\n├─────────────────────────┼──────────┼──────────┤\n│      prerequest-scripts │        0 │        0 │\n├─────────────────────────┼──────────┼──────────┤\n│              assertions │        1 │        1 │\n├─────────────────────────┴──────────┴──────────┤\n│ total run duration: 1012ms                    │\n├───────────────────────────────────────────────┤\n│ total data received: 0B (approx)              │\n└───────────────────────────────────────────────┘\n\n  #  failure         detail                                                          \n                                                                                     \n 1.  Error                                                                           \n                     connect ECONNREFUSED 127.0.0.1:8088                             \n                     at request                                                      \n                     inside \"Health\"                                                 \n                                                                                     \n 2.  AssertionError  Status code is 200                                              \n                     expected { Object (id, _details, ...) } to have property 'code' \n                     at assertion:0 in test-script                                   \n                     inside \"Health\"                                                 \n","outputType":"text/plain","errorMessage":"process error: exit status 1","steps":[{"name":"Health","duration":"0s","status":"failed","assertionResults":[{"name":"Status code is 200","status":"failed","errorMessage":"expected { Object (id, _details, ...) } to have property 'code'"}]}]}}
-`)
-
 var exampleLogEntryLine = []byte(`{"type":"line","content":"  GET http://localhost:8088/health "}`)
 var exampleLogEntryEvent = []byte(`{"type":"event","content":"running postman/collection from testkube.Execution","obj":["{\n\t\"id\": \"blablablablabla\",\n\t\"name\": \"some-testing-exec\",\n\t\"scriptContent\": \"{\\n\\t\\\"info\\\": {\\n\\t\\t\\\"_postman_id\\\": \\\"97b67bfb-c1ca-4572-af46-06cab8f68998\\\",\\n\\t\\t\\\"name\\\": \\\"Local-API-Health\\\",\\n\\t\\t\\\"schema\\\": \\\"https://schema.getpostman.com/json/collection/v2.1.0/collection.json\\\"\\n\\t},\\n\\t\\\"item\\\": [\\n\\t\\t{\\n\\t\\t\\t\\\"name\\\": \\\"Health\\\",\\n\\t\\t\\t\\\"event\\\": [\\n\\t\\t\\t\\t{\\n\\t\\t\\t\\t\\t\\\"listen\\\": \\\"test\\\",\\n\\t\\t\\t\\t\\t\\\"script\\\": {\\n\\t\\t\\t\\t\\t\\t\\\"exec\\\": [\\n\\t\\t\\t\\t\\t\\t\\t\\\"pm.test(\\\\\\\"Status code is 200\\\\\\\", function () {\\\",\\n\\t\\t\\t\\t\\t\\t\\t\\\"    pm.response.to.have.status(200);\\\",\\n\\t\\t\\t\\t\\t\\t\\t\\\"});\\\"\\n\\t\\t\\t\\t\\t\\t],\\n\\t\\t\\t\\t\\t\\t\\\"type\\\": \\\"text/javascript\\\"\\n\\t\\t\\t\\t\\t}\\n\\t\\t\\t\\t}\\n\\t\\t\\t],\\n\\t\\t\\t\\\"request\\\": {\\n\\t\\t\\t\\t\\\"method\\\": \\\"GET\\\",\\n\\t\\t\\t\\t\\\"header\\\": [],\\n\\t\\t\\t\\t\\\"url\\\": {\\n\\t\\t\\t\\t\\t\\\"raw\\\": \\\"http://localhost:8088/health\\\",\\n\\t\\t\\t\\t\\t\\\"protocol\\\": \\\"http\\\",\\n\\t\\t\\t\\t\\t\\\"host\\\": [\\n\\t\\t\\t\\t\\t\\t\\\"localhost\\\"\\n\\t\\t\\t\\t\\t],\\n\\t\\t\\t\\t\\t\\\"port\\\": \\\"8088\\\",\\n\\t\\t\\t\\t\\t\\\"path\\\": [\\n\\t\\t\\t\\t\\t\\t\\\"health\\\"\\n\\t\\t\\t\\t\\t]\\n\\t\\t\\t\\t}\\n\\t\\t\\t},\\n\\t\\t\\t\\\"response\\\": []\\n\\t\\t}\\n\\t],\\n\\t\\\"event\\\": []\\n}\"\n}"]}`)
 var exampleLogEntryError = []byte(`{"type":"error","content":"Some error message"}`)
@@ -51,36 +37,51 @@ func TestGetLogEntry(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, TypeResult, out.Type_)
 	})
-
 }
 
 func TestParseRunnerOutput(t *testing.T) {
-	t.Run("Valid runner output", func(t *testing.T) {
-		t.Parallel()
-		result, logs, err := ParseRunnerOutput(exampleOutput)
-
-		assert.Len(t, logs, 10)
-		assert.NoError(t, err)
-		assert.Equal(t, testkube.ExecutionStatusFailed, result.Status)
-	})
 	t.Run("Empty runner output", func(t *testing.T) {
 		t.Parallel()
-		result, logs, err := ParseRunnerOutput([]byte{})
+		result, err := ParseRunnerOutput([]byte{})
 
-		assert.Len(t, logs, 0)
+		assert.Equal(t, "no logs found", result.Output)
 		assert.NoError(t, err)
 		assert.Equal(t, testkube.ExecutionStatusFailed, result.Status)
 	})
-	t.Run("Invalid logline in output", func(t *testing.T) {
+	t.Run("Invalid log", func(t *testing.T) {
 		t.Parallel()
-		extendedExampleOutput := append(exampleOutput, []byte(`{not a json}`)...)
-		result, logs, err := ParseRunnerOutput(extendedExampleOutput)
+		invalidOutput := []byte(`{not a json}`)
+		result, err := ParseRunnerOutput(invalidOutput)
+		expectedErrMessage := "ERROR can't get log entry: invalid character 'n' looking for beginning of object key string, ((({not a json})))"
 
-		assert.Len(t, logs, 11)
+		assert.Equal(t, expectedErrMessage+"\n", result.Output)
 		assert.NoError(t, err)
 		assert.Equal(t, testkube.ExecutionStatusFailed, result.Status)
+		assert.Equal(t, expectedErrMessage, result.ErrorMessage)
 	})
-	t.Run("wrong order in logs", func(t *testing.T) {
+	t.Run("Runner output with no timestamps", func(t *testing.T) {
+		t.Parallel()
+		var exampleOutput = []byte(`
+{"type":"event","message":"running postman/collection from testkube.Execution","content":["{\n\t\"id\": \"blablablablabla\",\n\t\"name\": \"some-testing-exec\",\n\t\"scriptContent\": \"{\\n\\t\\\"info\\\": {\\n\\t\\t\\\"_postman_id\\\": \\\"97b67bfb-c1ca-4572-af46-06cab8f68998\\\",\\n\\t\\t\\\"name\\\": \\\"Local-API-Health\\\",\\n\\t\\t\\\"schema\\\": \\\"https://schema.getpostman.com/json/collection/v2.1.0/collection.json\\\"\\n\\t},\\n\\t\\\"item\\\": [\\n\\t\\t{\\n\\t\\t\\t\\\"name\\\": \\\"Health\\\",\\n\\t\\t\\t\\\"event\\\": [\\n\\t\\t\\t\\t{\\n\\t\\t\\t\\t\\t\\\"listen\\\": \\\"test\\\",\\n\\t\\t\\t\\t\\t\\\"script\\\": {\\n\\t\\t\\t\\t\\t\\t\\\"exec\\\": [\\n\\t\\t\\t\\t\\t\\t\\t\\\"pm.test(\\\\\\\"Status code is 200\\\\\\\", function () {\\\",\\n\\t\\t\\t\\t\\t\\t\\t\\\"    pm.response.to.have.status(200);\\\",\\n\\t\\t\\t\\t\\t\\t\\t\\\"});\\\"\\n\\t\\t\\t\\t\\t\\t],\\n\\t\\t\\t\\t\\t\\t\\\"type\\\": \\\"text/javascript\\\"\\n\\t\\t\\t\\t\\t}\\n\\t\\t\\t\\t}\\n\\t\\t\\t],\\n\\t\\t\\t\\\"request\\\": {\\n\\t\\t\\t\\t\\\"method\\\": \\\"GET\\\",\\n\\t\\t\\t\\t\\\"header\\\": [],\\n\\t\\t\\t\\t\\\"url\\\": {\\n\\t\\t\\t\\t\\t\\\"raw\\\": \\\"http://localhost:8088/health\\\",\\n\\t\\t\\t\\t\\t\\\"protocol\\\": \\\"http\\\",\\n\\t\\t\\t\\t\\t\\\"host\\\": [\\n\\t\\t\\t\\t\\t\\t\\\"localhost\\\"\\n\\t\\t\\t\\t\\t],\\n\\t\\t\\t\\t\\t\\\"port\\\": \\\"8088\\\",\\n\\t\\t\\t\\t\\t\\\"path\\\": [\\n\\t\\t\\t\\t\\t\\t\\\"health\\\"\\n\\t\\t\\t\\t\\t]\\n\\t\\t\\t\\t}\\n\\t\\t\\t},\\n\\t\\t\\t\\\"response\\\": []\\n\\t\\t}\\n\\t],\\n\\t\\\"event\\\": []\\n}\"\n}"]}
+{"type":"line","content":"newman\n\n"}
+{"type":"line","content":"Local-API-Health\n"}
+{"type":"line","content":"\n→ Health\n"}
+{"type":"line","content":"  GET http://localhost:8088/health "}
+{"type":"line","content":"[errored]\n"}
+{"type":"line","content":"     connect ECONNREFUSED 127.0.0.1:8088\n"}
+{"type":"line","content":"  2. Status code is 200\n"}
+{"type":"line","content":"\n┌─────────────────────────┬──────────┬──────────┐\n│                         │ executed │   failed │\n├─────────────────────────┼──────────┼──────────┤\n│              iterations │        1 │        0 │\n├─────────────────────────┼──────────┼──────────┤\n│                requests │        1 │        1 │\n├─────────────────────────┼──────────┼──────────┤\n│            test-scripts │        1 │        0 │\n├─────────────────────────┼──────────┼──────────┤\n│      prerequest-scripts │        0 │        0 │\n├─────────────────────────┼──────────┼──────────┤\n│              assertions │        1 │        1 │\n├─────────────────────────┴──────────┴──────────┤\n│ total run duration: 1012ms                    │\n├───────────────────────────────────────────────┤\n│ total data received: 0B (approx)              │\n└───────────────────────────────────────────────┘\n"}
+{"type":"line","content":"\n  #  failure         detail                                                          \n                                                                                     \n 1.  Error                                                                           \n                     connect ECONNREFUSED 127.0.0.1:8088                             \n                     at request                                                      \n                     inside \"Health\"                                                 \n                                                                                     \n 2.  AssertionError  Status code is 200                                              \n                     expected { Object (id, _details, ...) } to have property 'code' \n                     at assertion:0 in test-script                                   \n                     inside \"Health\"                                                 \n"}
+{"type":"result","result":{"status":"failed","startTime":"2021-10-29T11:35:35.759Z","endTime":"2021-10-29T11:35:36.771Z","output":"newman\n\nLocal-API-Health\n\n→ Health\n  GET http://localhost:8088/health [errored]\n     connect ECONNREFUSED 127.0.0.1:8088\n  2. Status code is 200\n\n┌─────────────────────────┬──────────┬──────────┐\n│                         │ executed │   failed │\n├─────────────────────────┼──────────┼──────────┤\n│              iterations │        1 │        0 │\n├─────────────────────────┼──────────┼──────────┤\n│                requests │        1 │        1 │\n├─────────────────────────┼──────────┼──────────┤\n│            test-scripts │        1 │        0 │\n├─────────────────────────┼──────────┼──────────┤\n│      prerequest-scripts │        0 │        0 │\n├─────────────────────────┼──────────┼──────────┤\n│              assertions │        1 │        1 │\n├─────────────────────────┴──────────┴──────────┤\n│ total run duration: 1012ms                    │\n├───────────────────────────────────────────────┤\n│ total data received: 0B (approx)              │\n└───────────────────────────────────────────────┘\n\n  #  failure         detail                                                          \n                                                                                     \n 1.  Error                                                                           \n                     connect ECONNREFUSED 127.0.0.1:8088                             \n                     at request                                                      \n                     inside \"Health\"                                                 \n                                                                                     \n 2.  AssertionError  Status code is 200                                              \n                     expected { Object (id, _details, ...) } to have property 'code' \n                     at assertion:0 in test-script                                   \n                     inside \"Health\"                                                 \n","outputType":"text/plain","errorMessage":"process error: exit status 1","steps":[{"name":"Health","duration":"0s","status":"failed","assertionResults":[{"name":"Status code is 200","status":"failed","errorMessage":"expected { Object (id, _details, ...) } to have property 'code'"}]}]}}
+`)
+		result, err := ParseRunnerOutput(exampleOutput)
+
+		assert.Len(t, result.Output, 4624)
+		assert.NoError(t, err)
+		assert.Equal(t, testkube.ExecutionStatusFailed, result.Status)
+		assert.Equal(t, "process error: exit status 1", result.ErrorMessage)
+	})
+	t.Run("Wrong order in logs", func(t *testing.T) {
 		t.Parallel()
 		unorderedOutput := []byte(`
 {"type":"line","content":"🚚 Preparing test runner","time":"2023-01-17T15:29:17.921466388Z"}
@@ -101,10 +102,137 @@ func TestParseRunnerOutput(t *testing.T) {
 {"type":"event","content":"running test [63c6bec1790802b7e3e57048]","time":"2023-01-17T15:29:17.921920596Z"}
 {"type":"line","content":"🚚 Preparing for test run","time":"2023-01-17T15:29:17.921931471Z"}
 `)
-		result, logs, err := ParseRunnerOutput(unorderedOutput)
+		expectedOutput := `🚚 Preparing test runner
+🌍 Reading environment variables...
+✅ Environment variables read successfully
+RUNNER_ENDPOINT="testkube-minio-service-testkube:9000"
+RUNNER_ACCESSKEYID="********"
+RUNNER_SECRETACCESSKEY="********"
+RUNNER_LOCATION=""
+RUNNER_TOKEN=""
+RUNNER_SSL=false
+RUNNER_SCRAPPERENABLED="true"
+RUNNER_GITUSERNAME=""
+RUNNER_GITTOKEN=""
+RUNNER_DATADIR="/data"
+❌ can't find branch or commit in params, repo:&{Type_:git-file Uri:https://github.com/kubeshop/testkube.git Branch: Commit: Path:test/cypress/executor-smoke/cypress-11 Username: Token: UsernameSecret:<nil> TokenSecret:<nil> WorkingDir:}
+can't find branch or commit in params, repo:&{Type_:git-file Uri:https://github.com/kubeshop/testkube.git Branch: Commit: Path:test/cypress/executor-smoke/cypress-11 Username: Token: UsernameSecret:<nil> TokenSecret:<nil> WorkingDir:}
+running test [63c6bec1790802b7e3e57048]
+🚚 Preparing for test run
+`
+		result, err := ParseRunnerOutput(unorderedOutput)
 
-		assert.Len(t, logs, 17)
+		assert.Equal(t, expectedOutput, result.Output)
 		assert.NoError(t, err)
 		assert.Equal(t, testkube.ExecutionStatusFailed, result.Status)
+		assert.Equal(t, "can't find branch or commit in params, repo:&{Type_:git-file Uri:https://github.com/kubeshop/testkube.git Branch: Commit: Path:test/cypress/executor-smoke/cypress-11 Username: Token: UsernameSecret:<nil> TokenSecret:<nil> WorkingDir:}", result.ErrorMessage)
+	})
+	t.Run("Output with failed result", func(t *testing.T) {
+		output := []byte(`{"type":"event","content":"running test [63c9606d7104b0fa0b7a45f1]"}
+{"type":"event","content":"Running [ ./zap-api-scan.py [-t https://www.example.com/openapi.json -f openapi -c examples/zap-api.conf -d -D 5 -I -l INFO -n examples/context.config -S -T 60 -U anonymous -O https://www.example.com -z -config aaa=bbb -r api-test-report.html]]"}
+{"type":"result","result":{"status":"failed","errorMessage":"could not start process: fork/exec ./zap-api-scan.py: no such file or directory"}}`)
+		expectedOutput := `running test [63c9606d7104b0fa0b7a45f1]
+Running [ ./zap-api-scan.py [-t https://www.example.com/openapi.json -f openapi -c examples/zap-api.conf -d -D 5 -I -l INFO -n examples/context.config -S -T 60 -U anonymous -O https://www.example.com -z -config aaa=bbb -r api-test-report.html]]
+could not start process: fork/exec ./zap-api-scan.py: no such file or directory
+`
+		result, err := ParseRunnerOutput(output)
+
+		assert.Equal(t, expectedOutput, result.Output)
+		assert.NoError(t, err)
+		assert.Equal(t, testkube.ExecutionStatusFailed, result.Status)
+		assert.Equal(t, "could not start process: fork/exec ./zap-api-scan.py: no such file or directory", result.ErrorMessage)
+	})
+	t.Run("Output with error", func(t *testing.T) {
+		output := []byte(`
+{"type":"line","content":"🚚 Preparing test runner","time":"2023-01-19T15:22:25.867379429Z"}
+{"type":"line","content":"🌍 Reading environment variables...","time":"2023-01-19T15:22:25.867927513Z"}
+{"type":"line","content":"✅ Environment variables read successfully","time":"2023-01-19T15:22:25.867944763Z"}
+{"type":"line","content":"RUNNER_ENDPOINT=\"testkube-minio-service-testkube:9000\"","time":"2023-01-19T15:22:25.867946929Z"}
+{"type":"line","content":"RUNNER_ACCESSKEYID=\"********\"","time":"2023-01-19T15:22:25.867948804Z"}
+{"type":"line","content":"RUNNER_SECRETACCESSKEY=\"********\"","time":"2023-01-19T15:22:25.867955263Z"}
+{"type":"line","content":"RUNNER_LOCATION=\"\"","time":"2023-01-19T15:22:25.867962596Z"}
+{"type":"line","content":"RUNNER_TOKEN=\"\"","time":"2023-01-19T15:22:25.867967971Z"}
+{"type":"line","content":"RUNNER_SSL=false","time":"2023-01-19T15:22:25.867974013Z"}
+{"type":"line","content":"RUNNER_SCRAPPERENABLED=\"true\"","time":"2023-01-19T15:22:25.867978888Z"}
+{"type":"line","content":"RUNNER_GITUSERNAME=\"\"","time":"2023-01-19T15:22:25.867984179Z"}
+{"type":"line","content":"RUNNER_GITTOKEN=\"\"","time":"2023-01-19T15:22:25.867986013Z"}
+{"type":"line","content":"RUNNER_DATADIR=\"/data\"","time":"2023-01-19T15:22:25.867987596Z"}
+{"type":"event","content":"running test [63c960287104b0fa0b7a45ef]","time":"2023-01-19T15:22:25.868132888Z"}
+{"type":"line","content":"🚚 Preparing for test run","time":"2023-01-19T15:22:25.868161346Z"}
+{"type":"line","content":"❌ can't find branch or commit in params, repo:\u0026{Type_:git-file Uri:https://github.com/kubeshop/testkube.git Branch: Commit: Path:test/cypress/executor-smoke/cypress-11 Username: Token: UsernameSecret:\u003cnil\u003e TokenSecret:\u003cnil\u003e WorkingDir:}","time":"2023-01-19T15:22:25.868183971Z"}
+{"type":"error","content":"can't find branch or commit in params, repo:\u0026{Type_:git-file Uri:https://github.com/kubeshop/testkube.git Branch: Commit: Path:test/cypress/executor-smoke/cypress-11 Username: Token: UsernameSecret:\u003cnil\u003e TokenSecret:\u003cnil\u003e WorkingDir:}","time":"2023-01-19T15:22:25.868198429Z"}
+`)
+		expectedOutput := `🚚 Preparing test runner
+🌍 Reading environment variables...
+✅ Environment variables read successfully
+RUNNER_ENDPOINT="testkube-minio-service-testkube:9000"
+RUNNER_ACCESSKEYID="********"
+RUNNER_SECRETACCESSKEY="********"
+RUNNER_LOCATION=""
+RUNNER_TOKEN=""
+RUNNER_SSL=false
+RUNNER_SCRAPPERENABLED="true"
+RUNNER_GITUSERNAME=""
+RUNNER_GITTOKEN=""
+RUNNER_DATADIR="/data"
+running test [63c960287104b0fa0b7a45ef]
+🚚 Preparing for test run
+❌ can't find branch or commit in params, repo:&{Type_:git-file Uri:https://github.com/kubeshop/testkube.git Branch: Commit: Path:test/cypress/executor-smoke/cypress-11 Username: Token: UsernameSecret:<nil> TokenSecret:<nil> WorkingDir:}
+can't find branch or commit in params, repo:&{Type_:git-file Uri:https://github.com/kubeshop/testkube.git Branch: Commit: Path:test/cypress/executor-smoke/cypress-11 Username: Token: UsernameSecret:<nil> TokenSecret:<nil> WorkingDir:}
+`
+
+		result, err := ParseRunnerOutput(output)
+
+		assert.Equal(t, expectedOutput, result.Output)
+		assert.NoError(t, err)
+		assert.Equal(t, testkube.ExecutionStatusFailed, result.Status)
+		assert.Equal(t, "can't find branch or commit in params, repo:&{Type_:git-file Uri:https://github.com/kubeshop/testkube.git Branch: Commit: Path:test/cypress/executor-smoke/cypress-11 Username: Token: UsernameSecret:<nil> TokenSecret:<nil> WorkingDir:}", result.ErrorMessage)
+	})
+	t.Run("flaky cypress test", func(t *testing.T) {
+		output := []byte(`
+{"type":"error","content":"can't find branch or commit in params, repo:\u0026{Type_:git-file Uri:https://github.com/kubeshop/testkube.git Branch: Commit: Path:test/cypress/executor-smoke/cypress-11 Username: Token: UsernameSecret:\u003cnil\u003e TokenSecret:\u003cnil\u003e WorkingDir:}","time":"2023-01-20T12:44:15.719459174Z"}
+{"type":"line","content":"🚚 Preparing test runner","time":"2023-01-20T12:44:15.714299549Z"}
+{"type":"line","content":"🌍 Reading environment variables...","time":"2023-01-20T12:44:15.718910883Z"}
+{"type":"line","content":"✅ Environment variables read successfully","time":"2023-01-20T12:44:15.718958008Z"}
+{"type":"line","content":"RUNNER_ENDPOINT=\"testkube-minio-service-testkube:9000\"","time":"2023-01-20T12:44:15.718962633Z"}
+{"type":"line","content":"RUNNER_ACCESSKEYID=\"********\"","time":"2023-01-20T12:44:15.718966091Z"}
+{"type":"line","content":"RUNNER_SECRETACCESSKEY=\"********\"","time":"2023-01-20T12:44:15.718969383Z"}
+{"type":"line","content":"RUNNER_LOCATION=\"\"","time":"2023-01-20T12:44:15.718972299Z"}
+{"type":"line","content":"RUNNER_TOKEN=\"\"","time":"2023-01-20T12:44:15.718975174Z"}
+{"type":"line","content":"RUNNER_SSL=false","time":"2023-01-20T12:44:15.718977924Z"}
+{"type":"line","content":"RUNNER_SCRAPPERENABLED=\"true\"","time":"2023-01-20T12:44:15.718980758Z"}
+{"type":"line","content":"RUNNER_GITUSERNAME=\"\"","time":"2023-01-20T12:44:15.718983549Z"}
+{"type":"line","content":"RUNNER_GITTOKEN=\"\"","time":"2023-01-20T12:44:15.718986174Z"}
+{"type":"line","content":"RUNNER_DATADIR=\"/data\"","time":"2023-01-20T12:44:15.718989049Z"}
+{"type":"event","content":"running test [63ca8c8988564860327a16b5]","time":"2023-01-20T12:44:15.719276383Z"}
+{"type":"line","content":"🚚 Preparing for test run","time":"2023-01-20T12:44:15.719285633Z"}
+{"type":"line","content":"❌ can't find branch or commit in params, repo:\u0026{Type_:git-file Uri:https://github.com/kubeshop/testkube.git Branch: Commit: Path:test/cypress/executor-smoke/cypress-11 Username: Token: UsernameSecret:\u003cnil\u003e TokenSecret:\u003cnil\u003e WorkingDir:}","time":"2023-01-20T12:44:15.719302049Z"}
+`)
+		expectedOutput := `can't find branch or commit in params, repo:&{Type_:git-file Uri:https://github.com/kubeshop/testkube.git Branch: Commit: Path:test/cypress/executor-smoke/cypress-11 Username: Token: UsernameSecret:<nil> TokenSecret:<nil> WorkingDir:}
+🚚 Preparing test runner
+🌍 Reading environment variables...
+✅ Environment variables read successfully
+RUNNER_ENDPOINT="testkube-minio-service-testkube:9000"
+RUNNER_ACCESSKEYID="********"
+RUNNER_SECRETACCESSKEY="********"
+RUNNER_LOCATION=""
+RUNNER_TOKEN=""
+RUNNER_SSL=false
+RUNNER_SCRAPPERENABLED="true"
+RUNNER_GITUSERNAME=""
+RUNNER_GITTOKEN=""
+RUNNER_DATADIR="/data"
+running test [63ca8c8988564860327a16b5]
+🚚 Preparing for test run
+❌ can't find branch or commit in params, repo:&{Type_:git-file Uri:https://github.com/kubeshop/testkube.git Branch: Commit: Path:test/cypress/executor-smoke/cypress-11 Username: Token: UsernameSecret:<nil> TokenSecret:<nil> WorkingDir:}
+`
+
+		result, err := ParseRunnerOutput(output)
+
+		assert.Equal(t, expectedOutput, result.Output)
+		assert.NoError(t, err)
+		assert.Equal(t, testkube.ExecutionStatusFailed, result.Status)
+		assert.Equal(t, "can't find branch or commit in params, repo:&{Type_:git-file Uri:https://github.com/kubeshop/testkube.git Branch: Commit: Path:test/cypress/executor-smoke/cypress-11 Username: Token: UsernameSecret:<nil> TokenSecret:<nil> WorkingDir:}", result.ErrorMessage)
+
 	})
 }


### PR DESCRIPTION
## Pull request description 

Made logs parsing clearer, fixed issue on logs with no timestamp, issue on executions seemingly running forever and added the logs to the output to have a more consistent behaviour.

## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [x] tested locally
- [ ] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [x] added a test

## Breaking changes

-

## Changes

-

## Fixes

-