### PR TITLE
feat: Add labels to the slave pods

### DIFF
--- a/contrib/executor/jmeterd/pkg/slaves/client.go
+++ b/contrib/executor/jmeterd/pkg/slaves/client.go
@@ -135,6 +135,12 @@ func (client *Client) getSlavePodConfiguration(currentSlavesCount int) (*v1.Pod,
 	return &v1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: podName,
+			Labels: map[string]string{
+				// Execution Id is the only unique field in case of multiple runs of the same test
+				// So this is the only field which can tag the slave pods to actual job of jmeterd executor
+				"testkube.io/managed-by": client.execution.Id,
+				"testkube.io/test-name":  client.execution.TestName,
+			},
 		},
 		Spec: v1.PodSpec{
 			RestartPolicy: v1.RestartPolicyAlways,


### PR DESCRIPTION
## Pull request description 
Added following two labels in the slave pods:
```
"testkube.io/managed-by": <MASTER_POD>,
"testkube.io/test-name":  <TEST_NAME>,
```

## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [ ] tested locally
- [ ] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Breaking changes

-

## Changes

-

## Fixes

-