### PR TITLE
fix: avoid COLLSCAN in favor of PROJECTION_COVERED while counting execution totals

### DIFF
--- a/pkg/repository/result/mongo.go
+++ b/pkg/repository/result/mongo.go
@@ -413,6 +413,8 @@ func (r *MongoRepository) GetExecutionTotals(ctx context.Context, paging bool, f
 			pipeline = append(pipeline, bson.D{{Key: "$skip", Value: int64(filter[0].Page() * filter[0].PageSize())}})
 			pipeline = append(pipeline, bson.D{{Key: "$limit", Value: int64(filter[0].PageSize())}})
 		}
+	} else {
+		pipeline = append(pipeline, bson.D{{Key: "$sort", Value: bson.D{{Key: "executionresult.status", Value: 1}}}})
 	}
 
 	pipeline = append(pipeline, bson.D{{Key: "$group", Value: bson.D{{Key: "_id", Value: "$executionresult.status"},

--- a/pkg/repository/testresult/mongo.go
+++ b/pkg/repository/testresult/mongo.go
@@ -307,6 +307,8 @@ func (r *MongoRepository) GetExecutionsTotals(ctx context.Context, filter ...Fil
 		pipeline = append(pipeline, bson.D{{Key: "$sort", Value: bson.D{{Key: "starttime", Value: -1}}}})
 		pipeline = append(pipeline, bson.D{{Key: "$skip", Value: int64(filter[0].Page() * filter[0].PageSize())}})
 		pipeline = append(pipeline, bson.D{{Key: "$limit", Value: int64(filter[0].PageSize())}})
+	} else {
+		pipeline = append(pipeline, bson.D{{Key: "$sort", Value: bson.D{{Key: "status", Value: 1}}}})
 	}
 
 	pipeline = append(pipeline, bson.D{{Key: "$group", Value: bson.D{{Key: "_id", Value: "$status"},


### PR DESCRIPTION
## Pull request description 

Use `$sort` + `$group` instead of pure `$group`, as the aggregate was planned with `COLLSCAN` instead of `PROJECTION_COVERED` despite being covered by index

## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [x] tested locally
- [x] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Breaking changes

-

## Changes

-

## Fixes

- https://linear.app/kubeshop/issue/TKC-1157/%5Bapi-performance%5D-test-suite-executions-query-performance

## Screenshots

| Before | After |
|-|-|
| <img width="583" alt="Zrzut ekranu 2024-01-5 o 15 00 21" src="https://github.com/kubeshop/testkube/assets/3843526/7a8f08c7-5f4d-4eb5-bf1c-df2b8220c5fd"> | <img width="552" alt="Zrzut ekranu 2024-01-5 o 15 01 20" src="https://github.com/kubeshop/testkube/assets/3843526/c4ea029c-3f2f-4a03-a7d2-71b9173c2d20"> |
