### PR TITLE
fix: mask slack token in log message

### DIFF
--- a/pkg/slack/slack.go
+++ b/pkg/slack/slack.go
@@ -10,6 +10,7 @@ import (
 	"github.com/kubeshop/testkube/pkg/api/v1/testkube"
 	"github.com/kubeshop/testkube/pkg/log"
 	"github.com/kubeshop/testkube/pkg/utils"
+	"github.com/kubeshop/testkube/pkg/utils/text"
 )
 
 type MessageArgs struct {
@@ -47,7 +48,7 @@ func NewNotifier(template, clusterName, dashboardURI string, config []Notificati
 		config: NewConfig(config), envs: envs}
 	notifier.timestamps = make(map[string]string)
 	if token, ok := os.LookupEnv("SLACK_TOKEN"); ok {
-		log.DefaultLogger.Infow("initializing slack client", "SLACK_TOKEN", token)
+		log.DefaultLogger.Infow("initializing slack client", "SLACK_TOKEN", text.Obfuscate(token))
 		notifier.client = slack.New(token, slack.OptionDebug(true))
 		notifier.Ready = true
 	} else {


### PR DESCRIPTION
## Pull request description 
When configured, the Slack token is shown in plain text in the logs. This is not desired and this PR masks all but the first part of the token.


## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [x] tested locally
- [ ] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [x] added a test

## Fixes

- Mask slack token in log message