### PR TITLE
docs: fix invalid flag in running-tests.md

### DIFF
--- a/docs/docs/articles/running-tests.md
+++ b/docs/docs/articles/running-tests.md
@@ -107,7 +107,7 @@ For some 'real world' tests, configuration variables are passed in order to run 
 
 Let's assume that our example Cypress test needs the `testparam` parameter with the value `testvalue`.
 
-This is done by using the `--variable` flag (or just `-v`). If you need to pass more parameters, either pass the values as a comma-separated string or simply pass multiple `-p` flags.
+This is done by using the `--variable` flag (or just `-v`). If you need to pass more parameters, either pass the values as a comma-separated string or simply pass multiple `-v` flags.
 
 It's possible to pass parameters securely to the executed test. It's necessary to use the `--secret` flag,
 which contains a key value pair - a name of the Kubernetes secret and a secret key.

--- a/docs/docs/articles/running-tests.md
+++ b/docs/docs/articles/running-tests.md
@@ -107,14 +107,14 @@ For some 'real world' tests, configuration variables are passed in order to run 
 
 Let's assume that our example Cypress test needs the `testparam` parameter with the value `testvalue`.
 
-This is done by using the `-p` parameter. If you need to pass more parameters, simply pass multiple `-p` flags.
+This is done by using the `--variable` flag (or just `-v`). If you need to pass more parameters, either pass the values as a comma-separated string or simply pass multiple `-p` flags.
 
 It's possible to pass parameters securely to the executed test. It's necessary to use the `--secret` flag,
 which contains a key value pair - a name of the Kubernetes secret and a secret key.
 It can be passed multiple times if needed.
 
 ```sh
-kubectl testkube run test kubeshop-cypress -p testparam=testvalue -f --secret secret-name=secret-key
+kubectl testkube run test kubeshop-cypress -v testparam=testvalue -f --secret secret-name=secret-key
 ```
 
 ```sh title="Expected output:"


### PR DESCRIPTION
## Pull request description 

Fix an invalid flag (`--parameter|-p` instead of `--variable|-v`) in the [Passing parameters](https://docs.testkube.io/articles/running-tests/#passing-parameters) section of Testkube docs.

This closes https://github.com/kubeshop/testkube/issues/4844

## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [ ] tested locally
- [ ] tested on cluster
- [ ] added new dependencies
- [x] updated the docs
- [ ] added a test

## Breaking changes

-

## Changes

-

## Fixes

-