### PR TITLE
docs: add info sections to executors

### DIFF
--- a/docs/docs/test-types/executor-ginkgo.md
+++ b/docs/docs/test-types/executor-ginkgo.md
@@ -1,9 +1,29 @@
+import Admonition from "@theme/Admonition";
+
 # Ginkgo
 
-Testkube allows us to run Ginkgo-based tests. (https://onsi.github.io/ginkgo/)
+Testkube allows us to run [Ginkgo-based tests](https://onsi.github.io/ginkgo/).
 
-| Ginkgo is a mature testing framework for Go designed to help you write expressive specs. Ginkgo builds on top of Go's testing foundation and is complemented by the Gomega matcher library. Together, Ginkgo and Gomega let you express the intent behind your specs clearly.
+export const ExecutorInfo = () => {
+  return (
+    <div>
+      <Admonition type="info" icon="🎓" title="What is Ginkgo Testing?">
+        <ul>
+          <li>Ginkgo is a mature testing framework for Go designed to help you write expressive specs. Ginkgo builds on top of Go's testing foundation and is complemented by the Gomega matcher library.</li>
+		  <li>Together, Ginkgo and Gomega let you express the intent behind your specs clearly.</li>
+        </ul>
+        <b>What can I do with the Ginkgo testing framework?</b>
+        <ul>
+          <li>With Ginkgo, you can run a huge variety of test types in all sorts of contexts: unit tests, integration tests, performance tests, acceptance tests, etc.</li>
+        </ul>
+      </Admonition>
+    </div>
+  );
+}
 
+<ExecutorInfo />
+
+**Check out our [blog post](https://testkube.io/blog/maximize-app-performance-in-kubernetes-with-ginkgo-and-testkube) to learn to write more expressive tests in Go using Ginkgo, Gomega, and Testkube.**
 
 ## **Test Environment**
 

--- a/docs/docs/test-types/executor-jmeter.md
+++ b/docs/docs/test-types/executor-jmeter.md
@@ -1,20 +1,34 @@
+import Admonition from "@theme/Admonition";
+
 # JMeter
 
+[JMeter](https://jmeter.apache.org/) is an integral part of Testkube. The Testkube JMeter executor is installed by default during the Testkube installation.
+
+export const ExecutorInfo = () => {
+  return (
+    <div>
+      <Admonition type="info" icon="🎓" title="What is JMeter?">
+        <ul>
+          <li>Apache JMeter is an open-source, pure Java application designed to load test functional behavior and measure performance. It was originally designed for testing Web Applications but has since expanded to other test functions.</li>
+        </ul>
+        <b>What can I do with JMeter?</b>
+        <ul>
+          <li>JMeter can be used to test performance both on static and dynamic resources and Web dynamic applications.</li>
+          <li>It can also be used to simulate a heavy load on a server, group of servers, network, or object to test its strength or to analyze overall performance under different load types.</li>
+        </ul>
+      </Admonition>
+    </div>
+  );
+}
+
+<ExecutorInfo />
+
 **Check out our [blog post](https://testkube.io/blog/jmeter-and-kubernetes-how-to-run-tests-efficiently-with-testkube) to follow tutorial steps for end-to-end testing of your Kubernetes applications with JMeter.**
-
-The Apache JMeter™ application is open source software, a 100% pure Java application designed to load test functional behavior and measure performance. It was originally designed for testing Web Applications but has since expanded to other test functions.
-
-## What can I do with it?
-
-Apache JMeter may be used to test performance both on static and dynamic resources and Web dynamic applications.
-It can be used to simulate a heavy load on a server, group of servers, network or object to test its strength or to analyze overall performance under different load types.
-
-[JMeter](https://jmeter.apache.org/) 
 
 
 ## **Running a JMeter Test**
 
-JMeter is integral part of Testkube. The Testkube JMeter executor is installed by default during the Testkube installation. To run a JMeter test in Testkube you need to create a Test. 
+To run a JMeter test in Testkube you need to create a Test: 
 
 ### **Using Files as Input**
 

--- a/docs/docs/test-types/executor-k6.mdx
+++ b/docs/docs/test-types/executor-k6.mdx
@@ -1,17 +1,32 @@
 import Tabs from "@theme/Tabs";
 import TabItem from "@theme/TabItem";
+import Admonition from "@theme/Admonition";
 
 # K6
 
+Testkube's k6 executor provides a convenient way of running k6 tests.
+
+export const ExecutorInfo = () => {
+  return (
+    <div>
+      <Admonition type="info" icon="🎓" title="What is k6?">
+        <ul>
+          <li><a href="https://k6.io/docs/">k6</a> is a free, developer-centric, and extensible open-source load testing tool that makes performance testing easy and productive for engineering teams.</li>
+        </ul>
+        <b>What can I do with k6?</b>
+        <ul>
+          <li>With k6, you can test the reliability and performance of your systems and catch performance regressions and problems earlier. K6 will help you to build resilient and performant applications that scale.</li>
+        </ul>
+        K6 is developed by Grafana Labs and the Open-Source community.
+      </Admonition>
+    </div>
+  );
+}
+
+<ExecutorInfo />
+
 **Check out our [blog post](https://kubeshop.io/blog/load-testing-in-kubernetes-with-k6-and-testkube) to follow tutorial steps to harness the power of k6 load testing in Kubernetes with Testkube's CLI and API.**
 
-[K6](https://k6.io/docs/) is an open-source load testing tool that makes performance testing easy and productive for engineering teams. K6 is free, developer-centric and extensible.
-
-Using k6, you can test the reliability and performance of your systems and catch performance regressions and problems earlier. K6 will help you to build resilient and performant applications that scale.
-
-K6 is developed by Grafana Labs and the community.
-
-Testkube's k6 executor provides a convenient way of running k6 tests.
 
 ## Example k6 test
 

--- a/docs/docs/test-types/executor-playwright.md
+++ b/docs/docs/test-types/executor-playwright.md
@@ -1,6 +1,30 @@
+import Admonition from "@theme/Admonition";
+
+
 # Playwright
 
-[Playwright](https://playwright.dev/) is an end-to-end testing and automation framework developed by Microsoft. Starting from the Testkube Helm chart version 1.9.5, it is now possible to use Testkube to manage your Playwright tests inside your Kubernetes cluster.
+Since the v1.9.5 Testkube Helm chart, it is now possible to use Testkube to manage your [Playwright](https://playwright.dev/) tests inside your Kubernetes cluster.
+
+export const ExecutorInfo = () => {
+  return (
+    <div>
+      <Admonition type="info" icon="🎓" title="What is Playwright Testing?">
+        <ul>
+          <li>Playwright is an end-to-end testing and automation framework developed by Microsoft.</li>
+        </ul>
+        <b>What can I do with Playwright?</b>
+        <ul>
+          <li>With Playwright, you can easily perform actions and assert the state against expectations.</li>
+          <li>Playwright supports end-to-end testing with multiple browsers, operating systems, and programming languages.</li>
+        </ul>
+      </Admonition>
+    </div>
+  );
+}
+
+<ExecutorInfo />
+
+**Check out our [blog post](https://testkube.io/blog/bring-playwright-tests-into-the-cloud-with-testkube) to learn how to harness the power of Playwright Testing in your cloud-native apps.**
 
 ## Running Playwright Tests
 

--- a/docs/docs/test-types/executor-postman.mdx
+++ b/docs/docs/test-types/executor-postman.mdx
@@ -1,16 +1,31 @@
 import Tabs from "@theme/Tabs";
 import TabItem from "@theme/TabItem";
+import Admonition from "@theme/Admonition";
 
 # Postman
 
-<!-- Watch this simple Testkube intro video for Postman collections with Testkube:
+Testkube is able to run Postman collections inside your Kubernetes cluster so it can be used to test internal or external services.
 
-<iframe width="560" height="315" src="https://www.youtube.com/embed/rWqlbVvd8Dc" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen>
-</iframe> -->
+export const ExecutorInfo = () => {
+  return (
+    <div>
+      <Admonition type="info" icon="🎓" title="What is Postman?">
+        <ul>
+          <li>Postman is a platform for designing, building, testing, and iterating APIs.</li>
+        </ul>
+        <b>What can I do with Postman?</b>
+        <ul>
+          <li>Postman simplifies every step of the API lifecycle, making it easy for you to iterate and test your APIs by sending and inspecting responses,
+          writing assertions to validate endpoints, or setting up logic to mirror your workflows.</li>
+        </ul>
+      </Admonition>
+    </div>
+  );
+}
+
+<ExecutorInfo />
 
 **Check out our [blog post](https://testkube.io/blog/api-testing-in-kubernetes-with-postman) to follow tutorial steps for end-to-end testing of your Kubernetes applications with Postman.**
-
-Testkube is able to run Postman collections inside your Kubernetes cluster so it can be used to test internal or external services.
 
 ## Prerequisite: Example Postman test
 ### Service Under Test

--- a/docs/docs/test-types/executor-soapui.md
+++ b/docs/docs/test-types/executor-soapui.md
@@ -1,8 +1,24 @@
+import Admonition from "@theme/Admonition";
+
 # SoapUI
 
-**Check out our [blog post](https://kubeshop.io/blog/run-kubernetes-tests-with-soapui-and-testkube) to follow tutorial steps to Learn how to run functional tests in Kubernetes with SoapUI and Testkube.**
+Testkube supports the [SoapUI](https://www.soapui.org) executor implementation.
 
-[SoapUI](https://www.soapui.org) is an open-source tool used for end-to-end testing of REST, SOAP and GraphQL APIs, as well as JMS, JDBC and other web services. Testkube supports the SoapUI executor implementation.
+export const ExecutorInfo = () => {
+   return (
+    <div>
+      <Admonition type="info" icon="🎓" title="What is SoapUI?">
+        <ul>
+          <li>SoapUI is an open-source tool used for end-to-end testing of REST, SOAP and GraphQL APIs, as well as JMS, JDBC and other web services.</li>
+        </ul>
+      </Admonition>
+    </div>
+  );
+}
+
+<ExecutorInfo />
+
+**Check out our [blog post](https://kubeshop.io/blog/run-kubernetes-tests-with-soapui-and-testkube) to follow tutorial steps to Learn how to run functional tests in Kubernetes with SoapUI and Testkube.**
 
 ## **Running a SoapUI Test**
 

--- a/docs/src/css/custom.css
+++ b/docs/src/css/custom.css
@@ -333,7 +333,9 @@ ul:hover {
   background-color: var(--ifm-color-third);
   border-left-color: var(--ifm-color-primary);
 }
-
+.theme-admonition-info ul {
+  margin: 1ch;
+}
 /* article {
   max-width: 700px;
   margin-left: auto;


### PR DESCRIPTION
## Pull request description 

added info sections with blog copy to executor pages: playwright, soapui, k6, postman, ginkgo


## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [ ] tested locally
- [ ] tested on cluster
- [ ] added new dependencies
- [x] updated the docs
- [ ] added a test

## Breaking changes

-

## Changes

-

## Fixes

-