### PR TITLE
docs: amend resource type in example to deployment

### DIFF
--- a/docs/docs/using-testkube/triggers.md
+++ b/docs/docs/using-testkube/triggers.md
@@ -86,7 +86,7 @@ conditionSpec:
 ## Example
 
 Here is an example for a **Test Trigger** *default/testtrigger-example* which runs the **TestSuite** *frontend/sanity-test*
-when a **pod** containing the label **testkube.io/tier: backend** gets **modified** and also has the conditions **Progressing: True: NewReplicaSetAvailable** and **Available: True**.
+when a **deployment** containing the label **testkube.io/tier: backend** gets **modified** and also has the conditions **Progressing: True: NewReplicaSetAvailable** and **Available: True**.
 
 ```yaml
 apiVersion: tests.testkube.io/v1
@@ -95,7 +95,7 @@ metadata:
   name: testtrigger-example
   namespace: default
 spec:
-  resource: pod
+  resource: deployment
   resourceSelector:
     labelSelector:
       matchLabels:


### PR DESCRIPTION
## Pull request description 
Amend the resource type in the example to `deployment` so it aligns with the conditions.


## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [ ] tested locally
- [ ] tested on cluster
- [ ] added new dependencies
- [x] updated the docs
- [ ] added a test

## Breaking changes

-

## Changes

-

## Fixes

-