### PR TITLE
fix: output too long for mongo

### DIFF
--- a/pkg/repository/result/mongo_test.go
+++ b/pkg/repository/result/mongo_test.go
@@ -388,10 +388,9 @@ func TestUpdateOutput(t *testing.T) {
 
 	testName := "example-test"
 	executionID := "example-execution"
-	executionStatus := testkube.RUNNING_ExecutionStatus
 
-	err = repository.insertExecutionResult(defaultName, testkube.FAILED_ExecutionStatus, time.Now(), map[string]string{"key1": "value1", "key2": "value2"})
-	assert.NoError(err)
+	err = repository.insertExecutionResult(testName, testkube.FAILED_ExecutionStatus, time.Now(), map[string]string{"key1": "value1", "key2": "value2"})
+	assert.NoError(t, err)
 
 	t.Run("valid input", func(t *testing.T) {
 		result := testkube.Execution{


### PR DESCRIPTION
## Pull request description 

https://github.com/kubeshop/testkube/issues/3463
Test result processing stopped when mongodb limit was reached. This fix ensures this will not block it.

## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [x] tested locally
- [ ] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Breaking changes

-

## Changes

-

## Fixes

-