### PR TITLE
Tests/TestSuites - namespaces removed, run script updated

### DIFF
--- a/test/artillery/executor-smoke/crd/crd.yaml
+++ b/test/artillery/executor-smoke/crd/crd.yaml
@@ -2,7 +2,6 @@ apiVersion: tests.testkube.io/v3
 kind: Test
 metadata:
   name: artillery-executor-smoke
-  namespace: testkube
   labels:
     core-tests: executors
 spec:
@@ -19,7 +18,6 @@ apiVersion: tests.testkube.io/v3
 kind: Test
 metadata:
   name: artillery-executor-smoke-negative
-  namespace: testkube
   labels:
     core-tests: executors-negative
 spec:

--- a/test/container-executor/executor-smoke/crd/curl.yaml
+++ b/test/container-executor/executor-smoke/crd/curl.yaml
@@ -2,7 +2,6 @@ apiVersion: tests.testkube.io/v3
 kind: Test
 metadata:
   name: container-executor-curl-smoke
-  namespace: testkube
   labels:
     core-tests: executors
 spec:
@@ -20,7 +19,6 @@ apiVersion: tests.testkube.io/v3
 kind: Test
 metadata:
   name: container-executor-curl-smoke-negative
-  namespace: testkube
   labels:
     core-tests: executors-negative
 spec:

--- a/test/container-executor/executor-smoke/crd/cypress.yaml
+++ b/test/container-executor/executor-smoke/crd/cypress.yaml
@@ -2,7 +2,6 @@ apiVersion: tests.testkube.io/v3
 kind: Test
 metadata:
   name: container-executor-cypress-v12.7.0-smoke
-  namespace: testkube
   labels:
     core-tests: executors
 spec:
@@ -37,7 +36,6 @@ apiVersion: tests.testkube.io/v3
 kind: Test
 metadata:
   name: container-executor-cypress-v12.7.0-smoke-git-dir
-  namespace: testkube
   labels:
     core-tests: executors
 spec:

--- a/test/container-executor/executor-smoke/crd/k6.yaml
+++ b/test/container-executor/executor-smoke/crd/k6.yaml
@@ -2,7 +2,6 @@ apiVersion: tests.testkube.io/v3
 kind: Test
 metadata:
   name: container-executor-k6-smoke
-  namespace: testkube
   labels:
     core-tests: executors
 spec:
@@ -22,7 +21,6 @@ apiVersion: tests.testkube.io/v3
 kind: Test
 metadata:
   name: container-executor-k6-smoke-git-file
-  namespace: testkube
   labels:
     core-tests: executors
 spec:

--- a/test/container-executor/executor-smoke/crd/playwright.yaml
+++ b/test/container-executor/executor-smoke/crd/playwright.yaml
@@ -2,7 +2,6 @@ apiVersion: tests.testkube.io/v3
 kind: Test
 metadata:
   name: container-executor-playwright-smoke
-  namespace: testkube
   labels:
     core-tests: executors
 spec:

--- a/test/curl/executor-tests/crd/smoke.yaml
+++ b/test/curl/executor-tests/crd/smoke.yaml
@@ -2,7 +2,6 @@ apiVersion: tests.testkube.io/v3
 kind: Test
 metadata:
   name: curl-executor-smoke
-  namespace: testkube
   labels:
     core-tests: executors
 spec:
@@ -19,7 +18,6 @@ apiVersion: tests.testkube.io/v3
 kind: Test
 metadata:
   name: curl-executor-smoke-negative
-  namespace: testkube
   labels:
     core-tests: executors-negative
 spec:

--- a/test/cypress/executor-tests/crd/crd.yaml
+++ b/test/cypress/executor-tests/crd/crd.yaml
@@ -2,7 +2,6 @@ apiVersion: tests.testkube.io/v3
 kind: Test
 metadata:
   name: cypress-12-executor-smoke-electron
-  namespace: testkube
   labels:
     core-tests: executors
 spec:
@@ -30,7 +29,6 @@ apiVersion: tests.testkube.io/v3
 kind: Test
 metadata:
   name: cypress-12-executor-smoke-chrome
-  namespace: testkube
   labels:
     core-tests: executors
 spec:
@@ -60,7 +58,6 @@ apiVersion: tests.testkube.io/v3
 kind: Test
 metadata:
   name: cypress-12-executor-smoke-firefox
-  namespace: testkube
   labels:
     core-tests: executors
 spec:
@@ -90,7 +87,6 @@ apiVersion: tests.testkube.io/v3
 kind: Test
 metadata:
   name: cypress-11-executor-smoke-electron
-  namespace: testkube
   labels:
     core-tests: executors
 spec:
@@ -118,7 +114,6 @@ apiVersion: tests.testkube.io/v3
 kind: Test
 metadata:
   name: cypress-11-executor-smoke-chrome
-  namespace: testkube
   labels:
     core-tests: executors
 spec:
@@ -148,7 +143,6 @@ apiVersion: tests.testkube.io/v3
 kind: Test
 metadata:
   name: cypress-11-executor-smoke-firefox
-  namespace: testkube
   labels:
     core-tests: executors
 spec:
@@ -178,7 +172,6 @@ apiVersion: tests.testkube.io/v3
 kind: Test
 metadata:
   name: cypress-default-executor-smoke-electron
-  namespace: testkube
   labels:
     core-tests: executors
 spec:
@@ -206,7 +199,6 @@ apiVersion: tests.testkube.io/v3
 kind: Test
 metadata:
   name: cypress-default-executor-smoke-video-recording-enabled
-  namespace: testkube
   labels:
     core-tests: executors
 spec:
@@ -234,7 +226,6 @@ apiVersion: tests.testkube.io/v3
 kind: Test
 metadata:
   name: cypress-default-executor-smoke-yarn
-  namespace: testkube
   labels:
     core-tests: executors
 spec:
@@ -266,7 +257,6 @@ apiVersion: tests.testkube.io/v3
 kind: Test
 metadata:
   name: cypress-default-executor-smoke-electron-git-dir
-  namespace: testkube
   labels:
     core-tests: executors
 spec:
@@ -295,7 +285,6 @@ apiVersion: tests.testkube.io/v1
 kind: TestSource
 metadata:
   name: testsource-cypress-default-executor-smoke-electron-testsource
-  namespace: testkube
 spec:
   type: git
   repository:
@@ -309,7 +298,6 @@ apiVersion: tests.testkube.io/v3
 kind: Test
 metadata:
   name: cypress-default-executor-smoke-electron-testsource
-  namespace: testkube
 spec:
   type: cypress/project
   content:
@@ -333,7 +321,6 @@ apiVersion: tests.testkube.io/v1
 kind: TestSource
 metadata:
   name: testsource-cypress-default-executor-smoke-electron-testsource-git-dir
-  namespace: testkube
 spec:
   type: git-dir # backwards compatibility check
   repository:
@@ -347,7 +334,6 @@ apiVersion: tests.testkube.io/v3
 kind: Test
 metadata:
   name: cypress-default-executor-smoke-electron-testsource-git-dir
-  namespace: testkube
 spec:
   type: cypress/project
   content:
@@ -370,7 +356,6 @@ apiVersion: tests.testkube.io/v3
 kind: Test
 metadata:
   name: cypress-10-executor-smoke-electron
-  namespace: testkube
   labels:
     core-tests: executors
 spec:
@@ -398,7 +383,6 @@ apiVersion: tests.testkube.io/v3
 kind: Test
 metadata:
   name: cypress-10-executor-smoke-chrome
-  namespace: testkube
   labels:
     core-tests: executors
 spec:
@@ -428,7 +412,6 @@ apiVersion: tests.testkube.io/v3
 kind: Test
 metadata:
   name: cypress-10-executor-smoke-firefox
-  namespace: testkube
   labels:
     core-tests: executors
 spec:
@@ -458,7 +441,6 @@ apiVersion: tests.testkube.io/v3
 kind: Test
 metadata:
   name: cypress-9-executor-smoke-electron
-  namespace: testkube
   labels:
     core-tests: executors
 spec:
@@ -475,7 +457,6 @@ apiVersion: tests.testkube.io/v3
 kind: Test
 metadata:
   name: cypress-9-executor-smoke-chrome
-  namespace: testkube
   labels:
     core-tests: executors
 spec:
@@ -498,7 +479,6 @@ apiVersion: tests.testkube.io/v3
 kind: Test
 metadata:
   name: cypress-9-executor-smoke-firefox
-  namespace: testkube
   labels:
     core-tests: executors
 spec:
@@ -521,7 +501,6 @@ apiVersion: tests.testkube.io/v3
 kind: Test
 metadata:
   name: cypress-8-executor-smoke-electron
-  namespace: testkube
   labels:
     core-tests: executors
 spec:
@@ -542,7 +521,6 @@ apiVersion: tests.testkube.io/v3
 kind: Test
 metadata:
   name: cypress-8-executor-smoke-chrome
-  namespace: testkube
   labels:
     core-tests: executors
 spec:
@@ -565,7 +543,6 @@ apiVersion: tests.testkube.io/v3
 kind: Test
 metadata:
   name: cypress-8-executor-smoke-firefox
-  namespace: testkube
   labels:
     core-tests: executors
 spec:
@@ -588,7 +565,6 @@ apiVersion: tests.testkube.io/v3
 kind: Test
 metadata:
   name: cypress-default-executor-smoke-electron-negative
-  namespace: testkube
   labels:
     core-tests: executors-negative
 spec:

--- a/test/dashboard-e2e/crd/crd.yaml
+++ b/test/dashboard-e2e/crd/crd.yaml
@@ -2,7 +2,6 @@ apiVersion: tests.testkube.io/v3
 kind: Test
 metadata:
   name: dashboard-e2e-tests
-  namespace: testkube
   labels:
     core-tests: executors
 spec:

--- a/test/executors/container-executor-curl.yaml
+++ b/test/executors/container-executor-curl.yaml
@@ -2,7 +2,6 @@ apiVersion: executor.testkube.io/v1
 kind: Executor
 metadata:
   name: container-executor-curl
-  namespace: testkube
 spec:
   image: curlimages/curl:latest
   command: ["curl"]

--- a/test/executors/container-executor-cypress.yaml
+++ b/test/executors/container-executor-cypress.yaml
@@ -2,7 +2,6 @@ apiVersion: executor.testkube.io/v1
 kind: Executor
 metadata:
   name: container-executor-cypress-v12.7.0
-  namespace: testkube
 spec:
   image: cypress/included:12.7.0
   executor_type: container

--- a/test/executors/container-executor-k6.yaml
+++ b/test/executors/container-executor-k6.yaml
@@ -2,7 +2,6 @@ apiVersion: executor.testkube.io/v1
 kind: Executor
 metadata:
   name: container-executor-k6-0.43.1
-  namespace: testkube
 spec:
   image: grafana/k6:0.43.1
   executor_type: container

--- a/test/executors/container-executor-playwright.yaml
+++ b/test/executors/container-executor-playwright.yaml
@@ -2,7 +2,6 @@ apiVersion: executor.testkube.io/v1
 kind: Executor
 metadata:
   name: container-executor-playwright-v1.32.3
-  namespace: testkube
 spec:
   image: mcr.microsoft.com/playwright:v1.32.3-focal
   command: ["/bin/sh", "-c"]
@@ -18,7 +17,6 @@ apiVersion: executor.testkube.io/v1
 kind: Executor
 metadata:
   name: container-executor-playwright-v1.31.1
-  namespace: testkube
 spec:
   image: mcr.microsoft.com/playwright:v1.31.1-focal
   command: ["/bin/sh", "-c"]

--- a/test/executors/cypress.yaml
+++ b/test/executors/cypress.yaml
@@ -2,7 +2,6 @@ apiVersion: executor.testkube.io/v1
 kind: Executor
 metadata:
   name: cypress-v12-executor
-  namespace: testkube
 spec:
   image: kubeshop/testkube-cypress-executor:cypress12
   command: ["./node_modules/cypress/bin/cypress"]
@@ -26,7 +25,6 @@ apiVersion: executor.testkube.io/v1
 kind: Executor
 metadata:
   name: cypress-v11-executor
-  namespace: testkube
 spec:
   image: kubeshop/testkube-cypress-executor:cypress11
   command: ["./node_modules/cypress/bin/cypress"]
@@ -50,7 +48,6 @@ apiVersion: executor.testkube.io/v1
 kind: Executor
 metadata:
   name: cypress-v10-executor
-  namespace: testkube
 spec:
   image: kubeshop/testkube-cypress-executor:cypress10
   command: ["./node_modules/cypress/bin/cypress"]
@@ -74,7 +71,6 @@ apiVersion: executor.testkube.io/v1
 kind: Executor
 metadata:
   name: cypress-v9-executor
-  namespace: testkube
 spec:
   image: kubeshop/testkube-cypress-executor:cypress9
   command: ["./node_modules/cypress/bin/cypress"]
@@ -98,7 +94,6 @@ apiVersion: executor.testkube.io/v1
 kind: Executor
 metadata:
   name: cypress-v8-executor
-  namespace: testkube
 spec:
   image: kubeshop/testkube-cypress-executor:cypress8
   command: ["./node_modules/cypress/bin/cypress"]

--- a/test/executors/gradle.yaml
+++ b/test/executors/gradle.yaml
@@ -2,7 +2,6 @@ apiVersion: executor.testkube.io/v1
 kind: Executor
 metadata:
   name: gradle-jdk18-executor
-  namespace: testkube
 spec:
   image: kubeshop/testkube-gradle-executor:0.1-jdk18
   types:
@@ -14,7 +13,6 @@ apiVersion: executor.testkube.io/v1
 kind: Executor
 metadata:
   name: gradle-jdk17-executor
-  namespace: testkube
 spec:
   image: kubeshop/testkube-gradle-executor:0.1-jdk17
   types:
@@ -26,7 +24,6 @@ apiVersion: executor.testkube.io/v1
 kind: Executor
 metadata:
   name: gradle-jdk11-executor
-  namespace: testkube
 spec:
   image: kubeshop/testkube-gradle-executor:0.1-jdk11
   types:
@@ -38,7 +35,6 @@ apiVersion: executor.testkube.io/v1
 kind: Executor
 metadata:
   name: gradle-jdk8-executor
-  namespace: testkube
 spec:
   image: kubeshop/testkube-gradle-executor:0.1-jdk8
   types:

--- a/test/executors/maven.yaml
+++ b/test/executors/maven.yaml
@@ -2,7 +2,6 @@ apiVersion: executor.testkube.io/v1
 kind: Executor
 metadata:
   name: maven-jdk18-executor
-  namespace: testkube
 spec:
   image: kubeshop/testkube-maven-executor:0.1-jdk18
   types:
@@ -14,7 +13,6 @@ apiVersion: executor.testkube.io/v1
 kind: Executor
 metadata:
   name: maven-jdk11-executor
-  namespace: testkube
 spec:
   image: kubeshop/testkube-maven-executor:0.1-jdk11
   types:
@@ -26,7 +24,6 @@ apiVersion: executor.testkube.io/v1
 kind: Executor
 metadata:
   name: maven-jdk8-executor
-  namespace: testkube
 spec:
   image: kubeshop/testkube-maven-executor:0.1-jdk8
   types:

--- a/test/ginkgo/executor-tests/crd/smoke.yaml
+++ b/test/ginkgo/executor-tests/crd/smoke.yaml
@@ -2,7 +2,6 @@ apiVersion: tests.testkube.io/v3
 kind: Test
 metadata:
   name: ginkgo-executor-smoke
-  namespace: testkube
   labels:
     core-tests: executors
 spec:
@@ -19,7 +18,6 @@ apiVersion: tests.testkube.io/v3
 kind: Test
 metadata:
   name: ginkgo-executor-smoke-negative
-  namespace: testkube
   labels:
     core-tests: executors
 spec:

--- a/test/gradle/executor-smoke/crd/crd.yaml
+++ b/test/gradle/executor-smoke/crd/crd.yaml
@@ -4,7 +4,6 @@ apiVersion: tests.testkube.io/v3
 kind: Test
 metadata:
   name: gradle-executor-smoke-jdk18
-  namespace: testkube
   labels:
     core-tests: executors
 spec:
@@ -27,7 +26,6 @@ apiVersion: tests.testkube.io/v3
 kind: Test
 metadata:
   name: gradle-executor-smoke-jdk17
-  namespace: testkube
   labels:
     core-tests: executors
 spec:
@@ -50,7 +48,6 @@ apiVersion: tests.testkube.io/v3
 kind: Test
 metadata:
   name: gradle-executor-smoke-jdk11
-  namespace: testkube
   labels:
     core-tests: executors
 spec:
@@ -73,7 +70,6 @@ apiVersion: tests.testkube.io/v3
 kind: Test
 metadata:
   name: gradle-executor-smoke-jdk8
-  namespace: testkube
   labels:
     core-tests: executors
 spec:
@@ -96,7 +92,6 @@ apiVersion: tests.testkube.io/v3
 kind: Test
 metadata:
   name: gradle-executor-smoke-jdk18-negative # expected failure - ENVs not set
-  namespace: testkube
   labels:
     core-tests: executors-negative
 spec:

--- a/test/jmeter/executor-tests/crd/smoke.yaml
+++ b/test/jmeter/executor-tests/crd/smoke.yaml
@@ -2,7 +2,6 @@ apiVersion: tests.testkube.io/v3
 kind: Test
 metadata:
   name: jmeter-executor-smoke
-  namespace: testkube
   labels:
     core-tests: executors
 spec:
@@ -19,7 +18,6 @@ apiVersion: tests.testkube.io/v3
 kind: Test
 metadata:
   name: jmeter-executor-smoke-directory
-  namespace: testkube
   labels:
     core-tests: executors
 spec:
@@ -39,7 +37,6 @@ apiVersion: tests.testkube.io/v3
 kind: Test
 metadata:
   name: jmeter-executor-smoke-env-and-property-values
-  namespace: testkube
   labels:
     core-tests: executors
 spec:
@@ -64,7 +61,6 @@ apiVersion: tests.testkube.io/v3
 kind: Test
 metadata:
   name: jmeter-executor-smoke-negative
-  namespace: testkube
   labels:
     core-tests: executors-negative
 spec:

--- a/test/k6/executor-tests/crd/other.yaml
+++ b/test/k6/executor-tests/crd/other.yaml
@@ -3,7 +3,6 @@ apiVersion: tests.testkube.io/v3
 kind: Test
 metadata:
   name: k6-executor-smoke-directory
-  namespace: testkube
   labels:
     core-tests: executors
 spec:

--- a/test/k6/executor-tests/crd/smoke.yaml
+++ b/test/k6/executor-tests/crd/smoke.yaml
@@ -2,7 +2,6 @@ apiVersion: tests.testkube.io/v3
 kind: Test
 metadata:
   name: k6-executor-smoke
-  namespace: testkube
   labels:
     core-tests: executors
 spec:
@@ -28,7 +27,6 @@ apiVersion: tests.testkube.io/v3
 kind: Test
 metadata:
   name: k6-executor-smoke-git-file
-  namespace: testkube
   labels:
     core-tests: executors
 spec:
@@ -54,7 +52,6 @@ apiVersion: tests.testkube.io/v3
 kind: Test
 metadata:
   name: k6-executor-smoke-negative
-  namespace: testkube
   labels:
     core-tests: executors-negative
 spec:

--- a/test/kubepug/executor-smoke/crd/crd.yaml
+++ b/test/kubepug/executor-smoke/crd/crd.yaml
@@ -2,7 +2,6 @@ apiVersion: tests.testkube.io/v3
 kind: Test
 metadata:
   name: kubepug-executor-smoke
-  namespace: testkube
   labels:
     core-tests: executors
 spec:
@@ -19,7 +18,6 @@ apiVersion: tests.testkube.io/v3
 kind: Test
 metadata:
   name: kubepug-executor-smoke-negative
-  namespace: testkube
   labels:
     core-tests: executors-negative
 spec:

--- a/test/maven/executor-smoke/crd/crd.yaml
+++ b/test/maven/executor-smoke/crd/crd.yaml
@@ -4,7 +4,6 @@ apiVersion: tests.testkube.io/v3
 kind: Test
 metadata:
   name: maven-executor-smoke-jdk18
-  namespace: testkube
   labels:
     core-tests: executors
 spec:
@@ -27,7 +26,6 @@ apiVersion: tests.testkube.io/v3
 kind: Test
 metadata:
   name: maven-executor-smoke-jdk11
-  namespace: testkube
   labels:
     core-tests: executors
 spec:
@@ -50,7 +48,6 @@ apiVersion: tests.testkube.io/v3
 kind: Test
 metadata:
   name: maven-executor-smoke-jdk18-negative # expected failure - ENVs not set
-  namespace: testkube
   labels:
     core-tests: executors-negative
 spec:

--- a/test/maven/executor-smoke/crd/negative.yaml
+++ b/test/maven/executor-smoke/crd/negative.yaml
@@ -4,7 +4,6 @@ apiVersion: tests.testkube.io/v3
 kind: Test
 metadata:
   name: maven-executor-smoke-jdk18-negative  # expected failure - ENVs not set
-  namespace: testkube
   labels:
     core-tests: executors-negative
 spec:

--- a/test/playwright/executor-tests/crd/crd.yaml
+++ b/test/playwright/executor-tests/crd/crd.yaml
@@ -2,7 +2,6 @@ apiVersion: tests.testkube.io/v3
 kind: Test
 metadata:
   name: playwright-executor-smoke
-  namespace: testkube
   labels:
     core-tests: executors
 spec:

--- a/test/postman/executor-tests/crd/crd.yaml
+++ b/test/postman/executor-tests/crd/crd.yaml
@@ -2,7 +2,6 @@ apiVersion: tests.testkube.io/v3
 kind: Test
 metadata:
   name: postman-executor-smoke
-  namespace: testkube
   labels:
     core-tests: executors
 spec:
@@ -23,7 +22,6 @@ apiVersion: tests.testkube.io/v3
 kind: Test
 metadata:
   name: postman-executor-smoke-git-file # backwards compatibility check
-  namespace: testkube
   labels:
     core-tests: executors
 spec:
@@ -45,7 +43,6 @@ apiVersion: tests.testkube.io/v1
 kind: TestSource
 metadata:
   name: testsource-postman-executor-smoke-testsource
-  namespace: testkube
 spec:
   type: git
   repository:
@@ -59,7 +56,6 @@ apiVersion: tests.testkube.io/v3
 kind: Test
 metadata:
   name: postman-executor-smoke-testsource
-  namespace: testkube
 spec:
   type: postman/collection
   source: testsource-postman-executor-smoke-testsource
@@ -73,7 +69,6 @@ apiVersion: tests.testkube.io/v1
 kind: TestSource
 metadata:
   name: testsource-postman-executor-smoke-testsource-git-file
-  namespace: testkube
 spec:
   type: git-file # backwards compatibility check
   repository:
@@ -87,7 +82,6 @@ apiVersion: tests.testkube.io/v3
 kind: Test
 metadata:
   name: postman-executor-smoke-testsource-git-file
-  namespace: testkube
 spec:
   type: postman/collection
   source: testsource-postman-executor-smoke-testsource-git-file
@@ -101,7 +95,6 @@ apiVersion: tests.testkube.io/v1
 kind: TestSource
 metadata:
   name: testsource-postman-executor-smoke-testsource-overwrite
-  namespace: testkube
 spec:
   type: git
   repository:
@@ -115,7 +108,6 @@ apiVersion: tests.testkube.io/v3
 kind: Test
 metadata:
   name: postman-executor-smoke-testsource-overwrite
-  namespace: testkube
 spec:
   type: postman/collection
   source: testsource-postman-executor-smoke-testsource-overwrite
@@ -132,7 +124,6 @@ apiVersion: tests.testkube.io/v3
 kind: Test
 metadata:
   name: postman-executor-smoke-negative
-  namespace: testkube
   labels:
     core-tests: executors-negative
 spec:

--- a/test/scripts/executor-tests/run.sh
+++ b/test/scripts/executor-tests/run.sh
@@ -37,7 +37,7 @@ print_title() {
 create_update_testsuite_json() { # testsuite_name testsuite_path
   exit_code=0
   type=""
-  testkube --namespace $namespace get testsuite $1 > /dev/null 2>&1 || exit_code=$?
+  kubectl testkube --namespace $namespace get testsuite $1 > /dev/null 2>&1 || exit_code=$?
 
   if [ $exit_code == 0 ] ; then # testsuite already created
     type="update"
@@ -47,9 +47,9 @@ create_update_testsuite_json() { # testsuite_name testsuite_path
 
   if [ "$schedule" = true ] ; then # workaround for appending schedule
     random_minute="$(($RANDOM % 59))"
-    cat $2 | testkube --namespace $namespace $type testsuite --name $1 --label app=testkube --schedule "$random_minute */4 * * *" 
+    cat $2 | kubectl testkube --namespace $namespace $type testsuite --name $1 --label app=kubectl testkube --schedule "$random_minute */4 * * *" 
   else
-    cat $2 | testkube --namespace $namespace $type testsuite --name $1 --label app=testkube
+    cat $2 | kubectl testkube --namespace $namespace $type testsuite --name $1 --label app=kubectl testkube
   fi
 }
 
@@ -68,7 +68,7 @@ run_follow_testsuite() { # testsuite_name
     branch_overwrite_param=" --git-branch $branch_overwrite"
   fi
 
-  testkube --namespace $namespace run testsuite $1 $follow_param $branch_overwrite_param
+  kubectl testkube --namespace $namespace run testsuite $1 $follow_param $branch_overwrite_param
 }
 
 common_run() { # name, test_crd_file, testsuite_name, testsuite_file, custom_executor_crd_file
@@ -85,7 +85,7 @@ common_run() { # name, test_crd_file, testsuite_name, testsuite_file, custom_exe
       kubectl --namespace $namespace delete -f $custom_executor_crd_file --ignore-not-found=true
     fi
     kubectl --namespace $namespace delete -f $test_crd_file --ignore-not-found=true
-    kubectl --namespace $namespace delete testsuite $testsuite_name -ntestkube --ignore-not-found=true
+    kubectl --namespace $namespace delete testsuite $testsuite_name -nkubectl testkube --ignore-not-found=true
   fi
 
   if [ "$create" = true ] ; then

--- a/test/scripts/executor-tests/run.sh
+++ b/test/scripts/executor-tests/run.sh
@@ -9,10 +9,11 @@ run='false'
 follow='false'
 schedule='false'
 executor_type='all'
+namespace='testkube'
 custom_testsuite=''
 branch_overwrite=''
 
-while getopts 'hdcrfse:t:b:v' flag; do
+while getopts 'hdcrfse:n:t:b:v' flag; do
   case "${flag}" in
     h) help='true' ;; # TODO: describe params
     d) delete='true' ;;
@@ -21,6 +22,7 @@ while getopts 'hdcrfse:t:b:v' flag; do
     f) follow='true' ;;
     s) schedule='true' ;;
     e) executor_type="${OPTARG}" ;;
+    n) namespace="${OPTARG}" ;;
     t) custom_testsuite="${OPTARG}" ;;
     b) branch_overwrite="${OPTARG}" ;;
     v) set -x ;;
@@ -35,7 +37,7 @@ print_title() {
 create_update_testsuite_json() { # testsuite_name testsuite_path
   exit_code=0
   type=""
-  kubectl testkube get testsuite $1 > /dev/null 2>&1 || exit_code=$?
+  testkube --namespace $namespace get testsuite $1 > /dev/null 2>&1 || exit_code=$?
 
   if [ $exit_code == 0 ] ; then # testsuite already created
     type="update"
@@ -45,14 +47,14 @@ create_update_testsuite_json() { # testsuite_name testsuite_path
 
   if [ "$schedule" = true ] ; then # workaround for appending schedule
     random_minute="$(($RANDOM % 59))"
-    cat $2 | kubectl testkube $type testsuite --name $1 --label app=testkube --schedule "$random_minute */4 * * *" 
+    cat $2 | testkube --namespace $namespace $type testsuite --name $1 --label app=testkube --schedule "$random_minute */4 * * *" 
   else
-    cat $2 | kubectl testkube $type testsuite --name $1 --label app=testkube
+    cat $2 | testkube --namespace $namespace $type testsuite --name $1 --label app=testkube
   fi
 }
 
 create_update_testsuite() { # testsuite_path
-    kubectl apply -f $1
+    kubectl --namespace $namespace apply -f $1
 }
 
 run_follow_testsuite() { # testsuite_name
@@ -66,7 +68,7 @@ run_follow_testsuite() { # testsuite_name
     branch_overwrite_param=" --git-branch $branch_overwrite"
   fi
 
-  testkube run testsuite $1 $follow_param $branch_overwrite_param
+  testkube --namespace $namespace run testsuite $1 $follow_param $branch_overwrite_param
 }
 
 common_run() { # name, test_crd_file, testsuite_name, testsuite_file, custom_executor_crd_file
@@ -80,20 +82,20 @@ common_run() { # name, test_crd_file, testsuite_name, testsuite_file, custom_exe
 
   if [ "$delete" = true ] ; then
     if [ ! -z "$custom_executor_crd_file" ] ; then
-      kubectl delete -f $custom_executor_crd_file --ignore-not-found=true
+      kubectl --namespace $namespace delete -f $custom_executor_crd_file --ignore-not-found=true
     fi
-    kubectl delete -f $test_crd_file --ignore-not-found=true
-    kubectl delete testsuite $testsuite_name -ntestkube --ignore-not-found=true
+    kubectl --namespace $namespace delete -f $test_crd_file --ignore-not-found=true
+    kubectl --namespace $namespace delete testsuite $testsuite_name -ntestkube --ignore-not-found=true
   fi
 
   if [ "$create" = true ] ; then
     if [ ! -z "$custom_executor_crd_file" ] ; then
       # Executors (not created by default)
-      kubectl apply -f $custom_executor_crd_file
+      kubectl --namespace $namespace apply -f $custom_executor_crd_file
     fi
     
     # Tests
-    kubectl apply -f $test_crd_file
+    kubectl --namespace $namespace apply -f $test_crd_file
 
     # TestsSuites
     create_update_testsuite "$testsuite_file"

--- a/test/scripts/executor-tests/run.sh
+++ b/test/scripts/executor-tests/run.sh
@@ -47,9 +47,9 @@ create_update_testsuite_json() { # testsuite_name testsuite_path
 
   if [ "$schedule" = true ] ; then # workaround for appending schedule
     random_minute="$(($RANDOM % 59))"
-    cat $2 | kubectl testkube --namespace $namespace $type testsuite --name $1 --label app=kubectl testkube --schedule "$random_minute */4 * * *" 
+    cat $2 | kubectl testkube --namespace $namespace $type testsuite --name $1 --label app=testkube --schedule "$random_minute */4 * * *" 
   else
-    cat $2 | kubectl testkube --namespace $namespace $type testsuite --name $1 --label app=kubectl testkube
+    cat $2 | kubectl testkube --namespace $namespace $type testsuite --name $1 --label app=testkube
   fi
 }
 
@@ -85,7 +85,7 @@ common_run() { # name, test_crd_file, testsuite_name, testsuite_file, custom_exe
       kubectl --namespace $namespace delete -f $custom_executor_crd_file --ignore-not-found=true
     fi
     kubectl --namespace $namespace delete -f $test_crd_file --ignore-not-found=true
-    kubectl --namespace $namespace delete testsuite $testsuite_name -nkubectl testkube --ignore-not-found=true
+    kubectl --namespace $namespace delete testsuite $testsuite_name -ntestkube --ignore-not-found=true
   fi
 
   if [ "$create" = true ] ; then

--- a/test/soapui/executor-smoke/crd/crd.yaml
+++ b/test/soapui/executor-smoke/crd/crd.yaml
@@ -2,7 +2,6 @@ apiVersion: tests.testkube.io/v3
 kind: Test
 metadata:
   name: soapui-executor-smoke
-  namespace: testkube
   labels:
     core-tests: executors
 spec:
@@ -19,7 +18,6 @@ apiVersion: tests.testkube.io/v3
 kind: Test
 metadata:
   name: soapui-executor-smoke-negative
-  namespace: testkube
   labels:
     core-tests: executors-negative
 spec:

--- a/test/suites/executor-artillery-smoke-tests.yaml
+++ b/test/suites/executor-artillery-smoke-tests.yaml
@@ -2,7 +2,6 @@ apiVersion: tests.testkube.io/v3
 kind: TestSuite
 metadata:
   name: executor-artillery-smoke-tests
-  namespace: testkube
 spec:
   description: artillery executor smoke tests
   steps:

--- a/test/suites/executor-container-curl-smoke-tests.yaml
+++ b/test/suites/executor-container-curl-smoke-tests.yaml
@@ -2,7 +2,6 @@ apiVersion: tests.testkube.io/v3
 kind: TestSuite
 metadata:
   name: executor-container-curl-smoke-tests
-  namespace: testkube
   labels:
     app: testkube
 spec:

--- a/test/suites/executor-container-cypress-smoke-tests.yaml
+++ b/test/suites/executor-container-cypress-smoke-tests.yaml
@@ -2,7 +2,6 @@ apiVersion: tests.testkube.io/v3
 kind: TestSuite
 metadata:
   name: executor-container-cypress-smoke-tests
-  namespace: testkube
   labels:
     app: testkube
 spec:

--- a/test/suites/executor-container-k6-smoke-tests.yaml
+++ b/test/suites/executor-container-k6-smoke-tests.yaml
@@ -2,7 +2,6 @@ apiVersion: tests.testkube.io/v3
 kind: TestSuite
 metadata:
   name: executor-container-k6-smoke-tests
-  namespace: testkube
   labels:
     app: testkube
 spec:

--- a/test/suites/executor-container-playwright-smoke-tests.yaml
+++ b/test/suites/executor-container-playwright-smoke-tests.yaml
@@ -2,7 +2,6 @@ apiVersion: tests.testkube.io/v3
 kind: TestSuite
 metadata:
   name: executor-container-playwright-smoke-tests
-  namespace: testkube
   labels:
     app: testkube
 spec:

--- a/test/suites/executor-curl-smoke-tests.yaml
+++ b/test/suites/executor-curl-smoke-tests.yaml
@@ -2,7 +2,6 @@ apiVersion: tests.testkube.io/v3
 kind: TestSuite
 metadata:
   name: executor-curl-smoke-tests
-  namespace: testkube
   labels:
     app: testkube
 spec:

--- a/test/suites/executor-cypress-smoke-tests.yaml
+++ b/test/suites/executor-cypress-smoke-tests.yaml
@@ -2,7 +2,6 @@ apiVersion: tests.testkube.io/v3
 kind: TestSuite
 metadata:
   name: executor-cypress-smoke-tests
-  namespace: testkube
   labels:
     app: testkube
 spec:

--- a/test/suites/executor-ginkgo-smoke-tests.yaml
+++ b/test/suites/executor-ginkgo-smoke-tests.yaml
@@ -2,7 +2,6 @@ apiVersion: tests.testkube.io/v3
 kind: TestSuite
 metadata:
   name: executor-ginkgo-smoke-tests
-  namespace: testkube
   labels:
     app: testkube
 spec:

--- a/test/suites/executor-gradle-smoke-tests.yaml
+++ b/test/suites/executor-gradle-smoke-tests.yaml
@@ -2,7 +2,6 @@ apiVersion: tests.testkube.io/v3
 kind: TestSuite
 metadata:
   name: executor-gradle-smoke-tests
-  namespace: testkube
   labels:
     app: testkube
 spec:

--- a/test/suites/executor-jmeter-smoke-tests.yaml
+++ b/test/suites/executor-jmeter-smoke-tests.yaml
@@ -2,7 +2,6 @@ apiVersion: tests.testkube.io/v3
 kind: TestSuite
 metadata:
   name: executor-jmeter-smoke-tests
-  namespace: testkube
   labels:
     app: testkube
 spec:

--- a/test/suites/executor-k6-other-tests.yaml
+++ b/test/suites/executor-k6-other-tests.yaml
@@ -2,7 +2,6 @@ apiVersion: tests.testkube.io/v3
 kind: TestSuite
 metadata:
   name: executor-k6-other-tests
-  namespace: testkube
   labels:
     app: testkube
 spec:

--- a/test/suites/executor-k6-smoke-tests.yaml
+++ b/test/suites/executor-k6-smoke-tests.yaml
@@ -2,7 +2,6 @@ apiVersion: tests.testkube.io/v3
 kind: TestSuite
 metadata:
   name: executor-k6-smoke-tests
-  namespace: testkube
   labels:
     app: testkube
 spec:

--- a/test/suites/executor-kubepug-smoke-tests.yaml
+++ b/test/suites/executor-kubepug-smoke-tests.yaml
@@ -2,7 +2,6 @@ apiVersion: tests.testkube.io/v3
 kind: TestSuite
 metadata:
   name: executor-kubepug-smoke-tests
-  namespace: testkube
   labels:
     app: testkube
 spec:

--- a/test/suites/executor-maven-smoke-tests.yaml
+++ b/test/suites/executor-maven-smoke-tests.yaml
@@ -2,7 +2,6 @@ apiVersion: tests.testkube.io/v3
 kind: TestSuite
 metadata:
   name: executor-maven-smoke-tests
-  namespace: testkube
   labels:
     app: testkube
 spec:

--- a/test/suites/executor-playwright-smoke-tests.yaml
+++ b/test/suites/executor-playwright-smoke-tests.yaml
@@ -2,7 +2,6 @@ apiVersion: tests.testkube.io/v3
 kind: TestSuite
 metadata:
   name: executor-playwright-smoke-tests
-  namespace: testkube
   labels:
     app: testkube
 spec:

--- a/test/suites/executor-postman-smoke-tests.yaml
+++ b/test/suites/executor-postman-smoke-tests.yaml
@@ -2,7 +2,6 @@ apiVersion: tests.testkube.io/v3
 kind: TestSuite
 metadata:
   name: executor-postman-smoke-tests
-  namespace: testkube
   labels:
     app: testkube
 spec:

--- a/test/suites/executor-soapui-smoke-tests.yaml
+++ b/test/suites/executor-soapui-smoke-tests.yaml
@@ -2,7 +2,6 @@ apiVersion: tests.testkube.io/v3
 kind: TestSuite
 metadata:
   name: executor-soapui-smoke-tests
-  namespace: testkube
   labels:
     app: testkube
 spec:


### PR DESCRIPTION
https://github.com/kubeshop/testkube/issues/4144
- namespaces removed from Tests/TestSuites
- Run script - `-n NAMESPACE_NAME` parameter added