### PR TITLE
feat: add spinner to testkube init

### DIFF
--- a/cmd/kubectl-testkube/commands/common.go
+++ b/cmd/kubectl-testkube/commands/common.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/spf13/cobra"
+	"github.com/briandowns/spinner"
 
 	"github.com/kubeshop/testkube/cmd/kubectl-testkube/commands/common"
 	"github.com/kubeshop/testkube/cmd/kubectl-testkube/config"
@@ -122,6 +123,8 @@ func HelmUpgradeOrInstalTestkube(options HelmUpgradeOrInstalTestkubeOptions) err
 	}
 
 	ui.Info("Helm installing testkube framework")
+	s := spinner.New(spinner.CharSets[9], 100*time.Millisecond) 
+	s.Start()
 	_, err = process.Execute(helmPath, "repo", "add", "kubeshop", "https://kubeshop.github.io/helm-charts")
 	if err != nil && !strings.Contains(err.Error(), "Error: repository name (kubeshop) already exists, please specify a different name") {
 		ui.WarnOnError("adding testkube repo", err)
@@ -146,6 +149,8 @@ func HelmUpgradeOrInstalTestkube(options HelmUpgradeOrInstalTestkubeOptions) err
 	}
 
 	out, err := process.Execute(helmPath, command...)
+	s.Stop()
+	
 	if err != nil {
 		return err
 	}

--- a/cmd/kubectl-testkube/commands/common.go
+++ b/cmd/kubectl-testkube/commands/common.go
@@ -6,8 +6,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/spf13/cobra"
 	"github.com/briandowns/spinner"
+	"github.com/spf13/cobra"
 
 	"github.com/kubeshop/testkube/cmd/kubectl-testkube/commands/common"
 	"github.com/kubeshop/testkube/cmd/kubectl-testkube/config"
@@ -124,10 +124,10 @@ func HelmUpgradeOrInstalTestkube(options HelmUpgradeOrInstalTestkubeOptions) err
 	}
 
 	ui.Info("Helm installing testkube framework")
-	
-	s := spinner.New(spinner.CharSets[9], 100*time.Millisecond) 
+
+	s := spinner.New(spinner.CharSets[9], 100*time.Millisecond)
 	s.Start()
-	
+
 	_, err = process.Execute(helmPath, "repo", "add", "kubeshop", "https://kubeshop.github.io/helm-charts")
 	if err != nil && !strings.Contains(err.Error(), "Error: repository name (kubeshop) already exists, please specify a different name") {
 		ui.WarnOnError("adding testkube repo", err)
@@ -153,7 +153,7 @@ func HelmUpgradeOrInstalTestkube(options HelmUpgradeOrInstalTestkubeOptions) err
 
 	out, err := process.Execute(helmPath, command...)
 	s.Stop()
-	
+
 	if err != nil {
 		return err
 	}

--- a/cmd/kubectl-testkube/commands/common.go
+++ b/cmd/kubectl-testkube/commands/common.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os/exec"
 	"strings"
+	"time"
 
 	"github.com/spf13/cobra"
 	"github.com/briandowns/spinner"
@@ -123,8 +124,10 @@ func HelmUpgradeOrInstalTestkube(options HelmUpgradeOrInstalTestkubeOptions) err
 	}
 
 	ui.Info("Helm installing testkube framework")
+	
 	s := spinner.New(spinner.CharSets[9], 100*time.Millisecond) 
 	s.Start()
+	
 	_, err = process.Execute(helmPath, "repo", "add", "kubeshop", "https://kubeshop.github.io/helm-charts")
 	if err != nil && !strings.Contains(err.Error(), "Error: repository name (kubeshop) already exists, please specify a different name") {
 		ui.WarnOnError("adding testkube repo", err)

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/99designs/gqlgen v0.17.27
 	github.com/Masterminds/semver v1.5.0
 	github.com/adhocore/gronx v1.1.2
+	github.com/briandowns/spinner v1.19.0
 	github.com/cli/cli/v2 v2.20.2
 	github.com/denisbrodbeck/machineid v1.0.1
 	github.com/dustinkirkland/golang-petname v0.0.0-20191129215211-8e5a1ed0cff0


### PR DESCRIPTION
## Pull request description 

Add spinner animation while installing the helm charts by using `testkube init` command

## Checklist (choose whats happened)


- [✅] tested locally
- [✅] tested on cluster
- [✅] added new dependencies


## Changes

![demo](https://user-images.githubusercontent.com/89198083/236848030-97d002b6-e0a1-49cf-a728-f49839368bac.gif)

## Fixes

- #3752