### PR TITLE
fix: return executions for all tests when requested

### DIFF
--- a/pkg/repository/result/mongo.go
+++ b/pkg/repository/result/mongo.go
@@ -208,7 +208,6 @@ func (r *MongoRepository) GetLatestByTests(ctx context.Context, testNames []stri
 
 		{"$lookup": bson.M{"from": "results", "localField": "doc.content._id", "foreignField": "_id", "as": "execution"}},
 		{"$replaceRoot": bson.M{"newRoot": bson.M{"$arrayElemAt": bson.A{"$execution", 0}}}},
-		{"$limit": 1},
 	}
 
 	opts := options.Aggregate()


### PR DESCRIPTION
## Pull request description 

With last PR I have introduced a bug, that limits fetched executions to 1 item. This PR is deleting this limit.

## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [x] tested locally
- [x] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test