### PR TITLE
fix: accept deprecated domain flags

### DIFF
--- a/cmd/kubectl-testkube/commands/common/masterFlags_test.go
+++ b/cmd/kubectl-testkube/commands/common/masterFlags_test.go
@@ -299,4 +299,36 @@ func TestMasterCmds(t *testing.T) {
 		assert.Equal(t, "http://app.testkube.io", opts.Master.URIs.Ui)
 		assert.Equal(t, "dummy-agent-uri", opts.Master.URIs.Agent)
 	})
+
+	t.Run("Test --root-domain for master flags", func(t *testing.T) {
+		cmd := NewTestCmd()
+		cmd.SetArgs([]string{"--root-domain", "test-domain"})
+		err := cmd.Execute()
+		assert.NoError(t, err)
+		assert.Equal(t, "test-domain", opts.Master.RootDomain)
+	})
+
+	t.Run("Test deprecated --cloud-root-domain for master flags", func(t *testing.T) {
+		cmd := NewTestCmd()
+		cmd.SetArgs([]string{"--cloud-root-domain", "test-domain"})
+		err := cmd.Execute()
+		assert.NoError(t, err)
+		assert.Equal(t, "test-domain", opts.Master.RootDomain)
+	})
+
+	t.Run("Test deprecated --pro-root-domain for master flags", func(t *testing.T) {
+		cmd := NewTestCmd()
+		cmd.SetArgs([]string{"--pro-root-domain", "test-domain"})
+		err := cmd.Execute()
+		assert.NoError(t, err)
+		assert.Equal(t, "test-domain", opts.Master.RootDomain)
+	})
+
+	t.Run("Test deprecated --cloud-root-domain and --pro-root-domain for master flags", func(t *testing.T) {
+		cmd := NewTestCmd()
+		cmd.SetArgs([]string{"--pro-root-domain", "pro-test-domain", "--cloud-root-domain", "cloud-test-domain"})
+		err := cmd.Execute()
+		assert.NoError(t, err)
+		assert.Equal(t, "pro-test-domain", opts.Master.RootDomain)
+	})
 }

--- a/cmd/kubectl-testkube/commands/context/set.go
+++ b/cmd/kubectl-testkube/commands/context/set.go
@@ -43,7 +43,7 @@ func NewSetContextCmd() *cobra.Command {
 			switch cfg.ContextType {
 			case config.ContextTypeCloud:
 				if opts.Master.OrgId == "" && opts.Master.EnvId == "" && apiKey == "" && opts.Master.RootDomain == "" {
-					ui.Errf("Please provide at least one of the following flags: --org, --env, --api-key, --cloud-root-domain")
+					ui.Errf("Please provide at least one of the following flags: --org, --env, --api-key, --root-domain")
 				}
 
 				cfg = common.PopulateCloudConfig(cfg, apiKey, &opts)


### PR DESCRIPTION
## Pull request description 

It came up on slack that we marked the flags `--pro-root-domain` and `--cloud-root-domain` deprecated, but not in a backwards-compatible manner. This PR fixes that.

## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [x] tested locally
- [ ] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Breaking changes

-

## Changes

-

## Fixes

-