### PR TITLE
add bool flag to modify git clone args for bitbucket server auth

### DIFF
--- a/api/v1/testkube.yaml
+++ b/api/v1/testkube.yaml
@@ -3474,6 +3474,10 @@ components:
         token:
           type: string
           description: git auth token for private repositories
+        isBitbucketServerToken:
+          type: boolean
+          description: if true git clone will be executed with the http.extraHeader arg set to the value specified in token
+          example: "false"
         usernameSecret:
           $ref: "#/components/schemas/SecretRef"
         tokenSecret:

--- a/cmd/kubectl-testkube/commands/tests/create.go
+++ b/cmd/kubectl-testkube/commands/tests/create.go
@@ -15,7 +15,7 @@ import (
 	"github.com/kubeshop/testkube/pkg/ui"
 )
 
-// NewCreateTestsCmd is a command tp create new Test Custom Resource
+// NewCreateTestsCmd is a command to create new Test Custom Resource
 func NewCreateTestsCmd() *cobra.Command {
 
 	var (
@@ -33,6 +33,7 @@ func NewCreateTestsCmd() *cobra.Command {
 		gitToken                 string
 		gitUsernameSecret        map[string]string
 		gitTokenSecret           map[string]string
+		isBitbucketToken         bool
 		gitCertificateSecret     string
 		sourceName               string
 		labels                   map[string]string
@@ -151,6 +152,7 @@ func NewCreateTestsCmd() *cobra.Command {
 	cmd.Flags().StringVarP(&gitWorkingDir, "git-working-dir", "", "", "if repository contains multiple directories with tests (like monorepo) and one starting directory we can set working directory parameter")
 	cmd.Flags().StringVarP(&gitUsername, "git-username", "", "", "if git repository is private we can use username as an auth parameter")
 	cmd.Flags().StringVarP(&gitToken, "git-token", "", "", "if git repository is private we can use token as an auth parameter")
+	cmd.Flags().BoolVar(&isBitbucketToken, "is-bitbucket-token", false, "if true the http.extraHeader arg will be appended to the git clone command")
 	cmd.Flags().StringToStringVarP(&gitUsernameSecret, "git-username-secret", "", map[string]string{}, "git username secret in a form of secret_name1=secret_key1 for private repository")
 	cmd.Flags().StringToStringVarP(&gitTokenSecret, "git-token-secret", "", map[string]string{}, "git token secret in a form of secret_name1=secret_key1 for private repository")
 	cmd.Flags().StringVarP(&gitCertificateSecret, "git-certificate-secret", "", "", "if git repository is private we can use certificate as an auth parameter stored in a kubernetes secret name")

--- a/cmd/kubectl-testkube/commands/testsources/create.go
+++ b/cmd/kubectl-testkube/commands/testsources/create.go
@@ -23,6 +23,7 @@ func NewCreateTestSourceCmd() *cobra.Command {
 		gitPath              string
 		gitUsername          string
 		gitToken             string
+		isBitbucketToken     bool
 		gitWorkingDir        string
 		labels               map[string]string
 		gitUsernameSecret    map[string]string
@@ -89,6 +90,7 @@ func NewCreateTestSourceCmd() *cobra.Command {
 	cmd.Flags().StringVarP(&gitPath, "git-path", "", "", "if repository is big we need to define additional path to directory/file to checkout partially")
 	cmd.Flags().StringVarP(&gitUsername, "git-username", "", "", "if git repository is private we can use username as an auth parameter")
 	cmd.Flags().StringVarP(&gitToken, "git-token", "", "", "if git repository is private we can use token as an auth parameter")
+	cmd.Flags().BoolVar(&isBitbucketToken, "is-bitbucket-token", false, "if true the http.extraHeader arg will be appended to the git clone command")
 	cmd.Flags().StringToStringVarP(&gitUsernameSecret, "git-username-secret", "", map[string]string{}, "git username secret in a form of secret_name1=secret_key1 for private repository")
 	cmd.Flags().StringToStringVarP(&gitTokenSecret, "git-token-secret", "", map[string]string{}, "git token secret in a form of secret_name1=secret_key1 for private repository")
 	cmd.Flags().StringVarP(&gitCertificateSecret, "git-certificate-secret", "", "", "if git repository is private we can use certificate as an auth parameter stored in a kubernetes secret name")

--- a/pkg/api/v1/testkube/model_repository.go
+++ b/pkg/api/v1/testkube/model_repository.go
@@ -24,9 +24,11 @@ type Repository struct {
 	// git auth username for private repositories
 	Username string `json:"username,omitempty"`
 	// git auth token for private repositories
-	Token          string     `json:"token,omitempty"`
-	UsernameSecret *SecretRef `json:"usernameSecret,omitempty"`
-	TokenSecret    *SecretRef `json:"tokenSecret,omitempty"`
+	Token string `json:"token,omitempty"`
+	// if true git clone will be executed with the http.extraHeader arg set to the value specified in token
+	IsBitbucketServerToken bool       `json:"isBitbucketServerToken,omitempty"`
+	UsernameSecret         *SecretRef `json:"usernameSecret,omitempty"`
+	TokenSecret            *SecretRef `json:"tokenSecret,omitempty"`
 	// secret with certificate for private repositories
 	CertificateSecret string `json:"certificateSecret,omitempty"`
 	// if provided we checkout the whole repository and run test from this directory

--- a/pkg/api/v1/testkube/model_repository_update.go
+++ b/pkg/api/v1/testkube/model_repository_update.go
@@ -24,9 +24,11 @@ type RepositoryUpdate struct {
 	// git auth username for private repositories
 	Username *string `json:"username,omitempty"`
 	// git auth token for private repositories
-	Token          *string     `json:"token,omitempty"`
-	UsernameSecret **SecretRef `json:"usernameSecret,omitempty"`
-	TokenSecret    **SecretRef `json:"tokenSecret,omitempty"`
+	Token *string `json:"token,omitempty"`
+	// if true git clone will be executed with the http.extraHeader arg set to the value specified in token
+	IsBitbucketServerToken *bool       `json:"isBitbucketServerToken,omitempty"`
+	UsernameSecret         **SecretRef `json:"usernameSecret,omitempty"`
+	TokenSecret            **SecretRef `json:"tokenSecret,omitempty"`
 	// secret with certificate for private repositories
 	CertificateSecret *string `json:"certificateSecret,omitempty"`
 	// if provided we checkout the whole repository and run test from this directory

--- a/pkg/executor/content/fetcher.go
+++ b/pkg/executor/content/fetcher.go
@@ -91,7 +91,7 @@ func (f Fetcher) FetchGitDir(repo *testkube.Repository) (path string, err error)
 
 	// if path not set make full repo checkout
 	if repo.Path == "" || repo.WorkingDir != "" {
-		path, err := git.Checkout(uri, repo.Branch, repo.Commit, f.path)
+		path, err := git.Checkout(uri, repo.Branch, repo.Commit, repo.Token, f.path, repo.IsBitbucketServerToken)
 		if err != nil {
 			output.PrintLog(fmt.Sprintf("%s Failed to fetch git dir: %s", ui.IconCross, err.Error()))
 			return path, fmt.Errorf("failed to fetch git dir: %w", err)
@@ -100,7 +100,7 @@ func (f Fetcher) FetchGitDir(repo *testkube.Repository) (path string, err error)
 		return path, nil
 	}
 
-	path, err = git.PartialCheckout(uri, repo.Path, repo.Branch, repo.Commit, f.path)
+	path, err = git.PartialCheckout(uri, repo.Path, repo.Branch, repo.Commit, repo.Token, f.path, repo.IsBitbucketServerToken)
 	if err != nil {
 		output.PrintLog(fmt.Sprintf("%s Failed to do partial checkout on git dir: %s", ui.IconCross, err.Error()))
 		return path, fmt.Errorf("failed to do partial checkout on git dir: %w", err)
@@ -117,7 +117,7 @@ func (f Fetcher) FetchGitFile(repo *testkube.Repository) (path string, err error
 		return path, err
 	}
 
-	repoPath, err := git.Checkout(uri, repo.Branch, repo.Commit, f.path)
+	repoPath, err := git.Checkout(uri, repo.Branch, repo.Commit, repo.Token, f.path, repo.IsBitbucketServerToken)
 	if err != nil {
 		output.PrintLog(fmt.Sprintf("%s Failed to checkout git file: %s", ui.IconCross, err.Error()))
 		return path, err
@@ -138,7 +138,7 @@ func (f Fetcher) FetchGit(repo *testkube.Repository) (path string, err error) {
 
 	// if path not set make full repo checkout
 	if repo.Path == "" || repo.WorkingDir != "" {
-		path, err := git.Checkout(uri, repo.Branch, repo.Commit, f.path)
+		path, err := git.Checkout(uri, repo.Branch, repo.Commit, repo.Token, f.path, repo.IsBitbucketServerToken)
 		if err != nil {
 			output.PrintLog(fmt.Sprintf("%s Failed to fetch git: %s", ui.IconCross, err.Error()))
 			return path, fmt.Errorf("failed to fetch git: %w", err)
@@ -160,7 +160,7 @@ func (f Fetcher) FetchGit(repo *testkube.Repository) (path string, err error) {
 		return path, nil
 	}
 
-	path, err = git.PartialCheckout(uri, repo.Path, repo.Branch, repo.Commit, f.path)
+	path, err = git.PartialCheckout(uri, repo.Path, repo.Branch, repo.Commit, repo.Token, f.path, repo.IsBitbucketServerToken)
 	if err != nil {
 		output.PrintLog(fmt.Sprintf("%s Failed to do partial checkout on git: %s", ui.IconCross, err.Error()))
 		return path, fmt.Errorf("failed to do partial checkout on git: %w", err)

--- a/pkg/git/checkout.go
+++ b/pkg/git/checkout.go
@@ -4,6 +4,7 @@
 package git
 
 import (
+	"fmt"
 	"os"
 
 	"github.com/kubeshop/testkube/pkg/process"
@@ -72,7 +73,7 @@ func CheckoutCommit(uri, path, commit, dir string) (err error) {
 }
 
 // Checkout will checkout directory from Git repository
-func Checkout(uri, branch, commit, dir string) (outputDir string, err error) {
+func Checkout(uri, branch, commit, token, dir string, isBitbucketServerToken bool) (outputDir string, err error) {
 	tmpDir := dir
 	if tmpDir == "" {
 		tmpDir, err = os.MkdirTemp("", "git-checkout")
@@ -83,6 +84,15 @@ func Checkout(uri, branch, commit, dir string) (outputDir string, err error) {
 
 	if commit == "" {
 		args := []string{"clone"}
+
+		// In some orgs using a username and a password to authenticate against Git servers is
+		// prohibited. This appends the HTTP Authorization header to the git clone args to
+		// authenticate using a bearer token. More info:
+		// https://confluence.atlassian.com/bitbucketserver/http-access-tokens-939515499.html
+		if isBitbucketServerToken {
+			args = append(args, "-c", fmt.Sprintf("http.extraHeader='Authorization: Bearer %s'", token))
+		}
+
 		if branch != "" {
 			args = append(args, "-b", branch)
 		}
@@ -106,7 +116,7 @@ func Checkout(uri, branch, commit, dir string) (outputDir string, err error) {
 }
 
 // PartialCheckout will checkout only given directory from Git repository
-func PartialCheckout(uri, path, branch, commit, dir string) (outputDir string, err error) {
+func PartialCheckout(uri, path, branch, commit, token, dir string, isBitbucketServerToken bool) (outputDir string, err error) {
 	tmpDir := dir
 	if tmpDir == "" {
 		tmpDir, err = os.MkdirTemp("", "git-sparse-checkout")
@@ -117,6 +127,15 @@ func PartialCheckout(uri, path, branch, commit, dir string) (outputDir string, e
 
 	if commit == "" {
 		args := []string{"clone"}
+
+		// In some orgs using a username and a password to authenticate against Git servers is
+		// prohibited. This appends the HTTP Authorization header to the git clone args to
+		// authenticate using a bearer token. More info:
+		// https://confluence.atlassian.com/bitbucketserver/http-access-tokens-939515499.html
+		if isBitbucketServerToken {
+			args = append(args, "-c", fmt.Sprintf("http.extraHeader='Authorization: Bearer %s'", token))
+		}
+
 		if branch != "" {
 			args = append(args, "-b", branch)
 		}

--- a/pkg/git/checkout_test.go
+++ b/pkg/git/checkout_test.go
@@ -11,7 +11,7 @@ func TestCheckOut(t *testing.T) {
 
 	repo := "https://github.com/cirosantilli/test-git-partial-clone-big-small"
 
-	dir, err := PartialCheckout(repo, "small", "master", "", "")
+	dir, err := PartialCheckout(repo, "small", "master", "", "", "", false)
 	t.Logf("partial repo checkedout to dir: %s", dir)
 	assert.NoError(t, err)
 	t.Fail()


### PR DESCRIPTION
## Pull request description 
By merging this PR, the API gets the functionality to inject a `git clone` command with the `http.extraHeader` arg set. This allows authentication with HTTP Access Tokesn on Bitbucket Server repositories. 


## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [ ] tested locally
- [ ] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Breaking changes

-

## Changes

- Updated OpenAPI definition
- Modified `Checkout` and `Fetch` functions to check if `isBitbucketServer` is set to `true`
- Added `isBitbucketServer` flag to CLI

## Fixes

-