### PR TITLE
fix: Dashboard E2E tests - filter tests list

### DIFF
--- a/test/dashboard-e2e/pages/MainPage.ts
+++ b/test/dashboard-e2e/pages/MainPage.ts
@@ -14,10 +14,11 @@ export class MainPage{
     }
 
     async openCreateTestDialog() {
-        await this.page.click('button[data-test="add-a-new-test-btn"]')
+      await this.page.click('button[data-test="add-a-new-test-btn"]')
     }
 
     async openTestExecutionDetails(realTestName) {
+      await this.page.locator(`input[data-cy="search-filter"]`).fill(realTestName)
       await this.page.click(`xpath=//div[@data-test="tests-list-item" and .//span[text()="${realTestName}"]]`)
     }
 }


### PR DESCRIPTION
Filter tests list before opening execution details