### PR TITLE
docs: fixing indentation around testkube ingress sample

### DIFF
--- a/docs/docs/articles/exposing-testkube-with-ingress-nginx.md
+++ b/docs/docs/articles/exposing-testkube-with-ingress-nginx.md
@@ -37,27 +37,27 @@ testkube-api:
     tlsenabled: "true"
     tls:
       - hosts:
-         - your-host.com
-      secretName: testkube-cert-secret
+          - your-host.com
+        secretName: testkube-cert-secret
 
 
 testkube-dashboard:
   ingress:
     enabled: "true"
     annotations:
-       kubernetes.io/ingress.class: nginx
-       nginx.ingress.kubernetes.io/force-ssl-redirect: "false"
-       nginx.ingress.kubernetes.io/ssl-redirect: "false"
-       cert-manager.io/cluster-issuer: letsencrypt-prod
-       acme.cert-manager.io/http01-edit-in-place: "true"
-  path: /
-  hosts:
-    - your-host.com
-  tlsenabled: "true"
-  tls:
-    - hosts:
-        - your-host.com
-      secretName: testkube-cert-secret
+      kubernetes.io/ingress.class: nginx
+      nginx.ingress.kubernetes.io/force-ssl-redirect: "false"
+      nginx.ingress.kubernetes.io/ssl-redirect: "false"
+      cert-manager.io/cluster-issuer: letsencrypt-prod
+      acme.cert-manager.io/http01-edit-in-place: "true"
+    path: /
+    hosts:
+      - your-host.com
+    tlsenabled: "true"
+    tls:
+      - hosts:
+          - your-host.com
+        secretName: testkube-cert-secret
 
   apiServerEndpoint: "your-host.com/results"
 ```


### PR DESCRIPTION
## Pull request description 
I ran into an issue trying to deploy the sample, and found that testkube-dashboard.ingress had some indentation problems. Fixed those and also tried to fix the tls ones (though I didn't try them in my scenario).


## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [ ] tested locally
- [ x] tested on cluster
- [ ] added new dependencies
- [ x] updated the docs
- [ ] added a test

## Breaking changes

-

## Changes
Docs updates to fix indentations around ingress
-

## Fixes

-