### PR TITLE
docs: deprecating internal /results route

### DIFF
--- a/docs/docs/articles/deprecations.md
+++ b/docs/docs/articles/deprecations.md
@@ -1,0 +1,14 @@
+# Deprecations
+
+Software deprecation refers to the process of phasing out or discontinuing support for a particular software feature, API (Application Programming Interface), or an entire software product. This decision is typically made by software developers or vendors due to various reasons such as security concerns, outdated technology, or the introduction of more efficient alternatives.
+
+Some of deprecations in Testkube are caused by security reasons, some of them are caused by changes in dependencies. Usually if possible and reasonable we try to keep backward compatibility.
+
+## List of Testkube deprecations
+
+### Since `v1.16.16` internal `/results` route 
+
+Reason of deprecation was that after Fiber (https://gofiber.io/) security update disallowing of using `Mount` in simple way. 
+Also route is not used by Testkube internally anymore
+
+As a workaround users who want's to configure own ingresses should use `/` route instead.

--- a/docs/docs/articles/deprecations.md
+++ b/docs/docs/articles/deprecations.md
@@ -2,13 +2,13 @@
 
 Software deprecation refers to the process of phasing out or discontinuing support for a particular software feature. This decision is typically made by software developers or vendors due to various reasons such as security concerns, outdated technology, or the introduction of more efficient alternatives.
 
-Usually if possible and reasonable we try to keep backward compatibility.
+Usually if possible and reasonable we try to keep the backward compatibility.
 
 ## List of Testkube deprecations
 
 ### Since `v1.16.16` internal `/results` route 
 
 Reason of deprecation was that after Fiber (https://gofiber.io/) security update disallowing of using `Mount` in simple way. 
-Also route is not used by Testkube internally anymore
+Also route is not used by the Testkube internally anymore.
 
 As a workaround users who want's to configure own ingresses should use `/` route instead.

--- a/docs/docs/articles/deprecations.md
+++ b/docs/docs/articles/deprecations.md
@@ -1,8 +1,8 @@
 # Deprecations
 
-Software deprecation refers to the process of phasing out or discontinuing support for a particular software feature, API (Application Programming Interface), or an entire software product. This decision is typically made by software developers or vendors due to various reasons such as security concerns, outdated technology, or the introduction of more efficient alternatives.
+Software deprecation refers to the process of phasing out or discontinuing support for a particular software feature. This decision is typically made by software developers or vendors due to various reasons such as security concerns, outdated technology, or the introduction of more efficient alternatives.
 
-Some of deprecations in Testkube are caused by security reasons, some of them are caused by changes in dependencies. Usually if possible and reasonable we try to keep backward compatibility.
+Usually if possible and reasonable we try to keep backward compatibility.
 
 ## List of Testkube deprecations
 

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -225,6 +225,7 @@ const sidebars = {
       ],
     },
     "articles/common-issues",
+    "articles/deprecations",
     {
       type: "category",
       label: "Contributing",


### PR DESCRIPTION
## Pull request description 



## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [ ] tested locally
- [ ] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Breaking changes

-

## Changes

-

## Fixes

-