### PR TITLE
fix: update default body size limit for http client

### DIFF
--- a/internal/app/api/v1/server.go
+++ b/internal/app/api/v1/server.go
@@ -45,7 +45,10 @@ import (
 	"github.com/kubeshop/testkube/pkg/utils/text"
 )
 
-const HeartbeatInterval = time.Hour
+const (
+	HeartbeatInterval = time.Hour
+	HttpBodyLimit     = 1 * 1024 * 1024 * 1024 // 1GB - needed for file uploads
+)
 
 func NewTestkubeAPI(
 	namespace string,
@@ -77,6 +80,7 @@ func NewTestkubeAPI(
 	}
 
 	httpConfig.ClusterID = clusterId
+	httpConfig.Http.BodyLimit = HttpBodyLimit
 
 	s := TestkubeAPI{
 		HTTPServer:           server.NewServer(httpConfig),


### PR DESCRIPTION
## Pull request description 

Complaint coming from user on Discord that uploading a file of size 250MB, the api server is returning: 413

![image](https://user-images.githubusercontent.com/10296566/222729572-714bf18a-3cb1-4318-a972-2263f95a8679.png)


## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [x] tested locally
- [ ] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Breaking changes

-

## Changes

-

## Fixes

-