### PR TITLE
fix: add simpler implementation of MongoDB queries for DocumentDB

### DIFF
--- a/cmd/api-server/main.go
+++ b/cmd/api-server/main.go
@@ -236,9 +236,10 @@ func main() {
 		mongoSSLConfig := getMongoSSLConfig(cfg, secretClient)
 		db, err := storage.GetMongoDatabase(cfg.APIMongoDSN, cfg.APIMongoDB, cfg.APIMongoDBType, cfg.APIMongoAllowTLS, mongoSSLConfig)
 		ui.ExitOnError("Getting mongo database", err)
-		mongoResultsRepository := result.NewMongoRepository(db, cfg.APIMongoAllowDiskUse)
+		isDocDb := cfg.APIMongoDBType == storage.TypeDocDB
+		mongoResultsRepository := result.NewMongoRepository(db, cfg.APIMongoAllowDiskUse, isDocDb)
 		resultsRepository = mongoResultsRepository
-		testResultsRepository = testresult.NewMongoRepository(db, cfg.APIMongoAllowDiskUse)
+		testResultsRepository = testresult.NewMongoRepository(db, cfg.APIMongoAllowDiskUse, isDocDb)
 		configRepository = configrepository.NewMongoRepository(db)
 		triggerLeaseBackend = triggers.NewMongoLeaseBackend(db)
 		minioClient := newStorageClient(cfg)

--- a/pkg/repository/result/mongo.go
+++ b/pkg/repository/result/mongo.go
@@ -32,13 +32,14 @@ const (
 	StepMaxCount = 100
 )
 
-func NewMongoRepository(db *mongo.Database, allowDiskUse bool, opts ...MongoRepositoryOpt) *MongoRepository {
+func NewMongoRepository(db *mongo.Database, allowDiskUse, isDocDb bool, opts ...MongoRepositoryOpt) *MongoRepository {
 	r := &MongoRepository{
 		db:               db,
 		ResultsColl:      db.Collection(CollectionResults),
 		SequencesColl:    db.Collection(CollectionSequences),
 		OutputRepository: NewMongoOutputRepository(db),
 		allowDiskUse:     allowDiskUse,
+		isDocDb:          isDocDb,
 	}
 
 	for _, opt := range opts {
@@ -86,6 +87,7 @@ type MongoRepository struct {
 	SequencesColl    *mongo.Collection
 	OutputRepository OutputRepository
 	allowDiskUse     bool
+	isDocDb          bool
 }
 
 type MongoRepositoryOpt func(*MongoRepository)
@@ -142,7 +144,53 @@ func (r *MongoRepository) GetLatestTestNumber(ctx context.Context, testName stri
 	return result.Number, err
 }
 
+func (r *MongoRepository) slowGetLatestByTest(ctx context.Context, testName string) (*testkube.Execution, error) {
+	opts := options.Aggregate()
+	pipeline := []bson.M{
+		{"$project": bson.M{"testname": 1, "starttime": 1, "endtime": 1}},
+		{"$match": bson.M{"testname": testName}},
+
+		{"$group": bson.D{
+			{Key: "_id", Value: "$testname"},
+			{Key: "doc", Value: bson.M{"$max": bson.D{
+				{Key: "updatetime", Value: bson.M{"$max": bson.A{"$starttime", "$endtime"}}},
+				{Key: "content", Value: "$$ROOT"},
+			}}},
+		}},
+		{"$sort": bson.M{"doc.updatetime": -1}},
+		{"$limit": 1},
+
+		{"$lookup": bson.M{"from": r.ResultsColl.Name(), "localField": "doc.content._id", "foreignField": "_id", "as": "execution"}},
+		{"$replaceRoot": bson.M{"newRoot": bson.M{"$arrayElemAt": bson.A{"$execution", 0}}}},
+	}
+	cursor, err := r.ResultsColl.Aggregate(ctx, pipeline, opts)
+	if err != nil {
+		return nil, err
+	}
+	var items []testkube.Execution
+	err = cursor.All(ctx, &items)
+	if err != nil {
+		return nil, err
+	}
+	if len(items) == 0 {
+		return nil, mongo.ErrNoDocuments
+	}
+	result := (&items[0]).UnscapeDots()
+	if len(result.ExecutionResult.Output) == 0 {
+		result.ExecutionResult.Output, err = r.OutputRepository.GetOutput(ctx, result.Id, result.TestName, result.TestSuiteName)
+		if err == mongo.ErrNoDocuments {
+			err = nil
+		}
+	}
+	return result, err
+}
+
 func (r *MongoRepository) GetLatestByTest(ctx context.Context, testName string) (*testkube.Execution, error) {
+	// Workaround, to use subset of MongoDB features available in AWS DocumentDB
+	if r.isDocDb {
+		return r.slowGetLatestByTest(ctx, testName)
+	}
+
 	opts := options.Aggregate()
 	pipeline := []bson.M{
 		{"$group": bson.M{"_id": "$testname", "doc": bson.M{"$first": bson.M{}}}},
@@ -195,9 +243,57 @@ func (r *MongoRepository) GetLatestByTest(ctx context.Context, testName string) 
 	return result, err
 }
 
+func (r *MongoRepository) slowGetLatestByTests(ctx context.Context, testNames []string) (executions []testkube.Execution, err error) {
+	documents := bson.A{}
+	for _, testName := range testNames {
+		documents = append(documents, bson.M{"testname": testName})
+	}
+
+	pipeline := []bson.M{
+		{"$project": bson.M{"testname": 1, "starttime": 1, "endtime": 1}},
+		{"$match": bson.M{"$or": documents}},
+
+		{"$group": bson.D{
+			{Key: "_id", Value: "$testname"},
+			{Key: "doc", Value: bson.M{"$max": bson.D{
+				{Key: "updatetime", Value: bson.M{"$max": bson.A{"$starttime", "$endtime"}}},
+				{Key: "content", Value: "$$ROOT"},
+			}}},
+		}},
+		{"$sort": bson.M{"doc.updatetime": -1}},
+
+		{"$lookup": bson.M{"from": r.ResultsColl.Name(), "localField": "doc.content._id", "foreignField": "_id", "as": "execution"}},
+		{"$replaceRoot": bson.M{"newRoot": bson.M{"$arrayElemAt": bson.A{"$execution", 0}}}},
+	}
+
+	opts := options.Aggregate()
+	if r.allowDiskUse {
+		opts.SetAllowDiskUse(r.allowDiskUse)
+	}
+
+	cursor, err := r.ResultsColl.Aggregate(ctx, pipeline, opts)
+	if err != nil {
+		return nil, err
+	}
+	err = cursor.All(ctx, &executions)
+	if err != nil {
+		return nil, err
+	}
+
+	for i := range executions {
+		executions[i].UnscapeDots()
+	}
+	return executions, nil
+}
+
 func (r *MongoRepository) GetLatestByTests(ctx context.Context, testNames []string) (executions []testkube.Execution, err error) {
 	if len(testNames) == 0 {
 		return executions, nil
+	}
+
+	// Workaround, to use subset of MongoDB features available in AWS DocumentDB
+	if r.isDocDb {
+		return r.slowGetLatestByTests(ctx, testNames)
 	}
 
 	documents := bson.A{}

--- a/pkg/repository/result/mongo_integration_test.go
+++ b/pkg/repository/result/mongo_integration_test.go
@@ -370,7 +370,7 @@ func TestTestExecutionsMetrics_Integration(t *testing.T) {
 
 func getRepository() (*MongoRepository, error) {
 	db, err := storage.GetMongoDatabase(mongoDns, mongoDbName, storage.TypeMongoDB, false, nil)
-	repository := NewMongoRepository(db, true)
+	repository := NewMongoRepository(db, true, false)
 	return repository, err
 }
 

--- a/pkg/repository/testresult/mongo.go
+++ b/pkg/repository/testresult/mongo.go
@@ -19,11 +19,12 @@ var _ Repository = (*MongoRepository)(nil)
 
 const CollectionName = "testresults"
 
-func NewMongoRepository(db *mongo.Database, allowDiskUse bool, opts ...MongoRepositoryOpt) *MongoRepository {
+func NewMongoRepository(db *mongo.Database, allowDiskUse, isDocDb bool, opts ...MongoRepositoryOpt) *MongoRepository {
 	r := &MongoRepository{
 		db:           db,
 		Coll:         db.Collection(CollectionName),
 		allowDiskUse: allowDiskUse,
+		isDocDb:      isDocDb,
 	}
 
 	for _, opt := range opts {
@@ -37,6 +38,7 @@ type MongoRepository struct {
 	db           *mongo.Database
 	Coll         *mongo.Collection
 	allowDiskUse bool
+	isDocDb      bool
 }
 
 func WithMongoRepositoryCollection(collection *mongo.Collection) MongoRepositoryOpt {
@@ -57,7 +59,49 @@ func (r *MongoRepository) GetByNameAndTestSuite(ctx context.Context, name, testS
 	return *result.UnscapeDots(), err
 }
 
+func (r *MongoRepository) slowGetLatestByTestSuite(ctx context.Context, testSuiteName string) (*testkube.TestSuiteExecution, error) {
+	opts := options.Aggregate()
+	pipeline := []bson.M{
+		{"$project": bson.M{"testsuite.name": 1, "starttime": 1, "endtime": 1}},
+		{"$match": bson.M{"testsuite.name": testSuiteName}},
+
+		{"$addFields": bson.M{
+			"updatetime": bson.M{"$max": bson.A{"$starttime", "$endtime"}},
+		}},
+		{"$group": bson.D{
+			{Key: "_id", Value: "$testsuite.name"},
+			{Key: "doc", Value: bson.M{"$max": bson.D{
+				{Key: "updatetime", Value: "$updatetime"},
+				{Key: "content", Value: "$$ROOT"},
+			}}},
+		}},
+		{"$sort": bson.M{"doc.updatetime": -1}},
+		{"$limit": 1},
+
+		{"$lookup": bson.M{"from": r.Coll.Name(), "localField": "doc.content._id", "foreignField": "_id", "as": "execution"}},
+		{"$replaceRoot": bson.M{"newRoot": bson.M{"$arrayElemAt": bson.A{"$execution", 0}}}},
+	}
+	cursor, err := r.Coll.Aggregate(ctx, pipeline, opts)
+	if err != nil {
+		return nil, err
+	}
+	var items []testkube.TestSuiteExecution
+	err = cursor.All(ctx, &items)
+	if err != nil {
+		return nil, err
+	}
+	if len(items) == 0 {
+		return nil, mongo.ErrNoDocuments
+	}
+	return items[0].UnscapeDots(), err
+}
+
 func (r *MongoRepository) GetLatestByTestSuite(ctx context.Context, testSuiteName string) (*testkube.TestSuiteExecution, error) {
+	// Workaround, to use subset of MongoDB features available in AWS DocumentDB
+	if r.isDocDb {
+		return r.slowGetLatestByTestSuite(ctx, testSuiteName)
+	}
+
 	opts := options.Aggregate()
 	pipeline := []bson.M{
 		{"$group": bson.M{"_id": "$testsuite.name", "doc": bson.M{"$first": bson.M{}}}},
@@ -104,9 +148,64 @@ func (r *MongoRepository) GetLatestByTestSuite(ctx context.Context, testSuiteNam
 	return items[0].UnscapeDots(), err
 }
 
+func (r *MongoRepository) slowGetLatestByTestSuites(ctx context.Context, testSuiteNames []string) (executions []testkube.TestSuiteExecution, err error) {
+	documents := bson.A{}
+	for _, testSuiteName := range testSuiteNames {
+		documents = append(documents, bson.M{"testsuite.name": testSuiteName})
+	}
+
+	pipeline := []bson.M{
+		{"$project": bson.M{"testsuite.name": 1, "starttime": 1, "endtime": 1}},
+		{"$match": bson.M{"$or": documents}},
+
+		{"$addFields": bson.M{
+			"updatetime": bson.M{"$max": bson.A{"$starttime", "$endtime"}},
+		}},
+		{"$group": bson.D{
+			{Key: "_id", Value: "$testsuite.name"},
+			{Key: "doc", Value: bson.M{"$max": bson.D{
+				{Key: "updatetime", Value: "$updatetime"},
+				{Key: "content", Value: "$$ROOT"},
+			}}},
+		}},
+		{"$sort": bson.M{"doc.updatetime": -1}},
+
+		{"$lookup": bson.M{"from": r.Coll.Name(), "localField": "doc.content._id", "foreignField": "_id", "as": "execution"}},
+		{"$replaceRoot": bson.M{"newRoot": bson.M{"$arrayElemAt": bson.A{"$execution", 0}}}},
+	}
+
+	opts := options.Aggregate()
+	if r.allowDiskUse {
+		opts.SetAllowDiskUse(r.allowDiskUse)
+	}
+
+	cursor, err := r.Coll.Aggregate(ctx, pipeline, opts)
+	if err != nil {
+		return nil, err
+	}
+	err = cursor.All(ctx, &executions)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(executions) == 0 {
+		return executions, nil
+	}
+
+	for i := range executions {
+		executions[i].UnscapeDots()
+	}
+	return executions, nil
+}
+
 func (r *MongoRepository) GetLatestByTestSuites(ctx context.Context, testSuiteNames []string) (executions []testkube.TestSuiteExecution, err error) {
 	if len(testSuiteNames) == 0 {
 		return executions, nil
+	}
+
+	// Workaround, to use subset of MongoDB features available in AWS DocumentDB
+	if r.isDocDb {
+		return r.slowGetLatestByTestSuites(ctx, testSuiteNames)
 	}
 
 	documents := bson.A{}

--- a/pkg/repository/testresult/mongo_test.go
+++ b/pkg/repository/testresult/mongo_test.go
@@ -107,7 +107,7 @@ func TestTestExecutionsMetrics(t *testing.T) {
 
 func getRepository() (*MongoRepository, error) {
 	db, err := storage.GetMongoDatabase(mongoDns, mongoDbName, storage.TypeMongoDB, false, nil)
-	repository := NewMongoRepository(db, true)
+	repository := NewMongoRepository(db, true, false)
 	return repository, err
 }
 


### PR DESCRIPTION
## Pull request description 

* add simpler implementation of MongoDB queries for DocumentDB
  * DocumentDB has pretty weak coverage of MongoDB features - https://www.isdocumentdbreallymongodb.com/
  * These won't be performant, but will allow using Testkube until we will fully deprecate DocumentDB

## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [x] tested locally
- [x] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Breaking changes

-

## Changes

-

## Fixes

- https://github.com/kubeshop/testkube/issues/4697