### PR TITLE
docs: fix default commands format

### DIFF
--- a/docs/docs/test-types/executor-ginkgo.md
+++ b/docs/docs/test-types/executor-ginkgo.md
@@ -4,9 +4,10 @@ import Admonition from "@theme/Admonition";
 
 Our dedicated Ginkgo executor allows running Ginkgo tests with Testkube - directly from your Git repository.
 
-Default command for this executor: ginkgo
-Default arguments for this executor command: -r -p --randomize-all --randomize-suites --keep-going --trace --junit-report &lt;reportFile&gt; &lt;envVars&gt; &lt;runPath&gt;
+* Default command for this executor: `ginkgo`
+* Default arguments for this executor command: `-r` `-p` `--randomize-all` `--randomize-suites` `--keep-going` `--trace` `--junit-report` `<reportFile>` `<envVars>` `<runPath>`
 (parameters in &lt;&gt; are calculated at test execution)
+
 
 export const ExecutorInfo = () => {
   return (


### PR DESCRIPTION
## Pull request description 
fixing default commands format for ginkgo


## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [ ] tested locally
- [ ] tested on cluster
- [ ] added new dependencies
- [x] updated the docs
- [ ] added a test

## Breaking changes

-

## Changes

-

## Fixes

-