### PR TITLE
fix: check git source when repo type is `git`

### DIFF
--- a/pkg/executor/content/fetcher.go
+++ b/pkg/executor/content/fetcher.go
@@ -191,12 +191,12 @@ func (f Fetcher) configureUseOfCertificate() error {
 }
 
 // CalculateGitContentType returns the type of the git test source
-func (f Fetcher) CalculateGitContentType(repo *testkube.Repository) (string, error) {
+func (f Fetcher) CalculateGitContentType(repo testkube.Repository) (string, error) {
 	if repo.Uri == "" || repo.Path == "" {
 		return "", errors.New("repository Uri and Path should be populated")
 	}
 
-	path, err := f.FetchGitFile(repo)
+	path, err := f.FetchGitFile(&repo)
 	if err != nil {
 		return "", fmt.Errorf("could not fetch: %w", err)
 	}

--- a/pkg/executor/content/fetcher.go
+++ b/pkg/executor/content/fetcher.go
@@ -193,10 +193,9 @@ func (f Fetcher) configureUseOfCertificate() error {
 // CalculateGitContentType returns the type of the git test source
 func (f Fetcher) CalculateGitContentType(repo testkube.Repository) (string, error) {
 	if repo.Uri == "" || repo.Path == "" {
-		return "", errors.New("repository Uri and Path should be populated")
+		return "", errors.New("repository uri and path should be populated")
 	}
 
-	// this will not overwrite the original path given how we used a value receiver for this function
 	dir, err := os.MkdirTemp("/tmp", "temp-git-files")
 	if err != nil {
 		return "", fmt.Errorf("could not create temporary directory for CalculateGitContentType: %s", err.Error())
@@ -208,10 +207,6 @@ func (f Fetcher) CalculateGitContentType(repo testkube.Repository) (string, erro
 			output.PrintLog(fmt.Sprintf("%s Could not clean up after CalculateGitContentType: %s", ui.IconWarning, err.Error()))
 		}
 	}()
-
-	if err != nil {
-		return "", fmt.Errorf("could not create temporary directory %s: %w", f.path, err)
-	}
 
 	path, err := f.FetchGitFile(&repo)
 	if err != nil {

--- a/pkg/executor/content/fetcher.go
+++ b/pkg/executor/content/fetcher.go
@@ -196,7 +196,7 @@ func (f Fetcher) CalculateGitContentType(repo testkube.Repository) (string, erro
 		return "", errors.New("repository uri and path should be populated")
 	}
 
-	dir, err := os.MkdirTemp("/tmp", "temp-git-files")
+	dir, err := os.MkdirTemp("", "temp-git-files")
 	if err != nil {
 		return "", fmt.Errorf("could not create temporary directory for CalculateGitContentType: %s", err.Error())
 	}

--- a/pkg/executor/content/fetcher_test.go
+++ b/pkg/executor/content/fetcher_test.go
@@ -1,5 +1,3 @@
-//go:build integration
-
 // this test need git to test fetchers
 package content
 
@@ -95,17 +93,17 @@ func TestFetcher(t *testing.T) {
 		t.Run("with file", func(t *testing.T) {
 			repo := testkube.NewGitRepository("https://github.com/kubeshop/testkube-examples.git", "main").WithPath("example.json")
 
-			ok, err := f.IsGitDir(repo)
+			contentType, err := f.CalculateGitContentType(repo)
 			assert.NoError(t, err)
-			assert.False(t, ok)
+			assert.Equal(t, "git-file", contentType)
 		})
 
 		t.Run("with dir", func(t *testing.T) {
 			repo := testkube.NewGitRepository("https://github.com/kubeshop/testkube-examples.git", "main").WithPath("subdir")
 
-			ok, err := f.IsGitDir(repo)
+			contentType, err := f.CalculateGitContentType(repo)
 			assert.NoError(t, err)
-			assert.True(t, ok)
+			assert.Equal(t, "git-dir", contentType)
 		})
 	})
 }

--- a/pkg/executor/content/fetcher_test.go
+++ b/pkg/executor/content/fetcher_test.go
@@ -90,4 +90,22 @@ func TestFetcher(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, "", path)
 	})
+
+	t.Run("test IsGitDir", func(t *testing.T) {
+		t.Run("with file", func(t *testing.T) {
+			repo := testkube.NewGitRepository("https://github.com/kubeshop/testkube-examples.git", "main").WithPath("example.json")
+
+			ok, err := f.IsGitDir(repo)
+			assert.NoError(t, err)
+			assert.False(t, ok)
+		})
+
+		t.Run("with dir", func(t *testing.T) {
+			repo := testkube.NewGitRepository("https://github.com/kubeshop/testkube-examples.git", "main").WithPath("subdir")
+
+			ok, err := f.IsGitDir(repo)
+			assert.NoError(t, err)
+			assert.True(t, ok)
+		})
+	})
 }

--- a/pkg/executor/content/fetcher_test.go
+++ b/pkg/executor/content/fetcher_test.go
@@ -1,3 +1,5 @@
+//go:build integration
+
 // this test need git to test fetchers
 package content
 
@@ -93,7 +95,7 @@ func TestFetcher(t *testing.T) {
 		t.Run("with file", func(t *testing.T) {
 			repo := testkube.NewGitRepository("https://github.com/kubeshop/testkube-examples.git", "main").WithPath("example.json")
 
-			contentType, err := f.CalculateGitContentType(repo)
+			contentType, err := f.CalculateGitContentType(*repo)
 			assert.NoError(t, err)
 			assert.Equal(t, "git-file", contentType)
 		})
@@ -101,7 +103,7 @@ func TestFetcher(t *testing.T) {
 		t.Run("with dir", func(t *testing.T) {
 			repo := testkube.NewGitRepository("https://github.com/kubeshop/testkube-examples.git", "main").WithPath("subdir")
 
-			contentType, err := f.CalculateGitContentType(repo)
+			contentType, err := f.CalculateGitContentType(*repo)
 			assert.NoError(t, err)
 			assert.Equal(t, "git-dir", contentType)
 		})

--- a/pkg/executor/content/interface.go
+++ b/pkg/executor/content/interface.go
@@ -10,6 +10,7 @@ type ContentFetcher interface {
 	GitFileFetcher
 
 	Fetch(content *testkube.TestContent) (path string, err error)
+	CalculateGitContentType(repo testkube.Repository) (string, error)
 }
 
 // StringFetcher interface for fetching string based content to file

--- a/pkg/scheduler/test_scheduler.go
+++ b/pkg/scheduler/test_scheduler.go
@@ -263,8 +263,6 @@ func (s *Scheduler) getExecuteOptions(namespace, id string, request testkube.Exe
 				s.logger.Warnf("Unable to calculate Git content type for Test Source %s: %w", testSourceCR.Name, err)
 			}
 		}
-
-		testCR.Spec = mergeContents(testCR.Spec, testSourceCR.Spec)
 	}
 
 	if request.ContentRequest != nil {


### PR DESCRIPTION
## Pull request description 

During investigation on https://github.com/kubeshop/testkube/issues/3198, I saw that we do not have the option to specify the git type (git-file or git-dir) when we are using test sources via the UI.

This PR addresses that by adding a function to decide on the go what the type of the input is. Unfortunately it is not possible to get the type of a path without cloning the repo, so this means the repo will be cloned twice on execution: once in the api-server to check the type on the go, and once in the init-container. This has the upside that in case the type changes between the creation of the test and the execution, Testkube will be aware of it.

## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [x] tested locally
- [ ] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [x] added a test

## Breaking changes

-

## Changes

-

## Fixes

-