### PR TITLE
fix: recover /results/v1 alias

### DIFF
--- a/internal/app/api/v1/server.go
+++ b/internal/app/api/v1/server.go
@@ -405,6 +405,10 @@ func (s *TestkubeAPI) InitRoutes() {
 	repositories := root.Group("/repositories")
 	repositories.Post("/", s.ValidateRepositoryHandler())
 
+	// mount everything on results
+	// TODO it should be named /api/ + dashboard refactor
+	s.Mux.Mount("/results", s.Mux)
+
 	// mount dashboard on /ui
 	dashboardURI := os.Getenv("TESTKUBE_DASHBOARD_URI")
 	if dashboardURI == "" {


### PR DESCRIPTION
## Pull request description 

Recover `/results/v1` alias deleted in https://github.com/kubeshop/testkube/commit/b80ca88af6f75fbc4464e26d62aceef6ac28a2b5 and https://github.com/kubeshop/testkube/commit/fc71643c52f2f3f3a24707b028adadea4a037010

## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [ ] tested locally
- [ ] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Fixes

- kubeshop/testkube#4850