### PR TITLE
fix: Close API server gracefully when signal appeared

### DIFF
--- a/internal/app/api/v1/graphql.go
+++ b/internal/app/api/v1/graphql.go
@@ -2,11 +2,12 @@ package v1
 
 import (
 	"context"
+	"net"
+	"net/http"
+
 	"github.com/kubeshop/testkube/internal/config"
 	"github.com/kubeshop/testkube/internal/graphql"
 	"github.com/kubeshop/testkube/pkg/log"
-	"net"
-	"net/http"
 )
 
 // RunGraphQLServer runs GraphQL server on go net/http server

--- a/internal/app/api/v1/graphql.go
+++ b/internal/app/api/v1/graphql.go
@@ -5,8 +5,8 @@ import (
 	"github.com/kubeshop/testkube/internal/config"
 	"github.com/kubeshop/testkube/internal/graphql"
 	"github.com/kubeshop/testkube/pkg/log"
+	"net"
 	"net/http"
-	"time"
 )
 
 // RunGraphQLServer runs GraphQL server on go net/http server
@@ -23,14 +23,16 @@ func (s *TestkubeAPI) RunGraphQLServer(
 
 	log.DefaultLogger.Infow("running GraphQL server", "port", cfg.GraphqlPort)
 
+	l, err := net.Listen("tcp", httpSrv.Addr)
+	if err != nil {
+		return err
+	}
+
 	go func() {
 		<-ctx.Done()
-		// sleep 2 seconds to cover the edge case if SIGTERM or SIGKILL signal occurs before the server is started,
-		// so the application does not get stuck
-		time.Sleep(2 * time.Second)
 		s.Log.Infof("shutting down Testkube GraphQL API server")
 		_ = httpSrv.Shutdown(context.Background())
 	}()
 
-	return httpSrv.ListenAndServe()
+	return httpSrv.Serve(l)
 }

--- a/pkg/server/httpserver.go
+++ b/pkg/server/httpserver.go
@@ -3,12 +3,13 @@ package server
 import (
 	"context"
 	"encoding/json"
+	"net"
+
 	"github.com/gofiber/adaptor/v2"
 	"github.com/gofiber/fiber/v2"
 	"github.com/gofiber/fiber/v2/middleware/pprof"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"go.uber.org/zap"
-	"net"
 
 	"github.com/kubeshop/testkube/pkg/log"
 	"github.com/kubeshop/testkube/pkg/problem"


### PR DESCRIPTION
## Pull request description 

* Close the GraphQL server gracefully when the app should be terminated
* Don't wait 2 seconds for closing the API servers, instead separate the listener and serve to avoid problems

## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [x] tested locally
- [ ] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Breaking changes

-

## Changes

-

## Fixes

- https://github.com/kubeshop/testkube/issues/3636