### PR TITLE
fix: executor tests - jmeterd-executor-smoke-slaves-sharedbetweenpods excluded from testsuite

### DIFF
--- a/test/jmeter/executor-tests/crd/special-cases.yaml
+++ b/test/jmeter/executor-tests/crd/special-cases.yaml
@@ -129,7 +129,7 @@ spec:
 apiVersion: tests.testkube.io/v3
 kind: Test
 metadata:
-  name: jmeterd-executor-smoke-slaves-sharedbetweenpods # can be run only at cluster with storageClassName (NFS volume)
+  name: jmeterd-executor-smoke-slaves-sharedbetweenpods # can be run only at cluster with storageClassName (NFS volume), not included in TestSuite
   labels:
     core-tests: executors
 spec:

--- a/test/suites/special-cases/jmeter-special-cases.yaml
+++ b/test/suites/special-cases/jmeter-special-cases.yaml
@@ -21,9 +21,6 @@ spec:
     - test: jmeterd-executor-smoke-directory-2
   - stopOnFailure: false
     execute:
-    - test: jmeterd-executor-smoke-slaves-sharedbetweenpods
-  - stopOnFailure: false
-    execute:
     - test: jmeterd-executor-smoke-directory-t-o
   - stopOnFailure: false
     execute:


### PR DESCRIPTION
`jmeterd-executor-smoke-slaves-sharedbetweenpods` test excluded from testsuite (have to be run at specific cluster with NFS volume)