### PR TITLE
fix: do not use object that is nil on error to register an error with…

### DIFF
--- a/internal/app/api/v1/tests.go
+++ b/internal/app/api/v1/tests.go
@@ -486,7 +486,7 @@ func (s TestkubeAPI) UpdateTestHandler() fiber.Handler {
 			updatedTest, err = s.TestsClient.Update(testSpec)
 		}
 
-		s.Metrics.IncUpdateTest(updatedTest.Spec.Type_, err)
+		s.Metrics.IncUpdateTest(testSpec.Spec.Type_, err)
 
 		if err != nil {
 			return s.Error(c, http.StatusBadGateway, fmt.Errorf("%s: client could not update test %w", errPrefix, err))


### PR DESCRIPTION
… on update test

## Pull request description 

user issue from discord


## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [ ] tested locally
- [ ] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Breaking changes

-

## Changes

-

## Fixes

-