### PR TITLE
fix: pin soapui starter image version

### DIFF
--- a/contrib/executor/soapui/build/agent/Dockerfile
+++ b/contrib/executor/soapui/build/agent/Dockerfile
@@ -1,13 +1,10 @@
-# Base image consists of:
-
-# FROM smartbear/soapuios-testrunner
-# RUN apt-get update && apt-get install -y git \
-#                                          curl && \
-   #  chmod 777 /usr/local/SmartBear && \
-   #  useradd -m -d /home/soapui -s /bin/bash -u 1001 -r -g root soapui
-
 # syntax=docker/dockerfile:1
-FROM kubeshop/testkube-soapui-executor:base
+FROM smartbear/soapuios-testrunner:5.7.2
+RUN apt-get update && apt-get install -y git \
+   curl && \
+   chmod 777 /usr/local/SmartBear && \
+   useradd -m -d /home/soapui -s /bin/bash -u 1001 -r -g root soapui
+
 COPY soapui /bin/runner
 USER 1001
 


### PR DESCRIPTION
## Pull request description 

Pin starter image version for security checks

Previous SoapUI version used: 5.7.0
New version: 5.7.2

Checked with:
```
$ docker run --entrypoint /bin/sh -it kubeshop/testkube-soapui-executor:6ec1f70
$ ls
EntryPoint.sh  RunProject.sh  SoapUI-5.7.0
```

## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [x] tested locally
- [ ] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Breaking changes

-

## Changes

-

## Fixes

-