### PR TITLE
fix: install script

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,5 +1,5 @@
+#!/bin/bash 
 echo "Getting kubectl-testkube plugin"
-#!/bin/sh 
 
 if [ ! -z "${DEBUG}" ]; 
 then set -x 

--- a/install.sh
+++ b/install.sh
@@ -56,7 +56,7 @@ _download_url() {
     version="$TESTKUBE_VERSION"
   fi
 
-  echo "https://github.com/kubeshop/testkube/releases/download/${version}/testkube_${version:1}_${os}_$arch.tar.gz"
+  echo "https://github.com/kubeshop/testkube/releases/download/${version}/testkube_${version:-1}_${os}_$arch.tar.gz"
 }
 
 if [ "$1" = "beta" ]; then

--- a/install.sh
+++ b/install.sh
@@ -63,10 +63,10 @@ _download_url() {
 
 if [ "$1" = "beta" ]; then
   echo "Downloading testkube from URL: $(_download_url "beta")"
-  curl -sSLf $(_download_url "beta") > testkube.tar.gz
+  curl -sSLf "$(_download_url "beta")" > testkube.tar.gz
 else
   echo "Downloading testkube from URL: $(_download_url)"
-  curl -sSLf $(_download_url) > testkube.tar.gz
+  curl -sSLf "$(_download_url)" > testkube.tar.gz
 fi
 
 tar -xzf testkube.tar.gz kubectl-testkube 

--- a/install.sh
+++ b/install.sh
@@ -39,9 +39,18 @@ _download_url() {
   os="$(_detect_os)"
   if [ -z "$TESTKUBE_VERSION" ]; then
     if [ "$1" = "beta" ]; then
-      version=$(curl -s "https://api.github.com/repos/kubeshop/testkube/releases" 2>/dev/null | jq -r '.[].tag_name | select(test("beta"))' | head -n 1)
+      version="$(
+        curl -s "https://api.github.com/repos/kubeshop/testkube/releases" \
+        2>/dev/null \
+        | jq -r '.[].tag_name | select(test("beta"))' \
+        | head -n 1 \
+      )"
     else
-      version=$(curl -s "https://api.github.com/repos/kubeshop/testkube/releases/latest" 2>/dev/null | jq -r '.tag_name')
+      version="$(
+        curl -s "https://api.github.com/repos/kubeshop/testkube/releases/latest" \
+        2>/dev/null \
+        | jq -r '.tag_name' \
+      )"
     fi
   else
     version="$TESTKUBE_VERSION"

--- a/install.sh
+++ b/install.sh
@@ -31,16 +31,20 @@ _detect_os(){
 }
 
 _download_url() {
-  local arch="$(_detect_arch)"
-  local os="$(_detect_os)"
+  local arch
+  local os
+  local version
+
+  arch="$(_detect_arch)"
+  os="$(_detect_os)"
   if [ -z "$TESTKUBE_VERSION" ]; then
     if [ "$1" = "beta" ]; then
-      local version=$(curl -s "https://api.github.com/repos/kubeshop/testkube/releases" 2>/dev/null | jq -r '.[].tag_name | select(test("beta"))' | head -n 1)
+      version=$(curl -s "https://api.github.com/repos/kubeshop/testkube/releases" 2>/dev/null | jq -r '.[].tag_name | select(test("beta"))' | head -n 1)
     else
-      local version=$(curl -s "https://api.github.com/repos/kubeshop/testkube/releases/latest" 2>/dev/null | jq -r '.tag_name')
+      version=$(curl -s "https://api.github.com/repos/kubeshop/testkube/releases/latest" 2>/dev/null | jq -r '.tag_name')
     fi
   else
-    local version="$TESTKUBE_VERSION"
+    version="$TESTKUBE_VERSION"
   fi
 
   echo "https://github.com/kubeshop/testkube/releases/download/${version}/testkube_${version:1}_${os}_$arch.tar.gz"

--- a/install.sh
+++ b/install.sh
@@ -33,30 +33,32 @@ _detect_os(){
 _download_url() {
   local arch
   local os
+  local tag
   local version
 
   arch="$(_detect_arch)"
   os="$(_detect_os)"
   if [ -z "$TESTKUBE_VERSION" ]; then
     if [ "$1" = "beta" ]; then
-      version="$(
+      tag="$(
         curl -s "https://api.github.com/repos/kubeshop/testkube/releases" \
         2>/dev/null \
         | jq -r '.[].tag_name | select(test("beta"))' \
         | head -n 1 \
       )"
     else
-      version="$(
+      tag="$(
         curl -s "https://api.github.com/repos/kubeshop/testkube/releases/latest" \
         2>/dev/null \
         | jq -r '.tag_name' \
       )"
     fi
   else
-    version="$TESTKUBE_VERSION"
+    tag="$TESTKUBE_VERSION"
   fi
+  version="${tag/#v/}" # remove leading v if present
 
-  echo "https://github.com/kubeshop/testkube/releases/download/${version}/testkube_${version:-1}_${os}_$arch.tar.gz"
+  echo "https://github.com/kubeshop/testkube/releases/download/${tag}/testkube_${version:-1}_${os}_$arch.tar.gz"
 }
 
 if [ "$1" = "beta" ]; then


### PR DESCRIPTION
related: #4071, fixes #4229

### Usage

```
❯ sudo bash ./install.sh
```

## Details

- fix: switch shebang to reflect existing code and move to the top
- chore: declare and assign separately to avoid masking return values.
- refactor: split to multiline so it simpler to read and maintain
- fix(install): correct typo in parameter expansion for default value
- fix: add a `tag` variable as download URL require `tag` and `version` (which differ)
