### PR TITLE
feat: improve performance of listing tests/test suites/executions

### DIFF
--- a/internal/app/api/v1/executions_test.go
+++ b/internal/app/api/v1/executions_test.go
@@ -135,11 +135,11 @@ func (r MockExecutionResultsRepository) GetByNameAndTest(ctx context.Context, na
 	panic("not implemented")
 }
 
-func (r MockExecutionResultsRepository) GetLatestByTest(ctx context.Context, testName, sortField string) (testkube.Execution, error) {
+func (r MockExecutionResultsRepository) GetLatestByTest(ctx context.Context, testName string) (testkube.Execution, error) {
 	panic("not implemented")
 }
 
-func (r MockExecutionResultsRepository) GetLatestByTests(ctx context.Context, testNames []string, sortField string) (executions []testkube.Execution, err error) {
+func (r MockExecutionResultsRepository) GetLatestByTests(ctx context.Context, testNames []string) (executions []testkube.Execution, err error) {
 	panic("not implemented")
 }
 

--- a/internal/app/api/v1/testsuites.go
+++ b/internal/app/api/v1/testsuites.go
@@ -228,32 +228,15 @@ func (s TestkubeAPI) GetTestSuiteWithExecutionHandler() fiber.Handler {
 		}
 
 		ctx := c.Context()
-		startExecution, startErr := s.TestExecutionResults.GetLatestByTestSuite(ctx, name, "starttime")
-		if startErr != nil && startErr != mongo.ErrNoDocuments {
-			return s.Error(c, http.StatusInternalServerError, fmt.Errorf("%s: could not get execution by start time :%w", errPrefix, startErr))
+		execution, err := s.TestExecutionResults.GetLatestByTestSuite(ctx, name)
+		if err != nil && err != mongo.ErrNoDocuments {
+			return s.Error(c, http.StatusInternalServerError, fmt.Errorf("%s: could not get execution: %w", errPrefix, err))
 		}
 
-		endExecution, endErr := s.TestExecutionResults.GetLatestByTestSuite(ctx, name, "endtime")
-		if endErr != nil && endErr != mongo.ErrNoDocuments {
-			return s.Error(c, http.StatusInternalServerError, fmt.Errorf("%s: could not get execution by end time :%w", errPrefix, endErr))
-		}
-
-		testSuiteWithExecution := testkube.TestSuiteWithExecution{
-			TestSuite: &testSuite,
-		}
-		if startErr == nil && endErr == nil {
-			if startExecution.StartTime.After(endExecution.EndTime) {
-				testSuiteWithExecution.LatestExecution = &startExecution
-			} else {
-				testSuiteWithExecution.LatestExecution = &endExecution
-			}
-		} else if startErr == nil {
-			testSuiteWithExecution.LatestExecution = &startExecution
-		} else if endErr == nil {
-			testSuiteWithExecution.LatestExecution = &endExecution
-		}
-
-		return c.JSON(testSuiteWithExecution)
+		return c.JSON(testkube.TestSuiteWithExecution{
+			TestSuite:       &testSuite,
+			LatestExecution: &execution,
+		})
 	}
 }
 
@@ -421,59 +404,18 @@ func (s TestkubeAPI) TestSuiteMetricsHandler() fiber.Handler {
 
 // getLatestTestSuiteExecutions return latest test suite executions either by starttime or endtine for tests
 func (s TestkubeAPI) getLatestTestSuiteExecutions(ctx context.Context, testSuiteNames []string) (map[string]testkube.TestSuiteExecution, error) {
-	executions, err := s.TestExecutionResults.GetLatestByTestSuites(ctx, testSuiteNames, "starttime")
+	executions, err := s.TestExecutionResults.GetLatestByTestSuites(ctx, testSuiteNames)
 	if err != nil && err != mongo.ErrNoDocuments {
 		return nil, err
 	}
 
-	startExecutionMap := make(map[string]testkube.TestSuiteExecution, len(executions))
+	executionMap := make(map[string]testkube.TestSuiteExecution, len(executions))
 	for i := range executions {
 		if executions[i].TestSuite == nil {
 			continue
 		}
-
-		startExecutionMap[executions[i].TestSuite.Name] = executions[i]
+		executionMap[executions[i].TestSuite.Name] = executions[i]
 	}
-
-	executions, err = s.TestExecutionResults.GetLatestByTestSuites(ctx, testSuiteNames, "endtime")
-	if err != nil && err != mongo.ErrNoDocuments {
-		return nil, err
-	}
-
-	endExecutionMap := make(map[string]testkube.TestSuiteExecution, len(executions))
-	for i := range executions {
-		if executions[i].TestSuite == nil {
-			continue
-		}
-
-		endExecutionMap[executions[i].TestSuite.Name] = executions[i]
-	}
-
-	executionMap := make(map[string]testkube.TestSuiteExecution)
-	for _, testSuiteName := range testSuiteNames {
-		startExecution, okStart := startExecutionMap[testSuiteName]
-		endExecution, okEnd := endExecutionMap[testSuiteName]
-		if !okStart && !okEnd {
-			continue
-		}
-
-		if okStart && !okEnd {
-			executionMap[testSuiteName] = startExecution
-			continue
-		}
-
-		if !okStart && okEnd {
-			executionMap[testSuiteName] = endExecution
-			continue
-		}
-
-		if startExecution.StartTime.After(endExecution.EndTime) {
-			executionMap[testSuiteName] = startExecution
-		} else {
-			executionMap[testSuiteName] = endExecution
-		}
-	}
-
 	return executionMap, nil
 }
 

--- a/pkg/cloud/data/testresult/testresult_test.go
+++ b/pkg/cloud/data/testresult/testresult_test.go
@@ -96,5 +96,7 @@ func TestCloudResultRepository_GetLatestByTestSuites(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GetLatestByTestSuites() returned an unexpected error: %v", err)
 	}
-	assert.Equal(t, expectedResults, results)
+	assert.Equal(t, len(results), len(expectedResults))
+	assert.Contains(t, results, expectedResults[0])
+	assert.Contains(t, results, expectedResults[1])
 }

--- a/pkg/executor/containerexecutor/containerexecutor_test.go
+++ b/pkg/executor/containerexecutor/containerexecutor_test.go
@@ -355,12 +355,12 @@ func (r FakeResultRepository) GetByNameAndTest(ctx context.Context, name, testNa
 	panic("implement me")
 }
 
-func (r FakeResultRepository) GetLatestByTest(ctx context.Context, testName, sortField string) (testkube.Execution, error) {
+func (r FakeResultRepository) GetLatestByTest(ctx context.Context, testName string) (testkube.Execution, error) {
 	//TODO implement me
 	panic("implement me")
 }
 
-func (r FakeResultRepository) GetLatestByTests(ctx context.Context, testNames []string, sortField string) (executions []testkube.Execution, err error) {
+func (r FakeResultRepository) GetLatestByTests(ctx context.Context, testNames []string) (executions []testkube.Execution, err error) {
 	//TODO implement me
 	panic("implement me")
 }

--- a/pkg/repository/result/interface.go
+++ b/pkg/repository/result/interface.go
@@ -38,9 +38,9 @@ type Repository interface {
 	// GetByNameAndTest gets execution result by name and test name
 	GetByNameAndTest(ctx context.Context, name, testName string) (testkube.Execution, error)
 	// GetLatestByTest gets latest execution result by test
-	GetLatestByTest(ctx context.Context, testName, sortField string) (testkube.Execution, error)
+	GetLatestByTest(ctx context.Context, testName string) (testkube.Execution, error)
 	// GetLatestByTests gets latest execution results by test names
-	GetLatestByTests(ctx context.Context, testNames []string, sortField string) (executions []testkube.Execution, err error)
+	GetLatestByTests(ctx context.Context, testNames []string) (executions []testkube.Execution, err error)
 	// GetExecutions gets executions using a filter, use filter with no data for all
 	GetExecutions(ctx context.Context, filter Filter) ([]testkube.Execution, error)
 	// GetExecutionTotals gets the statistics on number of executions using a filter, but without paging

--- a/pkg/repository/result/mock_repository.go
+++ b/pkg/repository/result/mock_repository.go
@@ -216,33 +216,33 @@ func (mr *MockRepositoryMockRecorder) GetLabels(arg0 interface{}) *gomock.Call {
 }
 
 // GetLatestByTest mocks base method.
-func (m *MockRepository) GetLatestByTest(arg0 context.Context, arg1, arg2 string) (testkube.Execution, error) {
+func (m *MockRepository) GetLatestByTest(arg0 context.Context, arg1 string) (testkube.Execution, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetLatestByTest", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "GetLatestByTest", arg0, arg1)
 	ret0, _ := ret[0].(testkube.Execution)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetLatestByTest indicates an expected call of GetLatestByTest.
-func (mr *MockRepositoryMockRecorder) GetLatestByTest(arg0, arg1, arg2 interface{}) *gomock.Call {
+func (mr *MockRepositoryMockRecorder) GetLatestByTest(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetLatestByTest", reflect.TypeOf((*MockRepository)(nil).GetLatestByTest), arg0, arg1, arg2)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetLatestByTest", reflect.TypeOf((*MockRepository)(nil).GetLatestByTest), arg0, arg1)
 }
 
 // GetLatestByTests mocks base method.
-func (m *MockRepository) GetLatestByTests(arg0 context.Context, arg1 []string, arg2 string) ([]testkube.Execution, error) {
+func (m *MockRepository) GetLatestByTests(arg0 context.Context, arg1 []string) ([]testkube.Execution, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetLatestByTests", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "GetLatestByTests", arg0, arg1)
 	ret0, _ := ret[0].([]testkube.Execution)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetLatestByTests indicates an expected call of GetLatestByTests.
-func (mr *MockRepositoryMockRecorder) GetLatestByTests(arg0, arg1, arg2 interface{}) *gomock.Call {
+func (mr *MockRepositoryMockRecorder) GetLatestByTests(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetLatestByTests", reflect.TypeOf((*MockRepository)(nil).GetLatestByTests), arg0, arg1, arg2)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetLatestByTests", reflect.TypeOf((*MockRepository)(nil).GetLatestByTests), arg0, arg1)
 }
 
 // GetNextExecutionNumber mocks base method.

--- a/pkg/repository/result/mongo_numbers.go
+++ b/pkg/repository/result/mongo_numbers.go
@@ -42,8 +42,8 @@ func (r *MongoRepository) GetNextExecutionNumber(ctx context.Context, name strin
 	err = r.SequencesColl.FindOne(ctx, bson.M{"name": name}).Decode(&execNmbr)
 	if err != nil {
 		var execution testkube.Execution
-		execution, err = r.GetLatestByTest(ctx, name, "number")
-		if err != nil {
+		number, _ = r.GetLatestTestNumber(ctx, name)
+		if number == 0 {
 			execNmbr.Number = 1
 		} else {
 			execNmbr.Number = int(execution.Number) + 1

--- a/pkg/repository/testresult/interface.go
+++ b/pkg/repository/testresult/interface.go
@@ -34,9 +34,9 @@ type Repository interface {
 	// GetByNameAndTestSuite gets execution result by name
 	GetByNameAndTestSuite(ctx context.Context, name, testSuiteName string) (testkube.TestSuiteExecution, error)
 	// GetLatestByTestSuite gets latest execution result by test suite
-	GetLatestByTestSuite(ctx context.Context, testSuiteName, sortField string) (testkube.TestSuiteExecution, error)
+	GetLatestByTestSuite(ctx context.Context, testSuiteName string) (testkube.TestSuiteExecution, error)
 	// GetLatestByTestSuites gets latest execution results by test suite names
-	GetLatestByTestSuites(ctx context.Context, testSuiteNames []string, sortField string) (executions []testkube.TestSuiteExecution, err error)
+	GetLatestByTestSuites(ctx context.Context, testSuiteNames []string) (executions []testkube.TestSuiteExecution, err error)
 	// GetExecutionsTotals gets executions total stats using a filter, use filter with no data for all
 	GetExecutionsTotals(ctx context.Context, filter ...Filter) (totals testkube.ExecutionsTotals, err error)
 	// GetExecutions gets executions using a filter, use filter with no data for all

--- a/pkg/repository/testresult/mock_repository.go
+++ b/pkg/repository/testresult/mock_repository.go
@@ -159,33 +159,33 @@ func (mr *MockRepositoryMockRecorder) GetExecutionsTotals(arg0 interface{}, arg1
 }
 
 // GetLatestByTestSuite mocks base method.
-func (m *MockRepository) GetLatestByTestSuite(arg0 context.Context, arg1, arg2 string) (testkube.TestSuiteExecution, error) {
+func (m *MockRepository) GetLatestByTestSuite(arg0 context.Context, arg1 string) (testkube.TestSuiteExecution, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetLatestByTestSuite", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "GetLatestByTestSuite", arg0, arg1)
 	ret0, _ := ret[0].(testkube.TestSuiteExecution)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetLatestByTestSuite indicates an expected call of GetLatestByTestSuite.
-func (mr *MockRepositoryMockRecorder) GetLatestByTestSuite(arg0, arg1, arg2 interface{}) *gomock.Call {
+func (mr *MockRepositoryMockRecorder) GetLatestByTestSuite(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetLatestByTestSuite", reflect.TypeOf((*MockRepository)(nil).GetLatestByTestSuite), arg0, arg1, arg2)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetLatestByTestSuite", reflect.TypeOf((*MockRepository)(nil).GetLatestByTestSuite), arg0, arg1)
 }
 
 // GetLatestByTestSuites mocks base method.
-func (m *MockRepository) GetLatestByTestSuites(arg0 context.Context, arg1 []string, arg2 string) ([]testkube.TestSuiteExecution, error) {
+func (m *MockRepository) GetLatestByTestSuites(arg0 context.Context, arg1 []string) ([]testkube.TestSuiteExecution, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetLatestByTestSuites", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "GetLatestByTestSuites", arg0, arg1)
 	ret0, _ := ret[0].([]testkube.TestSuiteExecution)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetLatestByTestSuites indicates an expected call of GetLatestByTestSuites.
-func (mr *MockRepositoryMockRecorder) GetLatestByTestSuites(arg0, arg1, arg2 interface{}) *gomock.Call {
+func (mr *MockRepositoryMockRecorder) GetLatestByTestSuites(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetLatestByTestSuites", reflect.TypeOf((*MockRepository)(nil).GetLatestByTestSuites), arg0, arg1, arg2)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetLatestByTestSuites", reflect.TypeOf((*MockRepository)(nil).GetLatestByTestSuites), arg0, arg1)
 }
 
 // GetTestSuiteMetrics mocks base method.


### PR DESCRIPTION
## Pull request description 

Redesigned MongoDB queries for loading test/test suite executions.

* **Earlier:** there were 4 queries to MongoDB: `aggregate()` to get latest executions ID per `starttime` and `find()` to get these executions, and both the same for `endtime`. Later these were compared based on latest date.
* **Now:** all of that is resolved in a single `aggregate()`

Thanks to that, it works faster. To make it even faster, we would need to persist something like `updatetime` (latest of `starttime`/`endtime`) in the execution, but it can be a further improvement in future.

> **Cloud implementation**
> As for now Cloud API is using similar strategy as OSS before, with loading two sets on both `starttime`/`endtime` and comparing them, I kept the same behavior as it was for the `CloudRepository`.
>
> When the Cloud API will have it reinvented (for backwards compatibility, probably: will have a new Command that will use similar strategy), we may replace the `CloudRepository` to call it directly. Cc: @exu 

## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [x] tested locally
- [x] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [x] updated tests
