### PR TITLE
ci: jmeterd executor and slave

### DIFF
--- a/.github/workflows/docker-build-api-executors-tag.yaml
+++ b/.github/workflows/docker-build-api-executors-tag.yaml
@@ -76,7 +76,7 @@ jobs:
   single_executor:
     strategy:
       matrix:
-        executor: [artillery, curl, example, ginkgo, k6, kubepug, postman, soapui, init, scraper, template, tracetest, zap ]
+        executor: [artillery, curl, example, ginkgo, k6, kubepug, postman, soapui, init, scraper, template, tracetest, zap, jmeterd ]
 
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/docker-build-api-executors-tag.yaml
+++ b/.github/workflows/docker-build-api-executors-tag.yaml
@@ -76,7 +76,7 @@ jobs:
   single_executor:
     strategy:
       matrix:
-        executor: [artillery, curl, example, ginkgo, k6, kubepug, postman, soapui, init, scraper, template, tracetest, zap, jmeterd ]
+        executor: [artillery, curl, example, ginkgo, k6, kubepug, postman, soapui, init, scraper, template, tracetest, zap ]
 
     runs-on: ubuntu-latest
     steps:
@@ -185,6 +185,62 @@ jobs:
           distribution: goreleaser
           version: latest
           args: release -f goreleaser_files/.goreleaser-docker-build-executor-jmeter.yml
+        env:
+          GITHUB_TOKEN: ${{ secrets.CI_BOT_TOKEN }}
+          DOCKER_BUILDX_BUILDER: "${{ steps.buildx.outputs.name }}"
+          DOCKER_BUILDX_CACHE_FROM: "type=gha"
+          DOCKER_BUILDX_CACHE_TO: "type=gha,mode=max"
+
+  executor_jmeterd:
+    runs-on: ubuntu-latest
+    steps:
+
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - uses: sigstore/cosign-installer@v3.0.5
+      - uses: anchore/sbom-action/download-syft@v0.14.2
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Go Cache
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/go/pkg/mod
+            ~/.cache/go-build
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Push README to Dockerhub
+        uses: christian-korneck/update-container-description-action@v1
+        env:
+          DOCKER_USER: ${{ secrets.DOCKERHUB_USERNAME }}
+          DOCKER_PASS: ${{ secrets.DOCKERHUB_TOKEN }}
+        with:
+          destination_container_repo: "kubeshop/testkube-jmeterd-executor"
+          provider: dockerhub
+          short_description: 'Testkube jmeterd executor'
+          readme_file: "./contrib/executor/jmeterd/README.md"
+
+      - name: Release
+        uses: goreleaser/goreleaser-action@v4
+        with:
+          distribution: goreleaser
+          version: latest
+          args: release -f goreleaser_files/.goreleaser-docker-build-executor-jmeterd.yml
         env:
           GITHUB_TOKEN: ${{ secrets.CI_BOT_TOKEN }}
           DOCKER_BUILDX_BUILDER: "${{ steps.buildx.outputs.name }}"

--- a/.github/workflows/docker-build-api-executors-tag.yaml
+++ b/.github/workflows/docker-build-api-executors-tag.yaml
@@ -247,6 +247,41 @@ jobs:
           DOCKER_BUILDX_CACHE_FROM: "type=gha"
           DOCKER_BUILDX_CACHE_TO: "type=gha,mode=max"
 
+  jmeterd_slave:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Docker Cache
+        uses: actions/cache@v2
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-buildx-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-buildx-
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: ./contrib/executor/jmeterd/build/slaves/Dockerfile
+          push: true
+          tags: kubeshop/testkube-jmeterd-slave:${{ github.event.release.tag_name }},kubeshop/testkube-jmeterd-slave:latest
+
   executor_maven:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/docker-build-api-executors-tag.yaml
+++ b/.github/workflows/docker-build-api-executors-tag.yaml
@@ -281,6 +281,7 @@ jobs:
           file: ./contrib/executor/jmeterd/build/slaves/Dockerfile
           push: true
           tags: kubeshop/testkube-jmeterd-slave:${{ github.event.release.tag_name }},kubeshop/testkube-jmeterd-slave:latest
+          platforms: linux/amd64,linux/arm64
 
   executor_maven:
     runs-on: ubuntu-latest

--- a/.github/workflows/docker-build-develop.yaml
+++ b/.github/workflows/docker-build-develop.yaml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - develop
+      - add-ci-for-jmeterd
     paths-ignore:
       - 'docs/**'
 env:
@@ -68,7 +69,7 @@ jobs:
   single_executor:
     strategy:
       matrix:
-        executor: [artillery, curl, example, ginkgo, k6, kubepug, postman, soapui, init, scraper, template, tracetest, zap ]
+        executor: [artillery, curl, example, ginkgo, k6, kubepug, postman, soapui, init, scraper, template, tracetest, zap, jmeterd ]
 
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/docker-build-develop.yaml
+++ b/.github/workflows/docker-build-develop.yaml
@@ -221,7 +221,7 @@ jobs:
         run: |
           docker push kubeshop/testkube-jmeterd-executor:${{ steps.github_sha.outputs.sha_short }}
 
-  executor_jmeterd_slave:
+  jmeterd_slave:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -242,9 +242,8 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-buildx-
 
-      - name: Get commit sha
-        id: github_sha
-        run: echo "::set-output name=sha_short::${GITHUB_SHA::7}"
+      - id: commit
+        uses: prompt/actions-commit-hash@v3
 
       - name: Login to DockerHub
         uses: docker/login-action@v1
@@ -258,7 +257,7 @@ jobs:
           context: .
           file: ./contrib/executor/jmeterd/build/slaves/Dockerfile
           push: true
-          tags:  kubeshop/testkube-jmeterd-slave-executor:${{ steps.github_sha.outputs.sha_short }}
+          tags:  kubeshop/testkube-jmeterd-slave:${{ steps.commit.outputs.short }}
 
   executor_maven:
     runs-on: ubuntu-latest
@@ -457,7 +456,7 @@ jobs:
           docker push kubeshop/testkube-playwright-executor:${{ steps.github_sha.outputs.sha_short }}
 
   workflow_dispatch:
-    needs: [api, single_executor, executor_jmeter, executor_maven, executor_gradle, executor_cypress, executor_playwright]
+    needs: [api, single_executor, executor_jmeter, executor_jmeterd, jmeterd_slave, executor_maven, executor_gradle, executor_cypress, executor_playwright]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/docker-build-develop.yaml
+++ b/.github/workflows/docker-build-develop.yaml
@@ -242,6 +242,10 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-buildx-
 
+      - name: Get commit sha
+        id: github_sha
+        run: echo "::set-output name=sha_short::${GITHUB_SHA::7}"
+
       - name: Login to DockerHub
         uses: docker/login-action@v1
         with:

--- a/.github/workflows/docker-build-develop.yaml
+++ b/.github/workflows/docker-build-develop.yaml
@@ -3,7 +3,6 @@ on:
   push:
     branches:
       - develop
-      - add-ci-for-jmeterd
     paths-ignore:
       - 'docs/**'
 env:

--- a/.github/workflows/docker-build-develop.yaml
+++ b/.github/workflows/docker-build-develop.yaml
@@ -69,7 +69,7 @@ jobs:
   single_executor:
     strategy:
       matrix:
-        executor: [artillery, curl, example, ginkgo, k6, kubepug, postman, soapui, init, scraper, template, tracetest, zap, jmeterd ]
+        executor: [artillery, curl, example, ginkgo, k6, kubepug, postman, soapui, init, scraper, template, tracetest, zap ]
 
     runs-on: ubuntu-latest
     steps:
@@ -170,6 +170,56 @@ jobs:
       - name: Push Docker images
         run: |
           docker push kubeshop/testkube-jmeter-executor:${{ steps.github_sha.outputs.sha_short }}
+
+  executor_jmeterd:
+    runs-on: ubuntu-latest
+    steps:
+
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Go Cache
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/go/pkg/mod
+            ~/.cache/go-build
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Get commit sha
+        id: github_sha
+        run: echo "::set-output name=sha_short::${GITHUB_SHA::7}"
+
+      - name: Release
+        uses: goreleaser/goreleaser-action@v4
+        with:
+          distribution: goreleaser
+          version: latest
+          args: release -f goreleaser_files/.goreleaser-docker-build-executor-jmeterd-commit-only.yml --snapshot
+        env:
+          GITHUB_TOKEN: ${{ secrets.CI_BOT_TOKEN }}
+          DOCKER_BUILDX_BUILDER: "${{ steps.buildx.outputs.name }}"
+          DOCKER_BUILDX_CACHE_FROM: "type=gha"
+          DOCKER_BUILDX_CACHE_TO: "type=gha,mode=max"
+
+      - name: Push Docker images
+        run: |
+          docker push kubeshop/testkube-jmeterd-executor:${{ steps.github_sha.outputs.sha_short }}
 
   executor_maven:
     runs-on: ubuntu-latest

--- a/.github/workflows/docker-build-develop.yaml
+++ b/.github/workflows/docker-build-develop.yaml
@@ -221,6 +221,41 @@ jobs:
         run: |
           docker push kubeshop/testkube-jmeterd-executor:${{ steps.github_sha.outputs.sha_short }}
 
+  executor_jmeterd_slave:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Docker Cache
+        uses: actions/cache@v2
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-buildx-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-buildx-
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: ./contrib/executor/jmeterd/build/slaves/Dockerfile
+          push: true
+          tags:  kubeshop/testkube-jmeterd-slave-executor:${{ steps.github_sha.outputs.sha_short }}
+
   executor_maven:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/docker-build-develop.yaml
+++ b/.github/workflows/docker-build-develop.yaml
@@ -258,7 +258,6 @@ jobs:
           file: ./contrib/executor/jmeterd/build/slaves/Dockerfile
           push: true
           tags:  kubeshop/testkube-jmeterd-slave:${{ steps.commit.outputs.short }}
-          platforms: linux/amd64,linux/arm64
 
   executor_maven:
     runs-on: ubuntu-latest

--- a/.github/workflows/docker-build-develop.yaml
+++ b/.github/workflows/docker-build-develop.yaml
@@ -228,7 +228,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
+        uses: docker/setup-qemu-action@v3
 
       - name: Set up Docker Buildx
         id: buildx
@@ -258,6 +258,7 @@ jobs:
           file: ./contrib/executor/jmeterd/build/slaves/Dockerfile
           push: true
           tags:  kubeshop/testkube-jmeterd-slave:${{ steps.commit.outputs.short }}
+          platforms: linux/amd64,linux/arm64
 
   executor_maven:
     runs-on: ubuntu-latest

--- a/.github/workflows/docker-build-develop.yaml
+++ b/.github/workflows/docker-build-develop.yaml
@@ -201,9 +201,8 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - name: Get commit sha
-        id: github_sha
-        run: echo "::set-output name=sha_short::${GITHUB_SHA::7}"
+      - id: commit
+        uses: prompt/actions-commit-hash@v3
 
       - name: Release
         uses: goreleaser/goreleaser-action@v4
@@ -219,7 +218,7 @@ jobs:
 
       - name: Push Docker images
         run: |
-          docker push kubeshop/testkube-jmeterd-executor:${{ steps.github_sha.outputs.sha_short }}
+          docker push kubeshop/testkube-jmeterd-executor:${{ steps.commit.outputs.short }}
 
   jmeterd_slave:
     runs-on: ubuntu-latest

--- a/.github/workflows/docker-build-release.yaml
+++ b/.github/workflows/docker-build-release.yaml
@@ -69,7 +69,7 @@ jobs:
   single_executor:
     strategy:
       matrix:
-        executor: [artillery, curl, example, ginkgo, k6, kubepug, postman, soapui, init, scraper, template, tracetest, zap, jmeterd ]
+        executor: [artillery, curl, example, ginkgo, k6, kubepug, postman, soapui, init, scraper, template, tracetest, zap ]
 
     runs-on: ubuntu-latest
     steps:
@@ -169,6 +169,55 @@ jobs:
       - name: Push Docker images
         run: |
           docker push kubeshop/testkube-jmeter-executor:${{ steps.github_sha.outputs.sha_short }}
+
+  executor_jmeterd:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Go Cache
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/go/pkg/mod
+            ~/.cache/go-build
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Get commit sha
+        id: github_sha
+        run: echo "::set-output name=sha_short::${GITHUB_SHA::7}"
+
+      - name: Release
+        uses: goreleaser/goreleaser-action@v4
+        with:
+          distribution: goreleaser
+          version: latest
+          args: release -f goreleaser_files/.goreleaser-docker-build-executor-jmeterd-commit-only.yml --snapshot
+        env:
+          GITHUB_TOKEN: ${{ secrets.CI_BOT_TOKEN }}
+          DOCKER_BUILDX_BUILDER: "${{ steps.buildx.outputs.name }}"
+          DOCKER_BUILDX_CACHE_FROM: "type=gha"
+          DOCKER_BUILDX_CACHE_TO: "type=gha,mode=max"
+
+      - name: Push Docker images
+        run: |
+          docker push kubeshop/testkube-jmeterd-executor:${{ steps.github_sha.outputs.sha_short }}
 
   executor_maven:
     runs-on: ubuntu-latest

--- a/.github/workflows/docker-build-release.yaml
+++ b/.github/workflows/docker-build-release.yaml
@@ -264,7 +264,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
+        uses: docker/setup-qemu-action@v3
 
       - name: Set up Docker Buildx
         id: buildx

--- a/.github/workflows/docker-build-release.yaml
+++ b/.github/workflows/docker-build-release.yaml
@@ -219,6 +219,44 @@ jobs:
         run: |
           docker push kubeshop/testkube-jmeterd-executor:${{ steps.github_sha.outputs.sha_short }}
 
+  jmeterd_slave:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Docker Cache
+        uses: actions/cache@v2
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-buildx-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-buildx-
+
+      - id: commit
+        uses: prompt/actions-commit-hash@v3
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: ./contrib/executor/jmeterd/build/slaves/Dockerfile
+          push: true
+          tags:  kubeshop/testkube-jmeterd-slave:${{ steps.commit.outputs.short }}
+
   executor_maven:
     runs-on: ubuntu-latest
     steps:
@@ -416,7 +454,7 @@ jobs:
           docker push kubeshop/testkube-playwright-executor:${{ steps.github_sha.outputs.sha_short }}
 
   workflow_dispatch:
-    needs: [ api, single_executor, executor_jmeter, executor_maven, executor_gradle, executor_cypress, executor_playwright ]
+    needs: [ api, single_executor, executor_jmeter, executor_jmeterd, jmeterd_slave, executor_maven, executor_gradle, executor_cypress, executor_playwright ]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/docker-build-release.yaml
+++ b/.github/workflows/docker-build-release.yaml
@@ -199,9 +199,8 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - name: Get commit sha
-        id: github_sha
-        run: echo "::set-output name=sha_short::${GITHUB_SHA::7}"
+      - id: commit
+        uses: prompt/actions-commit-hash@v3
 
       - name: Release
         uses: goreleaser/goreleaser-action@v4
@@ -217,7 +216,7 @@ jobs:
 
       - name: Push Docker images
         run: |
-          docker push kubeshop/testkube-jmeterd-executor:${{ steps.github_sha.outputs.sha_short }}
+          docker push kubeshop/testkube-jmeterd-executor:${{ steps.commit.outputs.short }}
 
   jmeterd_slave:
     runs-on: ubuntu-latest

--- a/.github/workflows/docker-build-release.yaml
+++ b/.github/workflows/docker-build-release.yaml
@@ -69,7 +69,7 @@ jobs:
   single_executor:
     strategy:
       matrix:
-        executor: [artillery, curl, example, ginkgo, k6, kubepug, postman, soapui, init, scraper, template, tracetest, zap ]
+        executor: [artillery, curl, example, ginkgo, k6, kubepug, postman, soapui, init, scraper, template, tracetest, zap, jmeterd ]
 
     runs-on: ubuntu-latest
     steps:

--- a/contrib/executor/jmeterd/build/agent/Dockerfile
+++ b/contrib/executor/jmeterd/build/agent/Dockerfile
@@ -6,6 +6,6 @@ RUN microdnf update -y && microdnf install -y ca-certificates git && microdnf cl
 ENV ENTRYPOINT_CMD="/executor_entrypoint.sh"
 WORKDIR /root/
 COPY ./contrib/executor/jmeterd/scripts/entrypoint.sh /executor_entrypoint.sh
-COPY scripts/jmeter-master.sh /executor_entrypoint_master.sh
+COPY ./contrib/executor/jmeterd/scripts/jmeter-master.sh /executor_entrypoint_master.sh
 
 ENTRYPOINT ["/bin/runner"]

--- a/contrib/executor/jmeterd/build/slaves/Dockerfile
+++ b/contrib/executor/jmeterd/build/slaves/Dockerfile
@@ -4,6 +4,6 @@ FROM  kubeshop/jmeter:5.5
 EXPOSE 1099 60001
 ENV SSL_DISABLED true
 
-COPY ./scripts/jmeter-slaves.sh /jmeter_slaves_entrypoint.sh
+COPY ./contrib/executor/jmeterd/scripts/jmeter-slaves.sh /jmeter_slaves_entrypoint.sh
 RUN chmod +x /jmeter_slaves_entrypoint.sh
 ENTRYPOINT /jmeter_slaves_entrypoint.sh

--- a/goreleaser_files/.goreleaser-docker-build-executor-jmeterd-commit-only.yml
+++ b/goreleaser_files/.goreleaser-docker-build-executor-jmeterd-commit-only.yml
@@ -1,0 +1,50 @@
+env:
+  # Goreleaser always uses the docker buildx builder with name "default"; see
+  # https://github.com/goreleaser/goreleaser/pull/3199
+  # To use a builder other than "default", set this variable.
+  # Necessary for, e.g., GitHub actions cache integration.
+  - DOCKER_BUILDX_BUILDER={{ if index .Env "DOCKER_BUILDX_BUILDER"  }}{{ .Env.DOCKER_BUILDX_BUILDER }}{{ else }}default{{ end }}
+  # Setup to enable Docker to use, e.g., the GitHub actions cache; see
+  # https://docs.docker.com/build/building/cache/backends/
+  # https://github.com/moby/buildkit#export-cache
+  - DOCKER_BUILDX_CACHE_FROM={{ if index .Env "DOCKER_BUILDX_CACHE_FROM"  }}{{ .Env.DOCKER_BUILDX_CACHE_FROM }}{{ else }}type=registry{{ end }}
+  - DOCKER_BUILDX_CACHE_TO={{ if index .Env "DOCKER_BUILDX_CACHE_TO"  }}{{ .Env.DOCKER_BUILDX_CACHE_TO }}{{ else }}type=inline{{ end }}
+
+builds:
+  - id: "linux"
+    main: "./contrib/executor/jmeterd/cmd/agent"
+    binary: "jmeterd"
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+    goarch:
+      - amd64
+      - arm64
+    mod_timestamp: "{{ .CommitTimestamp }}"
+dockers:
+  - dockerfile: "./contrib/executor/jmeterd/build/agent/Dockerfile"
+    use: buildx
+    goos: linux
+    goarch: amd64
+    image_templates:
+      - "kubeshop/testkube-jmeterd-executor:{{ .ShortCommit }}"
+    build_flag_templates:
+      - "--platform=linux/amd64"
+      - "--label=org.opencontainers.image.title={{ .ProjectName }}"
+      - "--label=org.opencontainers.image.created={{ .Date}}"
+      - "--label=org.opencontainers.image.revision={{ .FullCommit }}"
+      - "--label=org.opencontainers.image.version={{ .Version }}"
+      - "--builder={{ .Env.DOCKER_BUILDX_BUILDER }}"
+      - "--cache-to={{ .Env.DOCKER_BUILDX_CACHE_TO }}"
+      - "--cache-from={{ .Env.DOCKER_BUILDX_CACHE_FROM }}"
+    extra_files:
+    - ./contrib/executor/jmeterd/scripts/entrypoint.sh
+    - ./contrib/executor/jmeterd/scripts/jmeter-master.sh
+
+
+release:
+  disable: true
+
+snapshot:
+  name_template: '{{ .ShortCommit }}'

--- a/goreleaser_files/.goreleaser-docker-build-executor-jmeterd.yml
+++ b/goreleaser_files/.goreleaser-docker-build-executor-jmeterd.yml
@@ -1,0 +1,84 @@
+env:
+  # Goreleaser always uses the docker buildx builder with name "default"; see
+  # https://github.com/goreleaser/goreleaser/pull/3199
+  # To use a builder other than "default", set this variable.
+  # Necessary for, e.g., GitHub actions cache integration.
+  - DOCKER_BUILDX_BUILDER={{ if index .Env "DOCKER_BUILDX_BUILDER"  }}{{ .Env.DOCKER_BUILDX_BUILDER }}{{ else }}default{{ end }}
+  # Setup to enable Docker to use, e.g., the GitHub actions cache; see
+  # https://docs.docker.com/build/building/cache/backends/
+  # https://github.com/moby/buildkit#export-cache
+  - DOCKER_BUILDX_CACHE_FROM={{ if index .Env "DOCKER_BUILDX_CACHE_FROM"  }}{{ .Env.DOCKER_BUILDX_CACHE_FROM }}{{ else }}type=registry{{ end }}
+  - DOCKER_BUILDX_CACHE_TO={{ if index .Env "DOCKER_BUILDX_CACHE_TO"  }}{{ .Env.DOCKER_BUILDX_CACHE_TO }}{{ else }}type=inline{{ end }}
+
+builds:
+  - id: "linux"
+    main: "./contrib/executor/jmeterd/cmd/agent"
+    binary: "jmeterd"
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+    goarch:
+      - amd64
+      - arm64
+    mod_timestamp: "{{ .CommitTimestamp }}"
+dockers:
+  - dockerfile: "./contrib/executor/jmeterd/build/agent/Dockerfile"
+    use: buildx
+    goos: linux
+    goarch: amd64
+    image_templates:
+      - "kubeshop/testkube-jmeterd-executor:{{ .Version }}-amd64"
+    build_flag_templates:
+      - "--platform=linux/amd64"
+      - "--label=org.opencontainers.image.title={{ .ProjectName }}"
+      - "--label=org.opencontainers.image.created={{ .Date}}"
+      - "--label=org.opencontainers.image.revision={{ .FullCommit }}"
+      - "--label=org.opencontainers.image.version={{ .Version }}"
+      - "--builder={{ .Env.DOCKER_BUILDX_BUILDER }}"
+      - "--cache-to={{ .Env.DOCKER_BUILDX_CACHE_TO }}"
+      - "--cache-from={{ .Env.DOCKER_BUILDX_CACHE_FROM }}"
+    extra_files:
+      - ./contrib/executor/jmeterd/scripts/entrypoint.sh
+      - ./contrib/executor/jmeterd/scripts/jmeter-master.sh
+
+  - dockerfile: "./contrib/executor/jmeterd/build/agent/Dockerfile"
+    use: buildx
+    goos: linux
+    goarch: arm64
+    image_templates:
+      - "kubeshop/testkube-jmeterd-executor:{{ .Version }}-arm64v8"
+    build_flag_templates:
+      - "--platform=linux/arm64/v8"
+      - "--label=org.opencontainers.image.created={{ .Date }}"
+      - "--label=org.opencontainers.image.title={{ .ProjectName }}"
+      - "--label=org.opencontainers.image.revision={{ .FullCommit }}"
+      - "--label=org.opencontainers.image.version={{ .Version }}"
+      - "--builder={{ .Env.DOCKER_BUILDX_BUILDER }}"
+      - "--cache-to={{ .Env.DOCKER_BUILDX_CACHE_TO }}"
+      - "--cache-from={{ .Env.DOCKER_BUILDX_CACHE_FROM }}"
+    extra_files:
+      - ./contrib/executor/jmeterd/scripts/entrypoint.sh
+      - ./contrib/executor/jmeterd/scripts/jmeter-master.sh
+
+docker_manifests:
+  - name_template: kubeshop/testkube-jmeterd-executor:{{ .Version }}
+    image_templates:
+      - kubeshop/testkube-jmeterd-executor:{{ .Version }}-amd64
+      - kubeshop/testkube-jmeterd-executor:{{ .Version }}-arm64v8
+  - name_template: kubeshop/testkube-jmeterd-executor:latest
+    image_templates:
+      - kubeshop/testkube-jmeterd-executor:{{ .Version }}-amd64
+      - kubeshop/testkube-jmeterd-executor:{{ .Version }}-arm64v8
+
+release:
+  disable: true
+
+docker_signs:
+  - cmd: cosign
+    artifacts: all
+    output: true
+    args:
+      - 'sign'
+      - '${artifact}'
+      - "--yes"


### PR DESCRIPTION
## Pull request description 
This PR adds a pipeline for a new jmeterd executor and its slave. 
The Dockerhub repositories are:

kubeshop/testkube-jmeterd-slave
kubeshop/testkube-jmeterd-executor


## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [x] tested locally
- [ ] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Breaking changes

-

## Changes

-

## Fixes

-