### PR TITLE
feat(TKC-1462): add CLI commands for managing TestWorkflows

### DIFF
--- a/cmd/kubectl-testkube/commands/create.go
+++ b/cmd/kubectl-testkube/commands/create.go
@@ -10,6 +10,8 @@ import (
 	"github.com/kubeshop/testkube/cmd/kubectl-testkube/commands/tests"
 	"github.com/kubeshop/testkube/cmd/kubectl-testkube/commands/testsources"
 	"github.com/kubeshop/testkube/cmd/kubectl-testkube/commands/testsuites"
+	"github.com/kubeshop/testkube/cmd/kubectl-testkube/commands/testworkflows"
+	"github.com/kubeshop/testkube/cmd/kubectl-testkube/commands/testworkflowtemplates"
 	"github.com/kubeshop/testkube/cmd/kubectl-testkube/commands/webhooks"
 	"github.com/kubeshop/testkube/cmd/kubectl-testkube/config"
 	"github.com/kubeshop/testkube/pkg/ui"
@@ -43,6 +45,8 @@ func NewCreateCmd() *cobra.Command {
 	cmd.AddCommand(executors.NewCreateExecutorCmd())
 	cmd.AddCommand(testsources.NewCreateTestSourceCmd())
 	cmd.AddCommand(templates.NewCreateTemplateCmd())
+	cmd.AddCommand(testworkflows.NewCreateTestWorkflowCmd())
+	cmd.AddCommand(testworkflowtemplates.NewCreateTestWorkflowTemplateCmd())
 
 	cmd.PersistentFlags().BoolVar(&crdOnly, "crd-only", false, "generate only crd")
 

--- a/cmd/kubectl-testkube/commands/delete.go
+++ b/cmd/kubectl-testkube/commands/delete.go
@@ -10,6 +10,8 @@ import (
 	"github.com/kubeshop/testkube/cmd/kubectl-testkube/commands/tests"
 	"github.com/kubeshop/testkube/cmd/kubectl-testkube/commands/testsources"
 	"github.com/kubeshop/testkube/cmd/kubectl-testkube/commands/testsuites"
+	"github.com/kubeshop/testkube/cmd/kubectl-testkube/commands/testworkflows"
+	"github.com/kubeshop/testkube/cmd/kubectl-testkube/commands/testworkflowtemplates"
 	"github.com/kubeshop/testkube/cmd/kubectl-testkube/commands/webhooks"
 	"github.com/kubeshop/testkube/cmd/kubectl-testkube/config"
 	"github.com/kubeshop/testkube/pkg/ui"
@@ -42,6 +44,8 @@ func NewDeleteCmd() *cobra.Command {
 	cmd.AddCommand(executors.NewDeleteExecutorCmd())
 	cmd.AddCommand(testsources.NewDeleteTestSourceCmd())
 	cmd.AddCommand(templates.NewDeleteTemplateCmd())
+	cmd.AddCommand(testworkflows.NewDeleteTestWorkflowCmd())
+	cmd.AddCommand(testworkflowtemplates.NewDeleteTestWorkflowTemplateCmd())
 
 	return cmd
 }

--- a/cmd/kubectl-testkube/commands/get.go
+++ b/cmd/kubectl-testkube/commands/get.go
@@ -12,6 +12,8 @@ import (
 	"github.com/kubeshop/testkube/cmd/kubectl-testkube/commands/tests"
 	"github.com/kubeshop/testkube/cmd/kubectl-testkube/commands/testsources"
 	"github.com/kubeshop/testkube/cmd/kubectl-testkube/commands/testsuites"
+	"github.com/kubeshop/testkube/cmd/kubectl-testkube/commands/testworkflows"
+	"github.com/kubeshop/testkube/cmd/kubectl-testkube/commands/testworkflowtemplates"
 	"github.com/kubeshop/testkube/cmd/kubectl-testkube/commands/webhooks"
 	"github.com/kubeshop/testkube/cmd/kubectl-testkube/config"
 	"github.com/kubeshop/testkube/pkg/ui"
@@ -48,6 +50,8 @@ func NewGetCmd() *cobra.Command {
 	cmd.AddCommand(testsources.NewGetTestSourceCmd())
 	cmd.AddCommand(context.NewGetContextCmd())
 	cmd.AddCommand(templates.NewGetTemplateCmd())
+	cmd.AddCommand(testworkflows.NewGetTestWorkflowsCmd())
+	cmd.AddCommand(testworkflowtemplates.NewGetTestWorkflowTemplatesCmd())
 
 	cmd.PersistentFlags().StringP("output", "o", "pretty", "output type can be one of json|yaml|pretty|go-template")
 	cmd.PersistentFlags().StringP("go-template", "", "{{.}}", "go template to render")

--- a/cmd/kubectl-testkube/commands/testworkflows/create.go
+++ b/cmd/kubectl-testkube/commands/testworkflows/create.go
@@ -61,7 +61,7 @@ func NewCreateTestWorkflowCmd() *cobra.Command {
 			client, _, err := common.GetClient(cmd)
 			ui.ExitOnError("getting client", err)
 
-			workflow, err := client.GetTestWorkflow(obj.Name)
+			workflow, _ := client.GetTestWorkflow(obj.Name)
 			if workflow.Name != "" {
 				if !update {
 					ui.Failf("Test workflow with name '%s' already exists in namespace %s, use --update flag for upsert", obj.Name, namespace)

--- a/cmd/kubectl-testkube/commands/testworkflows/create.go
+++ b/cmd/kubectl-testkube/commands/testworkflows/create.go
@@ -1,0 +1,85 @@
+package testworkflows
+
+import (
+	"io"
+	"os"
+
+	"github.com/spf13/cobra"
+
+	testworkflowsv1 "github.com/kubeshop/testkube-operator/api/testworkflows/v1"
+	"github.com/kubeshop/testkube/cmd/kubectl-testkube/commands/common"
+	common2 "github.com/kubeshop/testkube/internal/common"
+	"github.com/kubeshop/testkube/pkg/ui"
+	"github.com/kubeshop/testkube/tcl/workflowstcl/mappers"
+)
+
+func NewCreateTestWorkflowCmd() *cobra.Command {
+	var (
+		name     string
+		filePath string
+		update   bool
+	)
+
+	cmd := &cobra.Command{
+		Use:     "testworkflow",
+		Aliases: []string{"testworkflows", "tw"},
+		Args:    cobra.MaximumNArgs(0),
+		Short:   "Create test workflow",
+
+		Run: func(cmd *cobra.Command, _ []string) {
+			namespace := cmd.Flag("namespace").Value.String()
+
+			var input io.Reader
+			if filePath == "" {
+				fi, err := os.Stdin.Stat()
+				ui.ExitOnError("reading stdin", err)
+				if fi.Mode()&os.ModeDevice != 0 {
+					ui.Failf("you need to pass stdin or --file argument with file path")
+				}
+				input = cmd.InOrStdin()
+			} else {
+				file, err := os.Open(filePath)
+				ui.ExitOnError("reading "+filePath+" file", err)
+				input = file
+			}
+
+			bytes, err := io.ReadAll(input)
+			ui.ExitOnError("reading input", err)
+
+			obj := new(testworkflowsv1.TestWorkflow)
+			err = common2.DeserializeCRD(obj, bytes)
+			ui.ExitOnError("deserializing input", err)
+			if obj.Kind != "" && obj.Kind != "TestWorkflow" {
+				ui.Failf("Only TestWorkflow objects are accepted. Received: %s", obj.Kind)
+			}
+			common2.AppendTypeMeta("TestWorkflow", testworkflowsv1.GroupVersion, obj)
+			obj.Namespace = namespace
+			if name != "" {
+				obj.Name = name
+			}
+
+			client, _, err := common.GetClient(cmd)
+			ui.ExitOnError("getting client", err)
+
+			workflow, err := client.GetTestWorkflow(obj.Name)
+			if workflow.Name != "" {
+				if !update {
+					ui.Failf("Test workflow with name '%s' already exists in namespace %s, use --update flag for upsert", obj.Name, namespace)
+				}
+				_, err = client.UpdateTestWorkflow(mappers.MapTestWorkflowKubeToAPI(*obj))
+				ui.ExitOnError("updating test workflow "+obj.Name+" in namespace "+obj.Namespace, err)
+				ui.Success("Test workflow updated", namespace, "/", obj.Name)
+			} else {
+				_, err = client.CreateTestWorkflow(mappers.MapTestWorkflowKubeToAPI(*obj))
+				ui.ExitOnError("creating test workflow "+obj.Name+" in namespace "+obj.Namespace, err)
+				ui.Success("Test workflow created", namespace, "/", obj.Name)
+			}
+		},
+	}
+
+	cmd.Flags().StringVar(&name, "name", "", "test workflow name")
+	cmd.Flags().BoolVar(&update, "update", false, "update, if test workflow already exists")
+	cmd.Flags().StringVarP(&filePath, "file", "f", "", "file path to get the test workflow specification")
+
+	return cmd
+}

--- a/cmd/kubectl-testkube/commands/testworkflows/create.go
+++ b/cmd/kubectl-testkube/commands/testworkflows/create.go
@@ -9,8 +9,8 @@ import (
 	testworkflowsv1 "github.com/kubeshop/testkube-operator/api/testworkflows/v1"
 	"github.com/kubeshop/testkube/cmd/kubectl-testkube/commands/common"
 	common2 "github.com/kubeshop/testkube/internal/common"
+	"github.com/kubeshop/testkube/pkg/tcl/workflowstcl/mappers"
 	"github.com/kubeshop/testkube/pkg/ui"
-	"github.com/kubeshop/testkube/tcl/workflowstcl/mappers"
 )
 
 func NewCreateTestWorkflowCmd() *cobra.Command {

--- a/cmd/kubectl-testkube/commands/testworkflows/delete.go
+++ b/cmd/kubectl-testkube/commands/testworkflows/delete.go
@@ -1,0 +1,54 @@
+package testworkflows
+
+import (
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/kubeshop/testkube/cmd/kubectl-testkube/commands/common"
+	"github.com/kubeshop/testkube/pkg/ui"
+)
+
+func NewDeleteTestWorkflowCmd() *cobra.Command {
+	var deleteAll bool
+	var selectors []string
+
+	cmd := &cobra.Command{
+		Use:     "testworkflow [name]",
+		Aliases: []string{"testworkflows", "tw"},
+		Args:    cobra.MaximumNArgs(1),
+		Short:   "Delete test workflows",
+
+		Run: func(cmd *cobra.Command, args []string) {
+			namespace := cmd.Flag("namespace").Value.String()
+			client, _, err := common.GetClient(cmd)
+			ui.ExitOnError("getting client", err)
+
+			if len(args) == 0 {
+				if len(selectors) > 0 {
+					selector := strings.Join(selectors, ",")
+					err = client.DeleteTestWorkflows(selector)
+					ui.ExitOnError("deleting test workflows by labels: "+selector, err)
+					ui.SuccessAndExit("Successfully deleted test workflows by labels", selector)
+				} else if deleteAll {
+					err = client.DeleteTestWorkflows("")
+					ui.ExitOnError("delete all test workflows from namespace "+namespace, err)
+					ui.SuccessAndExit("Successfully deleted all test workflows in namespace", namespace)
+				} else {
+					ui.Failf("Pass test workflow name, --all flag to delete all or labels to delete by labels")
+				}
+				return
+			}
+
+			name := args[0]
+			err = client.DeleteTestWorkflow(name)
+			ui.ExitOnError("delete test workflow "+name+" from namespace "+namespace, err)
+			ui.SuccessAndExit("Successfully deleted test workflow", name)
+		},
+	}
+
+	cmd.Flags().BoolVar(&deleteAll, "all", false, "Delete all test workflows")
+	cmd.Flags().StringSliceVarP(&selectors, "label", "l", nil, "label key value pair: --label key1=value1")
+
+	return cmd
+}

--- a/cmd/kubectl-testkube/commands/testworkflows/get.go
+++ b/cmd/kubectl-testkube/commands/testworkflows/get.go
@@ -1,0 +1,64 @@
+package testworkflows
+
+import (
+	"os"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	testworkflowsv1 "github.com/kubeshop/testkube-operator/api/testworkflows/v1"
+	"github.com/kubeshop/testkube/cmd/kubectl-testkube/commands/common"
+	"github.com/kubeshop/testkube/cmd/kubectl-testkube/commands/common/render"
+	"github.com/kubeshop/testkube/cmd/kubectl-testkube/commands/testworkflows/renderer"
+	"github.com/kubeshop/testkube/pkg/ui"
+	"github.com/kubeshop/testkube/tcl/workflowstcl/mappers"
+)
+
+func NewGetTestWorkflowsCmd() *cobra.Command {
+	var (
+		selectors []string
+		crdOnly   bool
+	)
+
+	cmd := &cobra.Command{
+		Use:     "testworkflow [name]",
+		Aliases: []string{"testworkflows", "tw"},
+		Args:    cobra.MaximumNArgs(1),
+		Short:   "Get all available test workflows",
+		Long:    `Getting all available test workflows from given namespace - if no namespace given "testkube" namespace is used`,
+
+		Run: func(cmd *cobra.Command, args []string) {
+			namespace := cmd.Flag("namespace").Value.String()
+			client, _, err := common.GetClient(cmd)
+			ui.ExitOnError("getting client", err)
+
+			if len(args) == 0 {
+				workflows, err := client.ListTestWorkflows(strings.Join(selectors, ","))
+				ui.ExitOnError("getting all test workflows in namespace "+namespace, err)
+
+				if crdOnly {
+					ui.PrintCRDs(mappers.MapListAPIToKube(workflows).Items, "TestWorkflow", testworkflowsv1.GroupVersion)
+				} else {
+					err = render.List(cmd, workflows, os.Stdout)
+					ui.PrintOnError("Rendering list", err)
+				}
+				return
+			}
+
+			name := args[0]
+			workflow, err := client.GetTestWorkflow(name)
+			ui.ExitOnError("getting test workflow in namespace "+namespace, err)
+
+			if crdOnly {
+				ui.PrintCRD(mappers.MapTestWorkflowAPIToKube(workflow), "TestWorkflow", testworkflowsv1.GroupVersion)
+			} else {
+				err = render.Obj(cmd, workflow, os.Stdout, renderer.TestWorkflowRenderer)
+				ui.ExitOnError("rendering obj", err)
+			}
+		},
+	}
+	cmd.Flags().StringSliceVarP(&selectors, "label", "l", nil, "label key value pair: --label key1=value1")
+	cmd.Flags().BoolVar(&crdOnly, "crd-only", false, "show only test workflow crd")
+
+	return cmd
+}

--- a/cmd/kubectl-testkube/commands/testworkflows/get.go
+++ b/cmd/kubectl-testkube/commands/testworkflows/get.go
@@ -10,8 +10,8 @@ import (
 	"github.com/kubeshop/testkube/cmd/kubectl-testkube/commands/common"
 	"github.com/kubeshop/testkube/cmd/kubectl-testkube/commands/common/render"
 	"github.com/kubeshop/testkube/cmd/kubectl-testkube/commands/testworkflows/renderer"
+	"github.com/kubeshop/testkube/pkg/tcl/workflowstcl/mappers"
 	"github.com/kubeshop/testkube/pkg/ui"
-	"github.com/kubeshop/testkube/tcl/workflowstcl/mappers"
 )
 
 func NewGetTestWorkflowsCmd() *cobra.Command {

--- a/cmd/kubectl-testkube/commands/testworkflows/renderer/testworkflow_obj.go
+++ b/cmd/kubectl-testkube/commands/testworkflows/renderer/testworkflow_obj.go
@@ -1,0 +1,32 @@
+package renderer
+
+import (
+	"fmt"
+
+	"github.com/kubeshop/testkube/pkg/api/v1/client"
+	"github.com/kubeshop/testkube/pkg/api/v1/testkube"
+	"github.com/kubeshop/testkube/pkg/ui"
+)
+
+func TestWorkflowRenderer(client client.Client, ui *ui.UI, obj interface{}) error {
+	workflow, ok := obj.(testkube.TestWorkflow)
+	if !ok {
+		return fmt.Errorf("can't use '%T' as testkube.TestWorkflow in RenderObj for test workflow", obj)
+	}
+
+	ui.Info("Test Workflow:")
+	ui.Warn("Name:     ", workflow.Name)
+	ui.Warn("Namespace:", workflow.Namespace)
+	ui.Warn("Created:  ", workflow.Created.String())
+	if workflow.Description != "" {
+		ui.NL()
+		ui.Warn("Description: ", workflow.Description)
+	}
+	if len(workflow.Labels) > 0 {
+		ui.NL()
+		ui.Warn("Labels:   ", testkube.MapToString(workflow.Labels))
+	}
+
+	return nil
+
+}

--- a/cmd/kubectl-testkube/commands/testworkflowtemplates/create.go
+++ b/cmd/kubectl-testkube/commands/testworkflowtemplates/create.go
@@ -9,8 +9,8 @@ import (
 	testworkflowsv1 "github.com/kubeshop/testkube-operator/api/testworkflows/v1"
 	"github.com/kubeshop/testkube/cmd/kubectl-testkube/commands/common"
 	common2 "github.com/kubeshop/testkube/internal/common"
+	"github.com/kubeshop/testkube/pkg/tcl/workflowstcl/mappers"
 	"github.com/kubeshop/testkube/pkg/ui"
-	"github.com/kubeshop/testkube/tcl/workflowstcl/mappers"
 )
 
 func NewCreateTestWorkflowTemplateCmd() *cobra.Command {

--- a/cmd/kubectl-testkube/commands/testworkflowtemplates/create.go
+++ b/cmd/kubectl-testkube/commands/testworkflowtemplates/create.go
@@ -61,7 +61,7 @@ func NewCreateTestWorkflowTemplateCmd() *cobra.Command {
 			client, _, err := common.GetClient(cmd)
 			ui.ExitOnError("getting client", err)
 
-			workflow, err := client.GetTestWorkflowTemplate(obj.Name)
+			workflow, _ := client.GetTestWorkflowTemplate(obj.Name)
 			if workflow.Name != "" {
 				if !update {
 					ui.Failf("Test workflow template with name '%s' already exists in namespace %s, use --update flag for upsert", obj.Name, namespace)

--- a/cmd/kubectl-testkube/commands/testworkflowtemplates/create.go
+++ b/cmd/kubectl-testkube/commands/testworkflowtemplates/create.go
@@ -1,0 +1,85 @@
+package testworkflowtemplates
+
+import (
+	"io"
+	"os"
+
+	"github.com/spf13/cobra"
+
+	testworkflowsv1 "github.com/kubeshop/testkube-operator/api/testworkflows/v1"
+	"github.com/kubeshop/testkube/cmd/kubectl-testkube/commands/common"
+	common2 "github.com/kubeshop/testkube/internal/common"
+	"github.com/kubeshop/testkube/pkg/ui"
+	"github.com/kubeshop/testkube/tcl/workflowstcl/mappers"
+)
+
+func NewCreateTestWorkflowTemplateCmd() *cobra.Command {
+	var (
+		name     string
+		filePath string
+		update   bool
+	)
+
+	cmd := &cobra.Command{
+		Use:     "testworkflowtemplate",
+		Aliases: []string{"testworkflowtemplates", "twt"},
+		Args:    cobra.MaximumNArgs(0),
+		Short:   "Create test workflow template",
+
+		Run: func(cmd *cobra.Command, _ []string) {
+			namespace := cmd.Flag("namespace").Value.String()
+
+			var input io.Reader
+			if filePath == "" {
+				fi, err := os.Stdin.Stat()
+				ui.ExitOnError("reading stdin", err)
+				if fi.Mode()&os.ModeDevice != 0 {
+					ui.Failf("you need to pass stdin or --file argument with file path")
+				}
+				input = cmd.InOrStdin()
+			} else {
+				file, err := os.Open(filePath)
+				ui.ExitOnError("reading "+filePath+" file", err)
+				input = file
+			}
+
+			bytes, err := io.ReadAll(input)
+			ui.ExitOnError("reading input", err)
+
+			obj := new(testworkflowsv1.TestWorkflowTemplate)
+			err = common2.DeserializeCRD(obj, bytes)
+			ui.ExitOnError("deserializing input", err)
+			if obj.Kind != "" && obj.Kind != "TestWorkflowTemplate" {
+				ui.Failf("Only TestWorkflowTemplate objects are accepted. Received: %s", obj.Kind)
+			}
+			common2.AppendTypeMeta("TestWorkflowTemplate", testworkflowsv1.GroupVersion, obj)
+			obj.Namespace = namespace
+			if name != "" {
+				obj.Name = name
+			}
+
+			client, _, err := common.GetClient(cmd)
+			ui.ExitOnError("getting client", err)
+
+			workflow, err := client.GetTestWorkflowTemplate(obj.Name)
+			if workflow.Name != "" {
+				if !update {
+					ui.Failf("Test workflow template with name '%s' already exists in namespace %s, use --update flag for upsert", obj.Name, namespace)
+				}
+				_, err = client.UpdateTestWorkflowTemplate(mappers.MapTestWorkflowTemplateKubeToAPI(*obj))
+				ui.ExitOnError("updating test workflow template "+obj.Name+" in namespace "+obj.Namespace, err)
+				ui.Success("Test workflow template updated", namespace, "/", obj.Name)
+			} else {
+				_, err = client.CreateTestWorkflowTemplate(mappers.MapTestWorkflowTemplateKubeToAPI(*obj))
+				ui.ExitOnError("creating test workflow "+obj.Name+" in namespace "+obj.Namespace, err)
+				ui.Success("Test workflow template created", namespace, "/", obj.Name)
+			}
+		},
+	}
+
+	cmd.Flags().StringVar(&name, "name", "", "test workflow template name")
+	cmd.Flags().BoolVar(&update, "update", false, "update, if test workflow template already exists")
+	cmd.Flags().StringVarP(&filePath, "file", "f", "", "file path to get the test workflow template specification")
+
+	return cmd
+}

--- a/cmd/kubectl-testkube/commands/testworkflowtemplates/delete.go
+++ b/cmd/kubectl-testkube/commands/testworkflowtemplates/delete.go
@@ -1,0 +1,54 @@
+package testworkflowtemplates
+
+import (
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/kubeshop/testkube/cmd/kubectl-testkube/commands/common"
+	"github.com/kubeshop/testkube/pkg/ui"
+)
+
+func NewDeleteTestWorkflowTemplateCmd() *cobra.Command {
+	var deleteAll bool
+	var selectors []string
+
+	cmd := &cobra.Command{
+		Use:     "testworkflowtemplate [name]",
+		Aliases: []string{"testworkflowtemplates", "twt"},
+		Args:    cobra.MaximumNArgs(1),
+		Short:   "Delete test workflow templates",
+
+		Run: func(cmd *cobra.Command, args []string) {
+			namespace := cmd.Flag("namespace").Value.String()
+			client, _, err := common.GetClient(cmd)
+			ui.ExitOnError("getting client", err)
+
+			if len(args) == 0 {
+				if len(selectors) > 0 {
+					selector := strings.Join(selectors, ",")
+					err = client.DeleteTestWorkflowTemplates(selector)
+					ui.ExitOnError("deleting test workflow templates by labels: "+selector, err)
+					ui.SuccessAndExit("Successfully deleted test workflow templates by labels", selector)
+				} else if deleteAll {
+					err = client.DeleteTestWorkflowTemplates("")
+					ui.ExitOnError("delete all test workflow templates from namespace "+namespace, err)
+					ui.SuccessAndExit("Successfully deleted all test workflow templates in namespace", namespace)
+				} else {
+					ui.Failf("Pass test workflow template name, --all flag to delete all or labels to delete by labels")
+				}
+				return
+			}
+
+			name := args[0]
+			err = client.DeleteTestWorkflowTemplate(name)
+			ui.ExitOnError("delete test workflow template "+name+" from namespace "+namespace, err)
+			ui.SuccessAndExit("Successfully deleted test workflow template", name)
+		},
+	}
+
+	cmd.Flags().BoolVar(&deleteAll, "all", false, "Delete all test workflow templates")
+	cmd.Flags().StringSliceVarP(&selectors, "label", "l", nil, "label key value pair: --label key1=value1")
+
+	return cmd
+}

--- a/cmd/kubectl-testkube/commands/testworkflowtemplates/get.go
+++ b/cmd/kubectl-testkube/commands/testworkflowtemplates/get.go
@@ -10,8 +10,8 @@ import (
 	"github.com/kubeshop/testkube/cmd/kubectl-testkube/commands/common"
 	"github.com/kubeshop/testkube/cmd/kubectl-testkube/commands/common/render"
 	"github.com/kubeshop/testkube/cmd/kubectl-testkube/commands/testworkflowtemplates/renderer"
+	"github.com/kubeshop/testkube/pkg/tcl/workflowstcl/mappers"
 	"github.com/kubeshop/testkube/pkg/ui"
-	"github.com/kubeshop/testkube/tcl/workflowstcl/mappers"
 )
 
 func NewGetTestWorkflowTemplatesCmd() *cobra.Command {

--- a/cmd/kubectl-testkube/commands/testworkflowtemplates/get.go
+++ b/cmd/kubectl-testkube/commands/testworkflowtemplates/get.go
@@ -1,0 +1,64 @@
+package testworkflowtemplates
+
+import (
+	"os"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	testworkflowsv1 "github.com/kubeshop/testkube-operator/api/testworkflows/v1"
+	"github.com/kubeshop/testkube/cmd/kubectl-testkube/commands/common"
+	"github.com/kubeshop/testkube/cmd/kubectl-testkube/commands/common/render"
+	"github.com/kubeshop/testkube/cmd/kubectl-testkube/commands/testworkflowtemplates/renderer"
+	"github.com/kubeshop/testkube/pkg/ui"
+	"github.com/kubeshop/testkube/tcl/workflowstcl/mappers"
+)
+
+func NewGetTestWorkflowTemplatesCmd() *cobra.Command {
+	var (
+		selectors []string
+		crdOnly   bool
+	)
+
+	cmd := &cobra.Command{
+		Use:     "testworkflowtemplate [name]",
+		Aliases: []string{"testworkflowtemplates", "twt"},
+		Args:    cobra.MaximumNArgs(1),
+		Short:   "Get all available test workflow templates",
+		Long:    `Getting all available test workflow templates from given namespace - if no namespace given "testkube" namespace is used`,
+
+		Run: func(cmd *cobra.Command, args []string) {
+			namespace := cmd.Flag("namespace").Value.String()
+			client, _, err := common.GetClient(cmd)
+			ui.ExitOnError("getting client", err)
+
+			if len(args) == 0 {
+				templates, err := client.ListTestWorkflowTemplates(strings.Join(selectors, ","))
+				ui.ExitOnError("getting all test workflow templates in namespace "+namespace, err)
+
+				if crdOnly {
+					ui.PrintCRDs(mappers.MapTemplateListAPIToKube(templates).Items, "TestWorkflowTemplate", testworkflowsv1.GroupVersion)
+				} else {
+					err = render.List(cmd, templates, os.Stdout)
+					ui.PrintOnError("Rendering list", err)
+				}
+				return
+			}
+
+			name := args[0]
+			template, err := client.GetTestWorkflowTemplate(name)
+			ui.ExitOnError("getting test workflow in namespace "+namespace, err)
+
+			if crdOnly {
+				ui.PrintCRD(mappers.MapTestWorkflowTemplateAPIToKube(template), "TestWorkflowTemplate", testworkflowsv1.GroupVersion)
+			} else {
+				err = render.Obj(cmd, template, os.Stdout, renderer.TestWorkflowTemplateRenderer)
+				ui.ExitOnError("rendering obj", err)
+			}
+		},
+	}
+	cmd.Flags().StringSliceVarP(&selectors, "label", "l", nil, "label key value pair: --label key1=value1")
+	cmd.Flags().BoolVar(&crdOnly, "crd-only", false, "show only test workflow template crd")
+
+	return cmd
+}

--- a/cmd/kubectl-testkube/commands/testworkflowtemplates/renderer/testworkflow_obj.go
+++ b/cmd/kubectl-testkube/commands/testworkflowtemplates/renderer/testworkflow_obj.go
@@ -1,0 +1,32 @@
+package renderer
+
+import (
+	"fmt"
+
+	"github.com/kubeshop/testkube/pkg/api/v1/client"
+	"github.com/kubeshop/testkube/pkg/api/v1/testkube"
+	"github.com/kubeshop/testkube/pkg/ui"
+)
+
+func TestWorkflowTemplateRenderer(client client.Client, ui *ui.UI, obj interface{}) error {
+	template, ok := obj.(testkube.TestWorkflowTemplate)
+	if !ok {
+		return fmt.Errorf("can't use '%T' as testkube.TestWorkflowTemplate in RenderObj for test workflow template", obj)
+	}
+
+	ui.Info("Test Workflow Template:")
+	ui.Warn("Name:     ", template.Name)
+	ui.Warn("Namespace:", template.Namespace)
+	ui.Warn("Created:  ", template.Created.String())
+	if template.Description != "" {
+		ui.NL()
+		ui.Warn("Description: ", template.Description)
+	}
+	if len(template.Labels) > 0 {
+		ui.NL()
+		ui.Warn("Labels:   ", testkube.MapToString(template.Labels))
+	}
+
+	return nil
+
+}

--- a/pkg/api/v1/testkube/model_test_workflow_extended.go
+++ b/pkg/api/v1/testkube/model_test_workflow_extended.go
@@ -1,3 +1,17 @@
 package testkube
 
 type TestWorkflows []TestWorkflow
+
+func (t TestWorkflows) Table() (header []string, output [][]string) {
+	header = []string{"Name", "Description", "Created", "Labels"}
+	for _, e := range t {
+		output = append(output, []string{
+			e.Name,
+			e.Description,
+			e.Created.String(),
+			MapToString(e.Labels),
+		})
+	}
+
+	return
+}

--- a/pkg/api/v1/testkube/model_test_workflow_template_extended.go
+++ b/pkg/api/v1/testkube/model_test_workflow_template_extended.go
@@ -1,3 +1,19 @@
 package testkube
 
+import "strings"
+
 type TestWorkflowTemplates []TestWorkflowTemplate
+
+func (t TestWorkflowTemplates) Table() (header []string, output [][]string) {
+	header = []string{"Name", "Description", "Created", "Labels"}
+	for _, e := range t {
+		output = append(output, []string{
+			strings.ReplaceAll(e.Name, "--", "/"),
+			e.Description,
+			e.Created.String(),
+			MapToString(e.Labels),
+		})
+	}
+
+	return
+}

--- a/pkg/ui/ui.go
+++ b/pkg/ui/ui.go
@@ -94,15 +94,8 @@ func Confirm(message string) bool                           { return ui.Confirm(
 func Select(title string, options []string) string          { return ui.Select(title, options) }
 func TextInput(message string) string                       { return ui.TextInput(message) }
 
-func PrintCRD(cr interface{}, kind string, groupVersion schema.GroupVersion) {
-	bytes, err := common.SerializeCRD(cr, common.SerializeOptions{
-		OmitCreationTimestamp: true,
-		CleanMeta:             true,
-		Kind:                  kind,
-		GroupVersion:          &groupVersion,
-	})
-	ui.ExitOnError("serializing the crd", err)
-	_, _ = os.Stdout.Write(bytes)
+func PrintCRD[T interface{}](cr T, kind string, groupVersion schema.GroupVersion) {
+	PrintCRDs([]T{cr}, kind, groupVersion)
 }
 
 func PrintCRDs[T interface{}](crs []T, kind string, groupVersion schema.GroupVersion) {

--- a/pkg/ui/ui.go
+++ b/pkg/ui/ui.go
@@ -4,6 +4,10 @@ package ui
 import (
 	"io"
 	"os"
+
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	"github.com/kubeshop/testkube/internal/common"
 )
 
 const (
@@ -89,6 +93,28 @@ func PrintArrayTable(a [][]string)                          { ui.PrintArrayTable
 func Confirm(message string) bool                           { return ui.Confirm(message) }
 func Select(title string, options []string) string          { return ui.Select(title, options) }
 func TextInput(message string) string                       { return ui.TextInput(message) }
+
+func PrintCRD(cr interface{}, kind string, groupVersion schema.GroupVersion) {
+	bytes, err := common.SerializeCRD(cr, common.SerializeOptions{
+		OmitCreationTimestamp: true,
+		CleanMeta:             true,
+		Kind:                  kind,
+		GroupVersion:          &groupVersion,
+	})
+	ui.ExitOnError("serializing the crd", err)
+	_, _ = os.Stdout.Write(bytes)
+}
+
+func PrintCRDs[T interface{}](crs []T, kind string, groupVersion schema.GroupVersion) {
+	bytes, err := common.SerializeCRDs(crs, common.SerializeOptions{
+		OmitCreationTimestamp: true,
+		CleanMeta:             true,
+		Kind:                  kind,
+		GroupVersion:          &groupVersion,
+	})
+	ui.ExitOnError("serializing the crds", err)
+	_, _ = os.Stdout.Write(bytes)
+}
 
 func UseStdout() { ui = uiOut }
 func UseStderr() { ui = uiErr }


### PR DESCRIPTION
## Pull request description 

* Add `tk get testworkflow` (`tw`) and `tk get testworkflowtemplate` (`twt`) commands to get list of resources
  * Selection by labels is available (`--labels`, `-l`)
  * Getting list of CRDs is available (`--crd-only`)
* Add `tk get testworkflow <name>` (`tw <name>`) and `tk get testworkflowtemplate <name>` (`twt <name>`) commands to describe the resources
  * Getting CRD is available (`--crd-only`)
* Add `tk delete testworkflow` and `tk delete testworkflowtemplate` commands
  * `tk delete tw --all` to delete all entries
  * `tk delete tw -l some=value` to delete entries by labels
  * `tk delete tw some-name` to delete specific one
* Add `tk create testworkflow` and `tk create testworkflowtemplate` commands
  * Only name can be configured by arguments, like `--name some-workflow`
  * The rest of the configuration needs to be passed by stdin or `-f` argument (more in *tk create examples* section)
  * To make an upsert, append `--update` flag
  * Only single `TestWorkflow` or `TestWorkflowTemplate` can be passed, no other resources
* Patch is not implemented, due to the complicated nested nature of workflows, so the `update` command is not there.

## `tk create` examples

### Using file path

```shell
tk create testworkflow -f some-file.yaml
tk create testworkflow --name different-name-than-in-file -f some-file.yaml
```

### Using pipe

```shell
cat some-file.yaml | tk create testworkflow
cat some-file.yaml | tk create testworkflow --name different-name-than-in-file
```

### Using regular stdin

```shell
tk create testworkflow --name different-name <<< "
metadata:
  labels:
    some: label
spec:
  pod:
    labels:
      different: label"
```

## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [x] tested locally
- [ ] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Fixes

- https://linear.app/kubeshop/issue/TKC-1462/testworkflows-cli-for-managing-them