### PR TITLE
fix: use proper Playwright version in its executors

### DIFF
--- a/docs/docs/test-types/container-executor.mdx
+++ b/docs/docs/test-types/container-executor.mdx
@@ -213,7 +213,7 @@ spec:
   image: mcr.microsoft.com/playwright:v1.31.1-focal
   command: ["/bin/sh", "-c"]
   args:
-  - "npm install; npx playwright test"
+  - "npm install; npx --yes playwright@1.31.1 test"
   executor_type: container
   types:
   - container-executor-playwright-v1.31.1/test

--- a/test/executors/container-executor-playwright.yaml
+++ b/test/executors/container-executor-playwright.yaml
@@ -6,7 +6,7 @@ spec:
   image: mcr.microsoft.com/playwright:v1.32.3-focal
   command: ["/bin/sh", "-c"]
   args:
-  - "npm ci && CI=1 npx playwright test --output /data/artifacts"
+  - "npm ci && npx --yes playwright@1.32.3 test --output /data/artifacts"
   executor_type: container
   types:
   - container-executor-playwright-v1.32.3/test
@@ -21,7 +21,7 @@ spec:
   image: mcr.microsoft.com/playwright:v1.31.1-focal
   command: ["/bin/sh", "-c"]
   args:
-  - "npm ci; npx playwright test --output /data/artifacts"
+  - "npm ci && npx --yes playwright@1.31.1 --output /data/artifacts"
   executor_type: container
   types:
   - container-executor-playwright-v1.31.1/test


### PR DESCRIPTION
## Pull request description 

Use proper Playwright version in executor. When not set and not detected, `npx` tries to install the latest one.

## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [x] tested locally
- [x] tested on cluster
- [ ] added new dependencies
- [x] updated the docs
- [ ] added a test