### PR TITLE
chore: Upgrade K6 executor to v0.44.0

### DIFF
--- a/contrib/executor/k6/build/agent/Dockerfile
+++ b/contrib/executor/k6/build/agent/Dockerfile
@@ -2,7 +2,7 @@
 FROM golang:1.18 as builder
 
 # build k6 0.36.0 with prometheus support
-ENV K6_VERSION=v0.43.1
+ENV K6_VERSION=v0.44.0
 RUN go install go.k6.io/xk6/cmd/xk6@v0.9.0 && xk6 build $K6_VERSION --with github.com/grafana/xk6-output-prometheus-remote@latest
 
 WORKDIR contrib/executor/k6/build
@@ -12,7 +12,7 @@ ENV GOOS=linux
 COPY . .
 RUN cd contrib/executor/k6/cmd/agent;go build -o /build/runner -mod mod -a .
 
-FROM loadimpact/k6:0.43.1
+FROM loadimpact/k6:0.44.0
 WORKDIR /home/k6
 COPY --from=builder /go/k6 /usr/bin/k6
 COPY --from=builder /build/runner /bin/runner


### PR DESCRIPTION
## Pull request description 

Upgraded the K6 executor to v0.44.0

https://github.com/grafana/k6/releases/tag/v0.44.0

> k6 v0.44.0 is here! 🎉 This release includes:
> 
> A new k6/experimental/webcrypto module implementing (partially) the [Web Crypto API](https://developer.mozilla.org/en-US/docs/Web/API/Web_Crypto_API) specification.
> A sampling option for the experimental tracing module.
> Memory usage improvements.
> Bug fixes and UX improvements.
> Some highlights from the k6/experimental/browser module are:
> 
> locator.click is now asynchronous, which is a breaking change.
> browserContext.addCookies has now been implemented.
> browserType.Connect has been implemented so k6 can now connect to an already running Chrome/Chromium browser instance.
> Web vitals are natively supported when working with the browser module.

```
~ $ k6 version
k6 v0.44.0 ((devel), go1.18.10, linux/arm64)
Extensions:
  github.com/grafana/xk6-output-prometheus-remote v0.2.0, xk6-prometheus-rw [output]
```

## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [x] tested locally
- [ ] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test