### PR TITLE
feat: add support for skip tls verify in minio

### DIFF
--- a/cmd/api-server/main.go
+++ b/cmd/api-server/main.go
@@ -244,6 +244,7 @@ func main() {
 			cfg.StorageToken,
 			cfg.StorageBucket,
 			cfg.StorageSSL,
+			cfg.StorageSkipVerify,
 		)
 		if err = minioClient.Connect(); err != nil {
 			ui.ExitOnError("Connecting to minio", err)

--- a/contrib/executor/init/pkg/runner/runner.go
+++ b/contrib/executor/init/pkg/runner/runner.go
@@ -122,7 +122,7 @@ func (r *InitRunner) Run(ctx context.Context, execution testkube.Execution) (res
 	// add copy files in case object storage is set
 	if r.Params.Endpoint != "" && !r.Params.CloudMode {
 		output.PrintLogf("%s Fetching uploads from object store %s...", ui.IconFile, r.Params.Endpoint)
-		minioClient := minio.NewClient(r.Params.Endpoint, r.Params.AccessKeyID, r.Params.SecretAccessKey, r.Params.Region, r.Params.Token, r.Params.Bucket, r.Params.Ssl)
+		minioClient := minio.NewClient(r.Params.Endpoint, r.Params.AccessKeyID, r.Params.SecretAccessKey, r.Params.Region, r.Params.Token, r.Params.Bucket, r.Params.Ssl, r.Params.SkipVerify)
 		fp := content.NewCopyFilesPlacer(minioClient)
 		fp.PlaceFiles(ctx, execution.TestName, execution.BucketName)
 	} else if r.Params.CloudMode {

--- a/internal/app/api/v1/executions.go
+++ b/internal/app/api/v1/executions.go
@@ -635,6 +635,7 @@ func (s *TestkubeAPI) getArtifactStorage(bucket string) (storage.ArtifactsStorag
 		s.storageParams.Token,
 		bucket,
 		s.storageParams.SSL,
+		s.storageParams.SkipVerify,
 	)
 	if err := minioClient.Connect(); err != nil {
 		return nil, err

--- a/internal/app/api/v1/server.go
+++ b/internal/app/api/v1/server.go
@@ -194,6 +194,7 @@ type TestkubeAPI struct {
 
 type storageParams struct {
 	SSL             bool
+	SkipVerify      bool
 	Endpoint        string
 	AccessKeyId     string
 	SecretAccessKey string

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -30,6 +30,7 @@ type Config struct {
 	StorageRegion                     string        `envconfig:"STORAGE_REGION" default:""`
 	StorageToken                      string        `envconfig:"STORAGE_TOKEN" default:""`
 	StorageSSL                        bool          `envconfig:"STORAGE_SSL" default:"false"`
+	StorageSkipVerify                 bool          `envconfig:"STORAGE_SKIP_VERIFY" default:"false"`
 	ScrapperEnabled                   bool          `envconfig:"SCRAPPERENABLED" default:"false"`
 	LogsBucket                        string        `envconfig:"LOGS_BUCKET" default:""`
 	LogsStorage                       string        `envconfig:"LOGS_STORAGE" default:""`

--- a/pkg/envs/variables.go
+++ b/pkg/envs/variables.go
@@ -18,6 +18,7 @@ type Params struct {
 	Token                     string // RUNNER_TOKEN
 	Bucket                    string // RUNNER_BUCKET
 	Ssl                       bool   // RUNNER_SSL
+	SkipVerify                bool   `envconfig:"RUNNER_SKIP_VERIFY" default:"false"` // RUNNER_SKIP_VERIFY
 	ScrapperEnabled           bool   // RUNNER_SCRAPPERENABLED
 	DataDir                   string // RUNNER_DATADIR
 	GitUsername               string // RUNNER_GITUSERNAME

--- a/pkg/executor/common.go
+++ b/pkg/executor/common.go
@@ -70,6 +70,10 @@ var RunnerEnvVars = []corev1.EnvVar{
 		Value: getOr("STORAGE_SSL", "false"),
 	},
 	{
+		Name:  "RUNNER_SKIP_VERIFY",
+		Value: getOr("STORAGE_SKIP_VERIFY", "false"),
+	},
+	{
 		Name:  "RUNNER_SCRAPPERENABLED",
 		Value: getOr("SCRAPPERENABLED", "false"),
 	},

--- a/pkg/executor/containerexecutor/containerexecutor_test.go
+++ b/pkg/executor/containerexecutor/containerexecutor_test.go
@@ -132,6 +132,7 @@ func TestNewExecutorJobSpecWithArgs(t *testing.T) {
 		{Name: "RUNNER_TOKEN", Value: ""},
 		{Name: "RUNNER_BUCKET", Value: ""},
 		{Name: "RUNNER_SSL", Value: "false"},
+		{Name: "RUNNER_SKIP_VERIFY", Value: "false"},
 		{Name: "RUNNER_SCRAPPERENABLED", Value: "false"},
 		{Name: "RUNNER_DATADIR", Value: "/data"},
 		{Name: "RUNNER_CDEVENTS_TARGET", Value: ""},

--- a/pkg/executor/scraper/factory/factory.go
+++ b/pkg/executor/scraper/factory/factory.go
@@ -121,5 +121,6 @@ func getMinIOLoader(params envs.Params) (*scraper.MinIOUploader, error) {
 		params.Token,
 		params.Bucket,
 		params.Ssl,
+		params.SkipVerify,
 	)
 }

--- a/pkg/executor/scraper/minio_scraper_integration_test.go
+++ b/pkg/executor/scraper/minio_scraper_integration_test.go
@@ -51,7 +51,7 @@ func TestMinIOScraper_Archive_Integration(t *testing.T) {
 
 	extractor := scraper.NewArchiveFilesystemExtractor(filesystem.NewOSFileSystem())
 
-	loader, err := scraper.NewMinIOUploader("localhost:9000", "minio99", "minio123", "us-east-1", "", "test-bucket-asdf", false)
+	loader, err := scraper.NewMinIOUploader("localhost:9000", "minio99", "minio123", "us-east-1", "", "test-bucket-asdf", false, false)
 	if err != nil {
 		t.Fatalf("error creating minio loader: %v", err)
 	}
@@ -77,7 +77,7 @@ func TestMinIOScraper_Archive_Integration(t *testing.T) {
 		t.Fatalf("error scraping: %v", err)
 	}
 
-	c := minio.NewClient("localhost:9000", "minio99", "minio123", "us-east-1", "", "test-bucket-asdf", false)
+	c := minio.NewClient("localhost:9000", "minio99", "minio123", "us-east-1", "", "test-bucket-asdf", false, false)
 	assert.NoError(t, c.Connect())
 	artifacts, err := c.ListFiles(context.Background(), "test-bucket-asdf")
 	if err != nil {
@@ -119,7 +119,7 @@ func TestMinIOScraper_Recursive_Integration(t *testing.T) {
 	extractor := scraper.NewRecursiveFilesystemExtractor(filesystem.NewOSFileSystem())
 
 	bucketName := "test-bucket-asdf1"
-	loader, err := scraper.NewMinIOUploader("localhost:9000", "minio99", "minio123", "us-east-1", "", bucketName, false)
+	loader, err := scraper.NewMinIOUploader("localhost:9000", "minio99", "minio123", "us-east-1", "", bucketName, false, false)
 	if err != nil {
 		t.Fatalf("error creating minio loader: %v", err)
 	}
@@ -145,7 +145,7 @@ func TestMinIOScraper_Recursive_Integration(t *testing.T) {
 		t.Fatalf("error scraping: %v", err)
 	}
 
-	c := minio.NewClient("localhost:9000", "minio99", "minio123", "us-east-1", "", bucketName, false)
+	c := minio.NewClient("localhost:9000", "minio99", "minio123", "us-east-1", "", bucketName, false, false)
 	assert.NoError(t, c.Connect())
 	artifacts, err := c.ListFiles(context.Background(), bucketName)
 	if err != nil {

--- a/pkg/executor/scraper/minio_uploader.go
+++ b/pkg/executor/scraper/minio_uploader.go
@@ -16,11 +16,11 @@ import (
 
 type MinIOUploader struct {
 	Endpoint, AccessKeyID, SecretAccessKey, Region, Token, Bucket string
-	Ssl                                                           bool
+	Ssl, SkipVerify                                               bool
 	client                                                        *minio.Client
 }
 
-func NewMinIOUploader(endpoint, accessKeyID, secretAccessKey, region, token, bucket string, ssl bool) (*MinIOUploader, error) {
+func NewMinIOUploader(endpoint, accessKeyID, secretAccessKey, region, token, bucket string, ssl, skipVerify bool) (*MinIOUploader, error) {
 	l := &MinIOUploader{
 		Endpoint:        endpoint,
 		AccessKeyID:     accessKeyID,
@@ -29,9 +29,10 @@ func NewMinIOUploader(endpoint, accessKeyID, secretAccessKey, region, token, buc
 		Token:           token,
 		Bucket:          bucket,
 		Ssl:             ssl,
+		SkipVerify:      skipVerify,
 	}
 
-	client := minio.NewClient(l.Endpoint, l.AccessKeyID, l.SecretAccessKey, l.Region, l.Token, l.Bucket, l.Ssl)
+	client := minio.NewClient(l.Endpoint, l.AccessKeyID, l.SecretAccessKey, l.Region, l.Token, l.Bucket, l.Ssl, l.SkipVerify)
 	err := client.Connect()
 	if err != nil {
 		return nil, errors.Errorf("error occured creating minio client: %v", err)

--- a/pkg/executor/scraper/minio_uploader_integration_test.go
+++ b/pkg/executor/scraper/minio_uploader_integration_test.go
@@ -22,7 +22,7 @@ func TestMinIOUploader_Upload_Tarball_Integration(t *testing.T) {
 	t.Parallel()
 
 	// Create a new MinIO uploader with the appropriate configuration
-	uploader, err := scraper.NewMinIOUploader("localhost:9000", "minio99", "minio123", "us-east-1", "", "test-bucket-fsgds", false)
+	uploader, err := scraper.NewMinIOUploader("localhost:9000", "minio99", "minio123", "us-east-1", "", "test-bucket-fsgds", false, false)
 	if err != nil {
 		t.Fatalf("failed to create MinIO loader: %v", err)
 	}
@@ -53,7 +53,7 @@ func TestMinIOUploader_Upload_Tarball_Integration(t *testing.T) {
 		t.Fatalf("failed to save file to MinIO: %v", err)
 	}
 
-	m := minio.NewClient("localhost:9000", "minio99", "minio123", "us-east-1", "", "test-bucket-fsgds", false)
+	m := minio.NewClient("localhost:9000", "minio99", "minio123", "us-east-1", "", "test-bucket-fsgds", false, false)
 	if err := m.Connect(); err != nil {
 		t.Fatalf("error conecting to minio: %v", err)
 	}
@@ -69,7 +69,7 @@ func TestMinIOUploader_Upload_Raw_Integration(t *testing.T) {
 	t.Parallel()
 
 	// Create a new MinIO loader with the appropriate configuration
-	uploader, err := scraper.NewMinIOUploader("localhost:9000", "minio99", "minio123", "us-east-1", "", "test-bucket-hgfhfg", false)
+	uploader, err := scraper.NewMinIOUploader("localhost:9000", "minio99", "minio123", "us-east-1", "", "test-bucket-hgfhfg", false, false)
 	if err != nil {
 		t.Fatalf("failed to create MinIO loader: %v", err)
 	}
@@ -93,7 +93,7 @@ func TestMinIOUploader_Upload_Raw_Integration(t *testing.T) {
 		t.Fatalf("failed to save file to MinIO: %v", err)
 	}
 
-	m := minio.NewClient("localhost:9000", "minio99", "minio123", "us-east-1", "", "test-bucket-hgfhfg", false)
+	m := minio.NewClient("localhost:9000", "minio99", "minio123", "us-east-1", "", "test-bucket-hgfhfg", false, false)
 	if err := m.Connect(); err != nil {
 		t.Fatalf("error conecting to minio: %v", err)
 	}

--- a/pkg/storage/minio/artifacts_storage_integration_test.go
+++ b/pkg/storage/minio/artifacts_storage_integration_test.go
@@ -26,7 +26,7 @@ func TestArtifactClient(t *testing.T) {
 		t.Fatalf("unable to create direct minio client: %v", err)
 	}
 	// Prepare MinIO client
-	minioClient := NewClient("localhost:9000", "minio99", "minio123", "us-east-1", "", "test-bucket-fsdf", false)
+	minioClient := NewClient("localhost:9000", "minio99", "minio123", "us-east-1", "", "test-bucket-fsdf", false, false)
 	if err := minioClient.Connect(); err != nil {
 		t.Fatalf("unable to connect to minio: %v", err)
 	}

--- a/pkg/storage/minio/minio.go
+++ b/pkg/storage/minio/minio.go
@@ -3,6 +3,7 @@ package minio
 import (
 	"bytes"
 	"context"
+	"crypto/tls"
 	"fmt"
 	"hash/fnv"
 	"io"
@@ -80,7 +81,9 @@ func (c *Client) Connect() error {
 		c.Log.Errorw("error creating minio transport", "error", err)
 		return err
 	}
-	transport.TLSClientConfig.InsecureSkipVerify = c.skipVerify
+	tlsConfig := &tls.Config{}
+	tlsConfig.InsecureSkipVerify = c.skipVerify
+	transport.TLSClientConfig = tlsConfig
 	opts := &minio.Options{
 		Creds:     creds,
 		Secure:    c.ssl,


### PR DESCRIPTION
## Pull request description 

This adds support to provide `STORAGE_SKIP_VERIFY` environment variable which disables TLS verification in MinIO

## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [ ] tested locally
- [ ] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Breaking changes

-

## Changes

-

## Fixes

- issue when using MinIO with a S3 storage which has a self-signed certificate