### PR TITLE
docs: fix navbar not showing on small screens

### DIFF
--- a/docs/src/css/custom.css
+++ b/docs/src/css/custom.css
@@ -342,6 +342,10 @@ ul:hover {
   margin-right: auto;
 } */
 
+.navbar-sidebar--show {
+  backdrop-filter: none !important;
+}
+
 @media screen and (max-width: 996px) {
   :root {
     --ifm-font-size-base: 18px;


### PR DESCRIPTION
## Pull request description 
sidebar was not showing on smaller screens for the docs. removed backdrop-filter to fix the issue.

before:
![CleanShot 2023-10-18 at 16 51 29](https://github.com/kubeshop/testkube/assets/93217218/cd798ff3-0c90-44dd-8b6e-86001ca2b4fa)
sidebar is behind main content when clicking on hamburger menu

without backdrop filter:
![CleanShot 2023-10-18 at 16 52 13](https://github.com/kubeshop/testkube/assets/93217218/9ace4dc2-b687-4072-b63e-87824a0f217f)
sidebar shows when clicked on


## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [ ] tested locally
- [ ] tested on cluster
- [ ] added new dependencies
- [x] updated the docs
- [ ] added a test

## Breaking changes

-

## Changes

-

## Fixes

-