### PR TITLE
fix: add condition to install latest release if no beta found

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,4 +1,4 @@
-#!/bin/bash 
+#!/bin/bash
 echo "Getting kubectl-testkube plugin"
 
 if [ ! -z "${DEBUG}" ];
@@ -20,14 +20,14 @@ _detect_arch() {
 }
 
 _detect_os(){
-    case $(uname) in 
-    Linux) echo "Linux" 
-    ;; 
+    case $(uname) in
+    Linux) echo "Linux"
+    ;;
     Darwin) echo "Darwin"
-    ;; 
-    Windows) echo "Windows" 
-    ;; 
-     esac    
+    ;;
+    Windows) echo "Windows"
+    ;;
+     esac
 }
 
 _download_url() {
@@ -46,6 +46,14 @@ _download_url() {
         | jq -r '.[].tag_name | select(test("beta"))' \
         | head -n 1 \
       )"
+        if [ -z "$tag" ]; then
+            echo "No beta releases found. Installing latest release" >&2
+            tag="$(
+              curl -s "https://api.github.com/repos/kubeshop/testkube/releases/latest" \
+              2>/dev/null \
+              | jq -r '.tag_name' \
+            )"
+        fi
     else
       tag="$(
         curl -s "https://api.github.com/repos/kubeshop/testkube/releases/latest" \
@@ -62,14 +70,15 @@ _download_url() {
 }
 
 if [ "$1" = "beta" ]; then
-  echo "Downloading testkube from URL: $(_download_url "beta")"
-  curl -sSLf "$(_download_url "beta")" > testkube.tar.gz
+  url="$(_download_url "beta")"
+  echo "Downloading testkube from URL: $url"
+  curl -sSLf "$url" > testkube.tar.gz
 else
   echo "Downloading testkube from URL: $(_download_url)"
   curl -sSLf "$(_download_url)" > testkube.tar.gz
 fi
 
-tar -xzf testkube.tar.gz kubectl-testkube 
+tar -xzf testkube.tar.gz kubectl-testkube
 rm testkube.tar.gz
 mv kubectl-testkube /usr/local/bin/kubectl-testkube
 ln -s /usr/local/bin/kubectl-testkube /usr/local/bin/testkube
@@ -79,7 +88,7 @@ echo "kubectl-testkube installed in:"
 echo "- /usr/local/bin/kubectl-testkube"
 echo "- /usr/local/bin/testkube"
 echo "- /usr/local/bin/tk"
-echo "" 
+echo ""
 echo "You'll also need `helm` and Kubernetes `kubectl` installed."
 echo "- Install Helm: https://helm.sh/docs/intro/install/"
 echo "- Install kubectl: https://kubernetes.io/docs/tasks/tools/#kubectl"


### PR DESCRIPTION
## Pull request description 
This PR updates the `install` script by adding a condition to install latest release if no beta ones are found.


## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [ ] tested locally
- [ ] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Breaking changes

-

## Changes

-

## Fixes

-