### PR TITLE
feat(TKC-1642): add TestWorkflow support of cloning Git, executing tests, and artifacts

### DIFF
--- a/.github/workflows/docker-build-api-executors-tag.yaml
+++ b/.github/workflows/docker-build-api-executors-tag.yaml
@@ -133,6 +133,61 @@ jobs:
           DOCKER_BUILDX_CACHE_TO: "type=gha,mode=max"
           ALPINE_IMAGE: ${{ env.ALPINE_IMAGE }}
 
+  testworkflow-toolkit:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - uses: sigstore/cosign-installer@v3.0.5
+      - uses: anchore/sbom-action/download-syft@v0.14.2
+
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+
+      - name: Set-up Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: ${{ env.GO_VERSION }}
+          cache: false
+
+      - name: Go Cache
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/go/pkg/mod
+            ~/.cache/go-build
+          key: testkube-tw-toolkit-go-${{ hashFiles('**/go.sum') }}
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Release
+        uses: goreleaser/goreleaser-action@v4
+        with:
+          distribution: goreleaser
+          version: latest
+          args: release -f goreleaser_files/.goreleaser-docker-build-testworkflow-toolkit.yml
+        env:
+          GITHUB_TOKEN: ${{ secrets.CI_BOT_TOKEN }}
+          ANALYTICS_TRACKING_ID: ${{secrets.TESTKUBE_API_GA_MEASUREMENT_ID}}
+          ANALYTICS_API_KEY: ${{secrets.TESTKUBE_API_GA_MEASUREMENT_SECRET}}
+          SLACK_BOT_CLIENT_ID: ${{secrets.TESTKUBE_SLACK_BOT_CLIENT_ID}}
+          SLACK_BOT_CLIENT_SECRET: ${{secrets.TESTKUBE_SLACK_BOT_CLIENT_SECRET}}
+          SEGMENTIO_KEY: ${{secrets.TESTKUBE_API_SEGMENTIO_KEY}}
+          CLOUD_SEGMENTIO_KEY: ${{secrets.TESTKUBE_API_CLOUD_SEGMENTIO_KEY}}
+          DOCKER_BUILDX_BUILDER: "${{ steps.buildx.outputs.name }}"
+          DOCKER_BUILDX_CACHE_FROM: "type=gha"
+          DOCKER_BUILDX_CACHE_TO: "type=gha,mode=max"
+          ALPINE_IMAGE: ${{ env.ALPINE_IMAGE }}
+
   single_executor:
     strategy:
       matrix:

--- a/.github/workflows/docker-build-develop.yaml
+++ b/.github/workflows/docker-build-develop.yaml
@@ -124,6 +124,63 @@ jobs:
         run: |
           docker push kubeshop/testkube-tw-init:${{ steps.commit.outputs.short }}
 
+  testworkflow-toolkit:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Set-up Go
+        uses: actions/setup-go@v4
+        with:
+          go-version:  ${{ env.GO_VERSION }}
+          cache: false
+
+      - name: Go Cache
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/go/pkg/mod
+            ~/.cache/go-build
+          key: testkube-tw-toolkit-go-${{ hashFiles('**/go.sum') }}
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - id: commit
+        uses: prompt/actions-commit-hash@v3
+
+      - name: Release
+        uses: goreleaser/goreleaser-action@v4
+        with:
+          distribution: goreleaser
+          version: latest
+          args: release -f goreleaser_files/.goreleaser-docker-build-testworkflow-toolkit.yml --snapshot
+        env:
+          GITHUB_TOKEN: ${{ secrets.CI_BOT_TOKEN }}
+          ANALYTICS_TRACKING_ID: ${{secrets.TESTKUBE_API_GA_MEASUREMENT_ID}}
+          ANALYTICS_API_KEY: ${{secrets.TESTKUBE_API_GA_MEASUREMENT_SECRET}}
+          SLACK_BOT_CLIENT_ID: ${{secrets.TESTKUBE_SLACK_BOT_CLIENT_ID}}
+          SLACK_BOT_CLIENT_SECRET: ${{secrets.TESTKUBE_SLACK_BOT_CLIENT_SECRET}}
+          SEGMENTIO_KEY: ${{secrets.TESTKUBE_API_SEGMENTIO_KEY}}
+          CLOUD_SEGMENTIO_KEY: ${{secrets.TESTKUBE_API_CLOUD_SEGMENTIO_KEY}}
+          DOCKER_BUILDX_BUILDER: "${{ steps.buildx.outputs.name }}"
+          DOCKER_BUILDX_CACHE_FROM: "type=gha"
+          DOCKER_BUILDX_CACHE_TO: "type=gha,mode=max"
+          ALPINE_IMAGE: ${{ env.ALPINE_IMAGE }}
+          IMAGE_TAG_SHA: true
+
+      - name: Push Docker images
+        run: |
+          docker push kubeshop/testkube-tw-toolkit:${{ steps.commit.outputs.short }}
+
   single_executor:
     strategy:
       matrix:

--- a/.github/workflows/docker-build-release.yaml
+++ b/.github/workflows/docker-build-release.yaml
@@ -125,6 +125,63 @@ jobs:
         run: |
           docker push kubeshop/testkube-tw-init:${{ steps.commit.outputs.short }}
 
+  testworkflow-toolkit:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Set-up Go
+        uses: actions/setup-go@v4
+        with:
+          go-version:  ${{ env.GO_VERSION }}
+          cache: false
+
+      - name: Go Cache
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/go/pkg/mod
+            ~/.cache/go-build
+          key: testkube-tw-toolkit-go-${{ hashFiles('**/go.sum') }}
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - id: commit
+        uses: prompt/actions-commit-hash@v3
+
+      - name: Release
+        uses: goreleaser/goreleaser-action@v4
+        with:
+          distribution: goreleaser
+          version: latest
+          args: release -f goreleaser_files/.goreleaser-docker-build-testworkflow-toolkit.yml --snapshot
+        env:
+          GITHUB_TOKEN: ${{ secrets.CI_BOT_TOKEN }}
+          ANALYTICS_TRACKING_ID: ${{secrets.TESTKUBE_API_GA_MEASUREMENT_ID}}
+          ANALYTICS_API_KEY: ${{secrets.TESTKUBE_API_GA_MEASUREMENT_SECRET}}
+          SLACK_BOT_CLIENT_ID: ${{secrets.TESTKUBE_SLACK_BOT_CLIENT_ID}}
+          SLACK_BOT_CLIENT_SECRET: ${{secrets.TESTKUBE_SLACK_BOT_CLIENT_SECRET}}
+          SEGMENTIO_KEY: ${{secrets.TESTKUBE_API_SEGMENTIO_KEY}}
+          CLOUD_SEGMENTIO_KEY: ${{secrets.TESTKUBE_API_CLOUD_SEGMENTIO_KEY}}
+          DOCKER_BUILDX_BUILDER: "${{ steps.buildx.outputs.name }}"
+          DOCKER_BUILDX_CACHE_FROM: "type=gha"
+          DOCKER_BUILDX_CACHE_TO: "type=gha,mode=max"
+          ALPINE_IMAGE: ${{ env.ALPINE_IMAGE }}
+          IMAGE_TAG_SHA: true
+
+      - name: Push Docker images
+        run: |
+          docker push kubeshop/testkube-tw-toolkit:${{ steps.commit.outputs.short }}
+
   single_executor:
     strategy:
       matrix:

--- a/api/v1/testkube.yaml
+++ b/api/v1/testkube.yaml
@@ -3838,6 +3838,148 @@ paths:
                 type: array
                 items:
                   $ref: "#/components/schemas/Problem"
+
+  /test-workflow-executions/{executionID}/artifacts:
+    get:
+      parameters:
+        - $ref: "#/components/parameters/ID"
+      tags:
+        - test-workflows
+        - artifacts
+        - executions
+        - api
+        - pro
+      summary: "Get test workflow execution's artifacts by ID"
+      description: "Returns artifacts of the given executionID"
+      operationId: getTestWorkflowExecutionArtifacts
+      responses:
+        200:
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/Artifact"
+        404:
+          description: "execution not found"
+          content:
+            application/problem+json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/Problem"
+        402:
+          description: "missing Pro subscription for a commercial feature"
+          content:
+            application/problem+json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/Problem"
+        500:
+          description: "problem with getting execution's artifacts from storage"
+          content:
+            application/problem+json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/Problem"
+
+  /test-workflow-executions/{executionID}/artifacts/{filename}:
+    get:
+      parameters:
+        - $ref: "#/components/parameters/ID"
+        - $ref: "#/components/parameters/Filename"
+      tags:
+        - test-workflows
+        - artifacts
+        - executions
+        - api
+        - pro
+      summary: "Download test workflow artifact"
+      description: "Download the artifact file from the given execution"
+      operationId: downloadTestWorkflowArtifact
+      responses:
+        200:
+          description: "successful operation"
+          content:
+            application/octet-stream:
+              schema:
+                type: string
+                format: binary
+        404:
+          description: "execution not found"
+          content:
+            application/problem+json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/Problem"
+        402:
+          description: "missing Pro subscription for a commercial feature"
+          content:
+            application/problem+json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/Problem"
+        500:
+          description: "problem with getting artifacts from storage"
+          content:
+            application/problem+json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/Problem"
+
+  /test-workflow-executions/{executionID}/artifact-archive:
+    get:
+      parameters:
+        - $ref: "#/components/parameters/ID"
+        - $ref: "#/components/parameters/Mask"
+      tags:
+        - test-workflows
+        - artifacts
+        - executions
+        - api
+        - pro
+      summary: "Download test workflow artifact archive"
+      description: "Download the artifact archive from the given execution"
+      operationId: downloadTestWorkflowArtifactArchive
+      responses:
+        200:
+          description: "successful operation"
+          content:
+            application/octet-stream:
+              schema:
+                type: string
+                format: binary
+        404:
+          description: "execution not found"
+          content:
+            application/problem+json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/Problem"
+        402:
+          description: "missing Pro subscription for a commercial feature"
+          content:
+            application/problem+json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/Problem"
+        500:
+          description: "problem with getting artifact archive from storage"
+          content:
+            application/problem+json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/Problem"
+
   /test-workflow-executions/{executionID}/abort:
     post:
       tags:

--- a/build/testworkflow-toolkit/Dockerfile
+++ b/build/testworkflow-toolkit/Dockerfile
@@ -1,6 +1,7 @@
 # syntax=docker/dockerfile:1
 ARG ALPINE_IMAGE
 FROM ${ALPINE_IMAGE}
+RUN apk --no-cache add ca-certificates libssl1.1 git
 COPY testworkflow-toolkit /toolkit
 USER 1001
 ENTRYPOINT ["/toolkit"]

--- a/build/testworkflow-toolkit/Dockerfile
+++ b/build/testworkflow-toolkit/Dockerfile
@@ -1,0 +1,6 @@
+# syntax=docker/dockerfile:1
+ARG ALPINE_IMAGE
+FROM ${ALPINE_IMAGE}
+COPY testworkflow-toolkit /toolkit
+USER 1001
+ENTRYPOINT ["/toolkit"]

--- a/cmd/api-server/main.go
+++ b/cmd/api-server/main.go
@@ -602,7 +602,15 @@ func main() {
 	}
 
 	// Apply Pro server enhancements
-	apitclv1.NewApiTCL(api, &proContext, kubeClient, inspector, testWorkflowResultsRepository, testWorkflowOutputRepository).AppendRoutes()
+	apitclv1.NewApiTCL(
+		api,
+		&proContext,
+		kubeClient,
+		inspector,
+		testWorkflowResultsRepository,
+		testWorkflowOutputRepository,
+		"http://"+cfg.APIServerFullname+":"+cfg.APIServerPort,
+	).AppendRoutes()
 
 	api.InitEvents()
 	if !cfg.DisableTestTriggers {

--- a/cmd/kubectl-testkube/commands/download.go
+++ b/cmd/kubectl-testkube/commands/download.go
@@ -90,10 +90,22 @@ func NewDownloadSingleArtifactsCmd() *cobra.Command {
 			client, _, err := common.GetClient(cmd)
 			ui.ExitOnError("getting client", err)
 
-			f, err := client.DownloadFile(executionID, filename, destination)
-			ui.ExitOnError("downloading file"+filename, err)
+			execution, err := client.GetExecution(executionID)
+			if err == nil && execution.Id != "" {
+				f, err := client.DownloadFile(executionID, filename, destination)
+				ui.ExitOnError("downloading file "+filename, err)
+				ui.Info(fmt.Sprintf("File %s downloaded.\n", f))
+				return
+			}
+			twExecution, err := client.GetTestWorkflowExecution(executionID)
+			if err == nil && twExecution.Id != "" {
+				f, err := client.DownloadTestWorkflowArtifact(executionID, filename, destination)
+				ui.ExitOnError("downloading file "+filename, err)
+				ui.Info(fmt.Sprintf("File %s downloaded.\n", f))
+				return
+			}
 
-			ui.Info(fmt.Sprintf("File %s downloaded.\n", f))
+			ui.ExitOnError("retrieving execution", err)
 		},
 	}
 
@@ -119,7 +131,16 @@ func NewDownloadAllArtifactsCmd() *cobra.Command {
 			client, _, err := common.GetClient(cmd)
 			ui.ExitOnError("getting client", err)
 
-			tests.DownloadArtifacts(executionID, downloadDir, format, masks, client)
+			execution, err := client.GetExecution(executionID)
+			if err == nil && execution.Id != "" {
+				tests.DownloadTestArtifacts(executionID, downloadDir, format, masks, client)
+				return
+			}
+			twExecution, err := client.GetTestWorkflowExecution(executionID)
+			if err == nil && twExecution.Id != "" {
+				tests.DownloadTestWorkflowArtifacts(executionID, downloadDir, format, masks, client)
+				return
+			}
 		},
 	}
 

--- a/cmd/kubectl-testkube/commands/tests/run.go
+++ b/cmd/kubectl-testkube/commands/tests/run.go
@@ -331,7 +331,7 @@ func NewRunTestCmd() *cobra.Command {
 				if execution.Id != "" {
 					if watchEnabled && len(args) > 0 {
 						if downloadArtifactsEnabled && (execution.IsPassed() || execution.IsFailed()) {
-							DownloadArtifacts(execution.Id, downloadDir, format, masks, client)
+							DownloadTestArtifacts(execution.Id, downloadDir, format, masks, client)
 						}
 					}
 

--- a/cmd/kubectl-testkube/commands/testsuites/common.go
+++ b/cmd/kubectl-testkube/commands/testsuites/common.go
@@ -411,7 +411,7 @@ func DownloadArtifacts(id, dir, format string, masks []string, client apiclientv
 		for _, step := range execution.Execute {
 			if step.Execution != nil && step.Step != nil && step.Step.Test != "" {
 				if step.Execution.IsPassed() || step.Execution.IsFailed() {
-					tests.DownloadArtifacts(step.Execution.Id, filepath.Join(dir, step.Execution.TestName+"-"+step.Execution.Id), format, masks, client)
+					tests.DownloadTestArtifacts(step.Execution.Id, filepath.Join(dir, step.Execution.TestName+"-"+step.Execution.Id), format, masks, client)
 				}
 			}
 		}

--- a/cmd/kubectl-testkube/commands/testworkflows/renderer/testworkflowexecution_obj.go
+++ b/cmd/kubectl-testkube/commands/testworkflows/renderer/testworkflowexecution_obj.go
@@ -3,6 +3,8 @@ package renderer
 import (
 	"fmt"
 
+	"github.com/pkg/errors"
+
 	"github.com/kubeshop/testkube/pkg/api/v1/client"
 	"github.com/kubeshop/testkube/pkg/api/v1/testkube"
 	"github.com/kubeshop/testkube/pkg/ui"
@@ -36,6 +38,11 @@ func TestWorkflowExecutionRenderer(client client.Client, ui *ui.UI, obj interfac
 				ui.Warn("Duration:         ", execution.Result.FinishedAt.Sub(execution.Result.QueuedAt).String())
 			}
 		}
+	}
+
+	if execution.Result != nil && execution.Result.Initialization != nil && execution.Result.Initialization.ErrorMessage != "" {
+		ui.NL()
+		ui.Err(errors.New(execution.Result.Initialization.ErrorMessage))
 	}
 
 	return nil

--- a/cmd/tcl/testworkflow-toolkit/artifacts/cloud_uploader.go
+++ b/cmd/tcl/testworkflow-toolkit/artifacts/cloud_uploader.go
@@ -1,0 +1,156 @@
+// Copyright 2024 Testkube.
+//
+// Licensed as a Testkube Pro file under the Testkube Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+//	https://github.com/kubeshop/testkube/blob/main/licenses/TCL.txt
+
+package artifacts
+
+import (
+	"context"
+	"crypto/tls"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/pkg/errors"
+
+	"github.com/kubeshop/testkube/cmd/tcl/testworkflow-toolkit/env"
+	"github.com/kubeshop/testkube/pkg/cloud/data/artifact"
+	cloudexecutor "github.com/kubeshop/testkube/pkg/cloud/data/executor"
+	"github.com/kubeshop/testkube/pkg/ui"
+)
+
+type CloudUploaderRequestEnhancer = func(req *http.Request, path string, size int64)
+
+func NewCloudUploader(opts ...CloudUploaderOpt) Uploader {
+	uploader := &cloudUploader{
+		parallelism:  1,
+		reqEnhancers: make([]CloudUploaderRequestEnhancer, 0),
+	}
+	for _, opt := range opts {
+		opt(uploader)
+	}
+	return uploader
+}
+
+type cloudUploader struct {
+	client       cloudexecutor.Executor
+	wg           sync.WaitGroup
+	sema         chan struct{}
+	parallelism  int
+	error        atomic.Bool
+	reqEnhancers []CloudUploaderRequestEnhancer
+}
+
+func (d *cloudUploader) Start() (err error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	d.client = env.Cloud(ctx)
+	d.sema = make(chan struct{}, d.parallelism)
+	return err
+}
+
+func (d *cloudUploader) getSignedURL(name string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	response, err := d.client.Execute(ctx, artifact.CmdScraperPutObjectSignedURL, &artifact.PutObjectSignedURLRequest{
+		Object:           name,
+		ExecutionID:      env.ExecutionId(),
+		TestWorkflowName: env.WorkflowName(),
+	})
+	if err != nil {
+		return "", err
+	}
+	var commandResponse artifact.PutObjectSignedURLResponse
+	if err := json.Unmarshal(response, &commandResponse); err != nil {
+		return "", err
+	}
+	return commandResponse.URL, nil
+}
+
+func (d *cloudUploader) putObject(url string, path string, file io.Reader, size int64) error {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Minute)
+	defer cancel()
+	req, err := http.NewRequestWithContext(ctx, http.MethodPut, url, file)
+	if err != nil {
+		return err
+	}
+	for _, r := range d.reqEnhancers {
+		r(req, path, size)
+	}
+	req.ContentLength = size
+	if req.Header.Get("Content-Type") == "" {
+		req.Header.Set("Content-Type", "application/octet-stream")
+	}
+	tr := http.DefaultTransport.(*http.Transport).Clone()
+	tr.TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
+	client := &http.Client{Transport: tr}
+	res, err := client.Do(req)
+	if err != nil {
+		return err
+	}
+	if res.StatusCode != http.StatusOK {
+		b, _ := io.ReadAll(res.Body)
+		return errors.Errorf("failed saving file: status code: %d / message: %s", res.StatusCode, string(b))
+	}
+	return nil
+}
+
+func (d *cloudUploader) upload(path string, file io.Reader, size int64) {
+	url, err := d.getSignedURL(path)
+	if err != nil {
+		d.error.Store(true)
+		ui.Errf("%s: failed: get signed URL: %s", path, err.Error())
+		return
+	}
+	err = d.putObject(url, path, file, size)
+	if err != nil {
+		d.error.Store(true)
+		ui.Errf("%s: failed: store file: %s", path, err.Error())
+		return
+	}
+}
+
+func (d *cloudUploader) Add(path string, file io.ReadCloser, size int64) error {
+	d.wg.Add(1)
+	d.sema <- struct{}{}
+	go func() {
+		d.upload(path, file, size)
+		_ = file.Close()
+		d.wg.Done()
+		<-d.sema
+	}()
+	return nil
+}
+
+func (d *cloudUploader) End() error {
+	d.wg.Wait()
+	if d.error.Load() {
+		return fmt.Errorf("upload failed")
+	}
+	return nil
+}
+
+type CloudUploaderOpt = func(uploader *cloudUploader)
+
+func WithParallelismCloud(parallelism int) CloudUploaderOpt {
+	return func(uploader *cloudUploader) {
+		if parallelism < 1 {
+			parallelism = 1
+		}
+		uploader.parallelism = parallelism
+	}
+}
+
+func WithRequestEnhancerCloud(enhancer CloudUploaderRequestEnhancer) CloudUploaderOpt {
+	return func(uploader *cloudUploader) {
+		uploader.reqEnhancers = append(uploader.reqEnhancers, enhancer)
+	}
+}

--- a/cmd/tcl/testworkflow-toolkit/artifacts/direct_processor.go
+++ b/cmd/tcl/testworkflow-toolkit/artifacts/direct_processor.go
@@ -1,0 +1,32 @@
+// Copyright 2024 Testkube.
+//
+// Licensed as a Testkube Pro file under the Testkube Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+//	https://github.com/kubeshop/testkube/blob/main/licenses/TCL.txt
+
+package artifacts
+
+import (
+	"io/fs"
+)
+
+func NewDirectProcessor() Processor {
+	return &directProcessor{}
+}
+
+type directProcessor struct {
+}
+
+func (d *directProcessor) Start() error {
+	return nil
+}
+
+func (d *directProcessor) Add(uploader Uploader, path string, file fs.File, stat fs.FileInfo) error {
+	return uploader.Add(path, file, stat.Size())
+}
+
+func (d *directProcessor) End() error {
+	return nil
+}

--- a/cmd/tcl/testworkflow-toolkit/artifacts/direct_uploader.go
+++ b/cmd/tcl/testworkflow-toolkit/artifacts/direct_uploader.go
@@ -1,0 +1,110 @@
+// Copyright 2024 Testkube.
+//
+// Licensed as a Testkube Pro file under the Testkube Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+//	https://github.com/kubeshop/testkube/blob/main/licenses/TCL.txt
+
+package artifacts
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"sync"
+	"sync/atomic"
+
+	minio2 "github.com/minio/minio-go/v7"
+
+	"github.com/kubeshop/testkube/cmd/tcl/testworkflow-toolkit/env"
+	"github.com/kubeshop/testkube/pkg/storage/minio"
+	"github.com/kubeshop/testkube/pkg/ui"
+)
+
+type PutObjectOptionsEnhancer = func(options *minio2.PutObjectOptions, path string, size int64)
+
+func NewDirectUploader(opts ...DirectUploaderOpt) Uploader {
+	uploader := &directUploader{
+		parallelism: 1,
+		options:     make([]PutObjectOptionsEnhancer, 0),
+	}
+	for _, opt := range opts {
+		opt(uploader)
+	}
+	return uploader
+}
+
+type directUploader struct {
+	client      *minio.Client
+	wg          sync.WaitGroup
+	sema        chan struct{}
+	parallelism int
+	error       atomic.Bool
+	options     []PutObjectOptionsEnhancer
+}
+
+func (d *directUploader) Start() (err error) {
+	d.client, err = env.ObjectStorageClient()
+	d.sema = make(chan struct{}, d.parallelism)
+	return err
+}
+
+func (d *directUploader) buildOptions(path string, size int64) (options minio2.PutObjectOptions) {
+	for _, enhance := range d.options {
+		enhance(&options, path, size)
+	}
+	if options.ContentType == "" {
+		options.ContentType = "application/octet-stream"
+	}
+	return options
+}
+
+func (d *directUploader) upload(path string, file io.ReadCloser, size int64) {
+	ns := env.ExecutionId()
+	opts := d.buildOptions(path, size)
+	err := d.client.SaveFileDirect(context.Background(), ns, path, file, size, opts)
+
+	if err != nil {
+		d.error.Store(true)
+		ui.Errf("%s: failed: %s", path, err.Error())
+		return
+	}
+}
+
+func (d *directUploader) Add(path string, file io.ReadCloser, size int64) error {
+	d.wg.Add(1)
+	d.sema <- struct{}{}
+	go func() {
+		d.upload(path, file, size)
+		_ = file.Close()
+		d.wg.Done()
+		<-d.sema
+	}()
+	return nil
+}
+
+func (d *directUploader) End() error {
+	d.wg.Wait()
+	if d.error.Load() {
+		return fmt.Errorf("upload failed")
+	}
+	return nil
+}
+
+type DirectUploaderOpt = func(uploader *directUploader)
+
+func WithParallelism(parallelism int) DirectUploaderOpt {
+	return func(uploader *directUploader) {
+		if parallelism < 1 {
+			parallelism = 1
+		}
+		uploader.parallelism = parallelism
+	}
+}
+
+func WithMinioOptionsEnhancer(fn PutObjectOptionsEnhancer) DirectUploaderOpt {
+	return func(uploader *directUploader) {
+		uploader.options = append(uploader.options, fn)
+	}
+}

--- a/cmd/tcl/testworkflow-toolkit/artifacts/handler.go
+++ b/cmd/tcl/testworkflow-toolkit/artifacts/handler.go
@@ -1,0 +1,92 @@
+// Copyright 2024 Testkube.
+//
+// Licensed as a Testkube Pro file under the Testkube Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+//	https://github.com/kubeshop/testkube/blob/main/licenses/TCL.txt
+
+package artifacts
+
+import (
+	"fmt"
+	"io/fs"
+	"sync/atomic"
+
+	"github.com/dustin/go-humanize"
+
+	"github.com/kubeshop/testkube/pkg/ui"
+)
+
+type handler struct {
+	uploader  Uploader
+	processor Processor
+
+	success   atomic.Uint32
+	errors    atomic.Uint32
+	totalSize atomic.Uint64
+}
+
+type Handler interface {
+	Start() error
+	Add(path string, file fs.File, stat fs.FileInfo) error
+	End() error
+}
+
+func NewHandler(uploader Uploader, processor Processor) Handler {
+	return &handler{
+		uploader:  uploader,
+		processor: processor,
+	}
+}
+
+func (h *handler) Start() (err error) {
+	err = h.processor.Start()
+	if err != nil {
+		return err
+	}
+	return h.uploader.Start()
+}
+
+func (h *handler) Add(path string, file fs.File, stat fs.FileInfo) (err error) {
+	size := uint64(stat.Size())
+	h.totalSize.Add(size)
+
+	fmt.Printf(ui.LightGray("%s (%s)\n"), path, humanize.Bytes(uint64(stat.Size())))
+
+	err = h.processor.Add(h.uploader, path, file, stat)
+	if err == nil {
+		h.success.Add(1)
+	} else {
+		h.errors.Add(1)
+		fmt.Printf(ui.Red("%s: failed: %s"), path, err.Error())
+	}
+	return err
+}
+
+func (h *handler) End() (err error) {
+	fmt.Printf("\n")
+
+	err = h.processor.End()
+	if err != nil {
+		go h.uploader.End()
+		return err
+	}
+	err = h.uploader.End()
+	if err != nil {
+		return err
+	}
+
+	errs := h.errors.Load()
+	success := h.success.Load()
+	totalSize := h.totalSize.Load()
+	if errs == 0 && success == 0 {
+		fmt.Printf("No artifacts found.\n")
+	} else {
+		fmt.Printf("Found and uploaded %s files (%s).\n", ui.LightCyan(success), ui.LightCyan(humanize.Bytes(totalSize)))
+	}
+	if errs > 0 {
+		return fmt.Errorf("  %d problems while uploading files", errs)
+	}
+	return nil
+}

--- a/cmd/tcl/testworkflow-toolkit/artifacts/mimetype.go
+++ b/cmd/tcl/testworkflow-toolkit/artifacts/mimetype.go
@@ -1,0 +1,29 @@
+// Copyright 2024 Testkube.
+//
+// Licensed as a Testkube Pro file under the Testkube Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+//	https://github.com/kubeshop/testkube/blob/main/licenses/TCL.txt
+
+package artifacts
+
+import (
+	"path/filepath"
+
+	"github.com/h2non/filetype"
+)
+
+func DetectMimetype(filePath string) string {
+	ext := filepath.Ext(filePath)
+
+	// Remove the dot from the file extension
+	if len(ext) > 0 && ext[0] == '.' {
+		ext = ext[1:]
+	}
+	t := filetype.GetType(ext)
+	if t == filetype.Unknown {
+		return ""
+	}
+	return t.MIME.Value
+}

--- a/cmd/tcl/testworkflow-toolkit/artifacts/processor.go
+++ b/cmd/tcl/testworkflow-toolkit/artifacts/processor.go
@@ -1,0 +1,17 @@
+// Copyright 2024 Testkube.
+//
+// Licensed as a Testkube Pro file under the Testkube Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+//	https://github.com/kubeshop/testkube/blob/main/licenses/TCL.txt
+
+package artifacts
+
+import "io/fs"
+
+type Processor interface {
+	Start() error
+	Add(uploader Uploader, path string, file fs.File, stat fs.FileInfo) error
+	End() error
+}

--- a/cmd/tcl/testworkflow-toolkit/artifacts/tar_processor.go
+++ b/cmd/tcl/testworkflow-toolkit/artifacts/tar_processor.go
@@ -1,0 +1,78 @@
+// Copyright 2024 Testkube.
+//
+// Licensed as a Testkube Pro file under the Testkube Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+//	https://github.com/kubeshop/testkube/blob/main/licenses/TCL.txt
+
+package artifacts
+
+import (
+	"fmt"
+	"io/fs"
+	"sync"
+
+	"github.com/kubeshop/testkube/pkg/ui"
+)
+
+func NewTarProcessor(name string) Processor {
+	return &tarProcessor{
+		name: name,
+	}
+}
+
+type tarProcessor struct {
+	name  string
+	mu    *sync.Mutex
+	errCh chan error
+	ts    *tarStream
+}
+
+func (d *tarProcessor) Start() (err error) {
+	d.errCh = make(chan error)
+	d.mu = &sync.Mutex{}
+
+	return err
+}
+
+func (d *tarProcessor) init(uploader Uploader) {
+	if d.ts != nil {
+		return
+	}
+	d.ts = NewTarStream()
+
+	// Start uploading the file
+	go func() {
+		err := uploader.Add(d.name, d.ts, -1)
+		if err != nil {
+			_ = d.ts.Close()
+		}
+		d.errCh <- err
+	}()
+}
+
+func (d *tarProcessor) upload(path string, file fs.File, stat fs.FileInfo) error {
+	defer file.Close()
+	return d.ts.Add(path, file, stat)
+}
+
+func (d *tarProcessor) Add(uploader Uploader, path string, file fs.File, stat fs.FileInfo) error {
+	d.mu.Lock()
+	d.init(uploader)
+	defer d.mu.Unlock()
+	return d.upload(path, file, stat)
+}
+
+func (d *tarProcessor) End() (err error) {
+	if d.ts != nil {
+		<-d.ts.Done()
+	}
+	err = d.ts.Close()
+	if err != nil {
+		return fmt.Errorf("problem closing writer: %w", err)
+	}
+
+	fmt.Printf("Archived everything in %s archive.\n", ui.LightCyan(d.name))
+	return <-d.errCh
+}

--- a/cmd/tcl/testworkflow-toolkit/artifacts/tar_stream.go
+++ b/cmd/tcl/testworkflow-toolkit/artifacts/tar_stream.go
@@ -1,0 +1,93 @@
+// Copyright 2024 Testkube.
+//
+// Licensed as a Testkube Pro file under the Testkube Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+//	https://github.com/kubeshop/testkube/blob/main/licenses/TCL.txt
+
+package artifacts
+
+import (
+	"archive/tar"
+	"compress/gzip"
+	"fmt"
+	"io"
+	"io/fs"
+	"sync"
+)
+
+type tarStream struct {
+	r  io.ReadCloser
+	w  io.WriteCloser
+	g  io.WriteCloser
+	t  *tar.Writer
+	mu *sync.Mutex
+	wg sync.WaitGroup
+}
+
+func NewTarStream() *tarStream {
+	r, w := io.Pipe()
+	g := gzip.NewWriter(w)
+	t := tar.NewWriter(g)
+	return &tarStream{
+		r:  r,
+		w:  w,
+		g:  g,
+		t:  t,
+		mu: &sync.Mutex{},
+	}
+}
+
+func (t *tarStream) Add(path string, file fs.File, stat fs.FileInfo) error {
+	t.wg.Add(1)
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	defer t.wg.Done()
+
+	// Write file header
+	name := stat.Name()
+	header, err := tar.FileInfoHeader(stat, name)
+	if err != nil {
+		return err
+	}
+	header.Name = path
+	err = t.t.WriteHeader(header)
+	if err != nil {
+		return err
+	}
+	_, err = io.Copy(t.t, file)
+	return err
+}
+
+func (t *tarStream) Read(p []byte) (n int, err error) {
+	return t.r.Read(p)
+}
+
+func (t *tarStream) Done() chan struct{} {
+	ch := make(chan struct{})
+	go func() {
+		t.wg.Wait()
+		close(ch)
+	}()
+	return ch
+}
+
+func (t *tarStream) Close() (err error) {
+	err = t.t.Close()
+	if err != nil {
+		_ = t.g.Close()
+		_ = t.w.Close()
+		return fmt.Errorf("closing tar: tar: %v", err)
+	}
+	err = t.g.Close()
+	if err != nil {
+		_ = t.w.Close()
+		return fmt.Errorf("closing tar: gzip: %v", err)
+	}
+	err = t.w.Close()
+	if err != nil {
+		return fmt.Errorf("closing tar: pipe: %v", err)
+	}
+	return nil
+}

--- a/cmd/tcl/testworkflow-toolkit/artifacts/tarcached_processor.go
+++ b/cmd/tcl/testworkflow-toolkit/artifacts/tarcached_processor.go
@@ -1,0 +1,111 @@
+// Copyright 2024 Testkube.
+//
+// Licensed as a Testkube Pro file under the Testkube Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+//	https://github.com/kubeshop/testkube/blob/main/licenses/TCL.txt
+
+package artifacts
+
+import (
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"sync"
+
+	"github.com/dustin/go-humanize"
+
+	"github.com/kubeshop/testkube/pkg/tmp"
+	"github.com/kubeshop/testkube/pkg/ui"
+)
+
+func NewTarCachedProcessor(name string, cachePath string) Processor {
+	if cachePath == "" {
+		cachePath = tmp.Name()
+	}
+	return &tarCachedProcessor{
+		name:      name,
+		cachePath: cachePath,
+	}
+}
+
+type tarCachedProcessor struct {
+	uploader  Uploader
+	name      string
+	cachePath string
+	mu        *sync.Mutex
+	errCh     chan error
+	file      *os.File
+	ts        *tarStream
+}
+
+func (d *tarCachedProcessor) Start() (err error) {
+	d.errCh = make(chan error)
+	d.mu = &sync.Mutex{}
+	d.file, err = os.Create(d.cachePath)
+
+	return err
+}
+
+func (d *tarCachedProcessor) init(uploader Uploader) {
+	if d.ts != nil {
+		return
+	}
+	d.ts = NewTarStream()
+	d.uploader = uploader
+	go func() {
+		_, err := io.Copy(d.file, d.ts)
+		d.errCh <- err
+	}()
+}
+
+func (d *tarCachedProcessor) clean() {
+	_ = os.Remove(d.cachePath)
+}
+
+func (d *tarCachedProcessor) upload(path string, file fs.File, stat fs.FileInfo) error {
+	defer file.Close()
+	return d.ts.Add(path, file, stat)
+}
+
+func (d *tarCachedProcessor) Add(uploader Uploader, path string, file fs.File, stat fs.FileInfo) error {
+	d.mu.Lock()
+	d.init(uploader)
+	defer d.mu.Unlock()
+	return d.upload(path, file, stat)
+}
+
+func (d *tarCachedProcessor) End() (err error) {
+	defer d.clean()
+
+	if d.ts != nil {
+		<-d.ts.Done()
+	}
+	err = d.ts.Close()
+	if err != nil {
+		return fmt.Errorf("problem closing writer: %w", err)
+	}
+	err = <-d.errCh
+	if err != nil {
+		return fmt.Errorf("problem writing to disk cache: %w", err)
+	}
+
+	if d.uploader == nil {
+		return nil
+	}
+
+	file, err := os.Open(d.cachePath)
+	if err != nil {
+		return fmt.Errorf("problem reading disk cache: %w", err)
+	}
+
+	stat, err := file.Stat()
+	if err != nil {
+		return fmt.Errorf("problem reading disk cache: stat: %w", err)
+	}
+
+	fmt.Printf("Archived everything in %s archive (%s).\n", ui.LightCyan(d.name), ui.LightCyan(humanize.Bytes(uint64(stat.Size()))))
+	return d.uploader.Add(d.name, file, stat.Size())
+}

--- a/cmd/tcl/testworkflow-toolkit/artifacts/uploader.go
+++ b/cmd/tcl/testworkflow-toolkit/artifacts/uploader.go
@@ -1,0 +1,19 @@
+// Copyright 2024 Testkube.
+//
+// Licensed as a Testkube Pro file under the Testkube Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+//	https://github.com/kubeshop/testkube/blob/main/licenses/TCL.txt
+
+package artifacts
+
+import (
+	"io"
+)
+
+type Uploader interface {
+	Start() error
+	Add(path string, file io.ReadCloser, size int64) error
+	End() error
+}

--- a/cmd/tcl/testworkflow-toolkit/artifacts/walker.go
+++ b/cmd/tcl/testworkflow-toolkit/artifacts/walker.go
@@ -1,0 +1,221 @@
+// Copyright 2024 Testkube.
+//
+// Licensed as a Testkube Pro file under the Testkube Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+//	https://github.com/kubeshop/testkube/blob/main/licenses/TCL.txt
+
+package artifacts
+
+import (
+	"fmt"
+	"io/fs"
+	"path/filepath"
+	"strings"
+
+	"github.com/bmatcuk/doublestar/v4"
+)
+
+func mapSlice[T any, U any](s []T, fn func(T) U) []U {
+	result := make([]U, len(s))
+	for i := range s {
+		result[i] = fn(s[i])
+	}
+	return result
+}
+
+func deduplicateRoots(paths []string) []string {
+	result := make([]string, 0)
+loop:
+	for _, path := range paths {
+		for _, path2 := range paths {
+			if strings.HasPrefix(path, path2+"/") {
+				continue loop
+			}
+		}
+		result = append(result, path)
+	}
+	return result
+}
+
+func findSearchRoot(pattern string) string {
+	path, _ := doublestar.SplitPattern(pattern + "/")
+	return strings.TrimRight(path, "/")
+}
+
+// TODO: Support wildcards better:
+//   - /**/*.json is a part of /data
+//   - /data/s*me/*a*/abc.json is a part of /data/some/path/
+func isPatternIn(pattern string, dirs []string) bool {
+	return isPathIn(findSearchRoot(pattern), dirs)
+}
+
+func isPathIn(path string, dirs []string) bool {
+	for _, dir := range dirs {
+		path = strings.TrimRight(path, "/")
+		if dir == path || strings.HasPrefix(path, dir+"/") {
+			return true
+		}
+	}
+	return false
+}
+
+func sanitizePath(path string) (string, error) {
+	path, err := filepath.Abs(path)
+	path = strings.TrimRight(filepath.ToSlash(path), "/")
+	if path == "" {
+		path = "/"
+	}
+	return path, err
+}
+
+func sanitizePaths(input []string) ([]string, error) {
+	paths := make([]string, len(input))
+	for i := range input {
+		var err error
+		paths[i], err = sanitizePath(input[i])
+		if err != nil {
+			return nil, fmt.Errorf("error while resolving path: %s: %w", input[i], err)
+		}
+	}
+	return paths, nil
+}
+
+func filterPatterns(patterns, dirs []string) []string {
+	result := make([]string, 0)
+	for _, p := range patterns {
+		if isPatternIn(p, dirs) {
+			result = append(result, p)
+		}
+	}
+	return result
+}
+
+func detectCommonPath(path1, path2 string) string {
+	if path1 == path2 {
+		return path1
+	}
+	common := 0
+	parts1 := strings.Split(path1, "/")
+	parts2 := strings.Split(path2, "/")
+	for i := 0; i < len(parts1) && i < len(parts2); i++ {
+		if parts1[i] != parts2[i] {
+			break
+		}
+		common++
+	}
+	if common == 1 && parts1[0] == "" {
+		return "/"
+	}
+	return strings.Join(parts1[0:common], "/")
+}
+
+func detectRoot(potential string, paths []string) string {
+	potential = strings.TrimRight(potential, "/")
+	if potential == "" {
+		potential = "/"
+	}
+	for _, path := range paths {
+		potential = detectCommonPath(potential, path)
+	}
+	return potential
+}
+
+func CreateWalker(patterns, roots []string, root string) (Walker, error) {
+	var err error
+
+	// Build absolute paths
+	if patterns, err = sanitizePaths(patterns); err != nil {
+		return nil, err
+	}
+	if roots, err = sanitizePaths(roots); err != nil {
+		return nil, err
+	}
+	if root, err = sanitizePath(root); err != nil {
+		return nil, err
+	}
+	// Include only if it is matching some mounted volumes
+	patterns = filterPatterns(patterns, roots)
+	// Detect top-level paths for searching
+	searchPaths := deduplicateRoots(mapSlice(patterns, findSearchRoot))
+	// Detect root path for the bucket
+	root = detectRoot(root, searchPaths)
+
+	return &walker{
+		root:        root,
+		searchPaths: searchPaths,
+		patterns:    patterns,
+	}, nil
+}
+
+type walker struct {
+	root        string
+	searchPaths []string
+	patterns    []string // TODO: Optimize to check only patterns matching specific searchPaths
+}
+
+type WalkerFn = func(path string, file fs.File, err error) error
+
+type Walker interface {
+	Root() string
+	SearchPaths() []string
+	Patterns() []string
+	Walk(fsys fs.FS, walker WalkerFn) error
+}
+
+func (w *walker) Root() string {
+	return w.root
+}
+
+func (w *walker) SearchPaths() []string {
+	return w.searchPaths
+}
+
+func (w *walker) Patterns() []string {
+	return w.patterns
+}
+
+func (w *walker) matches(filePath string) bool {
+	for _, p := range w.patterns {
+		v, _ := doublestar.PathMatch(p, filePath)
+		if v {
+			return true
+		}
+	}
+	return false
+}
+
+func (w *walker) walk(fsys fs.FS, path string, walker WalkerFn) error {
+	sanitizedPath := strings.TrimLeft(path, "/")
+	if sanitizedPath == "" {
+		sanitizedPath = "."
+	}
+
+	return fs.WalkDir(fsys, sanitizedPath, func(filePath string, d fs.DirEntry, err error) error {
+		resolvedPath := "/" + filepath.ToSlash(filePath)
+		if !w.matches(resolvedPath) {
+			return nil
+		}
+		if err != nil {
+			fmt.Printf("Warning: '%s' ignored from scraping: %v\n", resolvedPath, err)
+			return nil
+		}
+		if d.IsDir() {
+			return nil
+		}
+
+		file, err := fsys.Open(filePath)
+		return walker(strings.TrimLeft(resolvedPath[len(w.root):], "/"), file, err)
+	})
+}
+
+func (w *walker) Walk(fsys fs.FS, walker WalkerFn) (err error) {
+	for _, s := range w.searchPaths {
+		err = w.walk(fsys, s, walker)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/cmd/tcl/testworkflow-toolkit/commands/artifacts.go
+++ b/cmd/tcl/testworkflow-toolkit/commands/artifacts.go
@@ -1,0 +1,177 @@
+// Copyright 2024 Testkube.
+//
+// Licensed as a Testkube Pro file under the Testkube Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+//	https://github.com/kubeshop/testkube/blob/main/licenses/TCL.txt
+
+package commands
+
+import (
+	"fmt"
+	"io/fs"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/minio/minio-go/v7"
+	"github.com/spf13/cobra"
+
+	"github.com/kubeshop/testkube/cmd/tcl/testworkflow-toolkit/artifacts"
+	"github.com/kubeshop/testkube/cmd/tcl/testworkflow-toolkit/env"
+	"github.com/kubeshop/testkube/pkg/ui"
+)
+
+var directAddGzipEncoding = artifacts.WithMinioOptionsEnhancer(func(options *minio.PutObjectOptions, path string, size int64) {
+	options.ContentType = "application/gzip"
+	options.ContentEncoding = "gzip"
+})
+
+var directDisableMultipart = artifacts.WithMinioOptionsEnhancer(func(options *minio.PutObjectOptions, path string, size int64) {
+	options.DisableMultipart = true
+})
+
+var directDetectMimetype = artifacts.WithMinioOptionsEnhancer(func(options *minio.PutObjectOptions, path string, size int64) {
+	if options.ContentType == "" {
+		options.ContentType = artifacts.DetectMimetype(path)
+	}
+})
+
+var directUnpack = artifacts.WithMinioOptionsEnhancer(func(options *minio.PutObjectOptions, path string, size int64) {
+	options.UserMetadata = map[string]string{
+		"X-Amz-Meta-Snowball-Auto-Extract": "true",
+		"X-Amz-Meta-Minio-Snowball-Prefix": env.WorkflowName() + "/" + env.ExecutionId(),
+	}
+})
+
+var cloudAddGzipEncoding = artifacts.WithRequestEnhancerCloud(func(req *http.Request, path string, size int64) {
+	req.Header.Set("Content-Type", "application/gzip")
+	req.Header.Set("Content-Encoding", "gzip")
+})
+
+var cloudUnpack = artifacts.WithRequestEnhancerCloud(func(req *http.Request, path string, size int64) {
+	req.Header.Set("X-Amz-Meta-Snowball-Auto-Extract", "true")
+})
+
+var cloudDetectMimetype = artifacts.WithRequestEnhancerCloud(func(req *http.Request, path string, size int64) {
+	if req.Header.Get("Content-Type") == "" {
+		contentType := artifacts.DetectMimetype(path)
+		if contentType != "" {
+			req.Header.Set("Content-Type", contentType)
+		}
+		if contentType == "application/gzip" && req.Header.Get("Content-Encoding") == "" {
+			req.Header.Set("Content-Encoding", "gzip")
+		}
+	}
+})
+
+func NewArtifactsCmd() *cobra.Command {
+	var (
+		mounts            []string
+		id                string
+		compress          string
+		compressCachePath string
+		unpack            bool
+	)
+
+	cmd := &cobra.Command{
+		Use:   "artifacts <paths...>",
+		Short: "Save workflow artifacts",
+		Args:  cobra.MinimumNArgs(1),
+
+		Run: func(cmd *cobra.Command, paths []string) {
+			root, _ := os.Getwd()
+			walker, err := artifacts.CreateWalker(paths, mounts, root)
+			ui.ExitOnError("building a walker", err)
+
+			if len(walker.Patterns()) == 0 || len(walker.SearchPaths()) == 0 {
+				ui.Failf("error: did not found any valid path pattern in the mounted directories")
+			}
+
+			fmt.Printf("Root: %s\nPatterns:\n", ui.LightCyan(walker.Root()))
+			for _, p := range walker.Patterns() {
+				fmt.Printf("- %s\n", ui.LightMagenta(p))
+			}
+			fmt.Printf("\n")
+
+			// Configure uploader
+			var processor artifacts.Processor
+			var uploader artifacts.Uploader
+
+			// Sanitize archive name
+			compress = strings.Trim(filepath.ToSlash(filepath.Clean(compress)), "/.")
+			if compress != "" {
+				compressLower := strings.ToLower(compress)
+				if strings.HasSuffix(compressLower, ".tar") {
+					compress += ".gz"
+				} else if !strings.HasSuffix(compressLower, ".tgz") && !strings.HasSuffix(compressLower, ".tar.gz") {
+					compress += ".tar.gz"
+				}
+			}
+
+			// Archive
+			if env.CloudEnabled() {
+				if compress != "" {
+					processor = artifacts.NewTarCachedProcessor(compress, compressCachePath)
+					opts := []artifacts.CloudUploaderOpt{cloudAddGzipEncoding}
+					if unpack {
+						opts = append(opts, cloudUnpack)
+					}
+					uploader = artifacts.NewCloudUploader(opts...)
+				} else {
+					processor = artifacts.NewDirectProcessor()
+					uploader = artifacts.NewCloudUploader(artifacts.WithParallelismCloud(30), cloudDetectMimetype)
+				}
+			} else if compress != "" && unpack {
+				processor = artifacts.NewTarCachedProcessor(compress, compressCachePath)
+				uploader = artifacts.NewDirectUploader(directAddGzipEncoding, directDisableMultipart, directUnpack)
+			} else if compress != "" && compressCachePath != "" {
+				processor = artifacts.NewTarCachedProcessor(compress, compressCachePath)
+				uploader = artifacts.NewDirectUploader(directAddGzipEncoding, directDisableMultipart)
+			} else if compress != "" {
+				processor = artifacts.NewTarProcessor(compress)
+				uploader = artifacts.NewDirectUploader(directAddGzipEncoding)
+			} else {
+				processor = artifacts.NewDirectProcessor()
+				uploader = artifacts.NewDirectUploader(artifacts.WithParallelism(30), directDetectMimetype)
+			}
+
+			handler := artifacts.NewHandler(uploader, processor)
+
+			err = handler.Start()
+			ui.ExitOnError("initializing uploader", err)
+
+			started := time.Now()
+			err = walker.Walk(os.DirFS("/"), func(path string, file fs.File, err error) error {
+				if err != nil {
+					fmt.Printf("Warning: '%s' has been ignored, as there was a problem reading it: %s\n", path, err.Error())
+					return nil
+				}
+
+				stat, err := file.Stat()
+				if err != nil {
+					fmt.Printf("Warning: '%s' has been ignored, as there was a problem reading it: %s\n", path, err.Error())
+					return nil
+				}
+				return handler.Add(path, file, stat)
+			})
+			ui.ExitOnError("reading the file system", err)
+			err = handler.End()
+
+			// TODO: Emit information about artifacts
+			ui.ExitOnError("finishing upload", err)
+			fmt.Printf("Took %s.\n", time.Now().Sub(started).Truncate(time.Millisecond))
+		},
+	}
+
+	cmd.Flags().StringSliceVarP(&mounts, "mount", "m", nil, "mounted volumes for limiting paths")
+	cmd.Flags().StringVar(&id, "id", "", "execution ID")
+	cmd.Flags().StringVar(&compress, "compress", "", "tgz name if should be compressed")
+	cmd.Flags().BoolVar(&unpack, "unpack", false, "minio only: unpack the file if compressed")
+	cmd.Flags().StringVar(&compressCachePath, "compress-cache", "", "local cache path for passing compressed archive through")
+
+	return cmd
+}

--- a/cmd/tcl/testworkflow-toolkit/commands/clone.go
+++ b/cmd/tcl/testworkflow-toolkit/commands/clone.go
@@ -1,0 +1,103 @@
+// Copyright 2024 Testkube.
+//
+// Licensed as a Testkube Pro file under the Testkube Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+//	https://github.com/kubeshop/testkube/blob/main/licenses/TCL.txt
+
+package commands
+
+import (
+	"fmt"
+	"net/url"
+	"os"
+	"path/filepath"
+
+	"github.com/spf13/cobra"
+
+	"github.com/kubeshop/testkube/pkg/ui"
+)
+
+func NewCloneCmd() *cobra.Command {
+	var (
+		paths    []string
+		username string
+		token    string
+		authType string
+		revision string
+	)
+
+	cmd := &cobra.Command{
+		Use:   "clone <uri> <outputPath>",
+		Short: "Clone the Git repository",
+		Args:  cobra.ExactArgs(2),
+
+		Run: func(cmd *cobra.Command, args []string) {
+			uri, err := url.Parse(args[0])
+			ui.ExitOnError("repository uri", err)
+			outputPath, err := filepath.Abs(args[1])
+			ui.ExitOnError("output path", err)
+
+			// Disable interactivity
+			os.Setenv("GIT_TERMINAL_PROMPT", "0")
+
+			authArgs := make([]string, 0)
+
+			if authType == "header" {
+				ui.Debug("auth type: header")
+				if token != "" {
+					authArgs = append(authArgs, "-c", fmt.Sprintf("http.extraHeader='%s'", "Authorization: Bearer "+token))
+				}
+				if username != "" {
+					uri.User = url.User(username)
+				}
+			} else {
+				ui.Debug("auth type: token")
+				if username != "" && token != "" {
+					uri.User = url.UserPassword(username, token)
+				} else if username != "" {
+					uri.User = url.User(username)
+				} else if token != "" {
+					uri.User = url.User(token)
+				}
+			}
+
+			// Mark directory as safe
+			configArgs := []string{"-c", fmt.Sprintf("safe.directory=%s", outputPath), "-c", "advice.detachedHead=false"}
+
+			// Clone repository
+			if len(paths) == 0 {
+				ui.Debug("full checkout")
+				err = Run("git", "clone", configArgs, authArgs, "--depth", 1, "--verbose", uri.String(), outputPath)
+				ui.ExitOnError("cloning repository", err)
+			} else {
+				ui.Debug("sparse checkout")
+				err = Run("git", "clone", configArgs, authArgs, "--filter=blob:none", "--no-checkout", "--sparse", "--depth", 1, "--verbose", uri.String(), outputPath)
+				ui.ExitOnError("cloning repository", err)
+				err = Run("git", "-C", outputPath, configArgs, "sparse-checkout", "set", "--no-cone", paths)
+				ui.ExitOnError("sparse checkout repository", err)
+				if revision != "" {
+					err = Run("git", "-C", outputPath, configArgs, "fetch", authArgs, "--depth", 1, "origin", revision)
+					ui.ExitOnError("fetching revision", err)
+					err = Run("git", "-C", outputPath, configArgs, "checkout", "FETCH_HEAD")
+					ui.ExitOnError("checking out head", err)
+					// TODO: Don't do it for commits
+					err = Run("git", "-C", outputPath, configArgs, "checkout", "-B", revision)
+					ui.ExitOnError("checking out the branch", err)
+				} else {
+					err = Run("git", "-C", outputPath, configArgs, "checkout")
+					ui.ExitOnError("fetching head", err)
+				}
+			}
+		},
+	}
+
+	cmd.Flags().StringSliceVarP(&paths, "paths", "p", nil, "paths for sparse checkout")
+	cmd.Flags().StringVarP(&username, "username", "u", "", "")
+	cmd.Flags().StringVarP(&token, "token", "t", "", "")
+	cmd.Flags().StringVarP(&authType, "authType", "a", "basic", "allowed: basic, header")
+	cmd.Flags().StringVarP(&revision, "revision", "r", "", "commit hash, branch name or tag")
+
+	return cmd
+}

--- a/cmd/tcl/testworkflow-toolkit/commands/execute.go
+++ b/cmd/tcl/testworkflow-toolkit/commands/execute.go
@@ -1,0 +1,275 @@
+// Copyright 2024 Testkube.
+//
+// Licensed as a Testkube Pro file under the Testkube Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+//	https://github.com/kubeshop/testkube/blob/main/licenses/TCL.txt
+
+package commands
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+
+	"github.com/kubeshop/testkube/cmd/tcl/testworkflow-init/data"
+	"github.com/kubeshop/testkube/cmd/tcl/testworkflow-toolkit/env"
+	"github.com/kubeshop/testkube/pkg/api/v1/client"
+	"github.com/kubeshop/testkube/pkg/api/v1/testkube"
+	"github.com/kubeshop/testkube/pkg/tcl/testworkflowstcl/testworkflowprocessor"
+	"github.com/kubeshop/testkube/pkg/ui"
+)
+
+type testExecutionDetails struct {
+	Id       string `json:"id"`
+	Name     string `json:"name"`
+	TestName string `json:"testName"`
+}
+
+type testWorkflowExecutionDetails struct {
+	Id               string `json:"id"`
+	Name             string `json:"name"`
+	TestWorkflowName string `json:"testWorkflowName"`
+}
+
+type executionResult struct {
+	Id     string `json:"id"`
+	Status string `json:"status"`
+}
+
+func buildTestExecution(test string) (func() error, error) {
+	name, req, _ := strings.Cut(test, "=")
+	request := testkube.ExecutionRequest{}
+	if req != "" {
+		err := json.Unmarshal([]byte(req), &request)
+		if err != nil {
+			return nil, errors.Wrap(err, fmt.Sprintf("failed to unmarshal execution request: %s: %s", name, req))
+		}
+	}
+	if request.ExecutionLabels == nil {
+		request.ExecutionLabels = map[string]string{}
+	}
+	request.ExecutionLabels[testworkflowprocessor.ExecutionIdLabelName] = env.ExecutionId()
+
+	return func() (err error) {
+		c := env.Testkube()
+
+		exec, err := c.ExecuteTest(name, request.Name, client.ExecuteTestOptions{
+			IsVariablesFileUploaded:            request.IsVariablesFileUploaded,
+			ExecutionLabels:                    request.ExecutionLabels,
+			Command:                            request.Command,
+			Args:                               request.Args,
+			ArgsMode:                           request.ArgsMode,
+			Envs:                               request.Envs,
+			SecretEnvs:                         request.SecretEnvs,
+			HTTPProxy:                          request.HttpProxy,
+			HTTPSProxy:                         request.HttpsProxy,
+			Image:                              request.Image,
+			Uploads:                            request.Uploads,
+			BucketName:                         request.BucketName,
+			ArtifactRequest:                    request.ArtifactRequest,
+			JobTemplate:                        request.JobTemplate,
+			JobTemplateReference:               request.JobTemplateReference,
+			ContentRequest:                     request.ContentRequest,
+			PreRunScriptContent:                request.PreRunScript,
+			PostRunScriptContent:               request.PostRunScript,
+			ExecutePostRunScriptBeforeScraping: request.ExecutePostRunScriptBeforeScraping,
+			SourceScripts:                      request.SourceScripts,
+			ScraperTemplate:                    request.ScraperTemplate,
+			ScraperTemplateReference:           request.ScraperTemplateReference,
+			PvcTemplate:                        request.PvcTemplate,
+			PvcTemplateReference:               request.PvcTemplateReference,
+			NegativeTest:                       request.NegativeTest,
+			IsNegativeTestChangedOnRun:         request.IsNegativeTestChangedOnRun,
+			EnvConfigMaps:                      request.EnvConfigMaps,
+			EnvSecrets:                         request.EnvSecrets,
+			RunningContext:                     request.RunningContext,
+			SlavePodRequest:                    request.SlavePodRequest,
+			ExecutionNamespace:                 request.ExecutionNamespace,
+		})
+		execName := exec.Name
+		if err != nil {
+			ui.Errf("failed to execute test: %s: %s", name, err)
+			return
+		}
+
+		data.PrintOutput(env.Ref(), "test-start", &testExecutionDetails{
+			Id:       exec.Id,
+			Name:     exec.Name,
+			TestName: exec.TestName,
+		})
+		fmt.Printf("%s • scheduled %s\n", ui.LightCyan(execName), ui.DarkGray("("+exec.Id+")"))
+
+	loop:
+		for {
+			time.Sleep(time.Second)
+			exec, err = c.GetExecution(exec.Id)
+			if err != nil {
+				ui.Errf("error while getting execution result: %s: %s", ui.LightCyan(execName), err.Error())
+				return
+			}
+			if exec.ExecutionResult != nil && exec.ExecutionResult.Status != nil {
+				status := *exec.ExecutionResult.Status
+				switch status {
+				case testkube.QUEUED_ExecutionStatus, testkube.RUNNING_ExecutionStatus:
+					continue
+				default:
+					break loop
+				}
+			}
+		}
+
+		status := *exec.ExecutionResult.Status
+		color := ui.Green
+
+		if status != testkube.PASSED_ExecutionStatus {
+			err = errors.New("test failed")
+			color = ui.Red
+		}
+
+		data.PrintOutput(env.Ref(), "test-end", &executionResult{Id: exec.Id, Status: string(status)})
+		fmt.Printf("%s • %s\n", color(execName), string(status))
+		return
+	}, nil
+}
+
+func buildWorkflowExecution(workflow string) (func() error, error) {
+	name, req, _ := strings.Cut(workflow, "=")
+	request := testkube.TestWorkflowExecutionRequest{}
+	if req != "" {
+		err := json.Unmarshal([]byte(req), &request)
+		if err != nil {
+			return nil, errors.Wrap(err, fmt.Sprintf("failed to unmarshal execution request: %s: %s", name, req))
+		}
+	}
+
+	return func() (err error) {
+		c := env.Testkube()
+
+		exec, err := c.ExecuteTestWorkflow(name, request)
+		execName := exec.Name
+		if err != nil {
+			ui.Errf("failed to execute test workflow: %s: %s", name, err.Error())
+			return
+		}
+
+		data.PrintOutput(env.Ref(), "testworkflow-start", &testWorkflowExecutionDetails{
+			Id:               exec.Id,
+			Name:             exec.Name,
+			TestWorkflowName: exec.Workflow.Name,
+		})
+		fmt.Printf("%s • scheduled %s\n", ui.LightCyan(execName), ui.DarkGray("("+exec.Id+")"))
+
+	loop:
+		for {
+			time.Sleep(100 * time.Millisecond)
+			exec, err = c.GetTestWorkflowExecution(exec.Id)
+			if err != nil {
+				ui.Errf("error while getting execution result: %s: %s", ui.LightCyan(execName), err.Error())
+				return
+			}
+			if exec.Result != nil && exec.Result.Status != nil {
+				status := *exec.Result.Status
+				switch status {
+				case testkube.QUEUED_TestWorkflowStatus, testkube.RUNNING_TestWorkflowStatus:
+					continue
+				default:
+					break loop
+				}
+			}
+		}
+
+		status := *exec.Result.Status
+		color := ui.Green
+
+		if status != testkube.PASSED_TestWorkflowStatus {
+			err = errors.New("test workflow failed")
+			color = ui.Red
+		}
+
+		data.PrintOutput(env.Ref(), "testworkflow-end", &executionResult{Id: exec.Id, Status: string(status)})
+		fmt.Printf("%s • %s\n", color(execName), string(status))
+		return
+	}, nil
+}
+
+func NewExecuteCmd() *cobra.Command {
+	var (
+		tests       []string
+		workflows   []string
+		parallelism int
+	)
+
+	cmd := &cobra.Command{
+		Use:   "execute",
+		Short: "Execute other resources",
+		Args:  cobra.ExactArgs(0),
+
+		Run: func(cmd *cobra.Command, _ []string) {
+			// Calculate parallelism
+			if parallelism <= 0 {
+				parallelism = 20
+			}
+
+			// Build operations to run
+			operations := make([]func() error, 0)
+			for _, t := range tests {
+				fn, err := buildTestExecution(t)
+				if err != nil {
+					ui.Fail(err)
+				}
+				operations = append(operations, fn)
+			}
+			for _, w := range workflows {
+				fn, err := buildWorkflowExecution(w)
+				if err != nil {
+					ui.Fail(err)
+				}
+				operations = append(operations, fn)
+			}
+
+			// Validate if there is anything to run
+			if len(operations) == 0 {
+				fmt.Printf("nothing to run\n")
+				os.Exit(0)
+			}
+
+			// Create channel for execution
+			var wg sync.WaitGroup
+			wg.Add(len(operations))
+			ch := make(chan struct{}, parallelism)
+			success := true
+
+			// Execute all operations
+			for _, op := range operations {
+				ch <- struct{}{}
+				go func(op func() error) {
+					if op() != nil {
+						success = false
+					}
+					<-ch
+					wg.Done()
+				}(op)
+			}
+			wg.Wait()
+
+			if !success {
+				os.Exit(1)
+			}
+		},
+	}
+
+	// TODO: Support test suites too
+	cmd.Flags().StringArrayVarP(&tests, "test", "t", nil, "tests to run; either test name, or test-name=json-execution-request")
+	cmd.Flags().StringArrayVarP(&workflows, "workflow", "w", nil, "workflows to run; either workflow name, or workflow-name=json-execution-request")
+	cmd.Flags().IntVarP(&parallelism, "parallelism", "p", 0, "how many items could be executed at once")
+
+	return cmd
+}

--- a/cmd/tcl/testworkflow-toolkit/commands/root.go
+++ b/cmd/tcl/testworkflow-toolkit/commands/root.go
@@ -1,0 +1,69 @@
+// Copyright 2024 Testkube.
+//
+// Licensed as a Testkube Pro file under the Testkube Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+//	https://github.com/kubeshop/testkube/blob/main/licenses/TCL.txt
+
+package commands
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/signal"
+	"syscall"
+
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+
+	"github.com/kubeshop/testkube/cmd/tcl/testworkflow-toolkit/env"
+
+	"golang.org/x/sync/errgroup"
+)
+
+func init() {
+	RootCmd.AddCommand(NewExecuteCmd())
+}
+
+var RootCmd = &cobra.Command{
+	Use:   "testworkflow-toolkit",
+	Short: "Orchestrating Testkube workflows",
+	CompletionOptions: cobra.CompletionOptions{
+		DisableDefaultCmd:   true,
+		DisableNoDescFlag:   true,
+		DisableDescriptions: true,
+		HiddenDefaultCmd:    true,
+	},
+}
+
+func Execute() {
+	// Run services within an errgroup to propagate errors between services.
+	g, ctx := errgroup.WithContext(context.Background())
+
+	// Cancel the errgroup context on SIGINT and SIGTERM,
+	// which shuts everything down gracefully.
+	// Kill on recurring signal.
+	stopSignal := make(chan os.Signal, 1)
+	signal.Notify(stopSignal, syscall.SIGINT, syscall.SIGTERM)
+	g.Go(func() error {
+		select {
+		case <-ctx.Done():
+			return nil
+		case sig := <-stopSignal:
+			go func() {
+				<-stopSignal
+				os.Exit(137)
+			}()
+			return errors.Errorf("received signal: %v", sig)
+		}
+	})
+
+	RootCmd.PersistentFlags().BoolVar(&env.UseProxyValue, "proxy", false, "use Kubernetes proxy for TK access")
+
+	if err := RootCmd.ExecuteContext(ctx); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+}

--- a/cmd/tcl/testworkflow-toolkit/commands/root.go
+++ b/cmd/tcl/testworkflow-toolkit/commands/root.go
@@ -24,6 +24,7 @@ import (
 )
 
 func init() {
+	RootCmd.AddCommand(NewCloneCmd())
 	RootCmd.AddCommand(NewExecuteCmd())
 }
 

--- a/cmd/tcl/testworkflow-toolkit/commands/root.go
+++ b/cmd/tcl/testworkflow-toolkit/commands/root.go
@@ -26,6 +26,7 @@ import (
 func init() {
 	RootCmd.AddCommand(NewCloneCmd())
 	RootCmd.AddCommand(NewExecuteCmd())
+	RootCmd.AddCommand(NewArtifactsCmd())
 }
 
 var RootCmd = &cobra.Command{

--- a/cmd/tcl/testworkflow-toolkit/commands/utils.go
+++ b/cmd/tcl/testworkflow-toolkit/commands/utils.go
@@ -1,0 +1,43 @@
+// Copyright 2024 Testkube.
+//
+// Licensed as a Testkube Pro file under the Testkube Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+//	https://github.com/kubeshop/testkube/blob/main/licenses/TCL.txt
+
+package commands
+
+import (
+	"os"
+	"os/exec"
+	"strconv"
+)
+
+func concat(args ...interface{}) []string {
+	result := make([]string, 0)
+	for _, a := range args {
+		switch a.(type) {
+		case string:
+			result = append(result, a.(string))
+		case int:
+			result = append(result, strconv.Itoa(a.(int)))
+		case []string:
+			result = append(result, a.([]string)...)
+		case []interface{}:
+			result = append(result, concat(a.([]interface{})...)...)
+		}
+	}
+	return result
+}
+
+func Comm(cmd string, args ...interface{}) *exec.Cmd {
+	return exec.Command(cmd, concat(args...)...)
+}
+
+func Run(c string, args ...interface{}) error {
+	sub := Comm(c, args...)
+	sub.Stdout = os.Stdout
+	sub.Stderr = os.Stderr
+	return sub.Run()
+}

--- a/cmd/tcl/testworkflow-toolkit/env/client.go
+++ b/cmd/tcl/testworkflow-toolkit/env/client.go
@@ -1,0 +1,74 @@
+// Copyright 2024 Testkube.
+//
+// Licensed as a Testkube Pro file under the Testkube Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+//	https://github.com/kubeshop/testkube/blob/main/licenses/TCL.txt
+
+package env
+
+import (
+	"context"
+	"fmt"
+
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+
+	"github.com/kubeshop/testkube/cmd/kubectl-testkube/config"
+	"github.com/kubeshop/testkube/pkg/agent"
+	"github.com/kubeshop/testkube/pkg/api/v1/client"
+	"github.com/kubeshop/testkube/pkg/cloud"
+	cloudexecutor "github.com/kubeshop/testkube/pkg/cloud/data/executor"
+	phttp "github.com/kubeshop/testkube/pkg/http"
+	"github.com/kubeshop/testkube/pkg/k8sclient"
+	"github.com/kubeshop/testkube/pkg/log"
+	"github.com/kubeshop/testkube/pkg/storage/minio"
+	"github.com/kubeshop/testkube/pkg/ui"
+)
+
+func KubernetesConfig() *rest.Config {
+	c, err := rest.InClusterConfig()
+	if err != nil {
+		var fsErr error
+		c, fsErr = k8sclient.GetK8sClientConfig()
+		if fsErr != nil {
+			ui.Fail(fmt.Errorf("couldn't find Kubernetes config: %w and %w", err, fsErr))
+		}
+	}
+	return c
+}
+
+func Kubernetes() *kubernetes.Clientset {
+	c, err := kubernetes.NewForConfig(KubernetesConfig())
+	if err != nil {
+		ui.Fail(fmt.Errorf("couldn't instantiate Kubernetes client: %w", err))
+	}
+	return c
+}
+
+func Testkube() client.Client {
+	if UseProxy() {
+		return client.NewProxyAPIClient(Kubernetes(), client.NewAPIConfig(Namespace(), config.APIServerName, config.APIServerPort))
+	}
+	httpClient := phttp.NewClient(true)
+	sseClient := phttp.NewSSEClient(true)
+	return client.NewDirectAPIClient(httpClient, sseClient, fmt.Sprintf("http://%s:%d", config.APIServerName, config.APIServerPort), "")
+}
+
+func ObjectStorageClient() (*minio.Client, error) {
+	cfg := Config().ObjectStorage
+	opts := minio.GetTLSOptions(cfg.Ssl, cfg.SkipVerify, cfg.CertFile, cfg.KeyFile, cfg.CAFile)
+	c := minio.NewClient(cfg.Endpoint, cfg.AccessKeyID, cfg.SecretAccessKey, cfg.Region, cfg.Token, cfg.Bucket, opts...)
+	return c, c.Connect()
+}
+
+func Cloud(ctx context.Context) cloudexecutor.Executor {
+	cfg := Config().Cloud
+	grpcConn, err := agent.NewGRPCConnection(ctx, cfg.SkipVerify, cfg.SkipVerify, cfg.Url, log.DefaultLogger)
+	if err != nil {
+		ui.Fail(fmt.Errorf("failed to connect with Cloud: %w", err))
+	}
+	grpcClient := cloud.NewTestKubeCloudAPIClient(grpcConn)
+	return cloudexecutor.NewCloudGRPCExecutor(grpcClient, grpcConn, cfg.ApiKey)
+}

--- a/cmd/tcl/testworkflow-toolkit/env/client.go
+++ b/cmd/tcl/testworkflow-toolkit/env/client.go
@@ -65,7 +65,7 @@ func ObjectStorageClient() (*minio.Client, error) {
 
 func Cloud(ctx context.Context) cloudexecutor.Executor {
 	cfg := Config().Cloud
-	grpcConn, err := agent.NewGRPCConnection(ctx, cfg.SkipVerify, cfg.SkipVerify, cfg.Url, log.DefaultLogger)
+	grpcConn, err := agent.NewGRPCConnection(ctx, cfg.TlsInsecure, cfg.SkipVerify, cfg.Url, "", "", "", log.DefaultLogger)
 	if err != nil {
 		ui.Fail(fmt.Errorf("failed to connect with Cloud: %w", err))
 	}

--- a/cmd/tcl/testworkflow-toolkit/env/config.go
+++ b/cmd/tcl/testworkflow-toolkit/env/config.go
@@ -1,0 +1,103 @@
+// Copyright 2024 Testkube.
+//
+// Licensed as a Testkube Pro file under the Testkube Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+//	https://github.com/kubeshop/testkube/blob/main/licenses/TCL.txt
+
+package env
+
+import (
+	"github.com/kelseyhightower/envconfig"
+
+	"github.com/kubeshop/testkube/pkg/ui"
+)
+
+var (
+	UseProxyValue = false
+)
+
+type envObjectStorageConfig struct {
+	Endpoint        string `envconfig:"TK_OS_ENDPOINT"`
+	AccessKeyID     string `envconfig:"TK_OS_ACCESSKEY"`
+	SecretAccessKey string `envconfig:"TK_OS_SECRETKEY"`
+	Region          string `envconfig:"TK_OS_REGION"`
+	Token           string `envconfig:"TK_OS_TOKEN"`
+	Bucket          string `envconfig:"TK_OS_BUCKET"`
+	Ssl             bool   `envconfig:"TK_OS_SSL" default:"false"`
+	SkipVerify      bool   `envconfig:"TK_OS_SSL_SKIP_VERIFY" default:"false"`
+	CertFile        string `envconfig:"TK_OS_CERT_FILE"`
+	KeyFile         string `envconfig:"TK_OS_KEY_FILE"`
+	CAFile          string `envconfig:"TK_OS_CA_FILE"`
+}
+
+type envCloudConfig struct {
+	Url        string `envconfig:"TK_C_URL"`
+	ApiKey     string `envconfig:"TK_C_KEY"`
+	SkipVerify bool   `envconfig:"TK_C_SKIP_VERIFY" default:"false"`
+}
+
+type envExecutionConfig struct {
+	WorkflowName string `envconfig:"TK_WF"`
+	Id           string `envconfig:"TK_EX"`
+}
+
+type envSystemConfig struct {
+	Debug     string `envconfig:"DEBUG"`
+	Ref       string `envconfig:"TK_REF"`
+	Namespace string `envconfig:"TK_NS"`
+}
+
+type envConfig struct {
+	System        envSystemConfig
+	ObjectStorage envObjectStorageConfig
+	Cloud         envCloudConfig
+	Execution     envExecutionConfig
+}
+
+var cfg envConfig
+var cfgLoaded = false
+
+func Config() *envConfig {
+	if !cfgLoaded {
+		err := envconfig.Process("", &cfg.System)
+		ui.ExitOnError("configuring environment", err)
+		err = envconfig.Process("", &cfg.ObjectStorage)
+		ui.ExitOnError("configuring environment", err)
+		err = envconfig.Process("", &cfg.Cloud)
+		ui.ExitOnError("configuring environment", err)
+		err = envconfig.Process("", &cfg.Execution)
+		ui.ExitOnError("configuring environment", err)
+	}
+	cfgLoaded = true
+	return &cfg
+}
+
+func Debug() bool {
+	return Config().System.Debug == "1"
+}
+
+func CloudEnabled() bool {
+	return Config().Cloud.ApiKey != ""
+}
+
+func UseProxy() bool {
+	return UseProxyValue
+}
+
+func Ref() string {
+	return Config().System.Ref
+}
+
+func Namespace() string {
+	return Config().System.Namespace
+}
+
+func WorkflowName() string {
+	return Config().Execution.WorkflowName
+}
+
+func ExecutionId() string {
+	return Config().Execution.Id
+}

--- a/cmd/tcl/testworkflow-toolkit/env/config.go
+++ b/cmd/tcl/testworkflow-toolkit/env/config.go
@@ -33,9 +33,10 @@ type envObjectStorageConfig struct {
 }
 
 type envCloudConfig struct {
-	Url        string `envconfig:"TK_C_URL"`
-	ApiKey     string `envconfig:"TK_C_KEY"`
-	SkipVerify bool   `envconfig:"TK_C_SKIP_VERIFY" default:"false"`
+	Url         string `envconfig:"TK_C_URL"`
+	ApiKey      string `envconfig:"TK_C_KEY"`
+	SkipVerify  bool   `envconfig:"TK_C_SKIP_VERIFY" default:"false"`
+	TlsInsecure bool   `envconfig:"TK_C_TLS_INSECURE" default:"false"`
 }
 
 type envExecutionConfig struct {

--- a/cmd/tcl/testworkflow-toolkit/main.go
+++ b/cmd/tcl/testworkflow-toolkit/main.go
@@ -1,0 +1,29 @@
+// Copyright 2024 Testkube.
+//
+// Licensed as a Testkube Pro file under the Testkube Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+//	https://github.com/kubeshop/testkube/blob/main/licenses/TCL.txt
+
+package main
+
+import (
+	"errors"
+
+	"github.com/kubeshop/testkube/cmd/tcl/testworkflow-toolkit/commands"
+	"github.com/kubeshop/testkube/cmd/tcl/testworkflow-toolkit/env"
+	"github.com/kubeshop/testkube/pkg/ui"
+)
+
+func main() {
+	// Set verbosity
+	ui.SetVerbose(env.Debug())
+
+	// Validate provided data
+	if env.Namespace() == "" || env.Ref() == "" {
+		ui.Fail(errors.New("environment is misconfigured"))
+	}
+
+	commands.Execute()
+}

--- a/go.mod
+++ b/go.mod
@@ -68,6 +68,7 @@ require (
 	github.com/alecthomas/chroma v0.10.0 // indirect
 	github.com/aymanbagabas/go-osc52 v1.2.1 // indirect
 	github.com/aymerick/douceur v0.2.0 // indirect
+	github.com/bmatcuk/doublestar/v4 v4.6.1 // indirect
 	github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869 // indirect
 	github.com/briandowns/spinner v1.19.0 // indirect
 	github.com/charmbracelet/glamour v0.6.0 // indirect
@@ -91,6 +92,7 @@ require (
 	github.com/google/pprof v0.0.0-20210720184732-4bb14d4b1be1 // indirect
 	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 // indirect
 	github.com/gorilla/css v1.0.1 // indirect
+	github.com/h2non/filetype v1.1.3 // indirect
 	github.com/hashicorp/golang-lru/v2 v2.0.1 // indirect
 	github.com/henvic/httpretty v0.1.0 // indirect
 	github.com/itchyny/gojq v0.12.14 // indirect

--- a/go.sum
+++ b/go.sum
@@ -87,6 +87,8 @@ github.com/aymerick/douceur v0.2.0 h1:Mv+mAeH1Q+n9Fr+oyamOlAkUNPWPlA8PPGR0QAaYuP
 github.com/aymerick/douceur v0.2.0/go.mod h1:wlT5vV2O3h55X9m7iVYN0TBM0NH/MmbLnd30/FjWUq4=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
+github.com/bmatcuk/doublestar/v4 v4.6.1 h1:FH9SifrbvJhnlQpztAx++wlkk70QBf0iBWDwNy7PA4I=
+github.com/bmatcuk/doublestar/v4 v4.6.1/go.mod h1:xBQ8jztBU6kakFMg+8WGxn0c6z1fTSPVIjEY1Wr7jzc=
 github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869 h1:DDGfHa7BWjL4YnC6+E63dPcxHo2sUxDIu8g3QgEJdRY=
 github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869/go.mod h1:Ekp36dRnpXw/yCqJaO+ZrUyxD+3VXMFFr56k5XYrpB4=
 github.com/briandowns/spinner v1.19.0 h1:s8aq38H+Qju89yhp89b4iIiMzMm8YN3p6vGpwyh/a8E=
@@ -298,6 +300,8 @@ github.com/gorilla/css v1.0.1/go.mod h1:BvnYkspnSzMmwRK+b8/xgNPLiIuNZr6vbZBTPQ2A
 github.com/gorilla/websocket v1.4.2/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/gorilla/websocket v1.5.0 h1:PPwGk2jz7EePpoHN/+ClbZu8SPxiqlu12wZP/3sWmnc=
 github.com/gorilla/websocket v1.5.0/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
+github.com/h2non/filetype v1.1.3 h1:FKkx9QbD7HR/zjK1Ia5XiBsq9zdLi5Kf3zGyFTAFkGg=
+github.com/h2non/filetype v1.1.3/go.mod h1:319b3zT68BvV+WRj7cwy856M2ehB3HqNOt6sy1HndBY=
 github.com/h2non/parth v0.0.0-20190131123155-b4df798d6542 h1:2VTzZjLZBgl62/EtslCrtky5vbi9dd7HrQPQIx6wqiw=
 github.com/h2non/parth v0.0.0-20190131123155-b4df798d6542/go.mod h1:Ow0tF8D4Kplbc8s8sSb3V2oUCygFHVp8gC3Dn6U4MNI=
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=

--- a/goreleaser_files/.goreleaser-docker-build-testworkflow-toolkit.yml
+++ b/goreleaser_files/.goreleaser-docker-build-testworkflow-toolkit.yml
@@ -1,0 +1,93 @@
+project_name: testkube-tw-toolkit
+
+env:
+  # Goreleaser always uses the docker buildx builder with name "default"; see
+  # https://github.com/goreleaser/goreleaser/pull/3199
+  # To use a builder other than "default", set this variable.
+  # Necessary for, e.g., GitHub actions cache integration.
+  - DOCKER_REPO={{ if index .Env "DOCKER_REPO"  }}{{ .Env.DOCKER_REPO }}{{ else }}kubeshop{{ end }}
+  - DOCKER_BUILDX_BUILDER={{ if index .Env "DOCKER_BUILDX_BUILDER"  }}{{ .Env.DOCKER_BUILDX_BUILDER }}{{ else }}default{{ end }}
+  # Setup to enable Docker to use, e.g., the GitHub actions cache; see
+  # https://docs.docker.com/build/building/cache/backends/
+  # https://github.com/moby/buildkit#export-cache
+  - DOCKER_BUILDX_CACHE_FROM={{ if index .Env "DOCKER_BUILDX_CACHE_FROM"  }}{{ .Env.DOCKER_BUILDX_CACHE_FROM }}{{ else }}type=registry{{ end }}
+  - DOCKER_BUILDX_CACHE_TO={{ if index .Env "DOCKER_BUILDX_CACHE_TO"  }}{{ .Env.DOCKER_BUILDX_CACHE_TO }}{{ else }}type=inline{{ end }}
+  # Build image with commit sha tag
+  - IMAGE_TAG_SHA={{ if index .Env "IMAGE_TAG_SHA"  }}{{ .Env.IMAGE_TAG_SHA }}{{ else }}{{ end }}
+builds:
+  - id: "linux"
+    main: ./cmd/tcl/testworkflow-toolkit
+    binary: testworkflow-toolkit
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+    goarch:
+      - amd64
+      - arm64
+    mod_timestamp: "{{ .CommitTimestamp }}"
+    ldflags:
+      -X github.com/kubeshop/testkube/pkg/version.Version={{ .Version }}
+      -X github.com/kubeshop/testkube/pkg/version.Commit={{ .FullCommit }}
+      -s -w
+dockers:
+  - dockerfile: ./build/testworkflow-toolkit/Dockerfile
+    use: buildx
+    goos: linux
+    goarch: amd64
+    image_templates:
+      - "{{ if .Env.IMAGE_TAG_SHA }}{{ .Env.DOCKER_REPO }}/testkube-tw-toolkit:{{ .ShortCommit }}{{ end }}"
+      - "{{ if not .Env.IMAGE_TAG_SHA }}{{ .Env.DOCKER_REPO }}/testkube-tw-toolkit:{{ .Version }}-amd64{{ end }}"
+    build_flag_templates:
+      - "--platform=linux/amd64"
+      - "--label=org.opencontainers.image.title={{ .ProjectName }}"
+      - "--label=org.opencontainers.image.created={{ .Date}}"
+      - "--label=org.opencontainers.image.revision={{ .FullCommit }}"
+      - "--label=org.opencontainers.image.version={{ .Version }}"
+      - "--builder={{ .Env.DOCKER_BUILDX_BUILDER }}"
+      - "--cache-to={{ .Env.DOCKER_BUILDX_CACHE_TO }}"
+      - "--cache-from={{ .Env.DOCKER_BUILDX_CACHE_FROM }}"
+      - "--build-arg=ALPINE_IMAGE={{ .Env.ALPINE_IMAGE }}"
+
+  - dockerfile: ./build/testworkflow-toolkit/Dockerfile
+    use: buildx
+    goos: linux
+    goarch: arm64
+    image_templates:
+      - "{{ if not .Env.IMAGE_TAG_SHA }}{{ .Env.DOCKER_REPO }}/testkube-tw-toolkit:{{ .Version }}-arm64v8{{ end }}"
+    build_flag_templates:
+      - "--platform=linux/arm64/v8"
+      - "--label=org.opencontainers.image.created={{ .Date }}"
+      - "--label=org.opencontainers.image.title={{ .ProjectName }}"
+      - "--label=org.opencontainers.image.revision={{ .FullCommit }}"
+      - "--label=org.opencontainers.image.version={{ .Version }}"
+      - "--builder={{ .Env.DOCKER_BUILDX_BUILDER }}"
+      - "--cache-to={{ .Env.DOCKER_BUILDX_CACHE_TO }}"
+      - "--cache-from={{ .Env.DOCKER_BUILDX_CACHE_FROM }}"
+      - "--build-arg=ALPINE_IMAGE={{ .Env.ALPINE_IMAGE }}"
+
+docker_manifests:
+  - name_template: "{{ if not .Env.IMAGE_TAG_SHA }}{{ .Env.DOCKER_REPO }}/testkube-tw-toolkit:{{ .Version }}{{ end }}"
+    image_templates:
+      - "{{ if not .Env.IMAGE_TAG_SHA }}{{ .Env.DOCKER_REPO }}/testkube-tw-toolkit:{{ .Version }}-amd64{{ end }}"
+      - "{{ if not .Env.IMAGE_TAG_SHA }}{{ .Env.DOCKER_REPO }}/testkube-tw-toolkit:{{ .Version }}-arm64v8{{ end }}"
+  - name_template: "{{ if not .Env.IMAGE_TAG_SHA }}{{ .Env.DOCKER_REPO }}/testkube-tw-toolkit:latest{{ end }}"
+    image_templates:
+      - "{{ if not .Env.IMAGE_TAG_SHA }}{{ .Env.DOCKER_REPO }}/testkube-tw-toolkit:{{ .Version }}-amd64{{ end }}"
+      - "{{ if not .Env.IMAGE_TAG_SHA }}{{ .Env.DOCKER_REPO }}/testkube-tw-toolkit:{{ .Version }}-arm64v8{{ end }}"
+
+
+release:
+  disable: true
+
+docker_signs:
+  - cmd: cosign
+    artifacts: all
+    output: true
+    args:
+      - "sign"
+      - "${artifact}"
+      - "--yes"
+
+snapshot:
+  name_template: "{{ .ShortCommit }}"

--- a/internal/app/api/v1/executions.go
+++ b/internal/app/api/v1/executions.go
@@ -441,7 +441,7 @@ func (s *TestkubeAPI) GetArtifactHandler() fiber.Handler {
 
 		var file io.Reader
 		var bucket string
-		artifactsStorage := s.artifactsStorage
+		artifactsStorage := s.ArtifactsStorage
 		folder := execution.Id
 		if execution.ArtifactRequest != nil {
 			bucket = execution.ArtifactRequest.StorageBucket
@@ -457,7 +457,7 @@ func (s *TestkubeAPI) GetArtifactHandler() fiber.Handler {
 			}
 		}
 
-		file, err = artifactsStorage.DownloadFile(c.Context(), fileName, folder, execution.TestName, execution.TestSuiteName)
+		file, err = artifactsStorage.DownloadFile(c.Context(), fileName, folder, execution.TestName, execution.TestSuiteName, "")
 		if err != nil {
 			return s.Error(c, http.StatusInternalServerError, fmt.Errorf("%s: could not download file: %w", errPrefix, err))
 		}
@@ -489,7 +489,7 @@ func (s *TestkubeAPI) GetArtifactArchiveHandler() fiber.Handler {
 
 		var archive io.Reader
 		var bucket string
-		artifactsStorage := s.artifactsStorage
+		artifactsStorage := s.ArtifactsStorage
 		folder := execution.Id
 		if execution.ArtifactRequest != nil {
 			bucket = execution.ArtifactRequest.StorageBucket
@@ -532,7 +532,7 @@ func (s *TestkubeAPI) ListArtifactsHandler() fiber.Handler {
 
 		var files []testkube.Artifact
 		var bucket string
-		artifactsStorage := s.artifactsStorage
+		artifactsStorage := s.ArtifactsStorage
 		folder := execution.Id
 		if execution.ArtifactRequest != nil {
 			bucket = execution.ArtifactRequest.StorageBucket
@@ -548,7 +548,7 @@ func (s *TestkubeAPI) ListArtifactsHandler() fiber.Handler {
 			}
 		}
 
-		files, err = artifactsStorage.ListFiles(c.Context(), folder, execution.TestName, execution.TestSuiteName)
+		files, err = artifactsStorage.ListFiles(c.Context(), folder, execution.TestName, execution.TestSuiteName, "")
 		if err != nil {
 			return s.Error(c, http.StatusInternalServerError, fmt.Errorf("%s: storage client could not list files %w", errPrefix, err))
 		}
@@ -724,7 +724,7 @@ func (s *TestkubeAPI) getExecutorByTestType(testType string) (client.Executor, e
 
 func (s *TestkubeAPI) getArtifactStorage(bucket string) (storage.ArtifactsStorage, error) {
 	if s.mode == common.ModeAgent {
-		return s.artifactsStorage, nil
+		return s.ArtifactsStorage, nil
 	}
 
 	opts := minio.GetTLSOptions(s.storageParams.SSL, s.storageParams.SkipVerify, s.storageParams.CertFile, s.storageParams.KeyFile, s.storageParams.CAFile)

--- a/internal/app/api/v1/server.go
+++ b/internal/app/api/v1/server.go
@@ -133,7 +133,7 @@ func NewTestkubeAPI(
 		slackLoader:           slackLoader,
 		Storage:               storage,
 		graphqlPort:           graphqlPort,
-		artifactsStorage:      artifactsStorage,
+		ArtifactsStorage:      artifactsStorage,
 		TemplatesClient:       templatesClient,
 		dashboardURI:          dashboardURI,
 		helmchartVersion:      helmchartVersion,
@@ -194,7 +194,7 @@ type TestkubeAPI struct {
 	Clientset             kubernetes.Interface
 	slackLoader           *slack.SlackLoader
 	graphqlPort           string
-	artifactsStorage      storage.ArtifactsStorage
+	ArtifactsStorage      storage.ArtifactsStorage
 	TemplatesClient       *templatesclientv1.TemplatesClient
 	dashboardURI          string
 	helmchartVersion      string

--- a/internal/app/api/v1/testsuites.go
+++ b/internal/app/api/v1/testsuites.go
@@ -698,7 +698,7 @@ func (s TestkubeAPI) ListTestSuiteArtifactsHandler() fiber.Handler {
 
 			var stepArtifacts []testkube.Artifact
 			var bucket string
-			artifactsStorage := s.artifactsStorage
+			artifactsStorage := s.ArtifactsStorage
 			folder := stepResult.Execution.Id
 			if stepResult.Execution.ArtifactRequest != nil {
 				bucket = stepResult.Execution.ArtifactRequest.StorageBucket
@@ -715,7 +715,7 @@ func (s TestkubeAPI) ListTestSuiteArtifactsHandler() fiber.Handler {
 				}
 			}
 
-			stepArtifacts, err = artifactsStorage.ListFiles(c.Context(), folder, stepResult.Execution.TestName, stepResult.Execution.TestSuiteName)
+			stepArtifacts, err = artifactsStorage.ListFiles(c.Context(), folder, stepResult.Execution.TestName, stepResult.Execution.TestSuiteName, "")
 			if err != nil {
 				s.Log.Warnw("can't list artifacts", "executionID", stepResult.Execution.Id, "error", err)
 				continue

--- a/internal/app/api/v1/uploads.go
+++ b/internal/app/api/v1/uploads.go
@@ -24,7 +24,7 @@ func (s TestkubeAPI) UploadFiles() fiber.Handler {
 			return s.Error(c, fiber.StatusBadRequest, fmt.Errorf("%s: wrong input: filePath cannot be empty", errPrefix))
 		}
 
-		bucketName := s.artifactsStorage.GetValidBucketName(parentType, parentName)
+		bucketName := s.ArtifactsStorage.GetValidBucketName(parentType, parentName)
 		file, err := c.FormFile("attachment")
 		if err != nil {
 			return s.Error(c, fiber.StatusBadRequest, fmt.Errorf("%s: unable to upload file: %w", errPrefix, err))
@@ -35,7 +35,7 @@ func (s TestkubeAPI) UploadFiles() fiber.Handler {
 		}
 		defer f.Close()
 
-		err = s.artifactsStorage.UploadFile(c.Context(), bucketName, filePath, f, file.Size)
+		err = s.ArtifactsStorage.UploadFile(c.Context(), bucketName, filePath, f, file.Size)
 		if err != nil {
 			return s.Error(c, fiber.StatusInternalServerError, fmt.Errorf("%s: could not save uploaded file: %w", errPrefix, err))
 		}

--- a/internal/app/api/v1/uploads_test.go
+++ b/internal/app/api/v1/uploads_test.go
@@ -34,7 +34,7 @@ func TestTestkubeAPI_UploadCopyFiles(t *testing.T) {
 			Mux: app,
 			Log: log.DefaultLogger,
 		},
-		artifactsStorage: mockArtifactsStorage,
+		ArtifactsStorage: mockArtifactsStorage,
 	}
 	route := "/uploads"
 

--- a/internal/common/common.go
+++ b/internal/common/common.go
@@ -95,3 +95,12 @@ func GetMapValue[T any, K comparable](m map[K]T, k K, def T) T {
 	}
 	return def
 }
+
+func GetOr(v ...string) string {
+	for i := range v {
+		if v[i] != "" {
+			return v[i]
+		}
+	}
+	return ""
+}

--- a/pkg/api/v1/client/api.go
+++ b/pkg/api/v1/client/api.go
@@ -43,6 +43,7 @@ func NewProxyAPIClient(client kubernetes.Interface, config APIConfig) APIClient 
 			NewProxyClient[testkube.TestWorkflowWithExecution](client, config),
 			NewProxyClient[testkube.TestWorkflowExecution](client, config),
 			NewProxyClient[testkube.TestWorkflowExecutionsResult](client, config),
+			NewProxyClient[testkube.Artifact](client, config),
 		),
 		TestWorkflowTemplateClient: NewTestWorkflowTemplateClient(NewProxyClient[testkube.TestWorkflowTemplate](client, config)),
 	}
@@ -80,6 +81,7 @@ func NewDirectAPIClient(httpClient *http.Client, sseClient *http.Client, apiURI,
 			NewDirectClient[testkube.TestWorkflowWithExecution](httpClient, apiURI, apiPathPrefix),
 			NewDirectClient[testkube.TestWorkflowExecution](httpClient, apiURI, apiPathPrefix),
 			NewDirectClient[testkube.TestWorkflowExecutionsResult](httpClient, apiURI, apiPathPrefix),
+			NewDirectClient[testkube.Artifact](httpClient, apiURI, apiPathPrefix),
 		),
 		TestWorkflowTemplateClient: NewTestWorkflowTemplateClient(NewDirectClient[testkube.TestWorkflowTemplate](httpClient, apiURI, apiPathPrefix)),
 	}
@@ -117,6 +119,7 @@ func NewCloudAPIClient(httpClient *http.Client, sseClient *http.Client, apiURI, 
 			NewCloudClient[testkube.TestWorkflowWithExecution](httpClient, apiURI, apiPathPrefix),
 			NewCloudClient[testkube.TestWorkflowExecution](httpClient, apiURI, apiPathPrefix),
 			NewCloudClient[testkube.TestWorkflowExecutionsResult](httpClient, apiURI, apiPathPrefix),
+			NewCloudClient[testkube.Artifact](httpClient, apiURI, apiPathPrefix),
 		),
 		TestWorkflowTemplateClient: NewTestWorkflowTemplateClient(NewCloudClient[testkube.TestWorkflowTemplate](httpClient, apiURI, apiPathPrefix)),
 	}

--- a/pkg/api/v1/client/interface.go
+++ b/pkg/api/v1/client/interface.go
@@ -149,6 +149,9 @@ type TestWorkflowExecutionAPI interface {
 	ListTestWorkflowExecutions(id string, limit int, selector string) (executions testkube.TestWorkflowExecutionsResult, err error)
 	AbortTestWorkflowExecution(workflow string, id string) error
 	AbortTestWorkflowExecutions(workflow string) error
+	GetTestWorkflowExecutionArtifacts(executionID string) (artifacts testkube.Artifacts, err error)
+	DownloadTestWorkflowArtifact(executionID, fileName, destination string) (artifact string, err error)
+	DownloadTestWorkflowArtifactArchive(executionID, destination string, masks []string) (archive string, err error)
 }
 
 // TestWorkflowTemplateAPI describes test workflow api methods

--- a/pkg/api/v1/client/testworkflow.go
+++ b/pkg/api/v1/client/testworkflow.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"net/url"
 
 	"github.com/kubeshop/testkube/pkg/api/v1/testkube"
 )
@@ -14,12 +15,14 @@ func NewTestWorkflowClient(
 	testWorkflowWithExecutionTransport Transport[testkube.TestWorkflowWithExecution],
 	testWorkflowExecutionTransport Transport[testkube.TestWorkflowExecution],
 	testWorkflowExecutionsResultTransport Transport[testkube.TestWorkflowExecutionsResult],
+	artifactTransport Transport[testkube.Artifact],
 ) TestWorkflowClient {
 	return TestWorkflowClient{
 		testWorkflowTransport:                 testWorkflowTransport,
 		testWorkflowWithExecutionTransport:    testWorkflowWithExecutionTransport,
 		testWorkflowExecutionTransport:        testWorkflowExecutionTransport,
 		testWorkflowExecutionsResultTransport: testWorkflowExecutionsResultTransport,
+		artifactTransport:                     artifactTransport,
 	}
 }
 
@@ -29,6 +32,7 @@ type TestWorkflowClient struct {
 	testWorkflowWithExecutionTransport    Transport[testkube.TestWorkflowWithExecution]
 	testWorkflowExecutionTransport        Transport[testkube.TestWorkflowExecution]
 	testWorkflowExecutionsResultTransport Transport[testkube.TestWorkflowExecutionsResult]
+	artifactTransport                     Transport[testkube.Artifact]
 }
 
 // GetTestWorkflow returns single test workflow by id
@@ -154,4 +158,22 @@ func (c TestWorkflowClient) AbortTestWorkflowExecution(workflow, id string) erro
 func (c TestWorkflowClient) AbortTestWorkflowExecutions(workflow string) error {
 	uri := c.testWorkflowTransport.GetURI("/test-workflows/%s/abort", workflow)
 	return c.testWorkflowTransport.ExecuteMethod(http.MethodPost, uri, "", false)
+}
+
+// GetTestWorkflowExecutionArtifacts returns execution artifacts
+func (c TestWorkflowClient) GetTestWorkflowExecutionArtifacts(executionID string) (artifacts testkube.Artifacts, err error) {
+	uri := c.artifactTransport.GetURI("/test-workflow-executions/%s/artifacts", executionID)
+	return c.artifactTransport.ExecuteMultiple(http.MethodGet, uri, nil, nil)
+}
+
+// DownloadTestWorkflowArtifact downloads file
+func (c TestWorkflowClient) DownloadTestWorkflowArtifact(executionID, fileName, destination string) (artifact string, err error) {
+	uri := c.testWorkflowExecutionTransport.GetURI("/test-workflow-executions/%s/artifacts/%s", executionID, url.QueryEscape(fileName))
+	return c.testWorkflowExecutionTransport.GetFile(uri, fileName, destination, nil)
+}
+
+// DownloadTestWorkflowArtifactArchive downloads archive
+func (c TestWorkflowClient) DownloadTestWorkflowArtifactArchive(executionID, destination string, masks []string) (archive string, err error) {
+	uri := c.testWorkflowExecutionTransport.GetURI("/test-workflow-executions/%s/artifact-archive", executionID)
+	return c.testWorkflowExecutionTransport.GetFile(uri, fmt.Sprintf("%s.tar.gz", executionID), destination, map[string][]string{"mask": masks})
 }

--- a/pkg/api/v1/testkube/model_test_workflow_result_extended.go
+++ b/pkg/api/v1/testkube/model_test_workflow_result_extended.go
@@ -11,7 +11,7 @@ func (r *TestWorkflowResult) IsFinished() bool {
 }
 
 func (r *TestWorkflowResult) IsStatus(s TestWorkflowStatus) bool {
-	if r.Status == nil {
+	if r == nil || r.Status == nil {
 		return s == QUEUED_TestWorkflowStatus
 	}
 	return *r.Status == s

--- a/pkg/cloud/data/artifact/artifacts_storage.go
+++ b/pkg/cloud/data/artifact/artifacts_storage.go
@@ -1,7 +1,7 @@
 package artifact
 
 import (
-	context "context"
+	"context"
 	"encoding/json"
 	"io"
 	"net/http"
@@ -25,11 +25,12 @@ func NewCloudArtifactsStorage(cloudClient cloud.TestKubeCloudAPIClient, grpcConn
 	return &CloudArtifactsStorage{executor: executor.NewCloudGRPCExecutor(cloudClient, grpcConn, apiKey)}
 }
 
-func (c *CloudArtifactsStorage) ListFiles(ctx context.Context, executionID, testName, testSuiteName string) ([]testkube.Artifact, error) {
+func (c *CloudArtifactsStorage) ListFiles(ctx context.Context, executionID, testName, testSuiteName, testWorkflowName string) ([]testkube.Artifact, error) {
 	req := ListFilesRequest{
-		ExecutionID:   executionID,
-		TestName:      testName,
-		TestSuiteName: testSuiteName,
+		ExecutionID:      executionID,
+		TestName:         testName,
+		TestSuiteName:    testSuiteName,
+		TestWorkflowName: testWorkflowName,
 	}
 	response, err := c.executor.Execute(ctx, CmdArtifactsListFiles, req)
 	if err != nil {
@@ -43,12 +44,13 @@ func (c *CloudArtifactsStorage) ListFiles(ctx context.Context, executionID, test
 	return commandResponse.Artifacts, nil
 }
 
-func (c *CloudArtifactsStorage) DownloadFile(ctx context.Context, file, executionID, testName, testSuiteName string) (io.Reader, error) {
+func (c *CloudArtifactsStorage) DownloadFile(ctx context.Context, file, executionID, testName, testSuiteName, testWorkflowName string) (io.Reader, error) {
 	req := DownloadFileRequest{
-		File:          file,
-		ExecutionID:   executionID,
-		TestName:      testName,
-		TestSuiteName: testSuiteName,
+		File:             file,
+		ExecutionID:      executionID,
+		TestName:         testName,
+		TestSuiteName:    testSuiteName,
+		TestWorkflowName: testWorkflowName,
 	}
 	response, err := c.executor.Execute(ctx, CmdArtifactsDownloadFile, req)
 	if err != nil {

--- a/pkg/cloud/data/artifact/artifacts_storage_models.go
+++ b/pkg/cloud/data/artifact/artifacts_storage_models.go
@@ -3,9 +3,10 @@ package artifact
 import "github.com/kubeshop/testkube/pkg/api/v1/testkube"
 
 type ListFilesRequest struct {
-	ExecutionID   string
-	TestName      string
-	TestSuiteName string
+	ExecutionID      string
+	TestName         string
+	TestSuiteName    string
+	TestWorkflowName string
 }
 
 type ListFilesResponse struct {
@@ -13,10 +14,11 @@ type ListFilesResponse struct {
 }
 
 type DownloadFileRequest struct {
-	File          string
-	ExecutionID   string
-	TestName      string
-	TestSuiteName string
+	File             string
+	ExecutionID      string
+	TestName         string
+	TestSuiteName    string
+	TestWorkflowName string
 }
 
 type DownloadFileResponse struct {

--- a/pkg/cloud/data/artifact/scraper_model.go
+++ b/pkg/cloud/data/artifact/scraper_model.go
@@ -7,10 +7,11 @@ const (
 )
 
 type PutObjectSignedURLRequest struct {
-	Object        string `json:"object"`
-	ExecutionID   string `json:"executionId"`
-	TestName      string `json:"testName"`
-	TestSuiteName string `json:"testSuiteName"`
+	Object           string `json:"object"`
+	ExecutionID      string `json:"executionId"`
+	TestName         string `json:"testName"`
+	TestSuiteName    string `json:"testSuiteName"`
+	TestWorkflowName string `json:"testWorkflowName"`
 }
 
 type PutObjectSignedURLResponse struct {

--- a/pkg/storage/artifacts.go
+++ b/pkg/storage/artifacts.go
@@ -10,9 +10,9 @@ import (
 //go:generate mockgen -destination=./artifacts_mock.go -package=storage "github.com/kubeshop/testkube/pkg/storage" ArtifactsStorage
 type ArtifactsStorage interface {
 	// ListFiles lists available files in the configured bucket
-	ListFiles(ctx context.Context, executionId, testName, testSuiteName string) ([]testkube.Artifact, error)
+	ListFiles(ctx context.Context, executionId, testName, testSuiteName, testWorkflowName string) ([]testkube.Artifact, error)
 	// DownloadFile downloads file from configured
-	DownloadFile(ctx context.Context, file, executionId, testName, testSuiteName string) (io.Reader, error)
+	DownloadFile(ctx context.Context, file, executionId, testName, testSuiteName, testWorkflowName string) (io.Reader, error)
 	// DownloadArchive downloads archive from configured
 	DownloadArchive(ctx context.Context, executionId string, masks []string) (io.Reader, error)
 	// UploadFile uploads file to configured bucket

--- a/pkg/storage/artifacts_mock.go
+++ b/pkg/storage/artifacts_mock.go
@@ -52,18 +52,18 @@ func (mr *MockArtifactsStorageMockRecorder) DownloadArchive(arg0, arg1, arg2 int
 }
 
 // DownloadFile mocks base method.
-func (m *MockArtifactsStorage) DownloadFile(arg0 context.Context, arg1, arg2, arg3, arg4 string) (io.Reader, error) {
+func (m *MockArtifactsStorage) DownloadFile(arg0 context.Context, arg1, arg2, arg3, arg4, arg5 string) (io.Reader, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DownloadFile", arg0, arg1, arg2, arg3, arg4)
+	ret := m.ctrl.Call(m, "DownloadFile", arg0, arg1, arg2, arg3, arg4, arg5)
 	ret0, _ := ret[0].(io.Reader)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // DownloadFile indicates an expected call of DownloadFile.
-func (mr *MockArtifactsStorageMockRecorder) DownloadFile(arg0, arg1, arg2, arg3, arg4 interface{}) *gomock.Call {
+func (mr *MockArtifactsStorageMockRecorder) DownloadFile(arg0, arg1, arg2, arg3, arg4, arg5 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DownloadFile", reflect.TypeOf((*MockArtifactsStorage)(nil).DownloadFile), arg0, arg1, arg2, arg3, arg4)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DownloadFile", reflect.TypeOf((*MockArtifactsStorage)(nil).DownloadFile), arg0, arg1, arg2, arg3, arg4, arg5)
 }
 
 // GetValidBucketName mocks base method.
@@ -81,18 +81,18 @@ func (mr *MockArtifactsStorageMockRecorder) GetValidBucketName(arg0, arg1 interf
 }
 
 // ListFiles mocks base method.
-func (m *MockArtifactsStorage) ListFiles(arg0 context.Context, arg1, arg2, arg3 string) ([]testkube.Artifact, error) {
+func (m *MockArtifactsStorage) ListFiles(arg0 context.Context, arg1, arg2, arg3, arg4 string) ([]testkube.Artifact, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListFiles", arg0, arg1, arg2, arg3)
+	ret := m.ctrl.Call(m, "ListFiles", arg0, arg1, arg2, arg3, arg4)
 	ret0, _ := ret[0].([]testkube.Artifact)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ListFiles indicates an expected call of ListFiles.
-func (mr *MockArtifactsStorageMockRecorder) ListFiles(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+func (mr *MockArtifactsStorageMockRecorder) ListFiles(arg0, arg1, arg2, arg3, arg4 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListFiles", reflect.TypeOf((*MockArtifactsStorage)(nil).ListFiles), arg0, arg1, arg2, arg3)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListFiles", reflect.TypeOf((*MockArtifactsStorage)(nil).ListFiles), arg0, arg1, arg2, arg3, arg4)
 }
 
 // PlaceFiles mocks base method.

--- a/pkg/storage/minio/artifacts_storage.go
+++ b/pkg/storage/minio/artifacts_storage.go
@@ -18,12 +18,12 @@ func NewMinIOArtifactClient(client storage.Client) *ArtifactClient {
 }
 
 // ListFiles lists available files in the bucket from the config
-func (c *ArtifactClient) ListFiles(ctx context.Context, executionId, testName, testSuiteName string) ([]testkube.Artifact, error) {
+func (c *ArtifactClient) ListFiles(ctx context.Context, executionId, testName, testSuiteName, testWorkflowName string) ([]testkube.Artifact, error) {
 	return c.client.ListFiles(ctx, executionId)
 }
 
 // DownloadFile downloads file from bucket from the config
-func (c *ArtifactClient) DownloadFile(ctx context.Context, file, executionId, testName, testSuiteName string) (io.Reader, error) {
+func (c *ArtifactClient) DownloadFile(ctx context.Context, file, executionId, testName, testSuiteName, testWorkflowName string) (io.Reader, error) {
 	return c.client.DownloadFile(ctx, executionId, file)
 }
 

--- a/pkg/storage/minio/artifacts_storage_integration_test.go
+++ b/pkg/storage/minio/artifacts_storage_integration_test.go
@@ -46,7 +46,7 @@ func TestArtifactClient(t *testing.T) {
 			t.Fatalf("unable to upload file: %v", err)
 		}
 		// Call ListFiles
-		files, err := artifactClient.ListFiles(ctx, "test-execution-id-1", "", "")
+		files, err := artifactClient.ListFiles(ctx, "test-execution-id-1", "", "", "")
 		assert.NoError(t, err)
 
 		assert.Lenf(t, files, 1, "expected 1 file to be returned")
@@ -63,7 +63,7 @@ func TestArtifactClient(t *testing.T) {
 			t.Fatalf("unable to upload file: %v", err)
 		}
 
-		reader, err := artifactClient.DownloadFile(ctx, "test-file", "test-execution-id-2", "", "")
+		reader, err := artifactClient.DownloadFile(ctx, "test-file", "test-execution-id-2", "", "", "")
 		if err != nil {
 			t.Fatalf("unable to download file: %v", err)
 		}

--- a/pkg/tcl/apitcl/v1/server.go
+++ b/pkg/tcl/apitcl/v1/server.go
@@ -117,6 +117,9 @@ func (s *apiTCL) AppendRoutes() {
 	testWorkflowExecutions.Get("/:executionID/notifications/stream", s.pro(s.StreamTestWorkflowExecutionNotificationsWebSocketHandler()))
 	testWorkflowExecutions.Post("/:executionID/abort", s.pro(s.AbortTestWorkflowExecutionHandler()))
 	testWorkflowExecutions.Get("/:executionID/logs", s.pro(s.GetTestWorkflowExecutionLogsHandler()))
+	testWorkflowExecutions.Get("/:executionID/artifacts", s.pro(s.ListTestWorkflowExecutionArtifactsHandler()))
+	testWorkflowExecutions.Get("/:executionID/artifacts/:filename", s.pro(s.GetTestWorkflowArtifactHandler()))
+	testWorkflowExecutions.Get("/:executionID/artifact-archive", s.pro(s.GetTestWorkflowArtifactArchiveHandler()))
 
 	testWorkflowWithExecutions := root.Group("/test-workflow-with-executions")
 	testWorkflowWithExecutions.Get("/", s.pro(s.ListTestWorkflowWithExecutionsHandler()))

--- a/pkg/tcl/apitcl/v1/server.go
+++ b/pkg/tcl/apitcl/v1/server.go
@@ -34,6 +34,7 @@ type apiTCL struct {
 	TestWorkflowsClient         testworkflowsv1.Interface
 	TestWorkflowTemplatesClient testworkflowsv1.TestWorkflowTemplatesInterface
 	TestWorkflowExecutor        testworkflowexecutor.TestWorkflowExecutor
+	ApiUrl                      string
 }
 
 type ApiTCL interface {
@@ -47,6 +48,7 @@ func NewApiTCL(
 	imageInspector imageinspector.Inspector,
 	testWorkflowResults testworkflow.Repository,
 	testWorkflowOutput testworkflow.OutputRepository,
+	apiUrl string,
 ) ApiTCL {
 	executor := testworkflowexecutor.New(testkubeAPI.Events, testkubeAPI.Clientset, testWorkflowResults, testWorkflowOutput, testkubeAPI.Namespace)
 	go executor.Recover(context.Background())
@@ -59,6 +61,7 @@ func NewApiTCL(
 		TestWorkflowsClient:         testworkflowsv1.NewClient(kubeClient, testkubeAPI.Namespace),
 		TestWorkflowTemplatesClient: testworkflowsv1.NewTestWorkflowTemplatesClient(kubeClient, testkubeAPI.Namespace),
 		TestWorkflowExecutor:        executor,
+		ApiUrl:                      apiUrl,
 	}
 }
 

--- a/pkg/tcl/apitcl/v1/testworkflows.go
+++ b/pkg/tcl/apitcl/v1/testworkflows.go
@@ -306,7 +306,16 @@ func (s *apiTCL) ExecuteTestWorkflowHandler() fiber.Handler {
 		id := primitive.NewObjectID().Hex()
 		now := time.Now()
 		machine := expressionstcl.NewMachine().
-			Register("execution.id", id)
+			RegisterStringMap("internal", map[string]string{
+				"api.url":   s.ApiUrl,
+				"namespace": s.Namespace,
+			}).
+			RegisterStringMap("workflow", map[string]string{
+				"name": workflow.Name,
+			}).
+			RegisterStringMap("execution", map[string]string{
+				"id": id,
+			})
 
 		// Preserve resolved TestWorkflow
 		resolvedWorkflow := workflow.DeepCopy()

--- a/pkg/tcl/apitcl/v1/testworkflows.go
+++ b/pkg/tcl/apitcl/v1/testworkflows.go
@@ -12,6 +12,8 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"os"
+	"strconv"
 	"strings"
 	"time"
 
@@ -307,8 +309,26 @@ func (s *apiTCL) ExecuteTestWorkflowHandler() fiber.Handler {
 		now := time.Now()
 		machine := expressionstcl.NewMachine().
 			RegisterStringMap("internal", map[string]string{
-				"api.url":   s.ApiUrl,
-				"namespace": s.Namespace,
+				"storage.url":        os.Getenv("STORAGE_ENDPOINT"),
+				"storage.accessKey":  os.Getenv("STORAGE_ACCESSKEYID"),
+				"storage.secretKey":  os.Getenv("STORAGE_SECRETACCESSKEY"),
+				"storage.region":     os.Getenv("STORAGE_REGION"),
+				"storage.bucket":     os.Getenv("STORAGE_BUCKET"),
+				"storage.token":      os.Getenv("STORAGE_TOKEN"),
+				"storage.ssl":        common.GetOr(os.Getenv("STORAGE_SSL"), "false"),
+				"storage.skipVerify": common.GetOr(os.Getenv("STORAGE_SKIP_VERIFY"), "false"),
+				"storage.certFile":   os.Getenv("STORAGE_CERT_FILE"),
+				"storage.keyFile":    os.Getenv("STORAGE_KEY_FILE"),
+				"storage.caFile":     os.Getenv("STORAGE_CA_FILE"),
+
+				"cloud.enabled":        strconv.FormatBool(os.Getenv("TESTKUBE_PRO_API_KEY") != "" || os.Getenv("TESTKUBE_CLOUD_API_KEY") != ""),
+				"cloud.api.key":        common.GetOr(os.Getenv("TESTKUBE_PRO_API_KEY"), os.Getenv("TESTKUBE_CLOUD_API_KEY")),
+				"cloud.api.skipVerify": common.GetOr(os.Getenv("TESTKUBE_PRO_TLS_INSECURE"), os.Getenv("TESTKUBE_CLOUD_TLS_INSECURE"), "false"),
+				"cloud.api.url":        common.GetOr(os.Getenv("TESTKUBE_PRO_URL"), os.Getenv("TESTKUBE_CLOUD_URL")),
+
+				"dashboard.url": os.Getenv("TESTKUBE_DASHBOARD_URI"),
+				"api.url":       s.ApiUrl,
+				"namespace":     s.Namespace,
 			}).
 			RegisterStringMap("workflow", map[string]string{
 				"name": workflow.Name,

--- a/pkg/tcl/apitcl/v1/testworkflows.go
+++ b/pkg/tcl/apitcl/v1/testworkflows.go
@@ -321,10 +321,11 @@ func (s *apiTCL) ExecuteTestWorkflowHandler() fiber.Handler {
 				"storage.keyFile":    os.Getenv("STORAGE_KEY_FILE"),
 				"storage.caFile":     os.Getenv("STORAGE_CA_FILE"),
 
-				"cloud.enabled":        strconv.FormatBool(os.Getenv("TESTKUBE_PRO_API_KEY") != "" || os.Getenv("TESTKUBE_CLOUD_API_KEY") != ""),
-				"cloud.api.key":        common.GetOr(os.Getenv("TESTKUBE_PRO_API_KEY"), os.Getenv("TESTKUBE_CLOUD_API_KEY")),
-				"cloud.api.skipVerify": common.GetOr(os.Getenv("TESTKUBE_PRO_TLS_INSECURE"), os.Getenv("TESTKUBE_CLOUD_TLS_INSECURE"), "false"),
-				"cloud.api.url":        common.GetOr(os.Getenv("TESTKUBE_PRO_URL"), os.Getenv("TESTKUBE_CLOUD_URL")),
+				"cloud.enabled":         strconv.FormatBool(os.Getenv("TESTKUBE_PRO_API_KEY") != "" || os.Getenv("TESTKUBE_CLOUD_API_KEY") != ""),
+				"cloud.api.key":         common.GetOr(os.Getenv("TESTKUBE_PRO_API_KEY"), os.Getenv("TESTKUBE_CLOUD_API_KEY")),
+				"cloud.api.tlsInsecure": common.GetOr(os.Getenv("TESTKUBE_PRO_TLS_INSECURE"), os.Getenv("TESTKUBE_CLOUD_TLS_INSECURE"), "false"),
+				"cloud.api.skipVerify":  common.GetOr(os.Getenv("TESTKUBE_PRO_SKIP_VERIFY"), os.Getenv("TESTKUBE_CLOUD_SKIP_VERIFY"), "false"),
+				"cloud.api.url":         common.GetOr(os.Getenv("TESTKUBE_PRO_URL"), os.Getenv("TESTKUBE_CLOUD_URL")),
 
 				"dashboard.url": os.Getenv("TESTKUBE_DASHBOARD_URI"),
 				"api.url":       s.ApiUrl,

--- a/pkg/tcl/testworkflowstcl/testworkflowcontroller/utils.go
+++ b/pkg/tcl/testworkflowstcl/testworkflowcontroller/utils.go
@@ -416,6 +416,9 @@ func watchEvents(clientSet kubernetes.Interface, namespace string, options ListO
 				if !ok {
 					return
 				}
+				if event.Object == nil {
+					continue
+				}
 				switch event.Type {
 				case watch.Added, watch.Modified:
 					w.SendValue(event.Object.(*corev1.Event))

--- a/pkg/tcl/testworkflowstcl/testworkflowprocessor/constants.go
+++ b/pkg/tcl/testworkflowstcl/testworkflowprocessor/constants.go
@@ -36,6 +36,7 @@ var (
 
 var (
 	defaultInitImage       = getInitImage()
+	defaultToolkitImage    = getToolkitImage()
 	defaultContainerConfig = testworkflowsv1.ContainerConfig{
 		Image: defaultImage,
 		Env: []corev1.EnvVar{
@@ -52,6 +53,18 @@ func getInitImage() string {
 			version = "latest"
 		}
 		img = fmt.Sprintf("kubeshop/testkube-tw-init:%s", version)
+	}
+	return img
+}
+
+func getToolkitImage() string {
+	img := os.Getenv("TESTKUBE_TW_TOOLKIT_IMAGE")
+	if img == "" {
+		version := common.Version
+		if version == "" || version == "dev" {
+			version = "latest"
+		}
+		img = fmt.Sprintf("kubeshop/testkube-tw-toolkit:%s", version)
 	}
 	return img
 }

--- a/pkg/tcl/testworkflowstcl/testworkflowprocessor/container.go
+++ b/pkg/tcl/testworkflowstcl/testworkflowprocessor/container.go
@@ -405,6 +405,7 @@ func (c *container) EnableToolkit(ref string) Container {
 		"TK_EX":                 "{{execution.id}}",
 		"TK_C_URL":              "{{internal.cloud.api.url}}",
 		"TK_C_KEY":              "{{internal.cloud.api.key}}",
+		"TK_C_TLS_INSECURE":     "{{internal.cloud.api.tlsInsecure}}",
 		"TK_C_SKIP_VERIFY":      "{{internal.cloud.api.skipVerify}}",
 		"TK_OS_ENDPOINT":        "{{internal.storage.url}}",
 		"TK_OS_ACCESSKEY":       "{{internal.storage.accessKey}}",

--- a/pkg/tcl/testworkflowstcl/testworkflowprocessor/operations.go
+++ b/pkg/tcl/testworkflowstcl/testworkflowprocessor/operations.go
@@ -108,7 +108,9 @@ func ProcessExecute(_ InternalProcessor, layer Intermediate, container Container
 			args = append(args, "-w", fmt.Sprintf(`%s={"config":%s}`, w.Name, v))
 		}
 	}
-	// TODO: Support "async"
+	if step.Execute.Async {
+		args = append(args, "--async")
+	}
 	if step.Execute.Parallelism > 0 {
 		args = append(args, "-p", strconv.Itoa(int(step.Execute.Parallelism)))
 	}

--- a/pkg/tcl/testworkflowstcl/testworkflowprocessor/processor.go
+++ b/pkg/tcl/testworkflowstcl/testworkflowprocessor/processor.go
@@ -56,7 +56,8 @@ func NewFullFeatured(inspector imageinspector.Inspector) Processor {
 		Register(ProcessRunCommand).
 		Register(ProcessShellCommand).
 		Register(ProcessExecute).
-		Register(ProcessNestedSteps)
+		Register(ProcessNestedSteps).
+		Register(ProcessArtifacts)
 }
 
 func (p *processor) Register(operation Operation) Processor {

--- a/pkg/tcl/testworkflowstcl/testworkflowprocessor/processor.go
+++ b/pkg/tcl/testworkflowstcl/testworkflowprocessor/processor.go
@@ -52,6 +52,7 @@ func NewFullFeatured(inspector imageinspector.Inspector) Processor {
 	return New(inspector).
 		Register(ProcessDelay).
 		Register(ProcessContentFiles).
+		Register(ProcessContentGit).
 		Register(ProcessRunCommand).
 		Register(ProcessShellCommand).
 		Register(ProcessExecute).
@@ -65,6 +66,9 @@ func (p *processor) Register(operation Operation) Processor {
 
 func (p *processor) process(layer Intermediate, container Container, step testworkflowsv1.Step, ref string) (Stage, error) {
 	// Configure defaults
+	if step.WorkingDir != nil {
+		container.SetWorkingDir(*step.WorkingDir)
+	}
 	container.ApplyCR(step.Container)
 
 	// Build an initial group for the inner items

--- a/pkg/tcl/testworkflowstcl/testworkflowprocessor/processor.go
+++ b/pkg/tcl/testworkflowstcl/testworkflowprocessor/processor.go
@@ -54,6 +54,7 @@ func NewFullFeatured(inspector imageinspector.Inspector) Processor {
 		Register(ProcessContentFiles).
 		Register(ProcessRunCommand).
 		Register(ProcessShellCommand).
+		Register(ProcessExecute).
 		Register(ProcessNestedSteps)
 }
 


### PR DESCRIPTION
## Pull request description 

* Add `testkube-toolkit` image, that supports `clone`, `execute`, and `artifacts` commands
* Add corresponding `content.git`, `execute`, and `artifacts` support in the TestWorkflow
* Add API and CLI for listing and fetching artifacts
* Minor fixes for TestWorkflows

## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [x] tested locally
- [ ] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Fixes

- https://linear.app/kubeshop/issue/TKC-1642/testworkflows-build-and-use-orchestration-toolkit