### PR TITLE
fix: Login message is showed twice

### DIFF
--- a/cmd/kubectl-testkube/commands/cloud/login.go
+++ b/cmd/kubectl-testkube/commands/cloud/login.go
@@ -17,7 +17,6 @@ func NewLoginCmd() *cobra.Command {
 		Short:   "Login to Testkube Cloud",
 		Run: func(cmd *cobra.Command, args []string) {
 			opts.CloudUris = common.NewCloudUris(opts.CloudRootDomain)
-			ui.H1("Login")
 			token, refreshToken, err := common.LoginUser(opts.CloudUris.Auth)
 			ui.ExitOnError("getting token", err)
 


### PR DESCRIPTION
## Pull request description 

Fix Login message showed twice, common.LoginUser() already has this message https://github.com/kubeshop/testkube/blob/develop/cmd/kubectl-testkube/commands/common/helper.go#L383

## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [ ] tested locally
- [ ] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Breaking changes

-

## Changes

-

## Fixes

-