### PR TITLE
chore: add symbolic links for 'testkube' and 'tk' for kubeshop/testkube image

### DIFF
--- a/build/kubectl-testkube/Dockerfile
+++ b/build/kubectl-testkube/Dockerfile
@@ -2,6 +2,13 @@
 ARG ALPINE_IMAGE
 FROM ${ALPINE_IMAGE}
 COPY kubectl-testkube /bin/kubectl-testkube
+
+# Create symbolic links for 'testkube' and 'tk' as aliases for 'kubectl-testkube'
+RUN ln -s /bin/kubectl-testkube /bin/testkube
+RUN ln -s /bin/kubectl-testkube /bin/tk
+
+# Create and set permissions for /.testkube directory
 RUN mkdir /.testkube && echo "{}" > /.testkube/config.json && chmod -R 755 /.testkube && chown -R 1001:1001 /.testkube && chmod 660 /.testkube/config.json
+
 USER 1001
 ENTRYPOINT ["/bin/kubectl-testkube"]


### PR DESCRIPTION
## Pull request description 

This PR aims to simplify writing the testkube commands when using the official image in other CI/CD platforms

## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [ ] tested locally
- [ ] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Breaking changes

-

## Changes

-

## Fixes

-