### PR TITLE
chore: Update K6 Executor to 0.43.1

### DIFF
--- a/contrib/executor/k6/build/agent/Dockerfile
+++ b/contrib/executor/k6/build/agent/Dockerfile
@@ -2,8 +2,8 @@
 FROM golang:1.18 as builder
 
 # build k6 0.36.0 with prometheus support
-ENV K6_VERSION=v0.36.0
-RUN go install go.k6.io/xk6/cmd/xk6@v0.6.1 && xk6 build --with github.com/grafana/xk6-output-prometheus-remote@latest
+ENV K6_VERSION=v0.43.1
+RUN go install go.k6.io/xk6/cmd/xk6@v0.9.0 && xk6 build $K6_VERSION --with github.com/grafana/xk6-output-prometheus-remote@latest
 
 WORKDIR contrib/executor/k6/build
 
@@ -12,7 +12,7 @@ ENV GOOS=linux
 COPY . .
 RUN cd contrib/executor/k6/cmd/agent;go build -o /build/runner -mod mod -a .
 
-FROM loadimpact/k6:0.36.0
+FROM loadimpact/k6:0.43.1
 WORKDIR /home/k6
 COPY --from=builder /go/k6 /usr/bin/k6
 COPY --from=builder /build/runner /bin/runner


### PR DESCRIPTION
## Pull request description 

Updates K6 to 0.43.1.  Also uses the version env-var to the pin the version in a more predictable way.

I built locally and checked the version in the container, looking correct

```
~ $ k6 version
k6 v0.43.1 ((devel), go1.18.10, linux/arm64)
Extensions:
  github.com/grafana/xk6-output-prometheus-remote v0.2.0, xk6-prometheus-rw [output]
```

## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [x] tested locally
- [ ] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Changes

- Updated K6 Version
