### PR TITLE
fix: Changing Init Executor image to use Ubuntu instead of Alpine

### DIFF
--- a/contrib/executor/init/build/agent/Dockerfile
+++ b/contrib/executor/init/build/agent/Dockerfile
@@ -2,14 +2,15 @@
 FROM --platform=amd64 golang:1.18
 WORKDIR contrib/executor/init/build
 COPY . .
-ENV CGO_ENABLED=0 
+ENV CGO_ENABLED=0
 ENV GOOS=linux
 ARG TARGETOS TARGETARCH
 
 RUN cd contrib/executor/init/cmd/agent;GOOS=$TARGETOS GOARCH=$TARGETARCH go build -o /runner -mod mod -a .
 
-FROM alpine/git
-RUN apk --no-cache add ca-certificates
+FROM ubuntu
+RUN apt-get update
+RUN apt-get install ca-certificates git -y
 WORKDIR /root/
 RUN git config --global user.name "testkube"
 RUN chmod a=rw /root/.gitconfig


### PR DESCRIPTION
## Pull request description 
This pull request changes the Init Executor to use Ubuntu as the base image instead of Alpine. The reason for this PR is because myself and other users have seen DNS resolution problems when cloning git repositories. I noticed this issue myself in our cluster with the below configuration:

TestKube Version - **testkube-1.11.156**
Kubernetes Cluster Type - **Kubernetes on AWS instances** (not managed EKS)
Kubernetes Client version: **v1.22.16**
Kubernetes Server version: **v1.21.9**

We also have **CoreDNS** and **Istio** enabled on this. From looking online it seems that Alpine can have DNS resolution problems when running in Kubernetes, see: [Does Alpine Have Known DNS issues within Kubernetes](https://stackoverflow.com/questions/65181012/does-alpine-have-known-dns-issue-within-kubernetes)

I have tested this by creating a new image based on Ubuntu and pointing to it in the **executors.json** file in the TestKube Helm chart. I was able to have 10 consecutive git clones without any problems since making this change.

## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [X] tested locally
- [X] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Breaking changes
I do not believe that this should be a breaking change in any way.
-

## Changes
Updated the Init Executor image to switch from Alpine to Ubuntu as the base image.
-

## Fixes
This should resolve DNS resolution problems which some users have seen. I have seen these issues myself in our cluster which is using CoreDNS and Istio (only maybe 1 in 20 git clones were successful).
-