### PR TITLE
fix: update CRD for Dashboard tests to match mono-repository setup

### DIFF
--- a/test/dashboard-e2e/crd/crd.yaml
+++ b/test/dashboard-e2e/crd/crd.yaml
@@ -12,8 +12,8 @@ spec:
       type: git
       uri: https://github.com/kubeshop/testkube-dashboard
       branch: main
-      path: test/dashboard-e2e
-      workingDir: test/dashboard-e2e
+      path: packages/e2e-tests
+      workingDir: packages/e2e-tests
   executionRequest:
     variables:
       BASE_URL:


### PR DESCRIPTION
## Pull request description 

Update CRD for Dashboard tests to match the mono-repository setup (as per https://github.com/kubeshop/testkube-dashboard/pull/898)

## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [ ] tested locally
- [ ] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Breaking changes

-

## Changes

-

## Fixes

-