### PR TITLE
fix: Go template rendering in CLI

### DIFF
--- a/cmd/kubectl-testkube/commands/common/render/list.go
+++ b/cmd/kubectl-testkube/commands/common/render/list.go
@@ -3,6 +3,7 @@ package render
 import (
 	"fmt"
 	"io"
+	"reflect"
 
 	"github.com/spf13/cobra"
 
@@ -25,9 +26,13 @@ func List(cmd *cobra.Command, obj interface{}, w io.Writer) error {
 		return RenderJSON(obj, w)
 	case OutputGoTemplate:
 		tpl := cmd.Flag("go-template").Value.String()
-		list, ok := obj.([]interface{})
-		if !ok {
+		value := reflect.ValueOf(obj)
+		if value.Kind() != reflect.Slice {
 			return fmt.Errorf("can't render, need list type but got: %+v", obj)
+		}
+		list := make([]interface{}, value.Len())
+		for i := 0; i < value.Len(); i++ {
+			list[i] = value.Index(i).Interface()
 		}
 		return RenderGoTemplateList(list, w, tpl)
 	default:

--- a/cmd/kubectl-testkube/commands/common/render/obj.go
+++ b/cmd/kubectl-testkube/commands/common/render/obj.go
@@ -1,7 +1,6 @@
 package render
 
 import (
-	"fmt"
 	"io"
 
 	"github.com/spf13/cobra"
@@ -30,12 +29,7 @@ func Obj(cmd *cobra.Command, obj interface{}, w io.Writer, renderer ...CliObjRen
 		return RenderJSON(obj, w)
 	case OutputGoTemplate:
 		tpl := cmd.Flag("go-template").Value.String()
-		// need to make type assetion to list first
-		list, ok := obj.([]interface{})
-		if !ok {
-			return fmt.Errorf("can't render, need list type but got: %+v", obj)
-		}
-		return RenderGoTemplateList(list, w, tpl)
+		return RenderGoTemplate(obj, w, tpl)
 	default:
 		return RenderYaml(obj, w)
 	}


### PR DESCRIPTION
## Pull request description 

The CLI with `--output go --go-template "some-template-here"` was not working.

* The renderer for Lists is trying to convert `interface{}` (with some `[]T` under the hood) to `[]interface{}`, what will never succeed
   * Instead, it's using now reflection, to build actual Golang slice
* The renderer for Objects was trying to convert `interface{}` to `[]interface{}` similarly to the List one, despite the fact that we are passing `struct`s inside
   * Now, it's just passing the `interface{}` down

## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [x] tested locally
- [ ] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test