### PR TITLE
fix: ENV/param checks reanabled for Cypress tests

### DIFF
--- a/test/cypress/executor-tests/cypress-10/cypress/e2e/dummy_test.cy.js
+++ b/test/cypress/executor-tests/cypress-10/cypress/e2e/dummy_test.cy.js
@@ -2,10 +2,10 @@ describe('Testkube website', () => {
   it('Open Testkube website', () => {
     cy.visit('/')
   })
-  it.skip(`Validate CYPRESS_CUSTOM_ENV ENV (${Cypress.env('CUSTOM_ENV')})`, () => {
+  it(`Validate CYPRESS_CUSTOM_ENV ENV (${Cypress.env('CUSTOM_ENV')})`, () => {
     expect('CYPRESS_CUSTOM_ENV_value').to.equal(Cypress.env('CUSTOM_ENV')) //CYPRESS_CUSTOM_ENV - "cypress" prefix - auto-loaded from global ENVs
   })
-  it.skip(`Validate NON_CYPRESS_ENV ENV (${Cypress.env('NON_CYPRESS_ENV')})`, () => {
+  it(`Validate NON_CYPRESS_ENV ENV (${Cypress.env('NON_CYPRESS_ENV')})`, () => {
     expect('NON_CYPRESS_ENV_value').to.equal(Cypress.env('NON_CYPRESS_ENV')) //NON_CYPRESS_ENV - need to be loaded with --env parameter
   })
 })

--- a/test/cypress/executor-tests/cypress-11/cypress/e2e/smoke.cy.js
+++ b/test/cypress/executor-tests/cypress-11/cypress/e2e/smoke.cy.js
@@ -1,11 +1,11 @@
-describe('Testkube website', () => { //TODO: disabled for now - reenable after: https://github.com/kubeshop/testkube/issues/2540
+describe('Testkube website', () => {
   it('Open Testkube website', () => {
     cy.visit('/')
   })
-  it.skip(`Validate CYPRESS_CUSTOM_ENV ENV (${Cypress.env('CUSTOM_ENV')})`, () => {
+  it(`Validate CYPRESS_CUSTOM_ENV ENV (${Cypress.env('CUSTOM_ENV')})`, () => {
     expect('CYPRESS_CUSTOM_ENV_value').to.equal(Cypress.env('CUSTOM_ENV')) //CYPRESS_CUSTOM_ENV - "cypress" prefix - auto-loaded from global ENVs
   })
-  it.skip(`Validate NON_CYPRESS_ENV ENV (${Cypress.env('NON_CYPRESS_ENV')})`, () => {
+  it(`Validate NON_CYPRESS_ENV ENV (${Cypress.env('NON_CYPRESS_ENV')})`, () => {
     expect('NON_CYPRESS_ENV_value').to.equal(Cypress.env('NON_CYPRESS_ENV')) //NON_CYPRESS_ENV - need to be loaded with --env parameter
   })
 })


### PR DESCRIPTION
Reanabled after #2540 