### PR TITLE
fix: log sidecar never finishes

### DIFF
--- a/pkg/logs/sidecar/proxy.go
+++ b/pkg/logs/sidecar/proxy.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"os"
 	"os/signal"
+	"strings"
 	"syscall"
 	"time"
 
@@ -151,7 +152,12 @@ func (p *Proxy) streamLogsFromPod(pod corev1.Pod, logs chan events.Log) (err err
 	}
 
 	for _, container := range containers {
-
+		// We skip logsidecar container logs,
+		// because following the logs for it will never finish
+		// and the sidecar will run forever.
+		if strings.HasSuffix(container, "-logs") {
+			continue
+		}
 		req := p.podsClient.GetLogs(
 			pod.Name,
 			&corev1.PodLogOptions{
@@ -169,6 +175,7 @@ func (p *Proxy) streamLogsFromPod(pod corev1.Pod, logs chan events.Log) (err err
 		reader := bufio.NewReader(stream)
 		for {
 			b, err := utils.ReadLongLine(reader)
+
 			if err != nil {
 				if errors.Is(err, io.EOF) {
 					err = nil


### PR DESCRIPTION
## Pull request description 

Currentlly logs sidecar never finishes because it is forever tailing the logs of itself. To solve it we skip the log sidecar logs.


## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [x] tested locally
- [x] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Breaking changes

-

## Changes

-

## Fixes

-