### PR TITLE
fix: table output performance

### DIFF
--- a/cmd/kubectl-testkube/commands/testsuites/run.go
+++ b/cmd/kubectl-testkube/commands/testsuites/run.go
@@ -16,6 +16,10 @@ import (
 	"github.com/kubeshop/testkube/pkg/ui"
 )
 
+const (
+	maxErrorMessageLength = 100000
+)
+
 func NewRunTestSuiteCmd() *cobra.Command {
 	var (
 		name                     string
@@ -150,6 +154,7 @@ func NewRunTestSuiteCmd() *cobra.Command {
 						for execution := range executionCh {
 							ui.ExitOnError("watching test execution", err)
 							if !silentMode {
+								execution.TruncateErrorMessages(maxErrorMessageLength)
 								printExecution(execution, startTime)
 							}
 						}
@@ -158,6 +163,7 @@ func NewRunTestSuiteCmd() *cobra.Command {
 					execution, err = client.GetTestSuiteExecution(execution.Id)
 				}
 
+				execution.TruncateErrorMessages(maxErrorMessageLength)
 				printExecution(execution, startTime)
 				ui.ExitOnError("getting recent execution data id:"+execution.Id, err)
 

--- a/go.mod
+++ b/go.mod
@@ -30,7 +30,7 @@ require (
 	github.com/montanaflynn/stats v0.6.6
 	github.com/moogar0880/problems v0.1.1
 	github.com/nats-io/nats.go v1.22.1
-	github.com/olekukonko/tablewriter v0.0.5
+	github.com/olekukonko/tablewriter v0.0.6-0.20230925090304-df64c4bbad77
 	github.com/onsi/ginkgo/v2 v2.12.0
 	github.com/onsi/gomega v1.27.10
 	github.com/otiai10/copy v1.11.0

--- a/go.sum
+++ b/go.sum
@@ -425,7 +425,6 @@ github.com/nats-io/nuid v1.0.1 h1:5iA8DT8V7q8WK2EScv2padNa/rTESc1KdnPw4TC2paw=
 github.com/nats-io/nuid v1.0.1/go.mod h1:19wcPz3Ph3q0Jbyiqsd0kePYG7A95tJPxeL+1OSON2c=
 github.com/nxadm/tail v1.4.8 h1:nPr65rt6Y5JFSKQO7qToXr7pePgD6Gwiw05lkbyAQTE=
 github.com/nxadm/tail v1.4.8/go.mod h1:+ncqLTQzXmGhMZNUePPaPqPvBxHAIsmXswZKocGu+AU=
-github.com/olekukonko/tablewriter v0.0.5 h1:P2Ga83D34wi1o9J6Wh1mRuqd4mF/x/lgBS7N7AbDhec=
 github.com/olekukonko/tablewriter v0.0.5/go.mod h1:hPp6KlRPjbx+hW8ykQs1w3UBbZlj6HuIJcUGPhkA7kY=
 github.com/olekukonko/tablewriter v0.0.6-0.20230925090304-df64c4bbad77 h1:3bMMZ1f+GPXFQ1uNaYbO/uECWvSfqEA+ZEXn1rFAT88=
 github.com/olekukonko/tablewriter v0.0.6-0.20230925090304-df64c4bbad77/go.mod h1:8Hf+pH6thup1sPZPD+NLg7d6vbpsdilu9CPIeikvgMQ=

--- a/go.sum
+++ b/go.sum
@@ -371,6 +371,7 @@ github.com/mattn/go-isatty v0.0.17/go.mod h1:kYGgaQfpe5nmfYZH+SKPsOc2e4SrIfOl2e/
 github.com/mattn/go-isatty v0.0.19 h1:JITubQf0MOLdlGRuRq+jtsDlekdYPia9ZFsB8h/APPA=
 github.com/mattn/go-isatty v0.0.19/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/mattn/go-runewidth v0.0.9/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m2gUSrubnMI=
+github.com/mattn/go-runewidth v0.0.10/go.mod h1:RAqKPSqVFrSLVXbA8x7dzmKdmGzieGRCM46jaSJTDAk=
 github.com/mattn/go-runewidth v0.0.12/go.mod h1:RAqKPSqVFrSLVXbA8x7dzmKdmGzieGRCM46jaSJTDAk=
 github.com/mattn/go-runewidth v0.0.13/go.mod h1:Jdepj2loyihRzMpdS35Xk/zdY8IAYHsh153qUoGf23w=
 github.com/mattn/go-runewidth v0.0.14 h1:+xnbZSEeDbOIg5/mE6JF0w6n9duR1l3/WmbinWVwUuU=
@@ -426,6 +427,8 @@ github.com/nxadm/tail v1.4.8 h1:nPr65rt6Y5JFSKQO7qToXr7pePgD6Gwiw05lkbyAQTE=
 github.com/nxadm/tail v1.4.8/go.mod h1:+ncqLTQzXmGhMZNUePPaPqPvBxHAIsmXswZKocGu+AU=
 github.com/olekukonko/tablewriter v0.0.5 h1:P2Ga83D34wi1o9J6Wh1mRuqd4mF/x/lgBS7N7AbDhec=
 github.com/olekukonko/tablewriter v0.0.5/go.mod h1:hPp6KlRPjbx+hW8ykQs1w3UBbZlj6HuIJcUGPhkA7kY=
+github.com/olekukonko/tablewriter v0.0.6-0.20230925090304-df64c4bbad77 h1:3bMMZ1f+GPXFQ1uNaYbO/uECWvSfqEA+ZEXn1rFAT88=
+github.com/olekukonko/tablewriter v0.0.6-0.20230925090304-df64c4bbad77/go.mod h1:8Hf+pH6thup1sPZPD+NLg7d6vbpsdilu9CPIeikvgMQ=
 github.com/onsi/ginkgo v1.16.5 h1:8xi0RTUf59SOSfEtZMvwTvXYMzG4gV23XVHOZiXNtnE=
 github.com/onsi/ginkgo v1.16.5/go.mod h1:+E8gABHa3K6zRBolWtd+ROzc/U5bkGt0FwiG042wbpU=
 github.com/onsi/ginkgo/v2 v2.12.0 h1:UIVDowFPwpg6yMUpPjGkYvf06K3RAiJXUhCxEwQVHRI=

--- a/pkg/api/v1/testkube/model_test_suite_execution_extended.go
+++ b/pkg/api/v1/testkube/model_test_suite_execution_extended.go
@@ -260,3 +260,14 @@ func (e *TestSuiteExecution) CleanStepsOutput() *TestSuiteExecution {
 	}
 	return e
 }
+
+func (e *TestSuiteExecution) TruncateErrorMessages(length int) *TestSuiteExecution {
+	for _, bs := range e.ExecuteStepResults {
+		for _, sr := range bs.Execute {
+			if sr.Execution != nil && sr.Execution.ExecutionResult != nil && len(sr.Execution.ExecutionResult.ErrorMessage) > length {
+				sr.Execution.ExecutionResult.ErrorMessage = sr.Execution.ExecutionResult.ErrorMessage[0:length]
+			}
+		}
+	}
+	return e
+}

--- a/pkg/ui/table.go
+++ b/pkg/ui/table.go
@@ -13,7 +13,7 @@ type TableData interface {
 
 func (ui *UI) Table(tableData TableData, writer io.Writer) {
 	table := tablewriter.NewWriter(writer)
-	table.SetBorder(false)
+	table.EnableBorder(false)
 	table.SetHeaderLine(true)
 
 	table.SetHeaderAlignment(tablewriter.ALIGN_LEFT)


### PR DESCRIPTION
## Pull request description 

Speed up the table output, as it took a very long time for the test suites with long error messages.

## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [x] tested locally
- [ ] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Breaking changes

-

## Changes

- Use newer [**olekukonko/tablewriter**](https://github.com/olekukonko/tablewriter) - it's much faster (1MB of data in 1 second instead of minutes)
- Truncate the error messages to maximum of 100.000 characters (in the table)

## Fixes

- https://github.com/kubeshop/testkube/issues/4610