### PR TITLE
feat: improve performance for slowest operations / fix: loading total executions number for test suite

### DIFF
--- a/internal/app/api/v1/testsuites.go
+++ b/internal/app/api/v1/testsuites.go
@@ -673,7 +673,8 @@ func (s TestkubeAPI) ListTestSuiteExecutionsHandler() fiber.Handler {
 		if err != nil {
 			return s.Error(c, http.StatusInternalServerError, fmt.Errorf("%s: client could not get total executions: %w", errPrefix, err))
 		}
-		allExecutionsTotals, err := s.TestExecutionResults.GetExecutionsTotals(ctx)
+		nameFilter := testresult.NewExecutionsFilter().WithName(c.Query("id", ""))
+		allExecutionsTotals, err := s.TestExecutionResults.GetExecutionsTotals(ctx, nameFilter)
 		if err != nil {
 			return s.Error(c, http.StatusInternalServerError, fmt.Errorf("%s: client could not get all total executions: %w", errPrefix, err))
 		}

--- a/pkg/repository/result/mongo.go
+++ b/pkg/repository/result/mongo.go
@@ -160,7 +160,8 @@ func (r *MongoRepository) GetLatestByTests(ctx context.Context, testNames []stri
 		conditions = append(conditions, bson.M{"testname": testName})
 	}
 
-	pipeline := []bson.D{{{Key: "$match", Value: bson.M{"$or": conditions}}}}
+	pipeline := []bson.D{{{Key: "$project", Value: bson.D{{Key: "_id", Value: 1}, {Key: "id", Value: 1}, {Key: "testname", Value: 1}, {Key: sortField, Value: 1}}}}}
+	pipeline = append(pipeline, bson.D{{Key: "$match", Value: bson.M{"$or": conditions}}})
 	pipeline = append(pipeline, bson.D{{Key: "$sort", Value: bson.D{{Key: sortField, Value: -1}}}})
 	pipeline = append(pipeline, bson.D{
 		{Key: "$group", Value: bson.D{{Key: "_id", Value: "$testname"}, {Key: "latest_id", Value: bson.D{{Key: "$first", Value: "$id"}}}}}})

--- a/pkg/repository/testresult/mongo.go
+++ b/pkg/repository/testresult/mongo.go
@@ -76,7 +76,8 @@ func (r *MongoRepository) GetLatestByTestSuites(ctx context.Context, testSuiteNa
 		conditions = append(conditions, bson.M{"testsuite.name": testSuiteName})
 	}
 
-	pipeline := []bson.D{{{Key: "$match", Value: bson.M{"$or": conditions}}}}
+	pipeline := []bson.D{{{Key: "$project", Value: bson.D{{Key: "_id", Value: 1}, {Key: "id", Value: 1}, {Key: "testsuite.name", Value: 1}, {Key: sortField, Value: 1}}}}}
+	pipeline = append(pipeline, bson.D{{Key: "$match", Value: bson.M{"$or": conditions}}})
 	pipeline = append(pipeline, bson.D{{Key: "$sort", Value: bson.D{{Key: sortField, Value: -1}}}})
 	pipeline = append(pipeline, bson.D{
 		{Key: "$group", Value: bson.D{{Key: "_id", Value: "$testsuite.name"}, {Key: "latest_id", Value: bson.D{{Key: "$first", Value: "$id"}}}}}})


### PR DESCRIPTION
## Pull request description 

* Add projection for getting latest tests / test suites to speed up
* Add filtering by `testsuite.name` for getting total count of test suite executions

## Additional steps

We don't have MongoDB migrations mechanism yet, so we need to manually add these indexes:

```js
// Migrations
db.getSiblingDB("testkube").getCollection("testresults").createIndex({"id": "hashed"})
db.getSiblingDB("testkube").getCollection("testresults").createIndex({"testsuite.name": "hashed"})
db.getSiblingDB("testkube").getCollection("results").createIndex({"id": "hashed"})
db.getSiblingDB("testkube").getCollection("results").createIndex({"testname": "hashed"})

// Rollback
db.getSiblingDB("testkube").getCollection("testresults").dropIndex("id_hashed")
db.getSiblingDB("testkube").getCollection("testresults").dropIndex("testsuite.name_hashed")
db.getSiblingDB("testkube").getCollection("results").dropIndex("id_hashed")
db.getSiblingDB("testkube").getCollection("results").dropIndex("testname_hashed")
```

## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [x] tested locally
- [ ] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test