### PR TITLE
fix: remove version check from set command

### DIFF
--- a/cmd/kubectl-testkube/commands/set.go
+++ b/cmd/kubectl-testkube/commands/set.go
@@ -3,8 +3,6 @@ package commands
 import (
 	"github.com/spf13/cobra"
 
-	"github.com/kubeshop/testkube/cmd/kubectl-testkube/commands/common"
-	"github.com/kubeshop/testkube/cmd/kubectl-testkube/commands/common/validator"
 	"github.com/kubeshop/testkube/cmd/kubectl-testkube/commands/context"
 	"github.com/kubeshop/testkube/pkg/ui"
 )
@@ -20,9 +18,7 @@ func NewSetCmd() *cobra.Command {
 			err := cmd.Help()
 			ui.PrintOnError("Displaying help", err)
 		},
-		PersistentPreRun: func(cmd *cobra.Command, args []string) {
-			validator.PersistentPreRunVersionCheck(cmd, common.Version)
-		}}
+	}
 
 	cmd.AddCommand(context.NewSetContextCmd())
 

--- a/pkg/api/v1/client/proxy_client.go
+++ b/pkg/api/v1/client/proxy_client.go
@@ -13,9 +13,10 @@ import (
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 
+	"github.com/pkg/errors"
+
 	"github.com/kubeshop/testkube/pkg/executor/output"
 	"github.com/kubeshop/testkube/pkg/problem"
-	"github.com/pkg/errors"
 )
 
 // GetClientSet configures Kube client set, can override host with local proxy

--- a/pkg/api/v1/client/proxy_client.go
+++ b/pkg/api/v1/client/proxy_client.go
@@ -15,19 +15,20 @@ import (
 
 	"github.com/kubeshop/testkube/pkg/executor/output"
 	"github.com/kubeshop/testkube/pkg/problem"
+	"github.com/pkg/errors"
 )
 
 // GetClientSet configures Kube client set, can override host with local proxy
 func GetClientSet(overrideHost string) (clientset kubernetes.Interface, err error) {
 	clcfg, err := clientcmd.NewDefaultClientConfigLoadingRules().Load()
 	if err != nil {
-		return clientset, err
+		return clientset, errors.Wrap(err, "failed to get clientset config")
 	}
 
 	restcfg, err := clientcmd.NewNonInteractiveClientConfig(
 		*clcfg, "", &clientcmd.ConfigOverrides{}, nil).ClientConfig()
 	if err != nil {
-		return clientset, err
+		return clientset, errors.Wrap(err, "failed to get non-interactive client config")
 	}
 
 	// override host is needed to override kubeconfig kubernetes proxy host name


### PR DESCRIPTION
## Pull request description 

As during set clients are not configured yet - so we can't use them. 
Related to issue with `set context`. 

## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [ ] tested locally
- [ ] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Breaking changes

-

## Changes

-

## Fixes

-