### PR TITLE
docs: update executor playwright report setting

### DIFF
--- a/docs/docs/test-types/executor-playwright.md
+++ b/docs/docs/test-types/executor-playwright.md
@@ -66,15 +66,15 @@ Running tests in a containerized environment is convenient: it's simple, portabl
 
 ### Reports
 
-Similarly to many other testing tools, Playwright provides the option to open a browser window for reports. It is important to make sure reporters are not opening additional windows. Please update your configuration files located at `playwright.config.js` or `playwright.config.ts`:
+Similarly to many other testing tools, Playwright provides the option to open a browser window for reports. It is important to make sure reporters are not opening additional windows. Configuration files located at `playwright.config.js` or `playwright.config.ts`:
 
 ```bash
 reporter: [
-  ['html', { open: 'never' }]
+  ['html']
 ],
 ```
 
-Having this option on the default setting will not block the Testkube test runner, as the following environment variables are set on a Dockerfile-level, but it is still important to be mindful of these differences.
+The following environment variables are set on a Dockerfile-level, but it is still important to be mindful of these differences.
 
 ```bash
 ENV CI=1

--- a/docs/docs/test-types/executor-playwright.md
+++ b/docs/docs/test-types/executor-playwright.md
@@ -66,13 +66,7 @@ Running tests in a containerized environment is convenient: it's simple, portabl
 
 ### Reports
 
-Similarly to many other testing tools, Playwright provides the option to open a browser window for reports. It is important to make sure reporters are not opening additional windows. Configuration files located at `playwright.config.js` or `playwright.config.ts`:
-
-```bash
-reporter: [
-  ['html']
-],
-```
+Similarly to many other testing tools, Playwright provides the option to open a browser window for reports. It is important to make sure reporters are not opening additional windows. 
 
 The following environment variables are set on a Dockerfile-level, but it is still important to be mindful of these differences.
 


### PR DESCRIPTION
It is not mandatory to block the browser's opening at the end of the execution of the tests


## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [ ] tested locally
- [ ] tested on cluster
- [ ] added new dependencies
- [x] updated the docs
- [ ] added a test

## Breaking changes

-

## Changes

-

## Fixes

-