### PR TITLE
fix: propagate namespace when test is executed as part of a testsuite

### DIFF
--- a/pkg/scheduler/testsuite_scheduler.go
+++ b/pkg/scheduler/testsuite_scheduler.go
@@ -433,7 +433,7 @@ func (s *Scheduler) executeTestStep(ctx context.Context, testsuiteExecution test
 			l.Info("executing test", "variables", testsuiteExecution.Variables, "request", request)
 
 			testTuples = append(testTuples, testTuple{
-				test:        testkube.Test{Name: executeTestStep},
+				test:        testkube.Test{Name: executeTestStep, Namespace: testsuiteExecution.TestSuite.Namespace},
 				executionID: execution.Id,
 			})
 		case testkube.TestSuiteStepTypeDelay:


### PR DESCRIPTION
## Pull request description 

Jmeter Executor was failing when run in distributed mode because namespace was not propagated when test was executed as part of a testsuite.
This PR fixes propagation of test namespace when run as part of a testsuite.

## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [x] tested locally
- [ ] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Breaking changes

-

## Changes

-

## Fixes

-