### PR TITLE
fix: result line for websockets

### DIFF
--- a/pkg/executor/agent/agent.go
+++ b/pkg/executor/agent/agent.go
@@ -95,9 +95,9 @@ func Run(ctx context.Context, r runner.Runner, args []string) {
 
 	if r.GetType().IsMain() {
 		output.PrintEvent("test execution finished", e.Id)
+		output.PrintResult(result)
 	}
 
-	output.PrintResult(result)
 }
 
 // RunScript runs script


### PR DESCRIPTION
## Pull request description 

should fix this first line:

![image](https://github.com/kubeshop/testkube/assets/30776/88fdb7a1-930d-4f1f-813e-42a78b0e356a)



## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [ ] tested locally
- [ ] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Breaking changes

-

## Changes

-

## Fixes

-