### PR TITLE
fix: postman sanity - recent executions list fixed

### DIFF
--- a/test/postman/TestKube-Sanity.postman_collection.json
+++ b/test/postman/TestKube-Sanity.postman_collection.json
@@ -1,8 +1,9 @@
 {
 	"info": {
-		"_postman_id": "2bb973c5-c029-4cc9-b821-b5c766f82d8c",
+		"_postman_id": "25756fae-eca1-42e0-9ee7-4cb9b381fe32",
 		"name": "Testkube-Sanity",
-		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
+		"_exporter_id": "22855798"
 	},
 	"item": [
 		{
@@ -380,15 +381,20 @@
 					"listen": "test",
 					"script": {
 						"exec": [
-							"pm.test(\"Most recent execution is that one recently run\", function () {",
+							"pm.test(\"Execution is among the recent ones\", function () {",
 							"    console.log(\"response\", pm.response.json());",
 							"    let jsonArray = pm.response.json();",
-							"    let jsonData = jsonArray.results[0];",
+							"    let jsonData = jsonArray.results",
 							"",
-							"    pm.expect(jsonData[\"name\"]).to.eql(pm.environment.get(\"execution_name\"));",
-							"});",
+							"    let contains = false;",
+							"    for (let i=0; i<jsonData.length; i++) {",
+							"        if (jsonData[i].name == pm.environment.get(\"execution_name\")) {",
+							"            contains = true;",
+							"        }",
+							"    }",
 							"",
-							""
+							"    pm.expect(contains).to.be.true",
+							"});"
 						],
 						"type": "text/javascript"
 					}


### PR DESCRIPTION
Fix for random failures caused by `Most recent execution is that one recently run` test: https://github.com/kubeshop/helm-charts/actions/runs/4163212709/jobs/7203392780
Multiple tests may be executed at the same time, so `postman-test-` may not be the last one:
```
results: [
  │     {
  │       id: '63ea285d6191ca1b38acdb4b',
  │       name: 'executor-container-smoke-tests-container-
  │ executor-curl-smoke-1047',
  │       number: 1047,
  │       testName: 'container-executor-curl-smoke',
  │       testType: 'container-executor-curl/test',
  │       status: 'running',
  │       startTime: '2023-02-13T12:09:01.316Z',
  │       endTime: '0001-01-01T00:00:00Z',
  │       labels: { 'core-tests': 'executors' }
  │     },
  │     {
  │       id: '63ea28576191ca1b38acdb47',
  │       name: 'postman-test-k1lm3i-1',
  │       number: 1,
  │       testName: 'postman-test-k1lm3i',
  │       testType: 'postman/collection',
  │       status: 'passed',
  │       startTime: '2023-02-13T12:08:55.122Z',
  │       endTime: '2023-02-13T12:09:02.582Z',
  │       duration: '00:00:07',
  │       durationMs: 7460,
  │       labels: { toDelete: 'yes' }
  │     },
```