### PR TITLE
fix: allow terminating CLI while watching test/test suite run

### DIFF
--- a/cmd/kubectl-testkube/commands/root.go
+++ b/cmd/kubectl-testkube/commands/root.go
@@ -3,12 +3,12 @@ package commands
 import (
 	"context"
 	"fmt"
-	"github.com/pkg/errors"
-	"github.com/spf13/cobra"
 	"os"
 	"os/signal"
 	"syscall"
 
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
 	"golang.org/x/sync/errgroup"
 
 	"github.com/kubeshop/testkube/cmd/kubectl-testkube/commands/cloud"

--- a/cmd/kubectl-testkube/commands/root.go
+++ b/cmd/kubectl-testkube/commands/root.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
+
 	"golang.org/x/sync/errgroup"
 
 	"github.com/kubeshop/testkube/cmd/kubectl-testkube/commands/cloud"

--- a/cmd/kubectl-testkube/commands/root.go
+++ b/cmd/kubectl-testkube/commands/root.go
@@ -1,10 +1,15 @@
 package commands
 
 import (
+	"context"
 	"fmt"
-	"os"
-
+	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
+	"os"
+	"os/signal"
+	"syscall"
+
+	"golang.org/x/sync/errgroup"
 
 	"github.com/kubeshop/testkube/cmd/kubectl-testkube/commands/cloud"
 	"github.com/kubeshop/testkube/cmd/kubectl-testkube/commands/common"
@@ -160,13 +165,29 @@ func Execute() {
 		apiURI = os.Getenv("TESTKUBE_API_URI")
 	}
 
+	// Run services within an errgroup to propagate errors between services.
+	g, ctx := errgroup.WithContext(context.Background())
+
+	// Cancel the errgroup context on SIGINT and SIGTERM,
+	// which shuts everything down gracefully.
+	stopSignal := make(chan os.Signal, 1)
+	signal.Notify(stopSignal, syscall.SIGINT, syscall.SIGTERM)
+	g.Go(func() error {
+		select {
+		case <-ctx.Done():
+			return nil
+		case sig := <-stopSignal:
+			return errors.Errorf("received signal: %v", sig)
+		}
+	})
+
 	RootCmd.PersistentFlags().StringVarP(&client, "client", "c", "proxy", "client used for connecting to Testkube API one of proxy|direct")
 	RootCmd.PersistentFlags().StringVarP(&namespace, "namespace", "", defaultNamespace, "Kubernetes namespace, default value read from config if set")
 	RootCmd.PersistentFlags().BoolVarP(&verbose, "verbose", "", false, "show additional debug messages")
 	RootCmd.PersistentFlags().StringVarP(&apiURI, "api-uri", "a", apiURI, "api uri, default value read from config if set")
 	RootCmd.PersistentFlags().BoolVarP(&oauthEnabled, "oauth-enabled", "", cfg.OAuth2Data.Enabled, "enable oauth")
 
-	if err := RootCmd.Execute(); err != nil {
+	if err := RootCmd.ExecuteContext(ctx); err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	}

--- a/cmd/kubectl-testkube/commands/tests/run.go
+++ b/cmd/kubectl-testkube/commands/tests/run.go
@@ -1,12 +1,14 @@
 package tests
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"strings"
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 
 	"github.com/kubeshop/testkube/cmd/kubectl-testkube/commands/common"
@@ -15,8 +17,6 @@ import (
 	"github.com/kubeshop/testkube/pkg/api/v1/testkube"
 	"github.com/kubeshop/testkube/pkg/ui"
 )
-
-const WatchInterval = 2 * time.Second
 
 func NewRunTestCmd() *cobra.Command {
 	var (
@@ -241,6 +241,13 @@ func NewRunTestCmd() *cobra.Command {
 			default:
 				ui.Failf("Pass Test name or labels to run by labels ")
 			}
+
+			go func() {
+				<-cmd.Context().Done()
+				if errors.Is(cmd.Context().Err(), context.Canceled) {
+					os.Exit(0)
+				}
+			}()
 
 			var hasErrors bool
 			for _, execution := range executions {


### PR DESCRIPTION
## Changes

- pass the context down to Cobra commands, which is canceled on SIGINT/SIGTERM
- exit CLI on termination signal during test/test suite watch

## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [ ] tested locally
- [ ] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Breaking changes

-

## Fixes

-