### PR TITLE
feat: scraper updates and scraper template pattern function

### DIFF
--- a/pkg/cloud/data/artifact/scraper_integration_test.go
+++ b/pkg/cloud/data/artifact/scraper_integration_test.go
@@ -81,7 +81,7 @@ func TestCloudScraper(t *testing.T) {
 		Return([]byte(`{"URL":"`+testServer.URL+`/dummy"}`), nil)
 
 	req3 := &cloudscraper.PutObjectSignedURLRequest{
-		Object:        "file3.txt",
+		Object:        "subdir/file3.txt",
 		ExecutionID:   "my-execution-id",
 		TestName:      "my-test",
 		TestSuiteName: "my-test-suite",
@@ -96,7 +96,7 @@ func TestCloudScraper(t *testing.T) {
 		"testName":      "my-test",
 		"testSuiteName": "my-test-suite",
 	}
-	s := scraper.NewScraperV2(extractor, cloudLoader)
+	s := scraper.NewELScraper(extractor, cloudLoader)
 	err = s.Scrape(context.Background(), meta)
 	assert.NoError(t, err)
 	assert.Equal(t, 3, testServerRequests)

--- a/pkg/executor/agent/agent.go
+++ b/pkg/executor/agent/agent.go
@@ -2,10 +2,11 @@ package agent
 
 import (
 	"encoding/json"
-	"fmt"
 	"io"
 	"os"
 	"strings"
+
+	"github.com/pkg/errors"
 
 	"github.com/kubeshop/testkube/pkg/api/v1/testkube"
 	"github.com/kubeshop/testkube/pkg/executor"
@@ -23,16 +24,25 @@ func Run(r runner.Runner, args []string) {
 	var err error
 
 	stat, _ := os.Stdin.Stat()
-	if (stat.Mode() & os.ModeCharDevice) == 0 {
+	switch {
+	case (stat.Mode() & os.ModeCharDevice) == 0:
 		test, err = io.ReadAll(os.Stdin)
 		if err != nil {
-			output.PrintError(os.Stderr, fmt.Errorf("can't read stdin input: %w", err))
+			output.PrintError(os.Stderr, errors.Errorf("can't read stdin input: %v", err))
 			os.Exit(1)
 		}
-	} else if len(args) > 1 {
+	case len(args) > 1:
 		test = []byte(args[1])
-	} else {
-		output.PrintError(os.Stderr, fmt.Errorf("missing input JSON argument or stdin input"))
+		hasFileFlag := args[1] == "-f" || args[1] == "--file"
+		if hasFileFlag {
+			test, err = os.ReadFile(args[2])
+			if err != nil {
+				output.PrintError(os.Stderr, errors.Errorf("error reading JSON file: %v", err))
+				os.Exit(1)
+			}
+		}
+	default:
+		output.PrintError(os.Stderr, errors.Errorf("execution json must be provided using stdin, program argument or -f|--file flag"))
 		os.Exit(1)
 	}
 
@@ -40,7 +50,7 @@ func Run(r runner.Runner, args []string) {
 
 	err = json.Unmarshal(test, &e)
 	if err != nil {
-		output.PrintError(os.Stderr, err)
+		output.PrintError(os.Stderr, errors.Wrap(err, "error unmarshalling execution json"))
 		os.Exit(1)
 	}
 

--- a/pkg/executor/scraper/extractor_integration_test.go
+++ b/pkg/executor/scraper/extractor_integration_test.go
@@ -51,7 +51,7 @@ func TestFilesystemExtractor_Extract_Integration(t *testing.T) {
 			assert.Equal(t, b, []byte("test1"))
 		case "file2.txt":
 			assert.Equal(t, b, []byte("test2"))
-		case "file3.txt":
+		case "subdir/file3.txt":
 			assert.Equal(t, b, []byte("test3"))
 		default:
 			t.Fatalf("unexpected file: %s", object.Name)

--- a/pkg/executor/scraper/factory/factory.go
+++ b/pkg/executor/scraper/factory/factory.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/go-faster/errors"
+	"github.com/pkg/errors"
 
 	"github.com/kubeshop/testkube/pkg/agent"
 	"github.com/kubeshop/testkube/pkg/api/v1/testkube"

--- a/pkg/executor/scraper/factory/factory.go
+++ b/pkg/executor/scraper/factory/factory.go
@@ -1,0 +1,80 @@
+package factory
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/go-faster/errors"
+
+	"github.com/kubeshop/testkube/pkg/agent"
+	"github.com/kubeshop/testkube/pkg/api/v1/testkube"
+	"github.com/kubeshop/testkube/pkg/cloud"
+	cloudscraper "github.com/kubeshop/testkube/pkg/cloud/data/artifact"
+	cloudexecutor "github.com/kubeshop/testkube/pkg/cloud/data/executor"
+	"github.com/kubeshop/testkube/pkg/envs"
+	"github.com/kubeshop/testkube/pkg/executor/output"
+	"github.com/kubeshop/testkube/pkg/executor/scraper"
+	"github.com/kubeshop/testkube/pkg/filesystem"
+	"github.com/kubeshop/testkube/pkg/log"
+	"github.com/kubeshop/testkube/pkg/ui"
+)
+
+func Scrape(ctx context.Context, dirs []string, execution testkube.Execution, params envs.Params) (err error) {
+	output.PrintLog(fmt.Sprintf("%s Extracting artifacts from %s using Filesystem Extractor", ui.IconCheckMark, dirs))
+
+	extractor := scraper.NewFilesystemExtractor(dirs, filesystem.NewOSFileSystem())
+
+	var loader scraper.Uploader
+	var meta map[string]any
+	var closeF func() error
+	if params.CloudMode {
+		meta = cloudscraper.ExtractCloudLoaderMeta(execution)
+		loader, closeF, err = getCloudLoader(ctx, params)
+		if err != nil {
+			return errors.Wrap(err, "error creating cloud loader")
+		}
+		defer closeF()
+	} else {
+		meta = scraper.ExtractMinIOUploaderMeta(execution)
+
+		loader, err = getMinIOLoader(params)
+		if err != nil {
+			return errors.Wrap(err, "error creating minio loader")
+		}
+	}
+	elScraper := scraper.NewELScraper(extractor, loader)
+	if err = elScraper.Scrape(ctx, meta); err != nil {
+		output.PrintLog(fmt.Sprintf("%s Error encountered while scraping artifacts", ui.IconCross))
+		return errors.Errorf("error scraping artifacts: %v", err)
+	}
+
+	return nil
+}
+
+func getCloudLoader(ctx context.Context, params envs.Params) (uploader *cloudscraper.CloudUploader, closeF func() error, err error) {
+	output.PrintLog(fmt.Sprintf("%s Uploading artifacts using Cloud Uploader", ui.IconCheckMark))
+
+	grpcConn, err := agent.NewGRPCConnection(ctx, params.CloudAPITLSInsecure, params.CloudAPIURL, log.DefaultLogger)
+	if err != nil {
+		return nil, nil, err
+	}
+	closeF = func() error {
+		return grpcConn.Close()
+	}
+	grpcClient := cloud.NewTestKubeCloudAPIClient(grpcConn)
+	cloudExecutor := cloudexecutor.NewCloudGRPCExecutor(grpcClient, params.CloudAPIKey)
+	return cloudscraper.NewCloudUploader(cloudExecutor), closeF, nil
+}
+
+func getMinIOLoader(params envs.Params) (*scraper.MinIOUploader, error) {
+	output.PrintLog(fmt.Sprintf("%s Uploading artifacts using MinIO Uploader", ui.IconCheckMark))
+	return scraper.NewMinIOLoader(
+		params.Endpoint,
+		params.AccessKeyID,
+		params.SecretAccessKey,
+		params.Location,
+		params.Token,
+		params.Bucket,
+		params.Ssl,
+	)
+}

--- a/pkg/executor/scraper/filesystem_extractor.go
+++ b/pkg/executor/scraper/filesystem_extractor.go
@@ -52,6 +52,9 @@ func (e *FilesystemExtractor) Extract(ctx context.Context, process ProcessFn) er
 				if err != nil {
 					return errors.Wrapf(err, "error getting relative path for %s", path)
 				}
+				if relpath == "." {
+					relpath = fileInfo.Name()
+				}
 				object := &Object{
 					Name: relpath,
 					Size: fileInfo.Size(),

--- a/pkg/executor/scraper/filesystem_extractor.go
+++ b/pkg/executor/scraper/filesystem_extractor.go
@@ -3,6 +3,7 @@ package scraper
 import (
 	"context"
 	"os"
+	"path/filepath"
 
 	"github.com/kubeshop/testkube/pkg/log"
 
@@ -47,14 +48,18 @@ func (e *FilesystemExtractor) Extract(ctx context.Context, process ProcessFn) er
 				if err != nil {
 					return errors.Wrapf(err, "error opening buffered %s", path)
 				}
+				relpath, err := filepath.Rel(dir, path)
+				if err != nil {
+					return errors.Wrapf(err, "error getting relative path for %s", path)
+				}
 				object := &Object{
-					Name: fileInfo.Name(),
+					Name: relpath,
 					Size: fileInfo.Size(),
 					Data: reader,
 				}
-				log.DefaultLogger.Infof("filesystem extractor is sending file to be processed: %v", fileInfo.Name())
+				log.DefaultLogger.Infof("filesystem extractor is sending file to be processed: %v", object.Name)
 				if err := process(ctx, object); err != nil {
-					return errors.Wrapf(err, "failed to process file %s", fileInfo.Name())
+					return errors.Wrapf(err, "failed to process file %s", object.Name)
 				}
 
 				return nil

--- a/pkg/executor/scraper/minio_uploader.go
+++ b/pkg/executor/scraper/minio_uploader.go
@@ -13,14 +13,14 @@ import (
 	"github.com/kubeshop/testkube/pkg/utils"
 )
 
-type MinIOLoader struct {
+type MinIOUploader struct {
 	Endpoint, AccessKeyID, SecretAccessKey, Location, Token, Bucket string
 	Ssl                                                             bool
 	client                                                          *minio.Client
 }
 
-func NewMinIOLoader(endpoint, accessKeyID, secretAccessKey, location, token, bucket string, ssl bool) (*MinIOLoader, error) {
-	l := &MinIOLoader{
+func NewMinIOLoader(endpoint, accessKeyID, secretAccessKey, location, token, bucket string, ssl bool) (*MinIOUploader, error) {
+	l := &MinIOUploader{
 		Endpoint:        endpoint,
 		AccessKeyID:     accessKeyID,
 		SecretAccessKey: secretAccessKey,
@@ -40,7 +40,7 @@ func NewMinIOLoader(endpoint, accessKeyID, secretAccessKey, location, token, buc
 	return l, nil
 }
 
-func (l *MinIOLoader) Upload(ctx context.Context, object *Object, meta map[string]any) error {
+func (l *MinIOUploader) Upload(ctx context.Context, object *Object, meta map[string]any) error {
 	folder, err := utils.GetStringKey(meta, "executionId")
 	if err != nil {
 		return err
@@ -54,7 +54,7 @@ func (l *MinIOLoader) Upload(ctx context.Context, object *Object, meta map[strin
 	return nil
 }
 
-func ExtractMinIOLoaderMeta(execution testkube.Execution) map[string]any {
+func ExtractMinIOUploaderMeta(execution testkube.Execution) map[string]any {
 	return map[string]any{
 		"executionId": execution.Id,
 	}

--- a/pkg/executor/scraper/scraper.go
+++ b/pkg/executor/scraper/scraper.go
@@ -10,19 +10,19 @@ type Scraper interface {
 	Scrape(executionID string, directories []string) error
 }
 
-type ScraperV2 struct {
+type ELScraper struct {
 	extractor Extractor
 	loader    Uploader
 }
 
-func NewScraperV2(extractor Extractor, loader Uploader) *ScraperV2 {
-	return &ScraperV2{
+func NewELScraper(extractor Extractor, loader Uploader) *ELScraper {
+	return &ELScraper{
 		extractor: extractor,
 		loader:    loader,
 	}
 }
 
-func (s *ScraperV2) Scrape(ctx context.Context, meta map[string]any) error {
+func (s *ELScraper) Scrape(ctx context.Context, meta map[string]any) error {
 	return s.
 		extractor.
 		Extract(ctx, func(ctx context.Context, object *Object) error {


### PR DESCRIPTION
## Pull request description 

* Updates to Scraper so it has a blueprint Scrape method which all Executors will call, and that will hide any cloud related stuff from Runners.
* Fix and integration test for a special case for filepath.Rel in Filesystem Extractor
* Support for -f|--file in Executor Agent so Executors can easily be run locally 

## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [x] tested locally
- [x] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [x] added a test

## Breaking changes

-

## Changes

-

## Fixes

-