### PR TITLE
Update Step 3 of creating Tests

### DIFF
--- a/docs/docs/articles/step3-creating-first-test.md
+++ b/docs/docs/articles/step3-creating-first-test.md
@@ -43,7 +43,7 @@ For this example we will just copy and paste the test file to quickly create and
 
 
 
-And Voila! You can now run the test!
+Voila! You can now run the test!
 <img width="1896" alt="image" src="https://github.com/kubeshop/testkube/assets/13501228/e2d46e4f-641b-49b9-8a1f-f3b3100c4ad0">
 
 

--- a/docs/docs/articles/step3-creating-first-test.md
+++ b/docs/docs/articles/step3-creating-first-test.md
@@ -38,7 +38,7 @@ export default function () {
 
 Testkube can import any test files from git, from your computer or by copy & pasting a string.
 While in an automated setup, our advice is to keep everything in Git (including your Test CRDs).
-For this example we will just copy and paste the test file to quickly create and run it.
+For this example, we will copy and paste the test file to quickly create and run it.
 <img width="1896" alt="image" src="https://github.com/kubeshop/testkube/assets/13501228/cfb5d188-aaf6-4051-a44c-3859a23dd2a7">
 
 

--- a/docs/docs/articles/step3-creating-first-test.md
+++ b/docs/docs/articles/step3-creating-first-test.md
@@ -5,7 +5,7 @@
 Tests in Testkube are stored as a Custom Resource in Kubernetes and live inside your cluster.
 
 You can create your tests directly in the UI, using the CLI or deploy them as a Custom Resource.
-You can upload your test files to Testkube or you can provide your git credentials so that testkube can fetch them automatically from your Git Repo every time there's a new test execution.
+Upload your test files to Testkube or provide your Git credentials so that Testkube can fetch them automatically from your Git Repo every time there's a new test execution.
 
 This section provides an example of creating a _K6_ test. Nevertheless, Testkube supports a long [list of testing tools](../category/test-types).
 

--- a/docs/docs/articles/step3-creating-first-test.md
+++ b/docs/docs/articles/step3-creating-first-test.md
@@ -7,7 +7,7 @@ Tests in Testkube are stored as a Custom Resource in Kubernetes and live inside 
 You can create your tests directly in the UI, using the CLI or deploy them as a Custom Resource.
 Upload your test files to Testkube or provide your Git credentials so that Testkube can fetch them automatically from your Git Repo every time there's a new test execution.
 
-This section provides an example of creating a _K6_ test. Nevertheless, Testkube supports a long [list of testing tools](../category/test-types).
+This section provides an example of creating a _K6_ test. Testkube supports a long [list of testing tools](../category/test-types).
 
 ## Creating a K6 Test
 Now that you have your Testkube Environment up an running, the quickest way to add a new test is by clicking "Add New Test" on the Dashboard and select your test type:

--- a/docs/docs/articles/step3-creating-first-test.md
+++ b/docs/docs/articles/step3-creating-first-test.md
@@ -36,7 +36,7 @@ export default function () {
 }
 ```
 
-Testkube can import any test files from git, from your computer or by copy & pasting a string.
+Testkube can import any test files from Git, from your computer or by copy and pasting a string.
 While in an automated setup, our advice is to keep everything in Git (including your Test CRDs).
 For this example, we will copy and paste the test file to quickly create and run it.
 <img width="1896" alt="image" src="https://github.com/kubeshop/testkube/assets/13501228/cfb5d188-aaf6-4051-a44c-3859a23dd2a7">

--- a/docs/docs/articles/step3-creating-first-test.md
+++ b/docs/docs/articles/step3-creating-first-test.md
@@ -49,7 +49,7 @@ And Voila! You can now run the test!
 
 ## There's Different Mechanisms to Run the Tests
 #### Dashboard
-You can trigger their execution manually on the Dashboard
+Trigger test execution manually on the Dashboard:
 <img width="1896" alt="image" src="https://github.com/kubeshop/testkube/assets/13501228/97fe3119-60a8-4b40-ac54-3f1fc625111f">
 
 

--- a/docs/docs/articles/step3-creating-first-test.md
+++ b/docs/docs/articles/step3-creating-first-test.md
@@ -4,7 +4,7 @@
 
 Tests in Testkube are stored as a Custom Resource in Kubernetes and live inside your cluster.
 
-You can create your tests directly on the UI, using the CLI or deploy them as a Custom Resource.
+You can create your tests directly in the UI, using the CLI or deploy them as a Custom Resource.
 You can upload your test files to Testkube or you can provide your git credentials so that testkube can fetch them automatically from your Git Repo every time there's a new test execution.
 
 This section provides an example of creating a _K6_ test. Nevertheless, Testkube supports a long [list of testing tools](../category/test-types).

--- a/docs/docs/articles/step3-creating-first-test.md
+++ b/docs/docs/articles/step3-creating-first-test.md
@@ -64,7 +64,7 @@ For lists and details, you can use different output formats via the `--output` f
 - `JSON` - Test run data are encoded in JSON.
 - `GO` - For go-template formatting (like in Docker and Kubernetes), you'll need to add the `--go-template` flag with a custom format. The default is `{{ . | printf("%+v") }}`. This will help you check available fields.
 
-#### Other means of triggering tests
+#### Other Means of Triggering Tests
 - Your Test can run on a [Schedule](https://docs.testkube.io/articles/scheduling-tests)
   <img width="1896" alt="image" src="https://github.com/kubeshop/testkube/assets/13501228/aa3a1d87-e687-4364-9a8f-8bc8ffc73395">
 - Testkube can trigger the tests based on [Kubernetes events](https://docs.testkube.io/articles/test-triggers) (such as the deployment of an application).

--- a/docs/docs/articles/step3-creating-first-test.md
+++ b/docs/docs/articles/step3-creating-first-test.md
@@ -10,7 +10,7 @@ Upload your test files to Testkube or provide your Git credentials so that Testk
 This section provides an example of creating a _K6_ test. Testkube supports a long [list of testing tools](../category/test-types).
 
 ## Creating a K6 Test
-Now that you have your Testkube Environment up an running, the quickest way to add a new test is by clicking "Add New Test" on the Dashboard and select your test type:
+Now that you have your Testkube Environment up and running, the quickest way to add a new test is by clicking "Add New Test" on the Dashboard and select your test type:
 <img width="1896" alt="image" src="https://github.com/kubeshop/testkube/assets/13501228/683eae92-ef74-49c8-9db9-90da76fc17fc">
 
 We created the following Test example which verifies the status code of an https endpoint.

--- a/docs/docs/articles/step3-creating-first-test.md
+++ b/docs/docs/articles/step3-creating-first-test.md
@@ -13,7 +13,7 @@ This section provides an example of creating a _K6_ test. Testkube supports a lo
 Now that you have your Testkube Environment up and running, the quickest way to add a new test is by clicking "Add New Test" on the Dashboard and select your test type:
 <img width="1896" alt="image" src="https://github.com/kubeshop/testkube/assets/13501228/683eae92-ef74-49c8-9db9-90da76fc17fc">
 
-We created the following Test example which verifies the status code of an https endpoint.
+We created the following Test example which verifies the status code of an HTTPS endpoint.
 ```js
 // This k6 test was made to fail randomly 50% of the times.
 import http from 'k6/http';

--- a/docs/docs/articles/step3-creating-first-test.md
+++ b/docs/docs/articles/step3-creating-first-test.md
@@ -47,7 +47,7 @@ And Voila! You can now run the test!
 <img width="1896" alt="image" src="https://github.com/kubeshop/testkube/assets/13501228/e2d46e4f-641b-49b9-8a1f-f3b3100c4ad0">
 
 
-## There's Different Mechanisms to Run the Tests
+## Different Mechanisms to Run Tests
 #### Dashboard
 Trigger test execution manually on the Dashboard:
 <img width="1896" alt="image" src="https://github.com/kubeshop/testkube/assets/13501228/97fe3119-60a8-4b40-ac54-3f1fc625111f">

--- a/docs/docs/articles/step3-creating-first-test.md
+++ b/docs/docs/articles/step3-creating-first-test.md
@@ -54,7 +54,7 @@ You can trigger their execution manually on the Dashboard
 
 
 #### CLI
-You can run it manualy from your machine using the CLI as well, or from your CI/CD. Look [here](https://docs.testkube.io/articles/cicd-overview) for examples on how to setup our CI/CD system to trigger your tests.
+You can run tests manually from your machine using the CLI as well, or from your CI/CD. Visit [here](https://docs.testkube.io/articles/cicd-overview) for examples on how to setup our CI/CD system to trigger your tests.
 <img width="1896" alt="image" src="https://github.com/kubeshop/testkube/assets/13501228/6b5098d7-9b57-485d-8c5e-5f915f49d515">
 
 **Changing the Output Format**

--- a/docs/docs/articles/step3-creating-first-test.md
+++ b/docs/docs/articles/step3-creating-first-test.md
@@ -65,7 +65,7 @@ For lists and details, you can use different output formats via the `--output` f
 - `GO` - For go-template formatting (like in Docker and Kubernetes), you'll need to add the `--go-template` flag with a custom format. The default is `{{ . | printf("%+v") }}`. This will help you check available fields.
 
 #### Other means of triggering tests
-- Your Test can run on a [Schedulle](https://docs.testkube.io/articles/scheduling-tests)
+- Your Test can run on a [Schedule](https://docs.testkube.io/articles/scheduling-tests)
   <img width="1896" alt="image" src="https://github.com/kubeshop/testkube/assets/13501228/aa3a1d87-e687-4364-9a8f-8bc8ffc73395">
 - Testkube can trigger the tests based on [Kubernetes events](https://docs.testkube.io/articles/test-triggers) (such as the deployment of an application).
 


### PR DESCRIPTION
Fixing the following issues with the current step 3 of getting started:
- Remove the Testkube dashboard command which is not needed anymore on cloud.
- Change the Postman example to a K6 one to better highlight the value and for the users to get started faster.
- Change the examples of how users can run tests. 

## Pull request description 



## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [ ] tested locally
- [ ] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Breaking changes

-

## Changes

-

## Fixes

-