### PR TITLE
fix: use pointer everywhere when passing log chunk

### DIFF
--- a/cmd/api-server/main.go
+++ b/cmd/api-server/main.go
@@ -394,6 +394,7 @@ func main() {
 		"http://"+cfg.APIServerFullname+":"+cfg.APIServerPort,
 		cfg.NatsURI,
 		cfg.Debug,
+		logsStream,
 	)
 	if err != nil {
 		ui.ExitOnError("Creating executor client", err)
@@ -424,6 +425,7 @@ func main() {
 		"http://"+cfg.APIServerFullname+":"+cfg.APIServerPort,
 		cfg.NatsURI,
 		cfg.Debug,
+		logsStream,
 	)
 	if err != nil {
 		ui.ExitOnError("Creating container executor", err)
@@ -487,6 +489,7 @@ func main() {
 		eventBus,
 		cfg.EnableSecretsEndpoint,
 		ff,
+		logsStream,
 	)
 
 	if mode == common.ModeAgent {

--- a/cmd/api-server/main.go
+++ b/cmd/api-server/main.go
@@ -133,10 +133,10 @@ func main() {
 	cfg.CleanLegacyVars()
 	ui.ExitOnError("error getting application config", err)
 
-	ff, err := featureflags.Get()
+	features, err := featureflags.Get()
 	ui.ExitOnError("error getting application feature flags", err)
 
-	log.DefaultLogger.Infow("Feature flags configured", "ff", ff)
+	log.DefaultLogger.Infow("Feature flags configured", "ff", features)
 
 	// Run services within an errgroup to propagate errors between services.
 	g, ctx := errgroup.WithContext(context.Background())
@@ -350,7 +350,7 @@ func main() {
 
 	var logsStream logsclient.Stream
 
-	if ff.LogsV2 {
+	if features.LogsV2 {
 		logsStream, err = logsclient.NewNatsLogStream(nc.Conn)
 		if err != nil {
 			ui.ExitOnError("Creating logs streaming client", err)
@@ -395,6 +395,7 @@ func main() {
 		cfg.NatsURI,
 		cfg.Debug,
 		logsStream,
+		features,
 	)
 	if err != nil {
 		ui.ExitOnError("Creating executor client", err)
@@ -426,6 +427,7 @@ func main() {
 		cfg.NatsURI,
 		cfg.Debug,
 		logsStream,
+		features,
 	)
 	if err != nil {
 		ui.ExitOnError("Creating container executor", err)
@@ -449,7 +451,7 @@ func main() {
 		testsuiteExecutionsClient,
 		eventBus,
 		cfg.TestkubeDashboardURI,
-		ff,
+		features,
 		logsStream,
 	)
 
@@ -488,7 +490,7 @@ func main() {
 		mode,
 		eventBus,
 		cfg.EnableSecretsEndpoint,
-		ff,
+		features,
 		logsStream,
 	)
 

--- a/internal/app/api/v1/server.go
+++ b/internal/app/api/v1/server.go
@@ -44,6 +44,7 @@ import (
 	"github.com/kubeshop/testkube/pkg/event/kind/webhook"
 	ws "github.com/kubeshop/testkube/pkg/event/kind/websocket"
 	"github.com/kubeshop/testkube/pkg/executor/client"
+	logsclient "github.com/kubeshop/testkube/pkg/logs/client"
 	"github.com/kubeshop/testkube/pkg/oauth"
 	"github.com/kubeshop/testkube/pkg/scheduler"
 	"github.com/kubeshop/testkube/pkg/secret"
@@ -89,6 +90,7 @@ func NewTestkubeAPI(
 	eventsBus bus.Bus,
 	enableSecretsEndpoint bool,
 	ff featureflags.FeatureFlags,
+	logsStream logsclient.Stream,
 ) TestkubeAPI {
 
 	var httpConfig server.Config
@@ -134,6 +136,7 @@ func NewTestkubeAPI(
 		eventsBus:             eventsBus,
 		enableSecretsEndpoint: enableSecretsEndpoint,
 		featureFlags:          ff,
+		logsStream:            logsStream,
 	}
 
 	// will be reused in websockets handler
@@ -191,6 +194,7 @@ type TestkubeAPI struct {
 	eventsBus             bus.Bus
 	enableSecretsEndpoint bool
 	featureFlags          featureflags.FeatureFlags
+	logsStream            logsclient.Stream
 }
 
 type storageParams struct {

--- a/pkg/executor/client/job.go
+++ b/pkg/executor/client/job.go
@@ -234,10 +234,7 @@ func (c *JobExecutor) Execute(ctx context.Context, execution *testkube.Execution
 		return result.Err(err), err
 	}
 
-	if c.features.LogsV2 {
-		// TODO should we pass job spec here?
-		c.logsStream.Push(ctx, execution.Id, events.NewLog("created kubernetes job").WithSource(events.SourceJobExecutor))
-	}
+	c.streamLog(ctx, execution.Id, events.NewLog("created kubernetes job").WithSource(events.SourceJobExecutor))
 
 	if !options.Sync {
 		go c.MonitorJobForTimeout(ctx, execution.Id)
@@ -250,6 +247,8 @@ func (c *JobExecutor) Execute(ctx context.Context, execution *testkube.Execution
 	}
 
 	l := c.Log.With("executionID", execution.Id, "type", "async")
+
+	c.streamLog(ctx, execution.Id, events.NewLog("waiting for pod to spin up").WithSource(events.SourceJobExecutor))
 
 	for _, pod := range pods.Items {
 		if pod.Status.Phase != corev1.PodRunning && pod.Labels["job-name"] == execution.Id {
@@ -272,7 +271,7 @@ func (c *JobExecutor) Execute(ctx context.Context, execution *testkube.Execution
 
 	l.Debugw("no pods was found", "totalPodsCount", len(pods.Items))
 
-	return testkube.NewRunningExecutionResult(), nil
+	return result, nil
 }
 
 func (c *JobExecutor) MonitorJobForTimeout(ctx context.Context, jobName string) {
@@ -296,7 +295,7 @@ func (c *JobExecutor) MonitorJobForTimeout(ctx context.Context, jobName string) 
 			job := jobs.Items[0]
 
 			if job.Status.Succeeded > 0 {
-				l.Debugw("job succeeded", "status")
+				l.Debugw("job succeeded", "status", "succeded")
 				return
 			}
 
@@ -361,12 +360,14 @@ func (c *JobExecutor) updateResultsFromPod(ctx context.Context, pod corev1.Pod, 
 	// save stop time and final state
 	defer func() {
 		if err := c.stopExecution(ctx, l, execution, execution.ExecutionResult, isNegativeTest, err); err != nil {
+			c.streamLog(ctx, execution.Id, events.NewErrorLog(err))
 			l.Errorw("error stopping execution after updating results from pod", "error", err)
 		}
 	}()
 
 	// wait for pod to be loggable
 	if err = wait.PollUntilContextTimeout(ctx, pollInterval, c.podStartTimeout, true, executor.IsPodLoggable(c.ClientSet, pod.Name, c.Namespace)); err != nil {
+		c.streamLog(ctx, execution.Id, events.NewErrorLog(errors.Wrap(err, "can't start test job pod")))
 		l.Errorw("waiting for pod started error", "error", err)
 	}
 
@@ -374,13 +375,16 @@ func (c *JobExecutor) updateResultsFromPod(ctx context.Context, pod corev1.Pod, 
 	// wait for pod
 	if err = wait.PollUntilContextTimeout(ctx, pollInterval, pollTimeout, true, executor.IsPodReady(c.ClientSet, pod.Name, c.Namespace)); err != nil {
 		// continue on poll err and try to get logs later
+		c.streamLog(ctx, execution.Id, events.NewErrorLog(errors.Wrap(err, "can't read data from pod, pod was not completed")))
 		l.Errorw("waiting for pod complete error", "error", err)
 	}
+
 	if err != nil {
 		execution.ExecutionResult.Err(err)
 	}
 	l.Debug("poll immediate end")
 
+	c.streamLog(ctx, execution.Id, events.NewLog("analyzing test results and artfacts"))
 	if execution.ArtifactRequest != nil &&
 		execution.ArtifactRequest.StorageClassName != "" {
 		pvcsClient := c.ClientSet.CoreV1().PersistentVolumeClaims(c.Namespace)
@@ -394,13 +398,17 @@ func (c *JobExecutor) updateResultsFromPod(ctx context.Context, pod corev1.Pod, 
 	logs, err = executor.GetPodLogs(ctx, c.ClientSet, c.Namespace, pod)
 	if err != nil {
 		l.Errorw("get pod logs error", "error", err)
+		c.streamLog(ctx, execution.Id, events.NewErrorLog(err))
 		return execution.ExecutionResult, err
 	}
 
+	// attachLogs only for previous version of logs, they are not needed here as will be passed from other sources
+	attachLogs := !c.features.LogsV2
 	// parse job output log (JSON stream)
-	execution.ExecutionResult, err = output.ParseRunnerOutput(logs)
+	execution.ExecutionResult, err = output.ParseRunnerOutput(logs, attachLogs)
 	if err != nil {
 		l.Errorw("parse output error", "error", err)
+		c.streamLog(ctx, execution.Id, events.NewErrorLog(errors.Wrap(err, "can't get test execution job output")))
 		return execution.ExecutionResult, err
 	}
 
@@ -411,6 +419,10 @@ func (c *JobExecutor) updateResultsFromPod(ctx context.Context, pod corev1.Pod, 
 		}
 
 		execution.ExecutionResult.ErrorMessage = errorMessage
+
+		c.streamLog(ctx, execution.Id, events.NewErrorLog(errors.Wrap(err, "test execution finished with failed state")))
+	} else {
+		c.streamLog(ctx, execution.Id, events.NewLog("test execution finshed").WithMetadataEntry("status", string(*execution.ExecutionResult.Status)))
 	}
 
 	// saving result in the defer function
@@ -423,21 +435,28 @@ func (c *JobExecutor) stopExecution(ctx context.Context, l *zap.SugaredLogger, e
 		l.Errorw("get execution error", "error", err)
 		return err
 	}
+
+	logEvent := events.NewLog().WithSource(events.SourceJobExecutor)
+
 	l.Debugw("stopping execution", "executionId", execution.Id, "status", result.Status, "executionStatus", execution.ExecutionResult.Status, "passedError", passedErr, "savedExecutionStatus", savedExecution.ExecutionResult.Status)
 
+	c.streamLog(ctx, execution.Id, logEvent.WithContent("stopping execution"))
+	defer c.streamLog(ctx, execution.Id, logEvent.WithContent("execution stopped"))
+
 	if savedExecution.IsCanceled() || savedExecution.IsTimeout() {
+		c.streamLog(ctx, execution.Id, logEvent.WithContent("execution is cancelled"))
 		return nil
 	}
 
 	execution.Stop()
 	if isNegativeTest {
 		if result.IsFailed() {
-			l.Infow("test run was expected to fail, and it failed as expected", "test", execution.TestName)
+			l.Debugw("test run was expected to fail, and it failed as expected", "test", execution.TestName)
 			execution.ExecutionResult.Status = testkube.ExecutionStatusPassed
 			result.Status = testkube.ExecutionStatusPassed
 			result.Output = result.Output + "\nTest run was expected to fail, and it failed as expected"
 		} else {
-			l.Infow("test run was expected to fail - the result will be reversed", "test", execution.TestName)
+			l.Debugw("test run was expected to fail - the result will be reversed", "test", execution.TestName)
 			execution.ExecutionResult.Status = testkube.ExecutionStatusFailed
 			result.Status = testkube.ExecutionStatusFailed
 			result.Output = result.Output + "\nTest run was expected to fail, the result will be reversed"
@@ -752,6 +771,9 @@ func (c *JobExecutor) Timeout(ctx context.Context, jobName string) (result *test
 		l.Errorw("error getting execution", "error", err)
 		return
 	}
+
+	c.streamLog(ctx, execution.Id, events.NewLog("execution took too long, pod deadline exceeded"))
+
 	result = &testkube.ExecutionResult{
 		Status: testkube.ExecutionStatusTimeout,
 	}
@@ -760,6 +782,12 @@ func (c *JobExecutor) Timeout(ctx context.Context, jobName string) (result *test
 	}
 
 	return
+}
+
+func (c *JobExecutor) streamLog(ctx context.Context, id string, log *events.Log) {
+	if c.features.LogsV2 {
+		c.logsStream.Push(ctx, id, log)
+	}
 }
 
 // NewJobSpec is a method to create new job spec

--- a/pkg/executor/client/job.go
+++ b/pkg/executor/client/job.go
@@ -96,7 +96,7 @@ func NewJobExecutor(
 	natsURI string,
 	debug bool,
 	logsStream logsclient.Stream,
-	ff featureflags.FeatureFlags,
+	features featureflags.FeatureFlags,
 ) (client *JobExecutor, err error) {
 	return &JobExecutor{
 		ClientSet:            clientset,
@@ -120,7 +120,7 @@ func NewJobExecutor(
 		natsURI:              natsURI,
 		debug:                debug,
 		logsStream:           logsStream,
-		ff:                   ff,
+		features:             features,
 	}, nil
 }
 
@@ -152,7 +152,7 @@ type JobExecutor struct {
 	natsURI              string
 	debug                bool
 	logsStream           logsclient.Stream
-	ff                   featureflags.FeatureFlags
+	features             featureflags.FeatureFlags
 }
 
 type JobOptions struct {
@@ -234,7 +234,7 @@ func (c *JobExecutor) Execute(ctx context.Context, execution *testkube.Execution
 		return result.Err(err), err
 	}
 
-	if c.ff.LogsV2 {
+	if c.features.LogsV2 {
 		// TODO should we pass job spec here?
 		c.logsStream.Push(ctx, execution.Id, events.NewLog("created kubernetes job").WithSource(events.SourceJobExecutor))
 	}

--- a/pkg/executor/containerexecutor/containerexecutor.go
+++ b/pkg/executor/containerexecutor/containerexecutor.go
@@ -31,6 +31,7 @@ import (
 	"github.com/kubeshop/testkube/pkg/executor/output"
 	"github.com/kubeshop/testkube/pkg/k8sclient"
 	"github.com/kubeshop/testkube/pkg/log"
+	logsclient "github.com/kubeshop/testkube/pkg/logs/client"
 	testexecutionsmapper "github.com/kubeshop/testkube/pkg/mapper/testexecutions"
 	testsmapper "github.com/kubeshop/testkube/pkg/mapper/tests"
 	"github.com/kubeshop/testkube/pkg/telemetry"
@@ -71,6 +72,7 @@ func NewContainerExecutor(
 	apiURI string,
 	natsUri string,
 	debug bool,
+	logsStream logsclient.Stream,
 ) (client *ContainerExecutor, err error) {
 	clientSet, err := k8sclient.ConnectToK8s()
 	if err != nil {
@@ -99,6 +101,7 @@ func NewContainerExecutor(
 		apiURI:               apiURI,
 		natsURI:              natsUri,
 		debug:                debug,
+		logsStream:           logsStream,
 	}, nil
 }
 
@@ -129,6 +132,7 @@ type ContainerExecutor struct {
 	apiURI               string
 	natsURI              string
 	debug                bool
+	logsStream           logsclient.Stream
 }
 
 type JobOptions struct {

--- a/pkg/executor/containerexecutor/containerexecutor.go
+++ b/pkg/executor/containerexecutor/containerexecutor.go
@@ -73,7 +73,7 @@ func NewContainerExecutor(
 	natsUri string,
 	debug bool,
 	logsStream logsclient.Stream,
-	ff featureflags.FeatureFlags,
+	features featureflags.FeatureFlags,
 ) (client *ContainerExecutor, err error) {
 	clientSet, err := k8sclient.ConnectToK8s()
 	if err != nil {
@@ -103,7 +103,7 @@ func NewContainerExecutor(
 		natsURI:              natsUri,
 		debug:                debug,
 		logsStream:           logsStream,
-		ff:                   ff,
+		features:             features,
 	}, nil
 }
 
@@ -135,7 +135,7 @@ type ContainerExecutor struct {
 	natsURI              string
 	debug                bool
 	logsStream           logsclient.Stream
-	ff                   featureflags.FeatureFlags
+	features             featureflags.FeatureFlags
 }
 
 type JobOptions struct {

--- a/pkg/executor/containerexecutor/containerexecutor.go
+++ b/pkg/executor/containerexecutor/containerexecutor.go
@@ -73,6 +73,7 @@ func NewContainerExecutor(
 	natsUri string,
 	debug bool,
 	logsStream logsclient.Stream,
+	ff featureflags.FeatureFlags,
 ) (client *ContainerExecutor, err error) {
 	clientSet, err := k8sclient.ConnectToK8s()
 	if err != nil {
@@ -102,6 +103,7 @@ func NewContainerExecutor(
 		natsURI:              natsUri,
 		debug:                debug,
 		logsStream:           logsStream,
+		ff:                   ff,
 	}, nil
 }
 
@@ -133,6 +135,7 @@ type ContainerExecutor struct {
 	natsURI              string
 	debug                bool
 	logsStream           logsclient.Stream
+	ff                   featureflags.FeatureFlags
 }
 
 type JobOptions struct {

--- a/pkg/executor/output/parser.go
+++ b/pkg/executor/output/parser.go
@@ -36,11 +36,13 @@ func GetLogEntry(b []byte) (out Output, err error) {
 // {"type": "line", "message": "runner execution started  ------------", "time": "..."}
 // {"type": "line", "message": "GET /results", "time": "..."}
 // {"type": "result", "result": {"id": "2323", "output": "-----"}, "time": "..."}
-func ParseRunnerOutput(b []byte) (*testkube.ExecutionResult, error) {
+func ParseRunnerOutput(b []byte, attachLogs bool) (*testkube.ExecutionResult, error) {
 	result := &testkube.ExecutionResult{}
 	if len(b) == 0 {
 		errMessage := "no logs found"
-		result.Output = errMessage
+		if attachLogs {
+			result.Output = errMessage
+		}
 		return result.Err(errors.New(errMessage)), nil
 	}
 	logs, err := parseLogs(b)
@@ -69,7 +71,10 @@ func ParseRunnerOutput(b []byte) (*testkube.ExecutionResult, error) {
 	default:
 		result.Err(fmt.Errorf("wrong log type was found as last log: %v", log))
 	}
-	result.Output = sanitizeLogs(logs)
+
+	if attachLogs {
+		result.Output = sanitizeLogs(logs)
+	}
 
 	return result, nil
 }
@@ -308,7 +313,7 @@ func getResultMessage(result testkube.ExecutionResult) string {
 		return result.Output
 	}
 
-	return fmt.Sprintf("%s", *result.Status)
+	return string(*result.Status)
 }
 
 // sameSeverity decides if a and b are of the same severity type

--- a/pkg/executor/output/parser_test.go
+++ b/pkg/executor/output/parser_test.go
@@ -64,7 +64,7 @@ func TestParseRunnerOutput(t *testing.T) {
 	t.Run("Empty runner output", func(t *testing.T) {
 		t.Parallel()
 
-		result, err := ParseRunnerOutput([]byte{})
+		result, err := ParseRunnerOutput([]byte{}, true)
 
 		assert.Equal(t, "no logs found", result.Output)
 		assert.NoError(t, err)
@@ -75,7 +75,7 @@ func TestParseRunnerOutput(t *testing.T) {
 		t.Parallel()
 
 		invalidOutput := []byte(`{not a json}`)
-		result, err := ParseRunnerOutput(invalidOutput)
+		result, err := ParseRunnerOutput(invalidOutput, true)
 		expectedErrMessage := "ERROR can't get log entry: invalid character 'n' looking for beginning of object key string, ((({not a json})))"
 
 		assert.Equal(t, expectedErrMessage+"\n", result.Output)
@@ -100,7 +100,7 @@ func TestParseRunnerOutput(t *testing.T) {
 {"type":"line","content":"\n  #  failure         detail                                                          \n                                                                                     \n 1.  Error                                                                           \n                     connect ECONNREFUSED 127.0.0.1:8088                             \n                     at request                                                      \n                     inside \"Health\"                                                 \n                                                                                     \n 2.  AssertionError  Status code is 200                                              \n                     expected { Object (id, _details, ...) } to have property 'code' \n                     at assertion:0 in test-script                                   \n                     inside \"Health\"                                                 \n"}
 {"type":"result","result":{"status":"failed","startTime":"2021-10-29T11:35:35.759Z","endTime":"2021-10-29T11:35:36.771Z","output":"newman\n\nLocal-API-Health\n\n→ Health\n  GET http://localhost:8088/health [errored]\n     connect ECONNREFUSED 127.0.0.1:8088\n  2. Status code is 200\n\n┌─────────────────────────┬──────────┬──────────┐\n│                         │ executed │   failed │\n├─────────────────────────┼──────────┼──────────┤\n│              iterations │        1 │        0 │\n├─────────────────────────┼──────────┼──────────┤\n│                requests │        1 │        1 │\n├─────────────────────────┼──────────┼──────────┤\n│            test-scripts │        1 │        0 │\n├─────────────────────────┼──────────┼──────────┤\n│      prerequest-scripts │        0 │        0 │\n├─────────────────────────┼──────────┼──────────┤\n│              assertions │        1 │        1 │\n├─────────────────────────┴──────────┴──────────┤\n│ total run duration: 1012ms                    │\n├───────────────────────────────────────────────┤\n│ total data received: 0B (approx)              │\n└───────────────────────────────────────────────┘\n\n  #  failure         detail                                                          \n                                                                                     \n 1.  Error                                                                           \n                     connect ECONNREFUSED 127.0.0.1:8088                             \n                     at request                                                      \n                     inside \"Health\"                                                 \n                                                                                     \n 2.  AssertionError  Status code is 200                                              \n                     expected { Object (id, _details, ...) } to have property 'code' \n                     at assertion:0 in test-script                                   \n                     inside \"Health\"                                                 \n","outputType":"text/plain","errorMessage":"process error: exit status 1","steps":[{"name":"Health","duration":"0s","status":"failed","assertionResults":[{"name":"Status code is 200","status":"failed","errorMessage":"expected { Object (id, _details, ...) } to have property 'code'"}]}]}}
 `)
-		result, err := ParseRunnerOutput(exampleOutput)
+		result, err := ParseRunnerOutput(exampleOutput, true)
 
 		assert.Len(t, result.Output, 4624)
 		assert.NoError(t, err)
@@ -150,7 +150,7 @@ func TestParseRunnerOutput(t *testing.T) {
 {"type":"line","content":"✅ Got Newman result successfully","time":"2023-07-18T19:12:46.126116248Z"} 
 {"type":"line","content":"✅ Mapped Newman result successfully","time":"2023-07-18T19:12:46.126152021Z"} 
 {"type":"result","result":{"status":"passed","output":"newman\n\nCore App Tests - WebPlayer\n\n→ core-eks-test.poppcore.co client=testdb sign=testct1 company=41574150-b952-413b-898b-dc5336b4bd12\n  GET https://na.com/v6-wplt/?client=testdb\u0026sign=testct1\u0026company=41574150-b952-413b-898b-dc5336b4bd12 [200 OK, 33.9kB, 326ms]\n  ✓  Status code is 200\n\n┌─────────────────────────┬────────────────────┬───────────────────┐\n│                         │           executed │            failed │\n├─────────────────────────┼────────────────────┼───────────────────┤\n│              iterations │                  1 │      0 │\n├─────────────────────────┼────────────────────┼───────────────────┤\n│                requests │                  1 │                 0 │\n├─────────────────────────┼────────────────────┼───────────────────┤\n│            test-scripts │                  1 │                 0 │\n├─────────────────────────┼────────────────────┼───────────────────┤\n│      prerequest-scripts │                  0 │ 0 │\n├─────────────────────────┼────────────────────┼───────────────────┤\n│              assertions │                  1 │                 0 │\n├─────────────────────────┴────────────────────┴───────────────────┤\n│ total run duration: 429ms                                        │\n├──────────────────────────────────────────────────────────────────┤\n│ total data received: 33.45kB (approx)                            │\n├──────────────────────────────────────────────────────────────────┤\n│ average response time: 326ms [min: 326ms, max: 326ms, s.d.: 0µs] │\n└──────────────────────────────────────────────────────────────────┘\n","outputType":"text/plain","steps":[{"name":"na.com client=testdb sign=testct1 company=41574150-b952-413b-898b-dc5336b4bd12","duration":"326ms","status":"passed","assertionResults":[{"name":"Status code is 200","status":"passed"}]}]},"time":"2023-07-18T19:12:46.12615853Z"}`)
-		result, err := ParseRunnerOutput(exampleOutput)
+		result, err := ParseRunnerOutput(exampleOutput, true)
 
 		assert.Len(t, result.Output, 7304)
 		assert.NoError(t, err)
@@ -203,7 +203,7 @@ can't find branch or commit in params, repo:&{Type_:git-file Uri:https://github.
 running test [63c6bec1790802b7e3e57048]
 🚚 Preparing for test run
 `
-		result, err := ParseRunnerOutput(unorderedOutput)
+		result, err := ParseRunnerOutput(unorderedOutput, true)
 
 		assert.Equal(t, expectedOutput, result.Output)
 		assert.NoError(t, err)
@@ -221,7 +221,7 @@ running test [63c6bec1790802b7e3e57048]
 Running [ ./zap-api-scan.py [-t https://www.example.com/openapi.json -f openapi -c examples/zap-api.conf -d -D 5 -I -l INFO -n examples/context.config -S -T 60 -U anonymous -O https://www.example.com -z -config aaa=bbb -r api-test-report.html]]
 could not start process: fork/exec ./zap-api-scan.py: no such file or directory
 `
-		result, err := ParseRunnerOutput(output)
+		result, err := ParseRunnerOutput(output, true)
 
 		assert.Equal(t, expectedOutput, result.Output)
 		assert.NoError(t, err)
@@ -276,7 +276,7 @@ running test [63c960287104b0fa0b7a45ef]
 can't find branch or commit in params, repo:&{Type_:git-file Uri:https://github.com/kubeshop/testkube.git Branch: Commit: Path:test/cypress/executor-smoke/cypress-11 Username: Token: UsernameSecret:<nil> TokenSecret:<nil> WorkingDir:}
 `
 
-		result, err := ParseRunnerOutput(output)
+		result, err := ParseRunnerOutput(output, true)
 
 		assert.Equal(t, expectedOutput, result.Output)
 		assert.NoError(t, err)
@@ -337,7 +337,7 @@ running test [63c960287104b0fa0b7a45ef]
 can't find branch or commit in params, repo:&{Type_:git-file Uri:https://github.com/kubeshop/testkube.git Branch: Commit: Path:test/cypress/executor-smoke/cypress-11 Username: Token: UsernameSecret:<nil> TokenSecret:<nil> WorkingDir:}
 `
 
-		result, err := ParseRunnerOutput(output)
+		result, err := ParseRunnerOutput(output, true)
 
 		assert.Equal(t, expectedOutput, result.Output)
 		assert.NoError(t, err)
@@ -392,7 +392,7 @@ running test [63ca8c8988564860327a16b5]
 ❌ can't find branch or commit in params, repo:&{Type_:git-file Uri:https://github.com/kubeshop/testkube.git Branch: Commit: Path:test/cypress/executor-smoke/cypress-11 Username: Token: UsernameSecret:<nil> TokenSecret:<nil> WorkingDir:}
 `
 
-		result, err := ParseRunnerOutput(output)
+		result, err := ParseRunnerOutput(output, true)
 
 		assert.Equal(t, expectedOutput, result.Output)
 		assert.NoError(t, err)

--- a/pkg/logs/client/interface.go
+++ b/pkg/logs/client/interface.go
@@ -44,9 +44,9 @@ type StreamInitializer interface {
 
 type StreamPusher interface {
 	// Push sends logs to log stream
-	Push(ctx context.Context, id string, chunk events.Log) error
+	Push(ctx context.Context, id string, log *events.Log) error
 	// PushBytes sends RAW bytes to log stream, developer is responsible for marshaling valid data
-	PushBytes(ctx context.Context, id string, chunk []byte) error
+	PushBytes(ctx context.Context, id string, bytes []byte) error
 }
 
 // StreamGetter interface for getting logs stream channel

--- a/pkg/logs/client/mock_initializedstreampusher.go
+++ b/pkg/logs/client/mock_initializedstreampusher.go
@@ -51,7 +51,7 @@ func (mr *MockInitializedStreamPusherMockRecorder) Init(arg0, arg1 interface{}) 
 }
 
 // Push mocks base method.
-func (m *MockInitializedStreamPusher) Push(arg0 context.Context, arg1 string, arg2 events.Log) error {
+func (m *MockInitializedStreamPusher) Push(arg0 context.Context, arg1 string, arg2 *events.Log) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Push", arg0, arg1, arg2)
 	ret0, _ := ret[0].(error)

--- a/pkg/logs/client/mock_stream.go
+++ b/pkg/logs/client/mock_stream.go
@@ -66,7 +66,7 @@ func (mr *MockStreamMockRecorder) Init(arg0, arg1 interface{}) *gomock.Call {
 }
 
 // Push mocks base method.
-func (m *MockStream) Push(arg0 context.Context, arg1 string, arg2 events.Log) error {
+func (m *MockStream) Push(arg0 context.Context, arg1 string, arg2 *events.Log) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Push", arg0, arg1, arg2)
 	ret0, _ := ret[0].(error)

--- a/pkg/logs/client/stream.go
+++ b/pkg/logs/client/stream.go
@@ -51,8 +51,8 @@ func (c NatsLogStream) Init(ctx context.Context, id string) (StreamMetadata, err
 }
 
 // Push log chunk to NATS stream
-func (c NatsLogStream) Push(ctx context.Context, id string, chunk events.Log) error {
-	b, err := json.Marshal(chunk)
+func (c NatsLogStream) Push(ctx context.Context, id string, log *events.Log) error {
+	b, err := json.Marshal(log)
 	if err != nil {
 		return err
 	}
@@ -61,8 +61,8 @@ func (c NatsLogStream) Push(ctx context.Context, id string, chunk events.Log) er
 
 // Push log chunk to NATS stream
 // TODO handle message repeat with backoff strategy on error
-func (c NatsLogStream) PushBytes(ctx context.Context, id string, chunk []byte) error {
-	_, err := c.js.Publish(ctx, c.streamName(id), chunk)
+func (c NatsLogStream) PushBytes(ctx context.Context, id string, bytes []byte) error {
+	_, err := c.js.Publish(ctx, c.streamName(id), bytes)
 	return err
 }
 

--- a/pkg/logs/events/events.go
+++ b/pkg/logs/events/events.go
@@ -48,6 +48,17 @@ type LogOutputV1 struct {
 	Result *testkube.ExecutionResult
 }
 
+func NewErrorLog(err error) *Log {
+	var msg string
+	if err != nil {
+		msg = err.Error()
+	}
+	return &Log{
+		Error:   true,
+		Content: msg,
+	}
+}
+
 func NewLog(content string) *Log {
 	return &Log{
 		Time:     time.Now(),
@@ -56,7 +67,7 @@ func NewLog(content string) *Log {
 	}
 }
 
-func NewLogResponse(ts time.Time, content []byte) Log {
+func NewLogTs(ts time.Time, content []byte) Log {
 	return Log{
 		Time:     ts,
 		Content:  string(content),
@@ -96,7 +107,7 @@ var timestampRegexp = regexp.MustCompile("^[0-9]{4}-[0-9]{2}-[0-9]{2}T.*")
 
 // NewLogResponseFromBytes creates new LogResponse from bytes it's aware of new and old log formats
 // default log format will be based on raw bytes with timestamp on the beginning
-func NewLogResponseFromBytes(b []byte) Log {
+func NewLogResponseFromBytes(b []byte) *Log {
 
 	// detect timestamp - new logs have timestamp
 	var (
@@ -138,7 +149,7 @@ func NewLogResponseFromBytes(b []byte) Log {
 		if err != nil {
 			// try to read in case of some lines which we couldn't parse
 			// sometimes we're not able to control all stdout messages from libs
-			return Log{
+			return &Log{
 				Time:    ts,
 				Content: err.Error(),
 				Type:    o.Type_,
@@ -151,7 +162,7 @@ func NewLogResponseFromBytes(b []byte) Log {
 		// pass parsed results for v1
 		// for new executor it'll be omitted in logs (as looks like we're not using it already)
 		if o.Type_ == output.TypeResult {
-			return Log{
+			return &Log{
 				Time:    ts,
 				Content: o.Content,
 				Version: LogVersionV1,
@@ -161,7 +172,7 @@ func NewLogResponseFromBytes(b []byte) Log {
 			}
 		}
 
-		return Log{
+		return &Log{
 			Time:    ts,
 			Content: o.Content,
 			Version: LogVersionV1,
@@ -170,7 +181,7 @@ func NewLogResponseFromBytes(b []byte) Log {
 	// END DEPRECATED
 
 	// new non-JSON format (just raw lines will be logged)
-	return Log{
+	return &Log{
 		Time:    ts,
 		Content: string(b),
 		Version: LogVersionV2,

--- a/pkg/logs/events/events.go
+++ b/pkg/logs/events/events.go
@@ -62,12 +62,32 @@ func NewErrorLog(err error) *Log {
 	}
 }
 
-func NewLog(content string) *Log {
-	return &Log{
+func NewLog(content ...string) *Log {
+	log := &Log{
 		Time:     time.Now(),
-		Content:  content,
 		Metadata: map[string]string{},
 	}
+
+	if len(content) > 0 {
+		log.WithContent(content[0])
+	}
+
+	return log
+}
+
+func (l *Log) WithContent(s string) *Log {
+	l.Content = s
+	return l
+}
+
+func (l *Log) WithError(err error) *Log {
+	l.Error = true
+
+	if err != nil {
+		l.Content = err.Error()
+	}
+
+	return l
 }
 
 func (l *Log) WithMetadataEntry(key, value string) *Log {

--- a/pkg/logs/events/events.go
+++ b/pkg/logs/events/events.go
@@ -105,9 +105,9 @@ func (l *Log) WithV1Result(result *testkube.ExecutionResult) *Log {
 
 var timestampRegexp = regexp.MustCompile("^[0-9]{4}-[0-9]{2}-[0-9]{2}T.*")
 
-// NewLogResponseFromBytes creates new LogResponse from bytes it's aware of new and old log formats
+// NewLogFromBytes creates new LogResponse from bytes it's aware of new and old log formats
 // default log format will be based on raw bytes with timestamp on the beginning
-func NewLogResponseFromBytes(b []byte) *Log {
+func NewLogFromBytes(b []byte) *Log {
 
 	// detect timestamp - new logs have timestamp
 	var (

--- a/pkg/logs/events/events.go
+++ b/pkg/logs/events/events.go
@@ -147,7 +147,6 @@ func NewLogFromBytes(b []byte) *Log {
 				Type:    o.Type_,
 				Error:   true,
 				Version: LogVersionV1,
-				Source:  JobPodLogSource,
 			}
 		}
 
@@ -161,7 +160,6 @@ func NewLogFromBytes(b []byte) *Log {
 				V1: &LogOutputV1{
 					Result: o.Result,
 				},
-				Source: JobPodLogSource,
 			}
 		}
 
@@ -169,7 +167,6 @@ func NewLogFromBytes(b []byte) *Log {
 			Time:    ts,
 			Content: o.Content,
 			Version: LogVersionV1,
-			Source:  JobPodLogSource,
 		}
 	}
 	// END DEPRECATED
@@ -179,6 +176,5 @@ func NewLogFromBytes(b []byte) *Log {
 		Time:    ts,
 		Content: string(b),
 		Version: LogVersionV2,
-		Source:  JobPodLogSource,
 	}
 }

--- a/pkg/logs/events/events.go
+++ b/pkg/logs/events/events.go
@@ -24,7 +24,10 @@ const (
 	// v2 - raw binary format, timestamps are based on Kubernetes logs, line is raw log line
 	LogVersionV2 LogVersion = "v2"
 
-	JobPodLogSource = "job-pod"
+	SourceJobPod            = "job-pod"
+	SourceScheduler         = "test-scheduler"
+	SourceContainerExecutor = "container-executor"
+	SourceJobExecutor       = "job-executor"
 )
 
 type LogResponse struct {

--- a/pkg/logs/events/events.go
+++ b/pkg/logs/events/events.go
@@ -62,15 +62,7 @@ func NewErrorLog(err error) *Log {
 func NewLog(content string) *Log {
 	return &Log{
 		Time:     time.Now(),
-		Content:  string(content),
-		Metadata: map[string]string{},
-	}
-}
-
-func NewLogTs(ts time.Time, content []byte) Log {
-	return Log{
-		Time:     ts,
-		Content:  string(content),
+		Content:  content,
 		Metadata: map[string]string{},
 	}
 }
@@ -169,6 +161,7 @@ func NewLogFromBytes(b []byte) *Log {
 				V1: &LogOutputV1{
 					Result: o.Result,
 				},
+				Source: JobPodLogSource,
 			}
 		}
 
@@ -176,6 +169,7 @@ func NewLogFromBytes(b []byte) *Log {
 			Time:    ts,
 			Content: o.Content,
 			Version: LogVersionV1,
+			Source:  JobPodLogSource,
 		}
 	}
 	// END DEPRECATED

--- a/pkg/logs/events_test.go
+++ b/pkg/logs/events_test.go
@@ -79,8 +79,8 @@ func TestLogs_EventsFlow(t *testing.T) {
 		assert.NoError(t, err)
 
 		// and when data pushed to the log stream
-		stream.Push(ctx, id, events.NewLogResponse(time.Now(), []byte("hello 1")))
-		stream.Push(ctx, id, events.NewLogResponse(time.Now(), []byte("hello 2")))
+		stream.Push(ctx, id, events.NewLog("hello 1"))
+		stream.Push(ctx, id, events.NewLog("hello 2"))
 
 		// and stop event triggered
 		_, err = stream.Stop(ctx, id)
@@ -154,7 +154,7 @@ func TestLogs_EventsFlow(t *testing.T) {
 
 		for i := 0; i < messagesCount; i++ {
 			// and when data pushed to the log stream
-			err = stream.Push(ctx, id, events.NewLogResponse(time.Now(), []byte("hello")))
+			err = stream.Push(ctx, id, events.NewLog("hello"))
 			assert.NoError(t, err)
 		}
 
@@ -226,9 +226,9 @@ func TestLogs_EventsFlow(t *testing.T) {
 		stats := log.GetConsumersStats(ctx)
 		assert.Equal(t, 2, stats.Count)
 
-		stream.Push(ctx, id, events.NewLogResponse(time.Now(), []byte("hello 1")))
-		stream.Push(ctx, id, events.NewLogResponse(time.Now(), []byte("hello 1")))
-		stream.Push(ctx, id, events.NewLogResponse(time.Now(), []byte("hello 1")))
+		stream.Push(ctx, id, events.NewLog("hello 1"))
+		stream.Push(ctx, id, events.NewLog("hello 1"))
+		stream.Push(ctx, id, events.NewLog("hello 1"))
 
 		// when stop event triggered
 		r, err := stream.Stop(ctx, id)

--- a/pkg/logs/sidecar/proxy.go
+++ b/pkg/logs/sidecar/proxy.go
@@ -183,7 +183,7 @@ func (p *Proxy) streamLogsFromPod(pod corev1.Pod, logs chan *events.Log) (err er
 			}
 
 			// parse log line - also handle old (output.Output) and new format (just unstructured []byte)
-			logs <- events.NewLogResponseFromBytes(b)
+			logs <- events.NewLogFromBytes(b)
 		}
 
 		if err != nil {

--- a/pkg/logs/sidecar/proxy.go
+++ b/pkg/logs/sidecar/proxy.go
@@ -184,7 +184,7 @@ func (p *Proxy) streamLogsFromPod(pod corev1.Pod, logs chan *events.Log) (err er
 
 			// parse log line - also handle old (output.Output) and new format (just unstructured []byte)
 			logs <- events.NewLogFromBytes(b).
-				WithSource(events.JobPodLogSource)
+				WithSource(events.SourceJobPod)
 		}
 
 		if err != nil {

--- a/pkg/logs/sidecar/proxy.go
+++ b/pkg/logs/sidecar/proxy.go
@@ -183,7 +183,8 @@ func (p *Proxy) streamLogsFromPod(pod corev1.Pod, logs chan *events.Log) (err er
 			}
 
 			// parse log line - also handle old (output.Output) and new format (just unstructured []byte)
-			logs <- events.NewLogFromBytes(b)
+			logs <- events.NewLogFromBytes(b).
+				WithSource(events.JobPodLogSource)
 		}
 
 		if err != nil {

--- a/pkg/scheduler/test_scheduler.go
+++ b/pkg/scheduler/test_scheduler.go
@@ -139,16 +139,14 @@ func (s *Scheduler) handleExecutionStart(ctx context.Context, execution testkube
 		l := events.NewLog(fmt.Sprintf("starting execution %s (%s)", execution.Name, execution.Id)).
 			WithType("execution-config").
 			WithVersion(events.LogVersionV2).
-			WithSource("test-scheduler")
+			WithSource("test-scheduler").
+			WithMetadataEntry("command", strings.Join(execution.Command, " ")).
+			WithMetadataEntry("argsmode", execution.ArgsMode).
+			WithMetadataEntry("args", strings.Join(execution.Args, " ")).
+			WithMetadataEntry("pre-run", execution.PreRunScript).
+			WithMetadataEntry("post-run", execution.PostRunScript)
 
-		// TODO try to store map[strin]any through protobuf for now it'll be map[string]string
-		l.WithMetadataEntry("command", strings.Join(execution.Command, " "))
-		l.WithMetadataEntry("argsmode", execution.ArgsMode)
-		l.WithMetadataEntry("args", strings.Join(execution.Args, " "))
-		l.WithMetadataEntry("pre-run", execution.PreRunScript)
-		l.WithMetadataEntry("post-run", execution.PostRunScript)
-
-		s.logsStream.Push(ctx, execution.Id, *l)
+		s.logsStream.Push(ctx, execution.Id, l)
 	}
 }
 
@@ -160,7 +158,7 @@ func (s *Scheduler) handleExecutionError(ctx context.Context, execution testkube
 			WithVersion(events.LogVersionV2).
 			WithSource("test-scheduler")
 
-		s.logsStream.Push(ctx, execution.Id, *l)
+		s.logsStream.Push(ctx, execution.Id, l)
 
 	}
 


### PR DESCRIPTION
## Pull request description 

* one way to pass and create logs (was messy pointer and non-pointer) 
* passed logs stream as parameter to executors and api


## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [ ] tested locally
- [ ] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Breaking changes

-

## Changes

-

## Fixes

-