### PR TITLE
fix: put pre-run and post-run script files in the data volume

### DIFF
--- a/contrib/executor/init/pkg/runner/runner.go
+++ b/contrib/executor/init/pkg/runner/runner.go
@@ -80,7 +80,7 @@ func (r *InitRunner) Run(ctx context.Context, execution testkube.Execution) (res
 			shell = execution.ContainerShell
 		}
 
-		shebang := "#!" + shell + "\n"
+		shebang := "#!" + shell + "\nset -e\n"
 		entrypoint := shebang
 		command := shebang
 		preRunScript := shebang


### PR DESCRIPTION
## Pull request description 

* The pre-run and post-run scripts were put in the working directory, while it not necessarily was available as a volume.
  * Moved all of shell files into `DataDir`
  * Move command to separate file so initial `workingDir` will be persisted for post-run script
* Additionally, the failure of pre-run script is not blocking the rest of executing.
  * Added `set -e` to fail fast

## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [ ] tested locally
- [ ] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Breaking changes

-

## Changes

-

## Fixes

- testkube#4719