### PR TITLE
fix: do not return empty latestExecution with Test/TestSuite

### DIFF
--- a/internal/app/api/v1/executions_test.go
+++ b/internal/app/api/v1/executions_test.go
@@ -135,7 +135,7 @@ func (r MockExecutionResultsRepository) GetByNameAndTest(ctx context.Context, na
 	panic("not implemented")
 }
 
-func (r MockExecutionResultsRepository) GetLatestByTest(ctx context.Context, testName string) (testkube.Execution, error) {
+func (r MockExecutionResultsRepository) GetLatestByTest(ctx context.Context, testName string) (*testkube.Execution, error) {
 	panic("not implemented")
 }
 

--- a/internal/app/api/v1/tests.go
+++ b/internal/app/api/v1/tests.go
@@ -92,7 +92,7 @@ func (s TestkubeAPI) GetTestWithExecutionHandler() fiber.Handler {
 
 		return c.JSON(testkube.TestWithExecution{
 			Test:            &test,
-			LatestExecution: &execution,
+			LatestExecution: execution,
 		})
 	}
 }

--- a/internal/app/api/v1/testsuites.go
+++ b/internal/app/api/v1/testsuites.go
@@ -238,7 +238,7 @@ func (s TestkubeAPI) GetTestSuiteWithExecutionHandler() fiber.Handler {
 
 		return c.JSON(testkube.TestSuiteWithExecution{
 			TestSuite:       &testSuite,
-			LatestExecution: &execution,
+			LatestExecution: execution,
 		})
 	}
 }

--- a/pkg/cloud/data/result/result.go
+++ b/pkg/cloud/data/result/result.go
@@ -82,28 +82,28 @@ func (r *CloudRepository) getLatestByTest(ctx context.Context, testName, sortFie
 }
 
 // TODO: When it will be implemented, replace with a new Cloud command, to avoid 2 calls with 2 sort fields
-func (r *CloudRepository) GetLatestByTest(ctx context.Context, testName string) (testkube.Execution, error) {
+func (r *CloudRepository) GetLatestByTest(ctx context.Context, testName string) (*testkube.Execution, error) {
 	startExecution, startErr := r.getLatestByTest(ctx, testName, "starttime")
 	if startErr != nil && startErr != mongo.ErrNoDocuments {
-		return testkube.Execution{}, startErr
+		return nil, startErr
 	}
 	endExecution, endErr := r.getLatestByTest(ctx, testName, "endtime")
 	if endErr != nil && endErr != mongo.ErrNoDocuments {
-		return testkube.Execution{}, endErr
+		return nil, endErr
 	}
 
 	if startErr == nil && endErr == nil {
 		if startExecution.StartTime.After(endExecution.EndTime) {
-			return startExecution, nil
+			return &startExecution, nil
 		} else {
-			return endExecution, nil
+			return &endExecution, nil
 		}
 	} else if startErr == nil {
-		return startExecution, nil
+		return &startExecution, nil
 	} else if endErr == nil {
-		return endExecution, nil
+		return &endExecution, nil
 	}
-	return testkube.Execution{}, startErr
+	return nil, startErr
 }
 
 // TODO: When it will be implemented, replace with a new Cloud command, to avoid 2 calls with 2 sort fields

--- a/pkg/cloud/data/result/result_test.go
+++ b/pkg/cloud/data/result/result_test.go
@@ -117,7 +117,7 @@ func TestCloudResultRepository_GetLatestByTest(t *testing.T) {
 
 	result, err := repo.GetLatestByTest(ctx, testName)
 	assert.NoError(t, err)
-	assert.Equal(t, endExecution, result)
+	assert.Equal(t, &endExecution, result)
 }
 
 func TestCloudResultRepository_Insert(t *testing.T) {

--- a/pkg/cloud/data/testresult/testresult.go
+++ b/pkg/cloud/data/testresult/testresult.go
@@ -65,28 +65,28 @@ func (r *CloudRepository) getLatestByTestSuite(ctx context.Context, testSuiteNam
 }
 
 // TODO: When it will be implemented, replace with a new Cloud command, to avoid 2 calls with 2 sort fields
-func (r *CloudRepository) GetLatestByTestSuite(ctx context.Context, testSuiteName string) (testkube.TestSuiteExecution, error) {
+func (r *CloudRepository) GetLatestByTestSuite(ctx context.Context, testSuiteName string) (*testkube.TestSuiteExecution, error) {
 	startExecution, startErr := r.getLatestByTestSuite(ctx, testSuiteName, "starttime")
 	if startErr != nil && startErr != mongo.ErrNoDocuments {
-		return testkube.TestSuiteExecution{}, startErr
+		return nil, startErr
 	}
 	endExecution, endErr := r.getLatestByTestSuite(ctx, testSuiteName, "endtime")
 	if endErr != nil && endErr != mongo.ErrNoDocuments {
-		return testkube.TestSuiteExecution{}, endErr
+		return nil, endErr
 	}
 
 	if startErr == nil && endErr == nil {
 		if startExecution.StartTime.After(endExecution.EndTime) {
-			return startExecution, nil
+			return &startExecution, nil
 		} else {
-			return endExecution, nil
+			return &endExecution, nil
 		}
 	} else if startErr == nil {
-		return startExecution, nil
+		return &startExecution, nil
 	} else if endErr == nil {
-		return endExecution, nil
+		return &endExecution, nil
 	}
-	return testkube.TestSuiteExecution{}, startErr
+	return nil, startErr
 }
 
 func (r *CloudRepository) getLatestByTestSuites(ctx context.Context, testSuiteNames []string, sortField string) (executions []testkube.TestSuiteExecution, err error) {

--- a/pkg/executor/containerexecutor/containerexecutor_test.go
+++ b/pkg/executor/containerexecutor/containerexecutor_test.go
@@ -364,7 +364,7 @@ func (r FakeResultRepository) GetByNameAndTest(ctx context.Context, name, testNa
 	panic("implement me")
 }
 
-func (r FakeResultRepository) GetLatestByTest(ctx context.Context, testName string) (testkube.Execution, error) {
+func (r FakeResultRepository) GetLatestByTest(ctx context.Context, testName string) (*testkube.Execution, error) {
 	//TODO implement me
 	panic("implement me")
 }

--- a/pkg/repository/result/interface.go
+++ b/pkg/repository/result/interface.go
@@ -38,7 +38,7 @@ type Repository interface {
 	// GetByNameAndTest gets execution result by name and test name
 	GetByNameAndTest(ctx context.Context, name, testName string) (testkube.Execution, error)
 	// GetLatestByTest gets latest execution result by test
-	GetLatestByTest(ctx context.Context, testName string) (testkube.Execution, error)
+	GetLatestByTest(ctx context.Context, testName string) (*testkube.Execution, error)
 	// GetLatestByTests gets latest execution results by test names
 	GetLatestByTests(ctx context.Context, testNames []string) (executions []testkube.Execution, err error)
 	// GetExecutions gets executions using a filter, use filter with no data for all

--- a/pkg/repository/result/mock_repository.go
+++ b/pkg/repository/result/mock_repository.go
@@ -216,10 +216,10 @@ func (mr *MockRepositoryMockRecorder) GetLabels(arg0 interface{}) *gomock.Call {
 }
 
 // GetLatestByTest mocks base method.
-func (m *MockRepository) GetLatestByTest(arg0 context.Context, arg1 string) (testkube.Execution, error) {
+func (m *MockRepository) GetLatestByTest(arg0 context.Context, arg1 string) (*testkube.Execution, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetLatestByTest", arg0, arg1)
-	ret0, _ := ret[0].(testkube.Execution)
+	ret0, _ := ret[0].(*testkube.Execution)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }

--- a/pkg/repository/testresult/interface.go
+++ b/pkg/repository/testresult/interface.go
@@ -34,7 +34,7 @@ type Repository interface {
 	// GetByNameAndTestSuite gets execution result by name
 	GetByNameAndTestSuite(ctx context.Context, name, testSuiteName string) (testkube.TestSuiteExecution, error)
 	// GetLatestByTestSuite gets latest execution result by test suite
-	GetLatestByTestSuite(ctx context.Context, testSuiteName string) (testkube.TestSuiteExecution, error)
+	GetLatestByTestSuite(ctx context.Context, testSuiteName string) (*testkube.TestSuiteExecution, error)
 	// GetLatestByTestSuites gets latest execution results by test suite names
 	GetLatestByTestSuites(ctx context.Context, testSuiteNames []string) (executions []testkube.TestSuiteExecution, err error)
 	// GetExecutionsTotals gets executions total stats using a filter, use filter with no data for all

--- a/pkg/repository/testresult/mock_repository.go
+++ b/pkg/repository/testresult/mock_repository.go
@@ -159,10 +159,10 @@ func (mr *MockRepositoryMockRecorder) GetExecutionsTotals(arg0 interface{}, arg1
 }
 
 // GetLatestByTestSuite mocks base method.
-func (m *MockRepository) GetLatestByTestSuite(arg0 context.Context, arg1 string) (testkube.TestSuiteExecution, error) {
+func (m *MockRepository) GetLatestByTestSuite(arg0 context.Context, arg1 string) (*testkube.TestSuiteExecution, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetLatestByTestSuite", arg0, arg1)
-	ret0, _ := ret[0].(testkube.TestSuiteExecution)
+	ret0, _ := ret[0].(*testkube.TestSuiteExecution)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }

--- a/pkg/repository/testresult/mongo.go
+++ b/pkg/repository/testresult/mongo.go
@@ -57,7 +57,7 @@ func (r *MongoRepository) GetByNameAndTestSuite(ctx context.Context, name, testS
 	return *result.UnscapeDots(), err
 }
 
-func (r *MongoRepository) GetLatestByTestSuite(ctx context.Context, testSuiteName string) (result testkube.TestSuiteExecution, err error) {
+func (r *MongoRepository) GetLatestByTestSuite(ctx context.Context, testSuiteName string) (*testkube.TestSuiteExecution, error) {
 	opts := options.Aggregate()
 	pipeline := []bson.M{
 		{"$documents": bson.A{bson.M{"name": testSuiteName}}},
@@ -88,17 +88,17 @@ func (r *MongoRepository) GetLatestByTestSuite(ctx context.Context, testSuiteNam
 	}
 	cursor, err := r.db.Aggregate(ctx, pipeline, opts)
 	if err != nil {
-		return result, err
+		return nil, err
 	}
 	var items []testkube.TestSuiteExecution
 	err = cursor.All(ctx, &items)
 	if err != nil {
-		return result, err
+		return nil, err
 	}
 	if len(items) == 0 {
-		return result, mongo.ErrNoDocuments
+		return nil, mongo.ErrNoDocuments
 	}
-	return *items[0].UnscapeDots(), err
+	return items[0].UnscapeDots(), err
 }
 
 func (r *MongoRepository) GetLatestByTestSuites(ctx context.Context, testSuiteNames []string) (executions []testkube.TestSuiteExecution, err error) {


### PR DESCRIPTION
## Pull request description 

* Return (empty) pointer to the Execution instead of empty Execution struct

## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [x] tested locally
- [x] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [x] added a test

## Fixes

- https://github.com/kubeshop/testkube/issues/4635