### PR TITLE
docs: add separate webhooks section

### DIFF
--- a/docs/docs/7-integrations/webhooks.md
+++ b/docs/docs/7-integrations/webhooks.md
@@ -1,0 +1,26 @@
+---
+sidebar_position: 1
+---
+
+# Implementing Webhooks
+
+Webhooks allow you to build or set up integrations and send HTTP POST payloads (your Testkube Execution and its current state) whenever an event is triggered. In this case, when your Tests are started or finished.
+
+To set them up when using Testkube, you'll need to create your webhook as shown in the following format example and `kubectl apply` it:
+
+```yml
+apiVersion: executor.testkube.io/v1
+kind: Webhook
+metadata:
+  name: example-webhook
+  namespace: testkube
+spec:
+  uri: http://localhost:8080/events
+  events:
+  - start-test
+  - end-test
+  - end-test-success
+  - end-test-failed
+```
+
+Here you'll be able to pass events depending on which webhooks you want to be triggered. Testkube will pass `Event` which can have `type` and `testExecution` or `testsuiteExecution` fields.

--- a/docs/docs/7-integrations/webhooks.md
+++ b/docs/docs/7-integrations/webhooks.md
@@ -1,7 +1,7 @@
 ---
-sidebar_position: 1
+sidebar_position: 4
+sidebar_label: Implementing Webhooks
 ---
-
 # Implementing Webhooks
 
 Webhooks allow you to build or set up integrations and send HTTP POST payloads (your Testkube Execution and its current state) whenever an event is triggered. In this case, when your Tests are started or finished.


### PR DESCRIPTION
## Pull request description 

adding specific webhooks docs to integrations since it's currently only referenced in the contributing section and not showing up on search results

## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [ ] tested locally
- [ ] tested on cluster
- [ ] added new dependencies
- [x] updated the docs
- [ ] added a test

## Breaking changes

-

## Changes

-

## Fixes

-