### PR TITLE
feat: adding support for tracetest cloud on tracetest executor

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -146,6 +146,9 @@ jobs:
       - name: Set up Playwright
         run: pnpx playwright install --with-deps
 
+      - name: Set up Tracetest
+        run: curl -L https://raw.githubusercontent.com/kubeshop/tracetest/main/install-cli.sh | bash
+
       - name: Set up git
         run: sudo apt-get install -y git
 

--- a/config/executors.json
+++ b/config/executors.json
@@ -7,17 +7,7 @@
             "command": [
                 "tracetest"
             ],
-            "args": [
-                "test",
-                "run",
-                "--server-url",
-                "<tracetestServer>",
-                "--definition",
-                "<filePath>",
-                "--wait-for-result",
-                "--output",
-                "pretty"
-            ],
+            "args": [],
             "types": [
                 "tracetest/test"
             ],

--- a/contrib/executor/tracetest/Makefile
+++ b/contrib/executor/tracetest/Makefile
@@ -1,36 +1,28 @@
 NAME ?= testkube-executor-tracetest
 BIN_DIR ?= $(HOME)/bin
 
-build:
-	go build -o $(BIN_DIR)/$(NAME) cmd/agent/main.go 
+help: Makefile ## show list of commands
+	@echo "Choose a command run:"
+	@echo ""
+	@awk 'BEGIN {FS = ":.*?## "} /[a-zA-Z_-]+:.*?## / {sub("\\\\n",sprintf("\n%22c"," "), $$2);printf "\033[36m%-40s\033[0m %s\n", $$1, $$2}' $(MAKEFILE_LIST) | sort
+
+build: ## build executable locally
+	go build -o $(BIN_DIR)/$(NAME) cmd/agent/main.go
 
 .PHONY: test cover build
 
-run: 
+run: ## run the executor locally
 	EXECUTOR_PORT=8082 go run cmd/agent/main.go
 
-mongo-dev: 
-	docker run -p 27017:27017 mongo
-
-docker-build: 
+docker-build: ## build docker image
 	docker build -t kubeshop/$(NAME) -f build/agent/Dockerfile .
 
-install-swagger-codegen-mac: 
-	brew install swagger-codegen
-
-test: 
+test: ## run unit tests
 	go test ./... -cover
 
-test-e2e:
-	go test --tags=e2e -v ./test/e2e
-
-test-e2e-namespace:
-	NAMESPACE=$(NAMESPACE) go test --tags=e2e -v  ./test/e2e 
-
-cover: 
-	@go test -failfast -count=1 -v -tags test  -coverprofile=./testCoverage.txt ./... && go tool cover -html=./testCoverage.txt -o testCoverage.html && rm ./testCoverage.txt 
+cover: ## run coverage tests
+	@go test -failfast -count=1 -v -tags test  -coverprofile=./testCoverage.txt ./... && go tool cover -html=./testCoverage.txt -o testCoverage.html && rm ./testCoverage.txt
 	open testCoverage.html
-
 
 version-bump: version-bump-patch
 

--- a/contrib/executor/tracetest/README.md
+++ b/contrib/executor/tracetest/README.md
@@ -22,7 +22,7 @@ In your Kubernetes cluster you should have:
 
 1. `Testkube`: Use HELM or the Testkube CLI to [install](https://kubeshop.github.io/testkube/installing) Testkube Server components in your cluster.
 2. `Tracetest`: You need a running instance of [Tracetest](https://docs.tracetest.io/getting-started/installation/) or [Tracetest Core](https://docs.tracetest.io/core/getting-started/installation/) which is going to be executing your assertions. To do so you can follow the instructions defined in the Tracetest [documentation](https://docs.tracetest.io/getting-started/overview).
-3. `OpenTelemetry Instrumented Service`: In order to generate traces and spans, the service under test must support the basics for [propagation](https://opentelemetry.io/docs/reference/specification/context/api-propagators/) through HTTP requests, and also store traces and spans in a Data Store Backend (Jaeger, Grafana Tempo, OpenSearch, etc) or use the [OpenTelemetry Collector](https://docs.tracetest.io/configuration/overview#using-tracetest-without-a-trace-data-store).
+3. `OpenTelemetry Instrumented Service`: To generate traces and spans, the service under test must support the basics for [propagation](https://opentelemetry.io/docs/reference/specification/context/api-propagators/) through HTTP requests, and also store traces and spans in a Data Store Backend (Jaeger, Grafana Tempo, OpenSearch, etc) or use the [OpenTelemetry Collector](https://docs.tracetest.io/configuration/overview#using-tracetest-without-a-trace-data-store).
 
 On your machine you should have:
 

--- a/contrib/executor/tracetest/pkg/model/result.go
+++ b/contrib/executor/tracetest/pkg/model/result.go
@@ -24,14 +24,17 @@ func (r *Result) GetOutput() string {
 	return r.Output
 }
 
-func (r *Result) GetStatus() *testkube.ExecutionStatus {
-	if r.IsSuccessful() {
-		return testkube.ExecutionStatusPassed
+func (r *Result) ToSuccessfulExecutionResult() testkube.ExecutionResult {
+	return testkube.ExecutionResult{
+		Output: r.GetOutput(),
+		Status: testkube.ExecutionStatusPassed,
 	}
-
-	return testkube.ExecutionStatusFailed
 }
 
-func (r *Result) IsSuccessful() bool {
-	return !strings.Contains(r.Output, FAILED_TEST_ICON)
+func (r *Result) ToFailedExecutionResult(err error) testkube.ExecutionResult {
+	return testkube.ExecutionResult{
+		ErrorMessage: r.GetOutput(),
+		Output:       r.GetOutput(),
+		Status:       testkube.ExecutionStatusFailed,
+	}
 }

--- a/contrib/executor/tracetest/pkg/runner/runner.go
+++ b/contrib/executor/tracetest/pkg/runner/runner.go
@@ -118,8 +118,8 @@ func (r *TracetestRunner) getCLIExecutor(envManager *env.Manager) (TracetestCLIE
 	}
 
 	outputPkg.PrintLogf("%s [TracetestRunner]: Could not find variables to run the test with Tracetest or Tracetest Cloud.", ui.IconCross)
-	outputPkg.PrintLogf("[TracetestRunner]: Please define the [%s] variables to run a test with Tracetest", strings.Join(r.cloudExecutor.RequiredEnvVars(), ", "))
-	outputPkg.PrintLogf("[TracetestRunner]: Or define the [%s] variables to run a test with Tracetest Core", strings.Join(r.coreExecutor.RequiredEnvVars(), ", "))
+	outputPkg.PrintLogf("%s [TracetestRunner]: Please define the [%s] variables to run a test with Tracetest", ui.IconCross, strings.Join(r.cloudExecutor.RequiredEnvVars(), ", "))
+	outputPkg.PrintLogf("%s [TracetestRunner]: Or define the [%s] variables to run a test with Tracetest Core", ui.IconCross, strings.Join(r.coreExecutor.RequiredEnvVars(), ", "))
 	return nil, fmt.Errorf("could not find variables to run the test with Tracetest or Tracetest Cloud")
 }
 

--- a/contrib/executor/tracetest/pkg/runner/runner_integration_test.go
+++ b/contrib/executor/tracetest/pkg/runner/runner_integration_test.go
@@ -1,0 +1,179 @@
+package runner_test
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path"
+	"path/filepath"
+	"runtime"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/kubeshop/testkube/contrib/executor/tracetest/pkg/command"
+	"github.com/kubeshop/testkube/contrib/executor/tracetest/pkg/runner"
+	"github.com/kubeshop/testkube/pkg/api/v1/testkube"
+	"github.com/kubeshop/testkube/pkg/envs"
+	"github.com/kubeshop/testkube/pkg/utils/test"
+)
+
+func startTracetestEnvironment(t *testing.T, envType string) {
+	currentDir := getExecutingDir()
+	fullDockerComposeFilePath := fmt.Sprintf("%s/../testing/docker-compose-tracetest-%s.yaml", currentDir, envType)
+
+	result, err := command.Run("docker", "compose", "--file", fullDockerComposeFilePath, "up", "--detach")
+	require.NoErrorf(t, err, "error when starting tracetest core env: %s", string(result))
+
+	// pokeshop takes some time to warm up, so we need to wait a little bit before doing tests
+	time.Sleep(10 * time.Second)
+}
+
+func stopTracetestEnvironment(t *testing.T, envType string) {
+	currentDir := getExecutingDir()
+	fullDockerComposeFilePath := fmt.Sprintf("%s/../testing/docker-compose-tracetest-%s.yaml", currentDir, envType)
+
+	result, err := command.Run("docker", "compose", "--file", fullDockerComposeFilePath, "rm", "--force", "--volumes", "--stop")
+	require.NoErrorf(t, err, "error when stopping tracetest core env: %s", string(result))
+}
+
+func TestRunFiles_Integration(t *testing.T) {
+	test.IntegrationTest(t)
+
+	ctx := context.Background()
+
+	t.Run("Run tracetest core with no variables", func(t *testing.T) {
+		tempDir, err := os.MkdirTemp("", "*")
+		require.NoErrorf(t, err, "failed to create temp dir: %v", err)
+		defer os.RemoveAll(tempDir)
+
+		params := envs.Params{DataDir: tempDir}
+		runner, err := runner.NewRunner(context.Background(), params)
+		require.NoError(t, err)
+
+		execution := testkube.NewQueuedExecution()
+		execution.Content = testkube.NewStringTestContent("")
+		execution.TestType = "tracetest/test"
+		execution.Command = []string{
+			"tracetest",
+		}
+		execution.Args = []string{}
+		writeTestContent(t, tempDir, "../testing/tracetest-test-script.yaml")
+
+		// when
+		_, err = runner.Run(ctx, *execution)
+
+		// then
+		require.ErrorContains(t, err, "failed to get a Tracetest CLI executor")
+	})
+
+	t.Run("Run tracetest core with simple script", func(t *testing.T) {
+		envType := "core"
+
+		startTracetestEnvironment(t, envType)
+		defer stopTracetestEnvironment(t, envType)
+
+		tempDir, err := os.MkdirTemp("", "*")
+		require.NoErrorf(t, err, "failed to create temp dir: %v", err)
+		defer os.RemoveAll(tempDir)
+
+		params := envs.Params{DataDir: tempDir}
+		runner, err := runner.NewRunner(context.Background(), params)
+		require.NoError(t, err)
+
+		execution := testkube.NewQueuedExecution()
+		execution.Content = testkube.NewStringTestContent("")
+		execution.TestType = "tracetest/test"
+		execution.Command = []string{
+			"tracetest",
+		}
+		execution.Variables = map[string]testkube.Variable{
+			"TRACETEST_ENDPOINT": {
+				Name:  "TRACETEST_ENDPOINT",
+				Value: "http://localhost:11633",
+				Type_: testkube.VariableTypeBasic,
+			},
+		}
+		execution.Args = []string{}
+		writeTestContent(t, tempDir, "../testing/tracetest-test-script.yaml")
+
+		// when
+		result, err := runner.Run(ctx, *execution)
+
+		// then
+		require.NoError(t, err)
+		require.Equal(t, testkube.ExecutionStatusPassed, result.Status)
+	})
+
+	// t.Run("Run tracetest cloud with simple script", func(t *testing.T) {
+	// 	envType := "cloud"
+
+	// 	os.Setenv("TRACETEST_API_KEY", "some_api_key")
+
+	// 	startTracetestEnvironment(t, envType)
+	// 	defer stopTracetestEnvironment(t, envType)
+
+	// 	tempDir, err := os.MkdirTemp("", "*")
+	// 	require.NoErrorf(t, err, "failed to create temp dir: %v", err)
+	// 	defer os.RemoveAll(tempDir)
+
+	// 	params := envs.Params{DataDir: tempDir}
+	// 	runner, err := runner.NewRunner(context.Background(), params)
+	// 	require.NoError(t, err)
+
+	// 	execution := testkube.NewQueuedExecution()
+	// 	execution.Content = testkube.NewStringTestContent("")
+	// 	execution.TestType = "tracetest/test"
+	// 	execution.Command = []string{
+	// 		"tracetest",
+	// 	}
+	// 	execution.Variables = map[string]testkube.Variable{
+	// 		"TRACETEST_TOKEN": {
+	// 			Name:  "TRACETEST_TOKEN",
+	// 			Value: "some_token",
+	// 			Type_: testkube.VariableTypeBasic,
+	// 		},
+	// 		"TRACETEST_ORGANIZATION": {
+	// 			Name:  "TRACETEST_ORGANIZATION",
+	// 			Value: "some_token",
+	// 			Type_: testkube.VariableTypeBasic,
+	// 		},
+	// 		"TRACETEST_ENVIRONMENT": {
+	// 			Name:  "TRACETEST_ENVIRONMENT",
+	// 			Value: "some_token",
+	// 			Type_: testkube.VariableTypeBasic,
+	// 		},
+	// 	}
+	// 	execution.Args = []string{}
+	// 	writeTestContent(t, tempDir, "../testing/tracetest-test-script.yaml")
+
+	// 	// when
+	// 	result, err := runner.Run(ctx, *execution)
+
+	// 	// then
+	// 	require.NoError(t, err)
+	// 	require.Equal(t, testkube.ExecutionStatusPassed, result.Status)
+	// })
+}
+
+func writeTestContent(t *testing.T, dir string, testScriptPath string) {
+	currentDir := getExecutingDir()
+	fullTestScriptPath := fmt.Sprintf("%s/%s", currentDir, testScriptPath)
+
+	testScript, err := os.ReadFile(fullTestScriptPath)
+	if err != nil {
+		assert.FailNow(t, "Unable to read tracetest test script")
+	}
+
+	err = os.WriteFile(filepath.Join(dir, "test-content"), testScript, 0644)
+	if err != nil {
+		assert.FailNow(t, "Unable to write tracetest runner test content file")
+	}
+}
+
+func getExecutingDir() string {
+	_, filename, _, _ := runtime.Caller(0) // get file of the getExecutingDir caller
+	return path.Dir(filename)
+}

--- a/contrib/executor/tracetest/pkg/runner/runner_test.go
+++ b/contrib/executor/tracetest/pkg/runner/runner_test.go
@@ -1,28 +1,33 @@
 package runner_test
 
 import (
+	"context"
 	"testing"
 
-	"github.com/kubeshop/testkube-executor-tracetest/pkg/runner"
-
-	"github.com/kubeshop/testkube/pkg/api/v1/testkube"
 	"github.com/stretchr/testify/require"
+
+	"github.com/kubeshop/testkube/contrib/executor/tracetest/pkg/runner"
+	"github.com/kubeshop/testkube/pkg/api/v1/testkube"
+	"github.com/kubeshop/testkube/pkg/envs"
 )
 
 func TestRun(t *testing.T) {
 
 	t.Run("runner should fail if no env var is provided", func(t *testing.T) {
 		// given
-		runner, err := runner.NewRunner()
-		require.NoError(t, err)
+		ctx := context.Background()
+		params := envs.Params{
+			DataDir: "/tmp",
+		}
 
-		runner.Params.DataDir = "/tmp"
+		runner, err := runner.NewRunner(ctx, params)
+		require.NoError(t, err)
 
 		execution := testkube.NewQueuedExecution()
 		execution.Content = testkube.NewStringTestContent("hello I'm test content")
 
 		// when
-		_, err = runner.Run(*execution)
+		_, err = runner.Run(ctx, *execution)
 
 		// then
 		require.Error(t, err)

--- a/contrib/executor/tracetest/pkg/runner/runner_test.go
+++ b/contrib/executor/tracetest/pkg/runner/runner_test.go
@@ -1,29 +1,32 @@
-package runner
+package runner_test
 
 import (
-	"context"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
+	"github.com/kubeshop/testkube-executor-tracetest/pkg/runner"
 
 	"github.com/kubeshop/testkube/pkg/api/v1/testkube"
-	"github.com/kubeshop/testkube/pkg/envs"
+	"github.com/stretchr/testify/require"
 )
 
 func TestRun(t *testing.T) {
 
-	t.Run("runner should return error if Tracetest endpoint is not provided", func(t *testing.T) {
+	t.Run("runner should fail if no env var is provided", func(t *testing.T) {
 		// given
-		runner, _ := NewRunner(context.Background(), envs.Params{})
+		runner, err := runner.NewRunner()
+		require.NoError(t, err)
+
+		runner.Params.DataDir = "/tmp"
+
 		execution := testkube.NewQueuedExecution()
 		execution.Content = testkube.NewStringTestContent("hello I'm test content")
 
 		// when
-		_, err := runner.Run(context.Background(), *execution)
+		_, err = runner.Run(*execution)
 
 		// then
-		assert.Error(t, err)
-		assert.Equal(t, "TRACETEST_ENDPOINT variable was not found", err.Error())
+		require.Error(t, err)
+		require.Equal(t, "could not find variables to run the test with Tracetest or Tracetest Cloud", err.Error())
 	})
 
 }

--- a/contrib/executor/tracetest/pkg/runner/runner_test.go
+++ b/contrib/executor/tracetest/pkg/runner/runner_test.go
@@ -30,8 +30,7 @@ func TestRun(t *testing.T) {
 		_, err = runner.Run(ctx, *execution)
 
 		// then
-		require.Error(t, err)
-		require.Equal(t, "could not find variables to run the test with Tracetest or Tracetest Cloud", err.Error())
+		require.ErrorContains(t, err, "could not find variables to run the test with Tracetest or Tracetest Cloud")
 	})
 
 }

--- a/contrib/executor/tracetest/pkg/runner/tracetest_core_runner.go
+++ b/contrib/executor/tracetest/pkg/runner/tracetest_core_runner.go
@@ -1,0 +1,63 @@
+package runner
+
+import (
+	"strings"
+
+	"github.com/kubeshop/testkube/contrib/executor/tracetest/pkg/model"
+	"github.com/kubeshop/testkube/pkg/api/v1/testkube"
+	"github.com/kubeshop/testkube/pkg/executor"
+	"github.com/kubeshop/testkube/pkg/executor/env"
+	"github.com/kubeshop/testkube/pkg/executor/output"
+	"github.com/kubeshop/testkube/pkg/ui"
+)
+
+const (
+	TRACETEST_ENDPOINT_VAR        = "TRACETEST_ENDPOINT"
+	TRACETEST_OUTPUT_ENDPOINT_VAR = "TRACETEST_OUTPUT_ENDPOINT"
+)
+
+type tracetestCoreExecutor struct{}
+
+var _ TracetestCLIExecutor = (*tracetestCoreExecutor)(nil)
+
+func (e *tracetestCoreExecutor) RequiredEnvVars() []string {
+	return []string{TRACETEST_ENDPOINT_VAR}
+}
+
+func (e *tracetestCoreExecutor) HasEnvVarsDefined(envManager *env.Manager) bool {
+	_, hasEndpointVar := envManager.Variables[TRACETEST_ENDPOINT_VAR]
+	return hasEndpointVar
+}
+
+func (e *tracetestCoreExecutor) Execute(envManager *env.Manager, execution testkube.Execution, testFilePath string) (model.Result, error) {
+	// Get TRACETEST_ENDPOINT from execution variables
+	tracetestEndpoint, err := getVariable(envManager, TRACETEST_ENDPOINT_VAR)
+	if err != nil {
+		return model.Result{}, err
+	}
+
+	// Get TRACETEST_OUTPUT_ENDPOINT from execution variables
+	tracetestOutputEndpoint, _ := getOptionalVariable(envManager, TRACETEST_OUTPUT_ENDPOINT_VAR)
+
+	// Prepare args for test run command
+	// (since each strategy implementation has its own set of params, we are explicitly ignoring the execution.Args field)
+	args := []string{
+		"run", "test", "--server-url", tracetestEndpoint, "--file", testFilePath, "--output", "pretty",
+	}
+
+	output.PrintLogf("%s Using arguments: %v", ui.IconWorld, envManager.ObfuscateStringSlice(args))
+
+	command, args := executor.MergeCommandAndArgs(execution.Command, args)
+
+	// Run tracetest test from test file
+	output.PrintLogf("%s Test run command %s %s", ui.IconRocket, command, strings.Join(envManager.ObfuscateStringSlice(args), " "))
+	output, err := executor.Run("", command, envManager, args...)
+
+	result := model.Result{
+		Output:         string(output),
+		ServerEndpoint: tracetestEndpoint,
+		OutputEndpoint: tracetestOutputEndpoint,
+	}
+
+	return result, err
+}

--- a/contrib/executor/tracetest/pkg/runner/tracetest_runner.go
+++ b/contrib/executor/tracetest/pkg/runner/tracetest_runner.go
@@ -17,6 +17,7 @@ const (
 	TRACETEST_TOKEN_VAR        = "TRACETEST_TOKEN"
 	TRACETEST_ORGANIZATION_VAR = "TRACETEST_ORGANIZATION"
 	TRACETEST_ENVIRONMENT_VAR  = "TRACETEST_ENVIRONMENT"
+	TRACETEST_CLOUD_URL        = "https://app.tracetest.io"
 )
 
 type tracetestCloudExecutor struct{}
@@ -84,7 +85,7 @@ func (e *tracetestCloudExecutor) Execute(envManager *env.Manager, execution test
 
 	result := model.Result{
 		Output:         string(output),
-		ServerEndpoint: "https://app.tracetest.io",
+		ServerEndpoint: TRACETEST_CLOUD_URL,
 		OutputEndpoint: "",
 	}
 

--- a/contrib/executor/tracetest/pkg/runner/tracetest_runner.go
+++ b/contrib/executor/tracetest/pkg/runner/tracetest_runner.go
@@ -1,0 +1,92 @@
+package runner
+
+import (
+	"strings"
+
+	"github.com/kubeshop/testkube/contrib/executor/tracetest/pkg/model"
+
+	"github.com/kubeshop/testkube/pkg/api/v1/testkube"
+	"github.com/kubeshop/testkube/pkg/executor"
+	"github.com/kubeshop/testkube/pkg/executor/env"
+	"github.com/kubeshop/testkube/pkg/executor/output"
+	outputPkg "github.com/kubeshop/testkube/pkg/executor/output"
+	"github.com/kubeshop/testkube/pkg/ui"
+)
+
+const (
+	TRACETEST_TOKEN_VAR        = "TRACETEST_TOKEN"
+	TRACETEST_ORGANIZATION_VAR = "TRACETEST_ORGANIZATION"
+	TRACETEST_ENVIRONMENT_VAR  = "TRACETEST_ENVIRONMENT"
+)
+
+type tracetestCloudExecutor struct{}
+
+var _ TracetestCLIExecutor = (*tracetestCloudExecutor)(nil)
+
+func (e *tracetestCloudExecutor) RequiredEnvVars() []string {
+	return []string{TRACETEST_TOKEN_VAR, TRACETEST_ORGANIZATION_VAR, TRACETEST_ENVIRONMENT_VAR}
+}
+
+func (e *tracetestCloudExecutor) HasEnvVarsDefined(envManager *env.Manager) bool {
+	_, hasTokenVar := envManager.Variables[TRACETEST_TOKEN_VAR]
+	_, hasOrganizationVar := envManager.Variables[TRACETEST_ORGANIZATION_VAR]
+	_, hasEnvironmentVar := envManager.Variables[TRACETEST_ENVIRONMENT_VAR]
+
+	return hasTokenVar && hasOrganizationVar && hasEnvironmentVar
+}
+
+func (e *tracetestCloudExecutor) Execute(envManager *env.Manager, execution testkube.Execution, testFilePath string) (model.Result, error) {
+	tracetestToken, err := getVariable(envManager, TRACETEST_TOKEN_VAR)
+	if err != nil {
+		return model.Result{}, err
+	}
+
+	tracetestOrganization, err := getVariable(envManager, TRACETEST_ORGANIZATION_VAR)
+	if err != nil {
+		return model.Result{}, err
+	}
+
+	tracetestEnvironment, err := getVariable(envManager, TRACETEST_ENVIRONMENT_VAR)
+	if err != nil {
+		return model.Result{}, err
+	}
+
+	// setup config with API key
+	output.PrintLogf("%s Configuring Tracetest CLI with Token", ui.IconWorld)
+
+	configArgs := []string{
+		"configure", "--token", tracetestToken, "--organization", tracetestOrganization, "--environment", tracetestEnvironment,
+	}
+
+	output.PrintLogf("%s Using arguments to configure CLI: %v", ui.IconWorld, envManager.ObfuscateStringSlice(configArgs))
+	configCommand, configArgs := executor.MergeCommandAndArgs(execution.Command, configArgs)
+
+	output.PrintLogf("%s Configure command %s %s", ui.IconRocket, configCommand, strings.Join(envManager.ObfuscateStringSlice(configArgs), " "))
+	_, err = executor.Run("", configCommand, envManager, configArgs...)
+
+	if err != nil {
+		outputPkg.PrintLogf("%s Failed to configure Tracetest CLI %v", ui.IconCross, err)
+		return model.Result{}, err
+	}
+
+	// Prepare args for test run command
+	// (since each strategy implementation has its own set of params, we are explicitly ignoring the execution.Args field)
+	runTestArgs := []string{
+		"run", "test", "--file", testFilePath, "--output", "pretty",
+	}
+
+	output.PrintLogf("%s Using arguments to run test: %v", ui.IconWorld, envManager.ObfuscateStringSlice(runTestArgs))
+	runTestCommand, runTestArgs := executor.MergeCommandAndArgs(execution.Command, runTestArgs)
+
+	// Run tracetest test from definition file
+	output.PrintLogf("%s Test run command %s %s", ui.IconRocket, runTestCommand, strings.Join(envManager.ObfuscateStringSlice(runTestArgs), " "))
+	output, err := executor.Run("", runTestCommand, envManager, runTestArgs...)
+
+	result := model.Result{
+		Output:         string(output),
+		ServerEndpoint: "https://app.tracetest.io",
+		OutputEndpoint: "",
+	}
+
+	return result, err
+}

--- a/contrib/executor/tracetest/pkg/testing/docker-compose-tracetest-cloud.yaml
+++ b/contrib/executor/tracetest/pkg/testing/docker-compose-tracetest-cloud.yaml
@@ -1,0 +1,54 @@
+version: '3'
+services:
+  postgres:
+    image: postgres:15.2
+    environment:
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_USER: postgres
+    healthcheck:
+      test: pg_isready -U "$$POSTGRES_USER" -d "$$POSTGRES_DB"
+      interval: 1s
+      timeout: 5s
+      retries: 60
+
+  cache:
+    healthcheck:
+      test:
+        - CMD
+        - redis-cli
+        - ping
+      timeout: 3s
+      interval: 1s
+      retries: 60
+    image: redis:6
+    restart: unless-stopped
+
+  demo-api:
+    depends_on:
+      cache:
+        condition: service_healthy
+      postgres:
+        condition: service_healthy
+    environment:
+      COLLECTOR_ENDPOINT: http://tracetest-agent:4317
+      DATABASE_URL: postgresql://postgres:postgres@postgres:5432/postgres?schema=public
+      NPM_RUN_COMMAND: api
+      POKE_API_BASE_URL: https://pokeapi.co/api/v2
+      REDIS_URL: cache
+    healthcheck:
+      test:
+        - CMD
+        - wget
+        - --spider
+        - localhost:8081
+      timeout: 3s
+      interval: 1s
+      retries: 60
+    image: kubeshop/demo-pokemon-api:latest
+    pull_policy: always
+    
+  tracetest-agent:
+    environment:
+      TRACETEST_DEV: true
+      TRACETEST_API_KEY: ${TRACETEST_API_KEY}
+    image: kubeshop/tracetest-agent:latest

--- a/contrib/executor/tracetest/pkg/testing/docker-compose-tracetest-core.yaml
+++ b/contrib/executor/tracetest/pkg/testing/docker-compose-tracetest-core.yaml
@@ -1,0 +1,73 @@
+version: '3'
+services:
+  tracetest:
+    image: kubeshop/tracetest:${TAG:-latest}
+    volumes:
+      - type: bind
+        source: ./tracetest-config.yaml
+        target: /app/tracetest.yaml
+      - type: bind
+        source: ./tracetest-provision.yaml
+        target: /app/provision.yaml
+    command: --provisioning-file /app/provision.yaml
+    ports:
+      - 11633:11633
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    depends_on:
+      postgres:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "wget", "--spider", "localhost:11633"]
+      interval: 1s
+      timeout: 3s
+      retries: 60
+    environment:
+      TRACETEST_DEV: true
+
+  postgres:
+    image: postgres:15.2
+    environment:
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_USER: postgres
+    healthcheck:
+      test: pg_isready -U "$$POSTGRES_USER" -d "$$POSTGRES_DB"
+      interval: 1s
+      timeout: 5s
+      retries: 60
+
+  cache:
+    healthcheck:
+      test:
+        - CMD
+        - redis-cli
+        - ping
+      timeout: 3s
+      interval: 1s
+      retries: 60
+    image: redis:6
+    restart: unless-stopped
+
+  demo-api:
+    depends_on:
+      cache:
+        condition: service_healthy
+      postgres:
+        condition: service_healthy
+    environment:
+      COLLECTOR_ENDPOINT: http://tracetest:4317
+      DATABASE_URL: postgresql://postgres:postgres@postgres:5432/postgres?schema=public
+      NPM_RUN_COMMAND: api
+      POKE_API_BASE_URL: https://pokeapi.co/api/v2
+      REDIS_URL: cache
+    healthcheck:
+      test:
+        - CMD
+        - wget
+        - --spider
+        - localhost:8081
+      timeout: 3s
+      interval: 1s
+      retries: 60
+    image: kubeshop/demo-pokemon-api:latest
+    pull_policy: always

--- a/contrib/executor/tracetest/pkg/testing/tracetest-config.yaml
+++ b/contrib/executor/tracetest/pkg/testing/tracetest-config.yaml
@@ -1,0 +1,7 @@
+postgres:
+  host: postgres
+  user: postgres
+  password: postgres
+  port: 5432
+  dbname: postgres
+  params: sslmode=disable

--- a/contrib/executor/tracetest/pkg/testing/tracetest-provision.yaml
+++ b/contrib/executor/tracetest/pkg/testing/tracetest-provision.yaml
@@ -1,0 +1,24 @@
+---
+type: PollingProfile
+spec:
+  name: Default
+  strategy: periodic
+  default: true
+  periodic:
+    retryDelay: 500ms
+    timeout: 1m
+
+---
+type: TestRunner
+spec:
+  id: current
+  name: default
+  requiredGates:
+    - test-specs
+
+---
+type: DataStore
+spec:
+  name: OpenTelemetry Collector pipeline
+  type: otlp
+  default: true

--- a/contrib/executor/tracetest/pkg/testing/tracetest-test-script.yaml
+++ b/contrib/executor/tracetest/pkg/testing/tracetest-test-script.yaml
@@ -1,0 +1,20 @@
+type: Test
+spec:
+  id: R5NITR14g
+  name: Pokeshop - List
+  description: Get a Pokemon
+  trigger:
+    type: http
+    httpRequest:
+      url: http://demo-api:8081/pokemon?take=20&skip=0
+      method: GET
+      headers:
+        - key: Content-Type
+          value: application/json
+  specs:
+    - selector: span[tracetest.span.type="http"]
+      assertions:
+        - attr:http.method = "GET"
+    - selector: span[tracetest.span.type="database"]
+      assertions:
+        - attr:db.name = "postgres"


### PR DESCRIPTION
## Pull request description 

This PRs update Tracetest executor to support both [Tracetest](https://docs.tracetest.io/getting-started/installation/) and [Tracetest Core](https://docs.tracetest.io/core/getting-started/installation/).

## Checklist (choose what happened)

- [ ] breaking change! (describe)
- [ ] tested locally
- [ ] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Breaking changes

-

## Changes

-

## Fixes

-