### PR TITLE
fix: test artifacts failing due to empty file placement (#4444)

### DIFF
--- a/pkg/storage/minio/minio.go
+++ b/pkg/storage/minio/minio.go
@@ -557,6 +557,13 @@ func (c *Client) PlaceFiles(ctx context.Context, bucketFolders []string, prefix 
 			output.PrintEvent(fmt.Sprintf("%s Downloading file %s", ui.IconFile, f.Name))
 			c.Log.Infof("Getting file %s", f)
 			objectName := f.Name
+
+			isFileDownloadable := strings.TrimSpace(objectName) != "" && !strings.HasSuffix(objectName, "/")
+			if !isFileDownloadable {
+				output.PrintEvent(fmt.Sprintf("%s File %s cannot be downloaded", ui.IconCross, objectName))
+				continue
+			}
+
 			if folder != "" {
 				objectName = fmt.Sprintf("%s/%s", folder, objectName)
 			}


### PR DESCRIPTION
…cement (#4444)

## Pull request description 
Minio creates empty file for folder when AWS S3 is used causing subsequent files to fail downloading.


## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [x] tested locally
- [x] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Breaking changes

-

## Changes

- Added filter for empty file names and skip them

## Fixes

-