### PR TITLE
fix: log service doesnt start up

### DIFF
--- a/pkg/logs/service.go
+++ b/pkg/logs/service.go
@@ -123,7 +123,9 @@ func (ls *LogsService) Shutdown(ctx context.Context) (err error) {
 		return err
 	}
 
-	ls.grpcServer.GracefulStop()
+	if ls.grpcServer != nil {
+		ls.grpcServer.GracefulStop()
+	}
 
 	// TODO decide how to handle graceful shutdown of consumers
 
@@ -136,7 +138,7 @@ func (ls *LogsService) WithHttpAddress(address string) *LogsService {
 }
 
 func (ls *LogsService) WithGrpcAddress(address string) *LogsService {
-	ls.httpAddress = address
+	ls.grpcAddress = address
 	return ls
 }
 


### PR DESCRIPTION
## Pull request description 

currently if you try to run logs service it crashes with:
```
"level":"warn","ts":1703072402.26585,"caller":"logs/main.go:86","msg":"logs service run group returned an error","service":"logs-service-init","error":"listen tcp :9090: bind: address already in use"}\
```

and then panics due to grpc server being nil on shutdown

## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [ ] tested locally
- [ ] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Breaking changes

-

## Changes

-

## Fixes

-