### PR TITLE
docs: add pro feature badge to pro feature pages

### DIFF
--- a/docs/docs/testkube-cloud/articles/AI-test-insights.md
+++ b/docs/docs/testkube-cloud/articles/AI-test-insights.md
@@ -1,5 +1,15 @@
 # AI Test Insights
 
+export const ProBadge = () => {
+  return (
+    <span>
+      <p class="pro-badge">PRO FEATURE</p>
+    </span>
+  );
+}
+
+<ProBadge />
+
 :::note
 The AI Insights feature on Testkube utilizes artificial intelligence to help you debug your failed tests faster. It collects relevant bits of the failed logs and sends them to OpenAI which processes them and gives an assessment on why the test failed.
 :::

--- a/docs/docs/testkube-cloud/articles/cached-results.md
+++ b/docs/docs/testkube-cloud/articles/cached-results.md
@@ -1,5 +1,15 @@
 # Cached Test Results
 
+export const ProBadge = () => {
+  return (
+    <span>
+      <p class="pro-badge">PRO FEATURE</p>
+    </span>
+  );
+}
+
+<ProBadge />
+
 Testkube cached test results allows you to see and inspect test execution results even when your Testkube agent is offline.
 
 ## Overview

--- a/docs/docs/testkube-cloud/articles/status-pages.md
+++ b/docs/docs/testkube-cloud/articles/status-pages.md
@@ -1,5 +1,15 @@
 # Status Pages
 
+export const ProBadge = () => {
+  return (
+    <span>
+      <p class="pro-badge">PRO FEATURE</p>
+    </span>
+  );
+}
+
+<ProBadge />
+
 The Testkube status pages are designed to help both technical and non-technical users understand and utilize the results of tests run on Testkube effectively. Whether you're a developer, project manager, or simply a stakeholder interested in monitoring software project status via running tests, Testkube has you covered.
 
 ## Overview

--- a/docs/src/css/custom.css
+++ b/docs/src/css/custom.css
@@ -30,6 +30,8 @@
   --ifm-color-gray-300: #e2e8f0;
   --ifm-color-gray-200: #f1f5f9;
   --ifm-color-gray-100: #f8fafc;
+  --ifm-color-badge-border: #454fad;
+  --ifm-color-badge: #c8cdff;
   /* --ifm-menu-link-sublist-icon:  */
   --ifm-code-font-size: 90%; /*95%;*/
   --ifm-line-height-base: 1.45; /* Instead of 1.5 */
@@ -55,6 +57,8 @@
   --ifm-color-primary-light: #29d5b0;
   --ifm-color-primary-lighter: #32d8b4;
   --ifm-color-primary-lightest: #4fddbf;
+    --ifm-color-badge-border: #0EA5E9;
+  --ifm-color-badge: #0C4A6E;
   --docusaurus-highlighted-code-line-bg: var(var(--ifm-color-gray-1000));
 }
 
@@ -344,6 +348,19 @@ ul:hover {
 
 .navbar-sidebar--show {
   backdrop-filter: none !important;
+}
+
+.pro-badge {
+  width: fit-content;
+  background-color: var(--ifm-color-badge);
+  border: 1px var(--ifm-color-badge-border) solid;
+  border-radius: 4px;
+
+  color: var(--ifm-color-badge-border);
+  font-size: 75%;
+
+  padding: 0.3rem;
+  margin-top: -10px;
 }
 
 @media screen and (max-width: 996px) {

--- a/docs/src/css/custom.css
+++ b/docs/src/css/custom.css
@@ -57,7 +57,7 @@
   --ifm-color-primary-light: #29d5b0;
   --ifm-color-primary-lighter: #32d8b4;
   --ifm-color-primary-lightest: #4fddbf;
-    --ifm-color-badge-border: #0EA5E9;
+  --ifm-color-badge-border: #0EA5E9;
   --ifm-color-badge: #0C4A6E;
   --docusaurus-highlighted-code-line-bg: var(var(--ifm-color-gray-1000));
 }


### PR DESCRIPTION
## Pull request description 

Added PRO FEATURE badge to Pro Feature pages (AI Test Insights, Cached Test Results, Status Pages)

<img width="1008" alt="CleanShot 2023-10-26 at 16 56 36@2x" src="https://github.com/kubeshop/testkube/assets/93217218/51370939-a374-4698-abac-1c37f4a27e26">

Will add FREE badge as well to go side by side on same <span> element to those features that are available both in PRO and FREE versions of TK Cloud 

## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [ ] tested locally
- [ ] tested on cluster
- [ ] added new dependencies
- [x] updated the docs
- [ ] added a test

## Breaking changes

-

## Changes

-

## Fixes

-