### PR TITLE
fix: cloud cli set api uri correctly, removed explicit agent config from context

### DIFF
--- a/cmd/kubectl-testkube/commands/common.go
+++ b/cmd/kubectl-testkube/commands/common.go
@@ -167,3 +167,21 @@ func PopulateUpgradeInstallFlags(cmd *cobra.Command, options *HelmUpgradeOrInsta
 	cmd.Flags().BoolVar(&options.NoMongo, "no-mongo", false, "don't install MongoDB")
 	cmd.Flags().BoolVar(&options.NoConfirm, "no-confirm", false, "don't ask for confirmation - unatended installation mode")
 }
+
+func PopulateAgentDataToContext(options HelmUpgradeOrInstalTestkubeOptions, cfg config.Data) error {
+	updated := false
+	if options.AgentKey != "" {
+		cfg.CloudContext.AgentKey = options.AgentKey
+		updated = true
+	}
+	if options.AgentUri != "" {
+		cfg.CloudContext.AgentUri = options.AgentUri
+		updated = true
+	}
+
+	if updated {
+		return config.Save(cfg)
+	}
+
+	return nil
+}

--- a/cmd/kubectl-testkube/commands/common/client.go
+++ b/cmd/kubectl-testkube/commands/common/client.go
@@ -55,6 +55,8 @@ func GetClient(cmd *cobra.Command) (client.Client, string) {
 		options.CloudEnvironment = cfg.CloudContext.Environment
 		options.CloudOrganization = cfg.CloudContext.Organization
 		options.ApiUri = cfg.CloudContext.ApiUri
+	default:
+		ui.Failf("unknown context type: %s", cfg.ContextType)
 	}
 
 	c, err := client.GetClient(client.ClientType(clientType), options)

--- a/cmd/kubectl-testkube/commands/context/set.go
+++ b/cmd/kubectl-testkube/commands/context/set.go
@@ -30,7 +30,7 @@ func NewSetContextCmd() *cobra.Command {
 
 			switch cfg.ContextType {
 			case config.ContextTypeCloud:
-				if org == "" && env == "" && apiKey == "" && agentKey == "" && agentUri == "" {
+				if org == "" && env == "" && apiKey == "" && agentKey == "" && agentUri == "" && apiUri == "" {
 					ui.Errf("Please provide at least one of the following flags: --org, --env, --api-key, --cloud-api-uri, --cloud-agent-key, --cloud-agent-uri")
 				}
 
@@ -46,18 +46,9 @@ func NewSetContextCmd() *cobra.Command {
 				}
 				if apiKey != "" {
 					cfg.CloudContext.ApiKey = apiKey
+				}
+				if apiUri != "" {
 					cfg.CloudContext.ApiUri = apiUri
-				}
-				if apiKey != "" {
-					cfg.CloudContext.ApiKey = apiKey
-					cfg.CloudContext.ApiUri = apiUri
-				}
-
-				if agentKey != "" {
-					cfg.CloudContext.AgentKey = agentKey
-				}
-				if agentUri != "" {
-					cfg.CloudContext.AgentUri = agentUri
 				}
 
 			case config.ContextTypeKubeconfig:
@@ -77,12 +68,10 @@ func NewSetContextCmd() *cobra.Command {
 	}
 
 	cmd.Flags().BoolVarP(&kubeconfig, "kubeconfig", "", false, "reset context mode for CLI to default kubeconfig based")
-	cmd.Flags().StringVarP(&org, "org", "o", "", "Testkube Cloud organization ID")
-	cmd.Flags().StringVarP(&env, "env", "e", "", "Testkube Cloud environment ID")
+	cmd.Flags().StringVarP(&org, "org", "o", "", "Testkube Cloud Organization ID")
+	cmd.Flags().StringVarP(&env, "env", "e", "", "Testkube Cloud Environment ID")
 	cmd.Flags().StringVarP(&apiKey, "api-key", "k", "", "API Key for Testkube Cloud")
-	cmd.Flags().StringVarP(&apiUri, "cloud-api-uri", "", "https://api.testkube.io", "Testkube Cloud API URI")
-	cmd.Flags().StringVarP(&agentKey, "cloud-agent-key", "", "", "Agent Key for Testkube Cloud")
-	cmd.Flags().StringVarP(&agentUri, "cloud-agent-uri", "", "agent.testkube.io:443", "Testkube Cloud Agent URI")
+	cmd.Flags().StringVarP(&apiUri, "cloud-api-uri", "", "https://api.testkube.io", "Testkube Cloud API URI - defaults to api.testksube.io")
 
 	return cmd
 }

--- a/cmd/kubectl-testkube/commands/context/ui.go
+++ b/cmd/kubectl-testkube/commands/context/ui.go
@@ -11,14 +11,20 @@ func uiPrintCloudContext(contextType string, cloudContext config.CloudContext) {
 	ui.NL()
 
 	if contextType == string(config.ContextTypeCloud) {
-		ui.InfoGrid(map[string]string{
+		contextData := map[string]string{
 			"Organization ID": cloudContext.Organization,
 			"Environment ID ": cloudContext.Environment,
 			"API Key        ": text.Obfuscate(cloudContext.ApiKey),
 			"API URI        ": cloudContext.ApiUri,
-			"Agent Key      ": text.Obfuscate(cloudContext.AgentKey),
-			"Agent URI      ": cloudContext.AgentUri,
-		})
+		}
+
+		// add agent information only when need to change agent data, it's usually not needed in usual workflow
+		if ui.Verbose {
+			contextData["Agent Key"] = text.Obfuscate(cloudContext.AgentKey)
+			contextData["Agent URI"] = cloudContext.AgentUri
+		}
+
+		ui.InfoGrid(contextData)
 	} else {
 		ui.InfoGrid(map[string]string{
 			"context type": "kubeconfig",

--- a/cmd/kubectl-testkube/commands/init.go
+++ b/cmd/kubectl-testkube/commands/init.go
@@ -3,7 +3,9 @@ package commands
 import (
 	"github.com/spf13/cobra"
 
+	"github.com/kubeshop/testkube/cmd/kubectl-testkube/config"
 	"github.com/kubeshop/testkube/pkg/ui"
+	"github.com/kubeshop/testkube/pkg/utils/text"
 )
 
 func NewInitCmd() *cobra.Command {
@@ -17,13 +19,56 @@ func NewInitCmd() *cobra.Command {
 			ui.Info("WELCOME TO")
 			ui.Logo()
 
-			err := HelmUpgradeOrInstalTestkube(options)
+			cfg, err := config.Load()
+			ui.ExitOnError("loading config file", err)
+			ui.NL()
+
+			// set to cloud context explicitly when user pass agent key and store the key later
+			if options.AgentKey != "" {
+				cfg.CloudContext.AgentKey = options.AgentKey
+				cfg.ContextType = config.ContextTypeCloud
+			}
+
+			if !options.NoConfirm {
+				ui.Warn("This will install Testkube to the latest version. This may take a few minutes.")
+				ui.Warn("Please be sure you're on valid kubectl context before continuing!")
+				ui.NL()
+
+				currentContext, err := GetCurrentKubernetesContext()
+				ui.ExitOnError("getting current context", err)
+				ui.Alert("Current kubectl context:", currentContext)
+				ui.NL()
+
+				if ui.IsVerbose() && cfg.ContextType == config.ContextTypeCloud {
+					ui.Info("Your Testkube is in 'cloud' mode with following context")
+					ui.InfoGrid(map[string]string{
+						"Agent Key": text.Obfuscate(cfg.CloudContext.AgentKey),
+						"Agent URI": cfg.CloudContext.AgentUri,
+					})
+					ui.NL()
+				}
+
+				ok := ui.Confirm("Do you want to continue?")
+				if !ok {
+					ui.Errf("Testkube installation cancelled")
+					return
+				}
+			}
+
+			err = HelmUpgradeOrInstalTestkube(options)
 			ui.ExitOnError("Installing testkube", err)
 
-			ui.Info(`To help improve the quality of Testkube, we collect anonymous basic telemetry data.  Head out to https://kubeshop.github.io/testkube/telemetry/ to read our policy or feel free to:`)
+			if cfg.ContextType == config.ContextTypeCloud {
+				err = PopulateAgentDataToContext(options, cfg)
+				ui.ExitOnError("Storing agent data in context", err)
+			} else {
+				ui.Info(`To help improve the quality of Testkube, we collect anonymous basic telemetry data.  Head out to https://kubeshop.github.io/testkube/telemetry/ to read our policy or feel free to:`)
 
-			ui.NL()
-			ui.ShellCommand("disable telemetry by typing", "testkube disable telemetry")
+				ui.NL()
+				ui.ShellCommand("disable telemetry by typing", "testkube disable telemetry")
+				ui.NL()
+			}
+
 			ui.Info(" Happy Testing! 🚀")
 			ui.NL()
 

--- a/cmd/kubectl-testkube/commands/upgrade.go
+++ b/cmd/kubectl-testkube/commands/upgrade.go
@@ -41,6 +41,8 @@ func NewUpgradeCmd() *cobra.Command {
 				ui.Info("Testkube Cloud agent upgrade started")
 				err = HelmUpgradeOrInstallTestkubeCloud(options, cfg)
 				ui.ExitOnError("Upgrading Testkube Cloud Agent", err)
+				err = PopulateAgentDataToContext(options, cfg)
+				ui.ExitOnError("Storing agent data in context", err)
 			} else {
 				ui.Info("Updating testkube")
 				hasMigrations, err := RunMigrations(cmd)

--- a/cmd/kubectl-testkube/commands/upgrade.go
+++ b/cmd/kubectl-testkube/commands/upgrade.go
@@ -21,6 +21,12 @@ func NewUpgradeCmd() *cobra.Command {
 			ui.ExitOnError("loading config file", err)
 			ui.NL()
 
+			// set to cloud context explicitly when user pass agent key and store the key later
+			if options.AgentKey != "" {
+				cfg.CloudContext.AgentKey = options.AgentKey
+				cfg.ContextType = config.ContextTypeCloud
+			}
+
 			if !options.NoConfirm {
 				ui.Warn("This will upgrade Testkube to the latest version. This may take a few minutes.")
 				ui.Warn("Please be sure you're on valid kubectl context before continuing!")

--- a/cmd/kubectl-testkube/commands/upgrade.go
+++ b/cmd/kubectl-testkube/commands/upgrade.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/kubeshop/testkube/cmd/kubectl-testkube/config"
 	"github.com/kubeshop/testkube/pkg/ui"
+	"github.com/kubeshop/testkube/pkg/utils/text"
 )
 
 func NewUpgradeCmd() *cobra.Command {
@@ -29,6 +30,15 @@ func NewUpgradeCmd() *cobra.Command {
 				ui.ExitOnError("getting current context", err)
 				ui.Alert("Current kubectl context:", currentContext)
 				ui.NL()
+
+				if ui.IsVerbose() && cfg.ContextType == config.ContextTypeCloud {
+					ui.Info("Your Testkube is in 'cloud' mode with following context")
+					ui.InfoGrid(map[string]string{
+						"Agent Key": text.Obfuscate(cfg.CloudContext.AgentKey),
+						"Agent URI": cfg.CloudContext.AgentUri,
+					})
+					ui.NL()
+				}
 
 				ok := ui.Confirm("Do you want to continue?")
 				if !ok {

--- a/pkg/api/v1/client/factory.go
+++ b/pkg/api/v1/client/factory.go
@@ -41,10 +41,10 @@ func GetClient(clientType ClientType, options Options) (client Client, err error
 	sseClient := phttp.NewSSEClient()
 
 	switch clientType {
+
 	case ClientCloud:
 		ConfigureClient(httpClient, nil, options.CloudApiKey)
 		ConfigureClient(sseClient, nil, options.CloudApiKey)
-		// merge PATH prefix wirt
 		client = NewDirectAPIClient(httpClient, sseClient, options.ApiUri, options.CloudApiPathPrefix)
 
 	case ClientDirect:

--- a/pkg/ui/ui.go
+++ b/pkg/ui/ui.go
@@ -39,6 +39,7 @@ type UI struct {
 }
 
 func SetVerbose(verbose bool)                       { ui.Verbose = verbose }
+func IsVerbose() bool                               { return ui.Verbose }
 func ExitOnError(item string, errors ...error)      { ui.ExitOnError(item, errors...) }
 func PrintOnError(item string, errors ...error)     { ui.PrintOnError(item, errors...) }
 func WarnOnError(item string, errors ...error)      { ui.WarnOnError(item, errors...) }


### PR DESCRIPTION
## Pull request description 

Agent config is in upgrade context only

## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [ ] tested locally
- [ ] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Breaking changes

-

## Changes

-

## Fixes

-