### PR TITLE
feat: Executor tests updated after merging git-dir and git-file sources to single `git` source

### DIFF
--- a/test/artillery/executor-smoke/crd/crd.yaml
+++ b/test/artillery/executor-smoke/crd/crd.yaml
@@ -8,9 +8,9 @@ metadata:
 spec:
   type: artillery/test
   content:
-    type: git-file
+    type: git
     repository:
-      type: git-file
+      type: git
       uri: https://github.com/kubeshop/testkube.git
       branch: main
       path: test/artillery/executor-smoke/artillery-smoke-test.yaml
@@ -25,9 +25,9 @@ metadata:
 spec:
   type: artillery/test
   content:
-    type: git-file
+    type: git
     repository:
-      type: git-file
+      type: git
       uri: https://github.com/kubeshop/testkube.git
       branch: main
       path: test/artillery/executor-smoke/artillery-smoke-test-negative.yaml

--- a/test/container-executor/executor-smoke/crd/playwright.yaml
+++ b/test/container-executor/executor-smoke/crd/playwright.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   type: container-executor-playwright-v1.31.1/test
   content:
-    type: git-dir
+    type: git
     repository:
       type: git
       uri: https://github.com/kubeshop/testkube

--- a/test/curl/executor-tests/crd/smoke.yaml
+++ b/test/curl/executor-tests/crd/smoke.yaml
@@ -8,9 +8,9 @@ metadata:
 spec:
   type: curl/test
   content:
-    type: git-file
+    type: git
     repository:
-      type: git-file
+      type: git
       uri: https://github.com/kubeshop/testkube.git
       branch: main
       path: test/curl/executor-tests/curl-smoke-test.json
@@ -25,9 +25,9 @@ metadata:
 spec:
   type: curl/test
   content:
-    type: git-file
+    type: git
     repository:
-      type: git-file
+      type: git
       uri: https://github.com/kubeshop/testkube.git
       branch: main
       path: test/curl/executor-tests/curl-smoke-test-negative.json

--- a/test/cypress/executor-tests/crd/crd.yaml
+++ b/test/cypress/executor-tests/crd/crd.yaml
@@ -106,6 +106,68 @@ spec:
       - --env
       - NON_CYPRESS_ENV=NON_CYPRESS_ENV_value
 ---
+apiVersion: tests.testkube.io/v3
+kind: Test
+metadata:
+  name: cypress-default-executor-smoke-electron-git-dir
+  namespace: testkube
+  labels:
+    core-tests: executors
+spec:
+  type: cypress/project
+  content:
+    type: git-dir # backwards compatibility check
+    repository:
+      type: git
+      uri: https://github.com/kubeshop/testkube
+      branch: main
+      path: test/cypress/executor-tests/cypress-11
+  executionRequest:
+    variables:
+      CYPRESS_CUSTOM_ENV:
+        name: CYPRESS_CUSTOM_ENV
+        value: CYPRESS_CUSTOM_ENV_value
+        type: basic
+    args:
+      - --env
+      - NON_CYPRESS_ENV=NON_CYPRESS_ENV_value
+---
+# cypress-default-executor-smoke-electron-testsource TestSource
+apiVersion: tests.testkube.io/v1
+kind: TestSource
+metadata:
+  name: testsource-cypress-default-executor-smoke-electron-testsource
+  namespace: testkube
+spec:
+  type: git
+  repository:
+    type: git
+    uri: https://github.com/kubeshop/testkube.git
+    branch: main
+    path: test/cypress/executor-tests/cypress-11
+---
+# cypress-default-executor-smoke-electron-testsource - Test
+apiVersion: tests.testkube.io/v3
+kind: Test
+metadata:
+  name: cypress-default-executor-smoke-electron-testsource
+  namespace: testkube
+spec:
+  type: cypress/project
+  content:
+    repository:
+      path: test/cypress/executor-tests/cypress-11
+  source: testsource-cypress-default-executor-smoke-electron-testsource
+  executionRequest:
+    variables:
+      CYPRESS_CUSTOM_ENV:
+        name: CYPRESS_CUSTOM_ENV
+        value: CYPRESS_CUSTOM_ENV_value
+        type: basic
+    args:
+      - --env
+      - NON_CYPRESS_ENV=NON_CYPRESS_ENV_value
+---
 # cypress-default-executor-smoke-electron-testsource-git-dir - TestSource
 apiVersion: tests.testkube.io/v1
 kind: TestSource
@@ -113,7 +175,7 @@ metadata:
   name: testsource-cypress-default-executor-smoke-electron-testsource-git-dir
   namespace: testkube
 spec:
-  type: git
+  type: git-dir # backwards compatibility check
   repository:
     type: git
     uri: https://github.com/kubeshop/testkube.git

--- a/test/cypress/executor-tests/crd/crd.yaml
+++ b/test/cypress/executor-tests/crd/crd.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   type: cypress:v11/test
   content:
-    type: git-dir
+    type: git
     repository:
       type: git
       uri: https://github.com/kubeshop/testkube
@@ -34,7 +34,7 @@ metadata:
 spec:
   type: cypress:v11/test
   content:
-    type: git-dir
+    type: git
     repository:
       type: git
       uri: https://github.com/kubeshop/testkube
@@ -62,7 +62,7 @@ metadata:
 spec:
   type: cypress:v11/test
   content:
-    type: git-dir
+    type: git
     repository:
       type: git
       uri: https://github.com/kubeshop/testkube
@@ -90,7 +90,7 @@ metadata:
 spec:
   type: cypress/project
   content:
-    type: git-dir
+    type: git
     repository:
       type: git
       uri: https://github.com/kubeshop/testkube
@@ -113,7 +113,7 @@ metadata:
   name: testsource-cypress-default-executor-smoke-electron-testsource-git-dir
   namespace: testkube
 spec:
-  type: git-dir
+  type: git
   repository:
     type: git
     uri: https://github.com/kubeshop/testkube.git
@@ -152,7 +152,7 @@ metadata:
 spec:
   type: cypress:v10/test
   content:
-    type: git-dir
+    type: git
     repository:
       type: git
       uri: https://github.com/kubeshop/testkube
@@ -178,7 +178,7 @@ metadata:
 spec:
   type: cypress:v10/test
   content:
-    type: git-dir
+    type: git
     repository:
       type: git
       uri: https://github.com/kubeshop/testkube
@@ -207,7 +207,7 @@ metadata:
 spec:
   type: cypress:v10/test
   content:
-    type: git-dir
+    type: git
     repository:
       type: git
       uri: https://github.com/kubeshop/testkube
@@ -235,7 +235,7 @@ metadata:
 spec:
   type: cypress:v9/test
   content:
-    type: git-dir
+    type: git
     repository:
       type: git
       uri: https://github.com/kubeshop/testkube
@@ -252,7 +252,7 @@ metadata:
 spec:
   type: cypress:v9/test
   content:
-    type: git-dir
+    type: git
     repository:
       type: git
       uri: https://github.com/kubeshop/testkube
@@ -273,7 +273,7 @@ metadata:
 spec:
   type: cypress:v9/test
   content:
-    type: git-dir
+    type: git
     repository:
       type: git
       uri: https://github.com/kubeshop/testkube
@@ -294,7 +294,7 @@ metadata:
 spec:
   type: cypress:v8/test
   content:
-    type: git-dir
+    type: git
     repository:
       type: git
       uri: https://github.com/kubeshop/testkube
@@ -311,7 +311,7 @@ metadata:
 spec:
   type: cypress:v8/test
   content:
-    type: git-dir
+    type: git
     repository:
       type: git
       uri: https://github.com/kubeshop/testkube
@@ -332,7 +332,7 @@ metadata:
 spec:
   type: cypress:v8/test
   content:
-    type: git-dir
+    type: git
     repository:
       type: git
       uri: https://github.com/kubeshop/testkube
@@ -353,7 +353,7 @@ metadata:
 spec:
   type: cypress/project
   content:
-    type: git-dir
+    type: git
     repository:
       type: git
       uri: https://github.com/kubeshop/testkube

--- a/test/gradle/executor-smoke/crd/crd.yaml
+++ b/test/gradle/executor-smoke/crd/crd.yaml
@@ -10,7 +10,7 @@ metadata:
 spec:
   type: gradle:jdk18/test
   content:
-    type: git-dir
+    type: git
     repository:
       type: git
       uri: https://github.com/kubeshop/testkube-executor-gradle.git
@@ -33,7 +33,7 @@ metadata:
 spec:
   type: gradle:jdk17/test
   content:
-    type: git-dir
+    type: git
     repository:
       type: git
       uri: https://github.com/kubeshop/testkube-executor-gradle.git
@@ -56,7 +56,7 @@ metadata:
 spec:
   type: gradle:jdk11/test
   content:
-    type: git-dir
+    type: git
     repository:
       type: git
       uri: https://github.com/kubeshop/testkube-executor-gradle.git
@@ -79,7 +79,7 @@ metadata:
 spec:
   type: gradle:jdk8/test
   content:
-    type: git-dir
+    type: git
     repository:
       type: git
       uri: https://github.com/kubeshop/testkube-executor-gradle.git
@@ -102,7 +102,7 @@ metadata:
 spec:
   type: gradle:jdk18/test
   content:
-    type: git-dir
+    type: git
     repository:
       type: git
       uri: https://github.com/kubeshop/testkube-executor-gradle.git

--- a/test/jmeter/executor-tests/crd/smoke.yaml
+++ b/test/jmeter/executor-tests/crd/smoke.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   type: jmeter/test
   content:
-    type: git-file
+    type: git
     repository:
       type: git
       uri: https://github.com/kubeshop/testkube.git
@@ -25,7 +25,7 @@ metadata:
 spec:
   type: jmeter/test
   content:
-    type: git-file
+    type: git
     repository:
       type: git
       uri: https://github.com/kubeshop/testkube.git
@@ -50,7 +50,7 @@ metadata:
 spec:
   type: jmeter/test
   content:
-    type: git-file
+    type: git
     repository:
       type: git
       uri: https://github.com/kubeshop/testkube.git

--- a/test/k6/executor-tests/crd/other.yaml
+++ b/test/k6/executor-tests/crd/other.yaml
@@ -2,7 +2,7 @@
 apiVersion: tests.testkube.io/v3
 kind: Test
 metadata:
-  name: k6-executor-smoke-git-dir
+  name: k6-executor-smoke-directory
   namespace: testkube
   labels:
     core-tests: executors

--- a/test/k6/executor-tests/crd/other.yaml
+++ b/test/k6/executor-tests/crd/other.yaml
@@ -9,7 +9,7 @@ metadata:
 spec:
   type: k6/script
   content:
-    type: git-dir
+    type: git
     repository:
       type: git
       uri: https://github.com/kubeshop/testkube.git

--- a/test/k6/executor-tests/crd/smoke.yaml
+++ b/test/k6/executor-tests/crd/smoke.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   type: k6/script
   content:
-    type: git-file
+    type: git
     repository:
       type: git
       uri: https://github.com/kubeshop/testkube.git
@@ -34,7 +34,7 @@ metadata:
 spec:
   type: k6/script
   content:
-    type: git-file
+    type: git
     repository:
       type: git
       uri: https://github.com/kubeshop/testkube.git

--- a/test/k6/executor-tests/crd/smoke.yaml
+++ b/test/k6/executor-tests/crd/smoke.yaml
@@ -27,6 +27,32 @@ spec:
 apiVersion: tests.testkube.io/v3
 kind: Test
 metadata:
+  name: k6-executor-smoke-git-file
+  namespace: testkube
+  labels:
+    core-tests: executors
+spec:
+  type: k6/script
+  content:
+    type: git-file
+    repository:
+      type: git
+      uri: https://github.com/kubeshop/testkube.git
+      branch: main
+      path: test/k6/executor-tests/k6-smoke-test.js
+  executionRequest:
+    variables:
+      K6_SYSTEM_ENV:
+        name: K6_SYSTEM_ENV
+        value: K6_SYSTEM_ENV_value
+        type: basic
+    args:
+      - -e
+      - K6_ENV_FROM_PARAM=K6_ENV_FROM_PARAM_value
+---
+apiVersion: tests.testkube.io/v3
+kind: Test
+metadata:
   name: k6-executor-smoke-negative
   namespace: testkube
   labels:

--- a/test/kubepug/executor-smoke/crd/crd.yaml
+++ b/test/kubepug/executor-smoke/crd/crd.yaml
@@ -8,9 +8,9 @@ metadata:
 spec:
   type: kubepug/yaml
   content:
-    type: git-file
+    type: git
     repository:
-      type: git-file
+      type: git
       uri: https://github.com/kubeshop/testkube.git
       branch: main
       path: test/kubepug/executor-smoke/crd/crd.yaml
@@ -25,9 +25,9 @@ metadata:
 spec:
   type: kubepug/yaml
   content:
-    type: git-file
+    type: git
     repository:
-      type: git-file
+      type: git
       uri: https://github.com/kubeshop/testkube.git
       branch: main
       path: test/kubepug/executor-smoke/kubepug-smoke-test-negative.yaml

--- a/test/maven/executor-smoke/crd/crd.yaml
+++ b/test/maven/executor-smoke/crd/crd.yaml
@@ -10,7 +10,7 @@ metadata:
 spec:
   type: maven:jdk18/test
   content:
-    type: git-dir
+    type: git
     repository:
       type: git
       uri: https://github.com/kubeshop/testkube-executor-maven.git
@@ -33,7 +33,7 @@ metadata:
 spec:
   type: maven:jdk11/test
   content:
-    type: git-dir
+    type: git
     repository:
       type: git
       uri: https://github.com/kubeshop/testkube-executor-maven.git
@@ -56,7 +56,7 @@ metadata:
 spec:
   type: maven:jdk18/test
   content:
-    type: git-dir
+    type: git
     repository:
       type: git
       uri: https://github.com/kubeshop/testkube-executor-maven.git

--- a/test/maven/executor-smoke/crd/negative.yaml
+++ b/test/maven/executor-smoke/crd/negative.yaml
@@ -3,14 +3,14 @@
 apiVersion: tests.testkube.io/v3
 kind: Test
 metadata:
-  name: maven-executor-smoke-jdk18  # expected failure - ENVs not set
+  name: maven-executor-smoke-jdk18-negative  # expected failure - ENVs not set
   namespace: testkube
   labels:
     core-tests: executors-negative
 spec:
   type: maven:jdk18/test
   content:
-    type: git-dir
+    type: git
     repository:
       type: git
       uri: https://github.com/kubeshop/testkube-executor-maven.git

--- a/test/playwright/executor-tests/crd/crd.yaml
+++ b/test/playwright/executor-tests/crd/crd.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   type: playwright/test
   content:
-    type: git-dir
+    type: git
     repository:
       type: git
       uri: https://github.com/kubeshop/testkube

--- a/test/postman/executor-tests/crd/crd.yaml
+++ b/test/postman/executor-tests/crd/crd.yaml
@@ -8,9 +8,9 @@ metadata:
 spec:
   type: postman/collection
   content:
-    type: git-file
+    type: git
     repository:
-      type: git-file
+      type: git
       uri: https://github.com/kubeshop/testkube.git
       branch: main
       path: test/postman/executor-tests/postman-executor-smoke.postman_collection.json
@@ -26,7 +26,7 @@ metadata:
   name: testsource-postman-executor-smoke-testsource-git-file
   namespace: testkube
 spec:
-  type: git-file
+  type: git
   repository:
     type: git
     uri: https://github.com/kubeshop/testkube.git
@@ -54,7 +54,7 @@ metadata:
   name: testsource-postman-executor-smoke-testsource-overwrite
   namespace: testkube
 spec:
-  type: git-file
+  type: git
   repository:
     type: git
     uri: https://github.com/kubeshop/testkube.git
@@ -89,9 +89,9 @@ metadata:
 spec:
   type: postman/collection
   content:
-    type: git-file
+    type: git
     repository:
-      type: git-file
+      type: git
       uri: https://github.com/kubeshop/testkube.git
       branch: main
       path: test/postman/executor-tests/postman-executor-smoke-negative.postman_collection.json

--- a/test/postman/executor-tests/crd/crd.yaml
+++ b/test/postman/executor-tests/crd/crd.yaml
@@ -62,7 +62,7 @@ metadata:
   namespace: testkube
 spec:
   type: postman/collection
-  source: testsource-postman-executor-smoke-testsource-git-file
+  source: testsource-postman-executor-smoke-testsource
   executionRequest:
     args:
       - --env-var
@@ -75,7 +75,7 @@ metadata:
   name: testsource-postman-executor-smoke-testsource-git-file
   namespace: testkube
 spec:
-  type: git-file
+  type: git-file # backwards compatibility check
   repository:
     type: git
     uri: https://github.com/kubeshop/testkube.git

--- a/test/postman/executor-tests/crd/crd.yaml
+++ b/test/postman/executor-tests/crd/crd.yaml
@@ -19,6 +19,55 @@ spec:
       - --env-var
       - TESTKUBE_POSTMAN_PARAM=TESTKUBE_POSTMAN_PARAM_value
 ---
+apiVersion: tests.testkube.io/v3
+kind: Test
+metadata:
+  name: postman-executor-smoke-git-file # backwards compatibility check
+  namespace: testkube
+  labels:
+    core-tests: executors
+spec:
+  type: postman/collection
+  content:
+    type: git-file
+    repository:
+      type: git
+      uri: https://github.com/kubeshop/testkube.git
+      branch: main
+      path: test/postman/executor-tests/postman-executor-smoke.postman_collection.json
+  executionRequest:
+    args:
+      - --env-var
+      - TESTKUBE_POSTMAN_PARAM=TESTKUBE_POSTMAN_PARAM_value
+---
+# postman-executor-smoke-testsource - TestSource
+apiVersion: tests.testkube.io/v1
+kind: TestSource
+metadata:
+  name: testsource-postman-executor-smoke-testsource
+  namespace: testkube
+spec:
+  type: git
+  repository:
+    type: git
+    uri: https://github.com/kubeshop/testkube.git
+    branch: main
+    path: test/postman/executor-tests/postman-executor-smoke.postman_collection.json
+---
+# postman-executor-smoke-testsource - Test
+apiVersion: tests.testkube.io/v3
+kind: Test
+metadata:
+  name: postman-executor-smoke-testsource
+  namespace: testkube
+spec:
+  type: postman/collection
+  source: testsource-postman-executor-smoke-testsource-git-file
+  executionRequest:
+    args:
+      - --env-var
+      - TESTKUBE_POSTMAN_PARAM=TESTKUBE_POSTMAN_PARAM_value
+---
 # postman-executor-smoke-testsource-git-file - TestSource
 apiVersion: tests.testkube.io/v1
 kind: TestSource
@@ -26,7 +75,7 @@ metadata:
   name: testsource-postman-executor-smoke-testsource-git-file
   namespace: testkube
 spec:
-  type: git
+  type: git-file
   repository:
     type: git
     uri: https://github.com/kubeshop/testkube.git

--- a/test/soapui/executor-smoke/crd/crd.yaml
+++ b/test/soapui/executor-smoke/crd/crd.yaml
@@ -8,9 +8,9 @@ metadata:
 spec:
   type: soapui/xml
   content:
-    type: git-file
+    type: git
     repository:
-      type: git-file
+      type: git
       uri: https://github.com/kubeshop/testkube.git
       branch: main
       path: test/soapui/executor-smoke/soapui-smoke-test.xml
@@ -25,9 +25,9 @@ metadata:
 spec:
   type: soapui/xml
   content:
-    type: git-file
+    type: git
     repository:
-      type: git-file
+      type: git
       uri: https://github.com/kubeshop/testkube.git
       branch: main
       path: test/soapui/executor-smoke/soapui-smoke-test-negative.xml

--- a/test/suites/demo-testsuite.json
+++ b/test/suites/demo-testsuite.json
@@ -3,7 +3,7 @@
     "description": "Demo release tests",
     "steps": [
         {"execute": {"name": "postman-executor-smoke"}},
-        {"execute": {"name": "postman-executor-smoke-testsource-git-file"}},
+        {"execute": {"name": "postman-executor-smoke-testsource"}},
         {"execute": {"name": "k6-executor-smoke"}},
         {"execute": {"name": "container-executor-curl-smoke"}},
         {"execute" :{"name": "cypress-11-executor-smoke-chrome"}},

--- a/test/suites/demo-testsuite.json
+++ b/test/suites/demo-testsuite.json
@@ -7,6 +7,6 @@
         {"execute": {"name": "k6-executor-smoke"}},
         {"execute": {"name": "container-executor-curl-smoke"}},
         {"execute" :{"name": "cypress-11-executor-smoke-chrome"}},
-        {"execute" :{"name": "cypress-default-executor-smoke-electron-testsource-git-dir"}}
+        {"execute" :{"name": "cypress-default-executor-smoke-electron-testsource"}}
     ]
 }

--- a/test/suites/executor-cypress-smoke-tests.json
+++ b/test/suites/executor-cypress-smoke-tests.json
@@ -15,6 +15,8 @@
 		{"execute": {"name": "cypress-8-executor-smoke-chrome"}},
 		{"execute": {"name": "cypress-8-executor-smoke-firefox"}},
 		{"execute": {"name": "cypress-default-executor-smoke-electron"}},
+		{"execute": {"name": "cypress-default-executor-smoke-electron-git-dir"}},
+		{"execute": {"name": "cypress-default-executor-smoke-electron-testsource"}},
 		{"execute": {"name": "cypress-default-executor-smoke-electron-testsource-git-dir"}}
 	]
 }

--- a/test/suites/executor-k6-other-tests.json
+++ b/test/suites/executor-k6-other-tests.json
@@ -2,6 +2,6 @@
 	"name": "executor-k6-other-tests",
 	"description": "k6 executor - other tests and edge-cases",
 	"steps": [
-		{"execute": {"name": "k6-executor-smoke-git-dir"}}
+		{"execute": {"name": "k6-executor-smoke-directory"}}
 	]
 }

--- a/test/suites/executor-k6-smoke-tests.json
+++ b/test/suites/executor-k6-smoke-tests.json
@@ -3,6 +3,7 @@
 	"description": "k6 executor smoke tests",
 	"steps": [
 		{"execute": {"name": "k6-executor-smoke"}},
+		{"execute": {"name": "k6-executor-smoke-git-file"}},
 		{"execute": {"name": "k6-executor-smoke-negative"}}
 	]
 }

--- a/test/suites/executor-postman-smoke-tests.json
+++ b/test/suites/executor-postman-smoke-tests.json
@@ -3,6 +3,8 @@
 	"description": "postman executor smoke tests",
 	"steps": [
 		{"execute": {"name": "postman-executor-smoke"}},
+		{"execute": {"name": "postman-executor-smoke-git-file"}},
+		{"execute": {"name": "postman-executor-smoke-testsource"}},
 		{"execute": {"name": "postman-executor-smoke-testsource-git-file"}},
 		{"execute": {"name": "postman-executor-smoke-testsource-overwrite"}},
 		{"execute": {"name": "postman-executor-smoke-negative"}}

--- a/test/suites/staging-testsuite.json
+++ b/test/suites/staging-testsuite.json
@@ -3,7 +3,7 @@
     "description": "Staging release tests",
     "steps": [
         {"execute": {"name": "postman-executor-smoke"}},
-        {"execute": {"name": "postman-executor-smoke-testsource-git-file"}},
+        {"execute": {"name": "postman-executor-smoke-testsource"}},
         {"execute": {"name": "k6-executor-smoke"}},
         {"execute": {"name": "container-executor-curl-smoke"}},
         {"execute" :{"name": "cypress-11-executor-smoke-chrome"}},

--- a/test/suites/staging-testsuite.json
+++ b/test/suites/staging-testsuite.json
@@ -7,6 +7,6 @@
         {"execute": {"name": "k6-executor-smoke"}},
         {"execute": {"name": "container-executor-curl-smoke"}},
         {"execute" :{"name": "cypress-11-executor-smoke-chrome"}},
-        {"execute" :{"name": "cypress-default-executor-smoke-electron-testsource-git-dir"}}
+        {"execute" :{"name": "cypress-default-executor-smoke-electron-testsource"}}
     ]
 }


### PR DESCRIPTION
Tests updated to `git` source, additional tests added for backwards compatibility checks (postman, k6, and cypress):
- git-file
- git-dir
- TestSource (git-file)
- TestSource (git-dir)

**Merge after #3063** 