### PR TITLE
fix: kill application on 2nd termination signal

### DIFF
--- a/cmd/api-server/main.go
+++ b/cmd/api-server/main.go
@@ -150,6 +150,10 @@ func main() {
 		case <-ctx.Done():
 			return nil
 		case sig := <-stopSignal:
+			go func() {
+				<-stopSignal
+				os.Exit(137)
+			}()
 			// Returning an error cancels the errgroup.
 			return errors.Errorf("received signal: %v", sig)
 		}

--- a/cmd/kubectl-testkube/commands/root.go
+++ b/cmd/kubectl-testkube/commands/root.go
@@ -180,6 +180,10 @@ func Execute() {
 		case <-ctx.Done():
 			return nil
 		case sig := <-stopSignal:
+			go func() {
+				<-stopSignal
+				os.Exit(137)
+			}()
 			return errors.Errorf("received signal: %v", sig)
 		}
 	})


### PR DESCRIPTION
## Pull request description 

* At the moment, when the termination signal is received (i.e. <kbd>Ctrl</kbd>+<kbd>C</kbd>), the application (both API and CLI) starts graceful termination
   * It's not possible to stop it, until the graceful termination will end
* Often you may want to kill the application - second signal should kill the application

## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [x] tested locally
- [ ] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Breaking changes

-

## Changes

-

## Fixes

-