### PR TITLE
fix: Adjust GraphQL server initially

### DIFF
--- a/cmd/api-server/main.go
+++ b/cmd/api-server/main.go
@@ -64,7 +64,6 @@ import (
 	testsourcesclientv1 "github.com/kubeshop/testkube-operator/client/testsources/v1"
 	testsuitesclientv2 "github.com/kubeshop/testkube-operator/client/testsuites/v2"
 	apiv1 "github.com/kubeshop/testkube/internal/app/api/v1"
-	"github.com/kubeshop/testkube/internal/graphql"
 	"github.com/kubeshop/testkube/internal/migrations"
 	"github.com/kubeshop/testkube/pkg/configmap"
 	"github.com/kubeshop/testkube/pkg/log"
@@ -334,8 +333,6 @@ func main() {
 		ui.ExitOnError("Creating slack loader", err)
 	}
 
-	gqlServer := graphql.GetServer(eventBus, executorsClient)
-
 	api := apiv1.NewTestkubeAPI(
 		cfg.TestkubeNamespace,
 		resultsRepository,
@@ -358,7 +355,7 @@ func main() {
 		sched,
 		slackLoader,
 		storageClient,
-		gqlServer,
+		cfg.GraphqlPort,
 	)
 
 	isMinioStorage := cfg.LogsStorage == "minio"
@@ -436,7 +433,7 @@ func main() {
 	})
 
 	g.Go(func() error {
-		return api.RunGraphQLServer(ctx, cfg)
+		return api.RunGraphQLServer(ctx, cfg.GraphqlPort)
 	})
 
 	if err := g.Wait(); err != nil {

--- a/internal/app/api/v1/graphql.go
+++ b/internal/app/api/v1/graphql.go
@@ -20,7 +20,7 @@ func (s *TestkubeAPI) RunGraphQLServer(
 
 	mux := http.NewServeMux()
 	mux.Handle("/graphql", srv)
-	httpSrv := &http.Server{Addr: ":" + cfg.GraphqlPort}
+	httpSrv := &http.Server{Addr: ":" + cfg.GraphqlPort, Handler: mux}
 
 	log.DefaultLogger.Infow("running GraphQL server", "port", cfg.GraphqlPort)
 

--- a/internal/app/api/v1/graphql.go
+++ b/internal/app/api/v1/graphql.go
@@ -5,26 +5,21 @@ import (
 	"net"
 	"net/http"
 
-	"github.com/kubeshop/testkube/internal/config"
 	"github.com/kubeshop/testkube/internal/graphql"
 	"github.com/kubeshop/testkube/pkg/log"
 )
 
 // RunGraphQLServer runs GraphQL server on go net/http server
-// There is an issue with gqlgen and fasthttp server
-func (s *TestkubeAPI) RunGraphQLServer(
-	ctx context.Context,
-	cfg *config.Config,
-) error {
+func (s *TestkubeAPI) RunGraphQLServer(ctx context.Context, port string) error {
 	srv := graphql.GetServer(s.Events.Bus, s.ExecutorsClient)
 
 	mux := http.NewServeMux()
 	mux.Handle("/graphql", srv)
-	httpSrv := &http.Server{Addr: ":" + cfg.GraphqlPort, Handler: mux}
+	httpSrv := &http.Server{Handler: mux}
 
-	log.DefaultLogger.Infow("running GraphQL server", "port", cfg.GraphqlPort)
+	log.DefaultLogger.Infow("running GraphQL server", "port", port)
 
-	l, err := net.Listen("tcp", httpSrv.Addr)
+	l, err := net.Listen("tcp", ":"+port)
 	if err != nil {
 		return err
 	}

--- a/internal/app/api/v1/server.go
+++ b/internal/app/api/v1/server.go
@@ -356,8 +356,16 @@ func (s *TestkubeAPI) InitRoutes() {
 			}
 
 			// Extract Unix connection
-			serverSock, _ := serverConn.(*net.TCPConn)
-			clientSock, _ := reflect.Indirect(reflect.ValueOf(c)).FieldByName("Conn").Interface().(*net.TCPConn)
+			serverSock, ok := serverConn.(*net.TCPConn)
+			if !ok {
+				s.Log.Errorw("error while building TCPConn out ouf serverConn", "error", err)
+				return
+			}
+			clientSock, ok := reflect.Indirect(reflect.ValueOf(c)).FieldByName("Conn").Interface().(*net.TCPConn)
+			if !ok {
+				s.Log.Errorw("error while building TCPConn out of hijacked connection", "error", err)
+				return
+			}
 
 			// Close the connection afterward
 			defer clientSock.Close()

--- a/internal/app/api/v1/server.go
+++ b/internal/app/api/v1/server.go
@@ -2,8 +2,12 @@ package v1
 
 import (
 	"context"
+	"io"
+	"net"
 	"os"
+	"reflect"
 	"strconv"
+	"sync"
 	"time"
 
 	"github.com/kubeshop/testkube/pkg/repository/config"
@@ -16,7 +20,6 @@ import (
 
 	"k8s.io/client-go/kubernetes"
 
-	"github.com/99designs/gqlgen/graphql/handler"
 	"github.com/gofiber/fiber/v2"
 	"github.com/gofiber/fiber/v2/middleware/cors"
 	"github.com/gofiber/fiber/v2/middleware/proxy"
@@ -69,7 +72,7 @@ func NewTestkubeAPI(
 	scheduler *scheduler.Scheduler,
 	slackLoader *slack.SlackLoader,
 	storage storage.Client,
-	graphQL *handler.Server,
+	graphqlPort string,
 ) TestkubeAPI {
 
 	var httpConfig server.Config
@@ -104,7 +107,7 @@ func NewTestkubeAPI(
 		scheduler:            scheduler,
 		slackLoader:          slackLoader,
 		Storage:              storage,
-		GraphQL:              graphQL,
+		graphqlPort:          graphqlPort,
 	}
 
 	// will be reused in websockets handler
@@ -145,7 +148,7 @@ type TestkubeAPI struct {
 	scheduler            *scheduler.Scheduler
 	Clientset            kubernetes.Interface
 	slackLoader          *slack.SlackLoader
-	GraphQL              *handler.Server
+	graphqlPort          string
 }
 
 type storageParams struct {
@@ -328,12 +331,6 @@ func (s *TestkubeAPI) InitRoutes() {
 	repositories := s.Routes.Group("/repositories")
 	repositories.Post("/", s.ValidateRepositoryHandler())
 
-	// TODO it's not possible to mount graphql on FastHTTP
-	// https://github.com/99designs/gqlgen/issues/1664
-	// gql := s.Routes.Group("/graphql")
-	// gql.All("/query", adaptor.HTTPHandler(s.GraphQL))
-	// gql.All("/", adaptor.HTTPHandler(playground.Handler("GraphQL playground", "/v1/graphql/query")))
-
 	// mount everything on results
 	// TODO it should be named /api/ + dashboard refactor
 	s.Mux.Mount("/results", s.Mux)
@@ -346,6 +343,56 @@ func (s *TestkubeAPI) InitRoutes() {
 	s.Log.Infow("dashboard uri", "uri", dashboardURI)
 	s.Mux.All("/", proxy.Forward(dashboardURI))
 
+	// set up proxy for the internal GraphQL server
+	s.Mux.All("/graphql", func(ctx *fiber.Ctx) error {
+		header := ctx.Request().Header.Header()
+		ctx.Context().HijackSetNoResponse(true)
+		ctx.Context().Hijack(func(c net.Conn) {
+			// Connect to server
+			serverConn, err := net.Dial("tcp", ":"+s.graphqlPort)
+			if err != nil {
+				s.Log.Errorw("could not connect to GraphQL server as a proxy", "error", err)
+				return
+			}
+
+			// Extract Unix connection
+			serverSock, _ := serverConn.(*net.TCPConn)
+			clientSock, _ := reflect.Indirect(reflect.ValueOf(c)).FieldByName("Conn").Interface().(*net.TCPConn)
+
+			// Close the connection afterward
+			defer clientSock.Close()
+			defer serverSock.Close()
+
+			// Resend headers to the server
+			_, err = serverSock.Write(header)
+			if err != nil {
+				s.Log.Errorw("error while sending headers to GraphQL server", "error", err)
+				return
+			}
+
+			// Duplex communication between client and GraphQL server
+			var wg sync.WaitGroup
+			wg.Add(2)
+			go func() {
+				defer wg.Done()
+				_, err := io.Copy(clientSock, serverSock)
+				if err != io.EOF {
+					s.Log.Errorw("error while reading GraphQL client data", "error", err)
+				}
+				clientSock.CloseWrite()
+			}()
+			go func() {
+				defer wg.Done()
+				_, err := io.Copy(serverSock, clientSock)
+				if err != io.EOF {
+					s.Log.Errorw("error while reading GraphQL server data", "error", err)
+				}
+				serverSock.CloseWrite()
+			}()
+			wg.Wait()
+		})
+		return nil
+	})
 }
 
 func (s TestkubeAPI) StartTelemetryHeartbeats(ctx context.Context) {

--- a/internal/graphql/graph/schema.resolvers.go
+++ b/internal/graphql/graph/schema.resolvers.go
@@ -74,6 +74,8 @@ func (r *subscriptionResolver) Executors(ctx context.Context) (<-chan []testkube
 		execs, err := getExecutors(r.Client)
 		if err == nil {
 			ch <- execs
+		} else {
+			r.Log.Errorw("failed to get initial executors", "error", err)
 		}
 
 		r.Log.Infof("%+v\n", "subscribed to events.executor.>")
@@ -85,6 +87,7 @@ func (r *subscriptionResolver) Executors(ctx context.Context) (<-chan []testkube
 
 			execs, err := getExecutors(r.Client)
 			if err != nil {
+				r.Log.Errorw("failed to get executors", "error", err)
 				return err
 			}
 			ch <- execs


### PR DESCRIPTION
## Pull request description 

* Change Upgrader config, to support WebSocket connection from different origin
* Unsubscribe from Event Bus, when the GraphQL subscription is disconnected
* Emit the initial state of executors in the beginning
* Expose `/graphql` endpoint in the API

There are multiple improvements that could be done later, i.e.:
* Use Unix sockets for internal connection with the GraphQL server
* Prepare a common handler for transitioning events from EventBus into GraphQL subscriptions

## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [x] tested locally
- [ ] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Breaking changes

-

## Changes

-

## Fixes

- https://github.com/kubeshop/testkube/issues/3646