### PR TITLE
fix: e2e tests - crd - separate DASHBOARD_API_URL

### DIFF
--- a/test/dashboard-e2e/crd/crd.yaml
+++ b/test/dashboard-e2e/crd/crd.yaml
@@ -25,4 +25,8 @@ spec:
         name: API_URL
         value: testkube-api-server.testkube.svc.cluster.local:8088/v1
         type: basic
+      DASHBOARD_API_URL:
+        name: DASHBOARD_API_URL
+        value: testkube-api-server.testkube.svc.cluster.local:8088/v1
+        type: basic
   schedule: "15 */4 * * *"


### PR DESCRIPTION
Separate DASHBOARD_API_URL