### PR TITLE
fix: wrong struct used to marshal body into

### DIFF
--- a/internal/app/api/v1/testtriggers.go
+++ b/internal/app/api/v1/testtriggers.go
@@ -31,7 +31,7 @@ func (s *TestkubeAPI) CreateTestTriggerHandler() fiber.Handler {
 		if string(c.Request().Header.ContentType()) == mediaTypeYAML {
 			testTriggerSpec := string(c.Body())
 			decoder := yaml.NewYAMLOrJSONDecoder(bytes.NewBufferString(testTriggerSpec), len(testTriggerSpec))
-			if err := decoder.Decode(&testTriggerSpec); err != nil {
+			if err := decoder.Decode(&testTrigger); err != nil {
 				return s.Error(c, http.StatusBadRequest, fmt.Errorf("%s: could not parse yaml request: %w", errPrefix, err))
 			}
 		} else {

--- a/internal/app/api/v1/webhook.go
+++ b/internal/app/api/v1/webhook.go
@@ -22,7 +22,7 @@ func (s TestkubeAPI) CreateWebhookHandler() fiber.Handler {
 		if string(c.Request().Header.ContentType()) == mediaTypeYAML {
 			webhookSpec := string(c.Body())
 			decoder := yaml.NewYAMLOrJSONDecoder(bytes.NewBufferString(webhookSpec), len(webhookSpec))
-			if err := decoder.Decode(&webhookSpec); err != nil {
+			if err := decoder.Decode(&webhook); err != nil {
 				return s.Error(c, http.StatusBadRequest, fmt.Errorf("%s: could not parse yaml request: %w", errPrefix, err))
 			}
 		} else {


### PR DESCRIPTION
## Pull request description 

Creating triggers and webhooks via yaml was throwing error

## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [x] tested locally
- [ ] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Breaking changes

-

## Changes

-

## Fixes

-