### PR TITLE
docs: remove domain CNAME

### DIFF
--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -9,8 +9,8 @@ const config = {
   title: "Testkube Documentation",
   tagline:
     "Your somewhat opinionated and friendly Kubernetes testing framework",
-  url: "https://docs.testkube.io",
-  baseUrl: "/",
+  url: "https://kubeshop.github.io",
+  baseUrl: "/testkube/",
   onBrokenLinks: "throw",
   onBrokenMarkdownLinks: "warn",
   favicon: "img/logo.svg",

--- a/docs/static/CNAME
+++ b/docs/static/CNAME
@@ -1,1 +1,0 @@
-docs.testkube.io


### PR DESCRIPTION
Algolia search needs to work with the new domain, and we're stuck until the Algolia team updates the domain, which is unpredictable blocker. 

Returning to old link for now until we get new Algolia domain, 

## Pull request description 



## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [ ] tested locally
- [ ] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Breaking changes

-

## Changes

-

## Fixes

-