### PR TITLE
feat: add status field to artifacts

### DIFF
--- a/api/v1/testkube.yaml
+++ b/api/v1/testkube.yaml
@@ -4306,6 +4306,12 @@ components:
           type: string
           description: execution name that produced the artifact
           example: "test-1"
+        status:
+          type: string
+          enum:
+            - ready
+            - processing
+            - failed
 
     ExecutionsResult:
       description: the result for a page of executions

--- a/pkg/api/v1/testkube/model_artifact.go
+++ b/pkg/api/v1/testkube/model_artifact.go
@@ -17,4 +17,5 @@ type Artifact struct {
 	Size int32 `json:"size,omitempty"`
 	// execution name that produced the artifact
 	ExecutionName string `json:"executionName,omitempty"`
+	Status        string `json:"status,omitempty"`
 }

--- a/pkg/executor/scraper/extractor.go
+++ b/pkg/executor/scraper/extractor.go
@@ -41,4 +41,7 @@ type FilesMeta struct {
 type FileStat struct {
 	Name string `json:"name"`
 	Size int64  `json:"size"`
+	// Status shows if file is ready to be downloaded
+	// One of: ready, processing, error
+	Status string `json:"status,omitempty"`
 }


### PR DESCRIPTION
## Pull request description 

In cloud we upload artifacts.tar.gz and unpack them in background. In case of large files, it might take a while to unpack them. So artifact list needs to return status of the artifact.

## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [ ] tested locally
- [ ] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Breaking changes

-

## Changes

-

## Fixes

-