### PR TITLE
feat: add config option for skipping cert verify when connecting to cloud/enterprise (#4763)

### DIFF
--- a/cmd/api-server/main.go
+++ b/cmd/api-server/main.go
@@ -176,7 +176,7 @@ func main() {
 		mode = common.ModeAgent
 	}
 	if mode == common.ModeAgent {
-		grpcConn, err = agent.NewGRPCConnection(ctx, cfg.TestkubeProTLSInsecure, cfg.TestkubeProURL, log.DefaultLogger)
+		grpcConn, err = agent.NewGRPCConnection(ctx, cfg.TestkubeProTLSInsecure, cfg.TestkubeProSkipVerify, cfg.TestkubeProURL, log.DefaultLogger)
 		ui.ExitOnError("error creating gRPC connection", err)
 		defer grpcConn.Close()
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -65,6 +65,7 @@ type Config struct {
 	TestkubeProTLSInsecure           bool          `envconfig:"TESTKUBE_PRO_TLS_INSECURE" default:"false"`
 	TestkubeProWorkerCount           int           `envconfig:"TESTKUBE_PRO_WORKER_COUNT" default:"50"`
 	TestkubeProLogStreamWorkerCount  int           `envconfig:"TESTKUBE_PRO_LOG_STREAM_WORKER_COUNT" default:"25"`
+	TestkubeProSkipVerify            bool          `envconfig:"TESTKUBE_PRO_SKIP_VERIFY" default:"false"`
 	TestkubeWatcherNamespaces        string        `envconfig:"TESTKUBE_WATCHER_NAMESPACES" default:""`
 	GraphqlPort                      string        `envconfig:"TESTKUBE_GRAPHQL_PORT" default:"8070"`
 	TestkubeRegistry                 string        `envconfig:"TESTKUBE_REGISTRY" default:""`

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -2,6 +2,7 @@ package agent
 
 import (
 	"context"
+	"crypto/tls"
 	"fmt"
 	"math"
 	"os"
@@ -41,8 +42,12 @@ const (
 // buffer up to five messages per worker
 const bufferSizePerWorker = 5
 
-func NewGRPCConnection(ctx context.Context, isInsecure bool, server string, logger *zap.SugaredLogger) (*grpc.ClientConn, error) {
-	creds := credentials.NewTLS(nil)
+func NewGRPCConnection(ctx context.Context, isInsecure bool, skipVerify bool, server string, logger *zap.SugaredLogger) (*grpc.ClientConn, error) {
+	var tlsConfig *tls.Config
+	if skipVerify {
+		tlsConfig = &tls.Config{InsecureSkipVerify: true}
+	}
+	creds := credentials.NewTLS(tlsConfig)
 	if isInsecure {
 		creds = insecure.NewCredentials()
 	}

--- a/pkg/agent/agent_test.go
+++ b/pkg/agent/agent_test.go
@@ -47,7 +47,7 @@ func TestCommandExecution(t *testing.T) {
 		atomic.AddInt32(&msgCnt, 1)
 	}
 
-	grpcConn, err := agent.NewGRPCConnection(context.Background(), true, url, log.DefaultLogger)
+	grpcConn, err := agent.NewGRPCConnection(context.Background(), true, false, url, log.DefaultLogger)
 	ui.ExitOnError("error creating gRPC connection", err)
 	defer grpcConn.Close()
 

--- a/pkg/agent/events_test.go
+++ b/pkg/agent/events_test.go
@@ -45,7 +45,7 @@ func TestEventLoop(t *testing.T) {
 
 	logger, _ := zap.NewDevelopment()
 
-	grpcConn, err := agent.NewGRPCConnection(context.Background(), true, url, log.DefaultLogger)
+	grpcConn, err := agent.NewGRPCConnection(context.Background(), true, false, url, log.DefaultLogger)
 	ui.ExitOnError("error creating gRPC connection", err)
 	defer grpcConn.Close()
 

--- a/pkg/agent/logs_test.go
+++ b/pkg/agent/logs_test.go
@@ -43,7 +43,7 @@ func TestLogStream(t *testing.T) {
 		fmt.Fprintf(ctx, "Hi there! RequestURI is %q", ctx.RequestURI())
 	}
 
-	grpcConn, err := agent.NewGRPCConnection(context.Background(), true, url, log.DefaultLogger)
+	grpcConn, err := agent.NewGRPCConnection(context.Background(), true, false, url, log.DefaultLogger)
 	ui.ExitOnError("error creating gRPC connection", err)
 	defer grpcConn.Close()
 

--- a/pkg/envs/variables.go
+++ b/pkg/envs/variables.go
@@ -41,6 +41,7 @@ type Params struct {
 	CloudAPITLSInsecure       bool   `envconfig:"RUNNER_CLOUD_API_TLS_INSECURE"`                // RUNNER_CLOUD_API_TLS_INSECURE
 	CloudAPIURL               string `envconfig:"RUNNER_CLOUD_API_URL"`                         // RUNNER_CLOUD_API_URL
 	CloudConnectionTimeoutSec int    `envconfig:"RUNNER_CLOUD_CONNECTION_TIMEOUT" default:"10"` // RUNNER_CLOUD_CONNECTION_TIMEOUT
+	CloudAPISkipVerify        bool   `envconfig:"RUNNER_CLOUD_API_SKIP_VERIFY" default:"false"` // RUNNER_CLOUD_API_SKIP_VERIFY
 	SlavesConfigs             string `envconfig:"RUNNER_SLAVES_CONFIGS"`                        // RUNNER_SLAVES_CONFIGS
 }
 
@@ -89,6 +90,7 @@ func printParams(params Params) {
 	output.PrintLogf("RUNNER_CLOUD_API_URL=\"%s\"", params.CloudAPIURL)
 	printSensitiveParam("RUNNER_CLOUD_API_KEY", params.CloudAPIKey)
 	output.PrintLogf("RUNNER_CLOUD_CONNECTION_TIMEOUT=%d", params.CloudConnectionTimeoutSec)
+	output.PrintLogf("RUNNER_CLOUD_API_SKIP_VERIFY=\"%t\"", params.CloudAPISkipVerify)
 }
 
 // printSensitiveParam shows in logs if a parameter is set or not

--- a/pkg/executor/common.go
+++ b/pkg/executor/common.go
@@ -117,6 +117,10 @@ var RunnerEnvVars = []corev1.EnvVar{
 		Value: os.Getenv("TESTKUBE_CLOUD_URL"),
 	},
 	{
+		Name:  "RUNNER_CLOUD_API_SKIP_VERIFY",
+		Value: getOr("TESTKUBE_PRO_SKIP_VERIFY", "false"),
+	},
+	{
 		Name:  "RUNNER_DASHBOARD_URI",
 		Value: os.Getenv("TESTKUBE_DASHBOARD_URI"),
 	},

--- a/pkg/executor/containerexecutor/containerexecutor_test.go
+++ b/pkg/executor/containerexecutor/containerexecutor_test.go
@@ -152,6 +152,7 @@ func TestNewExecutorJobSpecWithArgs(t *testing.T) {
 		{Name: "RUNNER_CLOUD_API_KEY", Value: ""},
 		{Name: "RUNNER_CLOUD_API_URL", Value: ""},
 		{Name: "RUNNER_CLOUD_API_TLS_INSECURE", Value: "false"},
+		{Name: "RUNNER_CLOUD_API_SKIP_VERIFY", Value: "false"},
 		{Name: "RUNNER_CLUSTERID", Value: ""},
 		{Name: "CI", Value: "1"},
 		{Name: "key", Value: "value"},

--- a/pkg/executor/scraper/factory/factory.go
+++ b/pkg/executor/scraper/factory/factory.go
@@ -100,7 +100,7 @@ func getCloudLoader(ctx context.Context, params envs.Params) (uploader *cloudscr
 	defer cancel()
 
 	output.PrintLogf("%s Uploading artifacts using Cloud Uploader (timeout:%ds)", ui.IconCheckMark, params.CloudConnectionTimeoutSec)
-	grpcConn, err := agent.NewGRPCConnection(ctxTimeout, params.CloudAPITLSInsecure, params.CloudAPIURL, log.DefaultLogger)
+	grpcConn, err := agent.NewGRPCConnection(ctxTimeout, params.CloudAPITLSInsecure, params.SkipVerify, params.CloudAPIURL, log.DefaultLogger)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION

* add config option for skipping cert verify when connecting to cloud/enterprise

* revert .env change

* revert .env change again

* update envvar inconsistent names

* add newline to .env

* rename cloud to pro variable

## Pull request description 



## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [ ] tested locally
- [ ] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Breaking changes

-

## Changes

-

## Fixes

-