### PR TITLE
fix: pass command arguments down

### DIFF
--- a/contrib/executor/init/pkg/runner/runner.go
+++ b/contrib/executor/init/pkg/runner/runner.go
@@ -92,7 +92,7 @@ func (r *InitRunner) Run(ctx context.Context, execution testkube.Execution) (res
 		}
 
 		if len(execution.Command) != 0 {
-			entrypoint += strconv.Quote(filepath.Join(r.Params.DataDir, commandScriptName)) + " \"$@\"\n"
+			entrypoint += strconv.Quote(filepath.Join(r.Params.DataDir, commandScriptName)) + " $@\n"
 			command += strings.Join(execution.Command, " ")
 			command += " \"$@\"\n"
 		}

--- a/contrib/executor/init/pkg/runner/runner.go
+++ b/contrib/executor/init/pkg/runner/runner.go
@@ -92,7 +92,7 @@ func (r *InitRunner) Run(ctx context.Context, execution testkube.Execution) (res
 		}
 
 		if len(execution.Command) != 0 {
-			entrypoint += strconv.Quote(filepath.Join(r.Params.DataDir, commandScriptName)) + "\n"
+			entrypoint += strconv.Quote(filepath.Join(r.Params.DataDir, commandScriptName)) + " \"$@\"\n"
 			command += strings.Join(execution.Command, " ")
 			command += " \"$@\"\n"
 		}


### PR DESCRIPTION
## Pull request description 

* https://demo.testkube.dev/tests/container-executor-postman-smoke/executions/658443dba1e038c8cd41bb36 - arguments are not passed to command script

## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [ ] tested locally
- [ ] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Breaking changes

-

## Changes

-

## Fixes

-