### PR TITLE
fix: total number of test suite executions should ignore paging filters

### DIFF
--- a/internal/app/api/v1/testsuites.go
+++ b/internal/app/api/v1/testsuites.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"math"
 	"net/http"
 	"sort"
 	"strconv"
@@ -622,8 +623,9 @@ func (s TestkubeAPI) ListTestSuiteExecutionsHandler() fiber.Handler {
 			return s.Error(c, http.StatusInternalServerError, fmt.Errorf("%s: client could not get executions totals: %w", errPrefix, err))
 		}
 		l.Debugw("got executions totals", "totals", executionsTotals, "time", time.Since(now))
-		nameFilter := testresult.NewExecutionsFilter().WithName(c.Query("id", ""))
-		allExecutionsTotals, err := s.TestExecutionResults.GetExecutionsTotals(ctx, nameFilter)
+		filterAllTotals := *filter.(*testresult.FilterImpl)
+		filterAllTotals.WithPage(0).WithPageSize(math.MaxInt64)
+		allExecutionsTotals, err := s.TestExecutionResults.GetExecutionsTotals(ctx, filterAllTotals)
 		if err != nil {
 			return s.Error(c, http.StatusInternalServerError, fmt.Errorf("%s: client could not get all executions totals: %w", errPrefix, err))
 		}


### PR DESCRIPTION
## Pull request description 

- Right now, maximum results counted in test suites executions totals is the page size (defaults: 100). It should ignore paging filters, and instead return number for totals.

## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [x] tested locally
- [x] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test