### PR TITLE
fix: GetLatestByTest returns objet not found

### DIFF
--- a/pkg/repository/result/mongo.go
+++ b/pkg/repository/result/mongo.go
@@ -187,7 +187,7 @@ func (r *MongoRepository) GetLatestByTest(ctx context.Context, testName string) 
 	}
 	result := (&items[0]).UnscapeDots()
 	if len(result.ExecutionResult.Output) == 0 {
-		result.ExecutionResult.Output, err = r.OutputRepository.GetOutput(ctx, result.Id, result.TestName, "")
+		result.ExecutionResult.Output, err = r.OutputRepository.GetOutput(ctx, result.Id, result.TestName, result.TestSuiteName)
 		if err == mongo.ErrNoDocuments {
 			err = nil
 		}


### PR DESCRIPTION
## Pull request description 

In cloud we store test executions that are run part of test-suite differently, because of this currently - GetOutput returns err object not found and GetLatestByTest fails.

This doesn't affect OSS, since both minio and mongo use only execution id 
```
func (r *MongoOutputRepository) GetOutput(ctx context.Context, id, testName, testSuiteName string) (output string, err error) {
	var eOutput ExecutionOutput
	err = r.Coll.FindOne(ctx, bson.M{"$or": bson.A{bson.M{"id": id}, bson.M{"name": id}}}).Decode(&eOutput)
	return eOutput.Output, err
}
```


## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [ ] tested locally
- [ ] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Breaking changes

-

## Changes

-

## Fixes

-