### PR TITLE
fix: editUrl for docs

### DIFF
--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -46,7 +46,7 @@ const config = {
           sidebarPath: require.resolve("./sidebars.js"),
           // Please change this to your repo.
           // Remove this to remove the "edit this page" links.
-          editUrl: "https://github.com/kubeshop/testkube/docs",
+          editUrl: "https://github.com/kubeshop/testkube/tree/develop/docs",
         },
         blog: false,
         theme: {


### PR DESCRIPTION
"Edit this page" links on documentation pages were broken because of the change to have the `develop` branch as default. This PR fixes the editUrl in Docusaurus config.
