### PR TITLE
fix: fiber doesn't allow to use query string outside handler

### DIFF
--- a/internal/app/api/v1/executions.go
+++ b/internal/app/api/v1/executions.go
@@ -10,6 +10,7 @@ import (
 	"net/url"
 	"os"
 	"strconv"
+	"strings"
 
 	"k8s.io/apimachinery/pkg/api/errors"
 
@@ -86,7 +87,7 @@ func (s *TestkubeAPI) ExecuteTestsHandler() fiber.Handler {
 		}
 		var results []testkube.Execution
 		if len(tests) != 0 {
-			request.TestExecutionName = c.Query("testExecutionName")
+			request.TestExecutionName = strings.Clone(c.Query("testExecutionName"))
 			concurrencyLevel, err := strconv.Atoi(c.Query("concurrency", strconv.Itoa(scheduler.DefaultConcurrencyLevel)))
 			if err != nil {
 				return s.Error(c, http.StatusBadRequest, fmt.Errorf("%s: can't detect concurrency level: %w", errPrefix, err))

--- a/internal/app/api/v1/testsuites.go
+++ b/internal/app/api/v1/testsuites.go
@@ -577,7 +577,7 @@ func (s TestkubeAPI) ExecuteTestSuitesHandler() fiber.Handler {
 
 		var results []testkube.TestSuiteExecution
 		if len(testSuites) != 0 {
-			request.TestSuiteExecutionName = c.Query("testSuiteExecutionName")
+			request.TestSuiteExecutionName = strings.Clone(c.Query("testSuiteExecutionName"))
 			concurrencyLevel, err := strconv.Atoi(c.Query("concurrency", strconv.Itoa(scheduler.DefaultConcurrencyLevel)))
 			if err != nil {
 				return s.Error(c, http.StatusBadRequest, fmt.Errorf("%s: can't detect concurrency level: %w", errPrefix, err))


### PR DESCRIPTION
## Pull request description 

fix #4846

## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [ ] tested locally
- [x] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Breaking changes

-

## Changes

-

## Fixes

-