### PR TITLE
fix: use gzip and allow big repsonses in cloud executor

### DIFF
--- a/pkg/cloud/data/executor/executor.go
+++ b/pkg/cloud/data/executor/executor.go
@@ -3,8 +3,10 @@ package executor
 import (
 	"context"
 	"encoding/json"
+	"math"
 
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/encoding/gzip"
 	"google.golang.org/protobuf/types/known/structpb"
 
 	"github.com/kubeshop/testkube/pkg/agent"
@@ -41,7 +43,7 @@ func (e *CloudGRPCExecutor) Execute(ctx context.Context, command Command, payloa
 		Payload: &s,
 	}
 	ctx = agent.AddAPIKeyMeta(ctx, e.apiKey)
-	var opts []grpc.CallOption
+	opts := []grpc.CallOption{grpc.UseCompressor(gzip.Name), grpc.MaxCallRecvMsgSize(math.MaxInt32)}
 	cmdResponse, err := e.client.Call(ctx, &req, opts...)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
## Pull request description 

When calling cloud repositories we need to allow to receive more 4 mib from cloud api.
Also use gzip to improve performance.


## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [ ] tested locally
- [ ] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Breaking changes

-

## Changes

-

## Fixes

-