### PR TITLE
fix: link of Docs at README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ Checkout the [Getting Started](https://docs.testkube.io/articles/getting-started
 
 # Documentation
 
-Is available at [docs.testkube.io](docs.testkube.io)
+Is available at [docs.testkube.io](https://docs.testkube.io)
 
 ## Contributing
 


### PR DESCRIPTION
## Pull request description 

The original link pointed to a Github page which doesn't exists.

## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [X] tested locally
- [ ] tested on cluster
- [ ] added new dependencies
- [X] updated the docs
- [ ] added a test

## Breaking changes

-

## Changes

-

## Fixes

-