### PR TITLE
fix: [TKC-1611] execute post run script for container executors

### DIFF
--- a/contrib/executor/init/pkg/runner/runner_test.go
+++ b/contrib/executor/init/pkg/runner/runner_test.go
@@ -2,6 +2,7 @@ package runner
 
 import (
 	"context"
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -29,6 +30,47 @@ func TestRun(t *testing.T) {
 		// then
 		assert.NoError(t, err)
 		assert.Equal(t, result.Status, testkube.ExecutionStatusRunning)
+	})
+
+	t.Run("runner with pre and post run scripts should run test", func(t *testing.T) {
+		t.Parallel()
+
+		params := envs.Params{DataDir: "./testdir"}
+		runner := NewRunner(params)
+		execution := testkube.NewQueuedExecution()
+		execution.Content = testkube.NewStringTestContent("hello I'm  test content")
+		execution.PreRunScript = "echo \"===== pre-run script\""
+		execution.Command = []string{"command.sh"}
+		execution.PostRunScript = "echo \"===== pre-run script\""
+
+		// when
+		result, err := runner.Run(ctx, *execution)
+
+		// then
+		assert.NoError(t, err)
+		assert.Equal(t, result.Status, testkube.ExecutionStatusRunning)
+
+		expected := `#!/bin/sh
+"testdir/prerun.sh"
+prerun_exit_code=$?
+if [ $prerun_exit_code -ne 0 ]; then
+  exit $prerun_exit_code
+fi
+"testdir/command.sh" $@
+command_exit_code=$?
+"testdir/postrun.sh"
+postrun_exit_code=$?
+if [ $command_exit_code -ne 0 ]; then
+  exit $command_exit_code
+fi
+exit $postrun_exit_code
+`
+
+		data, err := os.ReadFile("testdir/entrypoint.sh")
+		if err != nil {
+			t.Fatalf("Failed to read file: %v", err)
+		}
+		assert.Equal(t, string(data), expected)
 	})
 
 }


### PR DESCRIPTION
## Pull request description 

Change the entrypoint generation to get rid of `set -e` and then store the exit code of the command and still run the post run script.

Fix  https://github.com/kubeshop/testkube/issues/5048

## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [ ] tested locally
- [ ] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [x] added a test

## Breaking changes

-

## Changes

-

## Fixes

-