### PR TITLE
feat: AWS DocDB connection

### DIFF
--- a/cmd/api-server/main.go
+++ b/cmd/api-server/main.go
@@ -181,7 +181,7 @@ func main() {
 		artifactStorage = cloudartifacts.NewCloudStorageClient(grpcClient, grpcConn, cfg.TestkubeCloudAPIKey)
 	} else {
 		mongoSSLConfig := getMongoSSLConfig(cfg, secretClient)
-		db, err := storage.GetMongoDatabase(cfg.APIMongoDSN, cfg.APIMongoDB, mongoSSLConfig)
+		db, err := storage.GetMongoDatabase(cfg.APIMongoDSN, cfg.APIMongoDB, cfg.APIMongoDBType, mongoSSLConfig)
 		ui.ExitOnError("Getting mongo database", err)
 		resultsRepository = result.NewMongoRepository(db, cfg.APIMongoAllowDiskUse)
 		testResultsRepository = testresult.NewMongoRepository(db, cfg.APIMongoAllowDiskUse)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -9,6 +9,7 @@ type Config struct {
 	APIMongoSSLCert                   string `envconfig:"API_MONGO_SSL_CERT" default:""`
 	APIMongoAllowDiskUse              bool   `envconfig:"API_MONGO_ALLOW_DISK_USE" default:"false"`
 	APIMongoDB                        string `envconfig:"API_MONGO_DB" default:"testkube"`
+	APIMongoDBType                    string `envconfig:"API_MONGO_DB_TYPE" default:"testkube"`
 	SlackToken                        string `envconfig:"SLACK_TOKEN" default:""`
 	SlackConfig                       string `envconfig:"SLACK_CONFIG" default:""`
 	SlackTemplate                     string `envconfig:"SLACK_TEMPLATE" default:""`

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -9,7 +9,7 @@ type Config struct {
 	APIMongoSSLCert                   string `envconfig:"API_MONGO_SSL_CERT" default:""`
 	APIMongoAllowDiskUse              bool   `envconfig:"API_MONGO_ALLOW_DISK_USE" default:"false"`
 	APIMongoDB                        string `envconfig:"API_MONGO_DB" default:"testkube"`
-	APIMongoDBType                    string `envconfig:"API_MONGO_DB_TYPE" default:"testkube"`
+	APIMongoDBType                    string `envconfig:"API_MONGO_DB_TYPE" default:"mongo"`
 	SlackToken                        string `envconfig:"SLACK_TOKEN" default:""`
 	SlackConfig                       string `envconfig:"SLACK_CONFIG" default:""`
 	SlackTemplate                     string `envconfig:"SLACK_TEMPLATE" default:""`

--- a/pkg/repository/storage/mongo.go
+++ b/pkg/repository/storage/mongo.go
@@ -3,7 +3,13 @@ package storage
 import (
 	"context"
 	"crypto/tls"
+	"crypto/x509"
+	"errors"
 	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"os"
 	"time"
 
 	"go.mongodb.org/mongo-driver/mongo"
@@ -20,19 +26,37 @@ type MongoSSLConfig struct {
 	SSLCertificateAuthoritiyFile string
 }
 
+const (
+	TypeMongoDB    = "mongo"
+	TypeDocDB      = "docdb"
+	DocDBcaFileURI = "https://s3.amazonaws.com/rds-downloads/rds-combined-ca-bundle.pem"
+)
+
 // GetMongoDatabase returns a valid database connection to the configured MongoDB database
-func GetMongoDatabase(dsn, name string, certConfig *MongoSSLConfig) (db *mongo.Database, err error) {
+func GetMongoDatabase(dsn, name, dbType string, certConfig *MongoSSLConfig) (db *mongo.Database, err error) {
 	var mongoOptions *tls.Config
-	if certConfig != nil {
-		mongoOptions, err = options.BuildTLSConfig(map[string]interface{}{
-			"sslClientCertificateKeyFile":     certConfig.SSLClientCertificateKeyFile,
-			"sslClientCertificateKeyPassword": certConfig.SSLClientCertificateKeyFilePassword,
-			"sslCertificateAuthorityFile":     certConfig.SSLCertificateAuthoritiyFile,
-		})
-		if err != nil {
-			return nil, fmt.Errorf("could not build SSL config: %w", err)
+
+	switch dbType {
+	case TypeMongoDB, "":
+		if certConfig != nil {
+			mongoOptions, err = options.BuildTLSConfig(map[string]interface{}{
+				"sslClientCertificateKeyFile":     certConfig.SSLClientCertificateKeyFile,
+				"sslClientCertificateKeyPassword": certConfig.SSLClientCertificateKeyFilePassword,
+				"sslCertificateAuthorityFile":     certConfig.SSLCertificateAuthoritiyFile,
+			})
+			if err != nil {
+				return nil, fmt.Errorf("could not build SSL config: %w", err)
+			}
 		}
+	case TypeDocDB:
+		mongoOptions, err = getDocDBTLSConfig()
+		if err != nil {
+			return nil, fmt.Errorf("could not get DocDB: %w", err)
+		}
+	default:
+		return nil, fmt.Errorf("unsupported database type %s", dbType)
 	}
+
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 	client, err := mongo.Connect(ctx, options.Client().SetTLSConfig(mongoOptions).ApplyURI(dsn))
@@ -41,4 +65,51 @@ func GetMongoDatabase(dsn, name string, certConfig *MongoSSLConfig) (db *mongo.D
 	}
 
 	return client.Database(name), nil
+}
+
+func getDocDBTLSConfig() (*tls.Config, error) {
+	caFilePath, err := GetDocDBcaFile()
+	if err != nil {
+		return nil, fmt.Errorf("could not get CA file: %w", err)
+	}
+
+	tlsConfig := new(tls.Config)
+	certs, err := ioutil.ReadFile(caFilePath)
+
+	if err != nil {
+		return nil, fmt.Errorf("could not read CA file: %s", err)
+	}
+
+	tlsConfig.RootCAs = x509.NewCertPool()
+	ok := tlsConfig.RootCAs.AppendCertsFromPEM(certs)
+
+	if !ok {
+		return nil, errors.New("failed parsing pem file")
+	}
+
+	return tlsConfig, nil
+}
+
+// GetDocDBcaFile will fetch the file located at DocDBcaFileURI into a local file
+// Due to size limitations we cannot use Kubernetes secrets like we use for MongoDB TLS configs
+func GetDocDBcaFile() (string, error) {
+	// Get the data
+	resp, err := http.Get(DocDBcaFileURI)
+	if err != nil {
+		return "", fmt.Errorf("could not fetch file from %s: %w", DocDBcaFileURI, err)
+	}
+	defer resp.Body.Close()
+
+	docDBcaPath := "/tmp/rds-combined-ca-bundle.pem"
+	out, err := os.Create(docDBcaPath)
+	if err != nil {
+		return "", fmt.Errorf("could not create file %s: %w", docDBcaPath, err)
+	}
+	defer out.Close()
+
+	_, err = io.Copy(out, resp.Body)
+	if err != nil {
+		return "", fmt.Errorf("could not write file %s: %w", docDBcaPath, err)
+	}
+	return docDBcaPath, nil
 }


### PR DESCRIPTION
## Pull request description 

Fix without docs to https://github.com/kubeshop/testkube/issues/3116

This PR adds code to automatically download the pem files for aws docdb. There is no way to configure client certificates, is uses user/pass only.

## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [ ] tested locally
- [x] tested on cluster - created cluster and docdb on aws and connected them
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Breaking changes

-

## Changes

-

## Fixes

-