### PR TITLE
feat: allow to pass multi namespace flags for testkube cloud init com…

### DIFF
--- a/cmd/kubectl-testkube/commands/cloud/init.go
+++ b/cmd/kubectl-testkube/commands/cloud/init.go
@@ -18,7 +18,7 @@ func NewInitCmd() *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:     "init",
-		Short:   "Install Helm chart registry in current kubectl context and update dependencies",
+		Short:   "Install Testkube Cloud Agent and connect to Testkube Cloud environment",
 		Aliases: []string{"install"},
 		Run: func(cmd *cobra.Command, args []string) {
 			ui.Info("WELCOME TO")
@@ -76,8 +76,11 @@ func NewInitCmd() *cobra.Command {
 
 	cmd.Flags().StringVar(&options.Chart, "chart", "kubeshop/testkube", "chart name (usually you don't need to change it)")
 	cmd.Flags().StringVar(&options.Name, "name", "testkube", "installation name (usually you don't need to change it)")
-	cmd.Flags().StringVar(&options.Namespace, "namespace", "testkube", "namespace where to install")
 	cmd.Flags().StringVar(&options.Values, "values", "", "path to Helm values file")
+
+	cmd.Flags().BoolVar(&options.MultiNamespace, "multi-namespace", false, "multi namespace mode")
+	cmd.Flags().BoolVar(&options.NoOperator, "no-operator", false, "should operator be installed (for more instances in multi namespace mode it should be set to true)")
+	cmd.Flags().StringVar(&options.Namespace, "namespace", "testkube", "namespace where to install")
 
 	cmd.Flags().StringVar(&options.CloudAgentToken, "agent-token", "", "Testkube Cloud agent key")
 	cmd.Flags().StringVar(&options.CloudOrgId, "org-id", "", "Testkube Cloud organization id")

--- a/pkg/cloud/client/rest.go
+++ b/pkg/cloud/client/rest.go
@@ -42,7 +42,8 @@ func (c RESTClient[T]) List() ([]T, error) {
 }
 
 func (c RESTClient[T]) Get(id string) (e T, err error) {
-	req, err := nethttp.NewRequest("GET", c.BaseUrl+c.Path+"/"+id, nil)
+	path := c.BaseUrl + c.Path + "/" + id
+	req, err := nethttp.NewRequest("GET", path, nil)
 	req.Header.Add("Authorization", "Bearer "+c.Token)
 	if err != nil {
 		return e, err
@@ -57,7 +58,7 @@ func (c RESTClient[T]) Get(id string) (e T, err error) {
 		if err != nil {
 			return e, fmt.Errorf("error creating %s: can't read response: %s", c.Path, err)
 		}
-		return e, fmt.Errorf("error creating %s: %s", c.Path, d)
+		return e, fmt.Errorf("error getting %s: %s", path, d)
 	}
 
 	err = json.NewDecoder(resp.Body).Decode(&e)


### PR DESCRIPTION
I was able to install cloud agent in two separate namespaces with that change

<img width="625" alt="image" src="https://github.com/kubeshop/testkube/assets/30776/853c9ebd-1d45-400a-8bf2-a88c9d07ff04">



## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [ ] tested locally
- [ ] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Breaking changes

-

## Changes

-

## Fixes

-