### PR TITLE
fix: performance of execution status queries

### DIFF
--- a/pkg/repository/result/mongo.go
+++ b/pkg/repository/result/mongo.go
@@ -403,7 +403,10 @@ func (r *MongoRepository) GetExecutionTotals(ctx context.Context, paging bool, f
 		query, _ = composeQueryAndOpts(filter[0])
 	}
 
-	pipeline := []bson.D{{{Key: "$match", Value: query}}}
+	pipeline := []bson.D{
+		{{Key: "$sort", Value: bson.M{"executionresult.status": 1}}},
+		{{Key: "$match", Value: query}},
+	}
 	if len(filter) > 0 {
 		pipeline = append(pipeline, bson.D{{Key: "$sort", Value: bson.D{{Key: "starttime", Value: -1}}}})
 		if paging {

--- a/pkg/repository/testresult/mongo.go
+++ b/pkg/repository/testresult/mongo.go
@@ -299,7 +299,10 @@ func (r *MongoRepository) GetExecutionsTotals(ctx context.Context, filter ...Fil
 		query, _ = composeQueryAndOpts(filter[0])
 	}
 
-	pipeline := []bson.D{{{Key: "$match", Value: query}}}
+	pipeline := []bson.D{
+		{{Key: "$sort", Value: bson.M{"status": 1}}},
+		{{Key: "$match", Value: query}},
+	}
 	if len(filter) > 0 {
 		pipeline = append(pipeline, bson.D{{Key: "$sort", Value: bson.D{{Key: "starttime", Value: -1}}}})
 		pipeline = append(pipeline, bson.D{{Key: "$skip", Value: int64(filter[0].Page() * filter[0].PageSize())}})


### PR DESCRIPTION
## Pull request description 

Fix the performance of execution status queries. `$group` itself is not using indexes, but `$sort` + `$group` does.

The query performs is the longest running one, and does it frequently:

<img width="1495" alt="Zrzut ekranu 2023-12-1 o 08 25 50" src="https://github.com/kubeshop/testkube/assets/3843526/17be849e-5744-4910-a206-747145f9a15b">

## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [x] tested locally
- [x] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
