### PR TITLE
fix: avoid hashed indexes and aggregate: 1

### DIFF
--- a/internal/db-migrations/01_create_indexes.down.json
+++ b/internal/db-migrations/01_create_indexes.down.json
@@ -1,10 +1,10 @@
 [
   {
     "dropIndexes": "testresults",
-    "index": ["id_hashed", "testsuite.name_hashed", "name_hashed", "status_hashed", "starttime_-1", "endtime_-1"]
+    "index": ["id_1", "testsuite.name_1", "name_1", "status_1", "starttime_-1", "endtime_-1"]
   },
   {
     "dropIndexes": "results",
-    "index": ["id_hashed", "testname_hashed", "name_hashed", "executionresult.status_hashed", "starttime_-1", "endtime_-1"]
+    "index": ["id_1", "testname_1", "name_1", "executionresult.status_1", "starttime_-1", "endtime_-1"]
   }
 ]

--- a/internal/db-migrations/01_create_indexes.up.json
+++ b/internal/db-migrations/01_create_indexes.up.json
@@ -3,20 +3,20 @@
     "createIndexes": "testresults",
     "indexes": [
       {
-        "key": {"id": "hashed"},
-        "name": "id_hashed"
+        "key": {"id": 1},
+        "name": "id_1"
       },
       {
-        "key": {"testsuite.name": "hashed"},
-        "name": "testsuite.name_hashed"
+        "key": {"testsuite.name": 1},
+        "name": "testsuite.name_1"
       },
       {
-        "key": {"name": "hashed"},
-        "name": "name_hashed"
+        "key": {"name": 1},
+        "name": "name_1"
       },
       {
-        "key": {"status": "hashed"},
-        "name": "status_hashed"
+        "key": {"status": 1},
+        "name": "status_1"
       },
       {
         "key": {"starttime": -1},
@@ -32,20 +32,20 @@
     "createIndexes": "results",
     "indexes": [
       {
-        "key": {"id": "hashed"},
-        "name": "id_hashed"
+        "key": {"id": 1},
+        "name": "id_1"
       },
       {
-        "key": {"testname": "hashed"},
-        "name": "testname_hashed"
+        "key": {"testname": 1},
+        "name": "testname_1"
       },
       {
-        "key": {"name": "hashed"},
-        "name": "name_hashed"
+        "key": {"name": 1},
+        "name": "name_1"
       },
       {
-        "key": {"executionresult.status": "hashed"},
-        "name": "executionresult.status_hashed"
+        "key": {"executionresult.status": 1},
+        "name": "executionresult.status_1"
       },
       {
         "key": {"starttime": -1},

--- a/internal/db-migrations/02_execution_search_indexes.down.json
+++ b/internal/db-migrations/02_execution_search_indexes.down.json
@@ -1,10 +1,10 @@
 [
   {
     "dropIndexes": "testresults",
-    "index": ["testsuite.name_hashed_starttime-1", "testsuite.name_hashed_endtime-1"]
+    "index": ["testsuite.name_1_starttime-1", "testsuite.name_1_endtime-1"]
   },
   {
     "dropIndexes": "results",
-    "index": ["testname_hashed_starttime-1", "testname_hashed_endtime-1"]
+    "index": ["testname_1_starttime-1", "testname_1_endtime-1"]
   }
 ]

--- a/internal/db-migrations/02_execution_search_indexes.up.json
+++ b/internal/db-migrations/02_execution_search_indexes.up.json
@@ -3,12 +3,12 @@
     "createIndexes": "testresults",
     "indexes": [
       {
-        "key": {"testsuite.name": "hashed", "starttime": -1},
-        "name": "testsuite.name_hashed_starttime-1"
+        "key": {"testsuite.name": 1, "starttime": -1},
+        "name": "testsuite.name_1_starttime-1"
       },
       {
-        "key": {"testsuite.name": "hashed", "endtime": -1},
-        "name": "testsuite.name_hashed_endtime-1"
+        "key": {"testsuite.name": 1, "endtime": -1},
+        "name": "testsuite.name_1_endtime-1"
       }
     ]
   },
@@ -16,12 +16,12 @@
     "createIndexes": "results",
     "indexes": [
       {
-        "key": {"testname": "hashed", "starttime": -1},
-        "name": "testname_hashed_starttime-1"
+        "key": {"testname": 1, "starttime": -1},
+        "name": "testname_1_starttime-1"
       },
       {
-        "key": {"testname": "hashed", "endtime": -1},
-        "name": "testname_hashed_endtime-1"
+        "key": {"testname": 1, "endtime": -1},
+        "name": "testname_1_endtime-1"
       }
     ]
   }


### PR DESCRIPTION
## Pull request description 

Make the Testkube OSS compatible with AWS DocumentDB

## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [x] tested locally
- [x] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Changes

- Use `aggregate` on collection instead of database
- Use regular indexes instead of hashed

## Fixes

- https://github.com/kubeshop/testkube/issues/4680