### PR TITLE
fix(TKC-1642): update TestWorkflow Toolkit to use libssl3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -117,6 +117,7 @@ openapi-generate-model-testkube:
 	rm -rf tmp
 	find ./pkg/api/v1/testkube -type f -exec sed -i '' -e "s/package swagger/package testkube/g" {} \;
 	find ./pkg/api/v1/testkube -type f -exec sed -i '' -e "s/\*map\[string\]/map[string]/g" {} \;
+	find ./pkg/api/v1/testkube -name "*.go" -type f -exec sed -i '' -e "s/ map\[string\]Object / map\[string\]interface\{\} /g" {} \; # support map with empty additional properties
 	find ./pkg/api/v1/testkube -name "*update*.go" -type f -exec sed -i '' -e "s/ map/ \*map/g" {} \;
 	find ./pkg/api/v1/testkube -name "*update*.go" -type f -exec sed -i '' -e "s/ string/ \*string/g" {} \;
 	find ./pkg/api/v1/testkube -name "*update*.go" -type f -exec sed -i '' -e "s/ \[\]/ \*\[\]/g" {} \;

--- a/api/v1/testkube.yaml
+++ b/api/v1/testkube.yaml
@@ -7630,6 +7630,7 @@ components:
           description: output kind name
         value:
           type: object
+          additionalProperties: {}
           description: value returned
 
     TestWorkflowResult:

--- a/build/testworkflow-toolkit/Dockerfile
+++ b/build/testworkflow-toolkit/Dockerfile
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1
 ARG ALPINE_IMAGE
 FROM ${ALPINE_IMAGE}
-RUN apk --no-cache add ca-certificates libssl1.1 git
+RUN apk --no-cache add ca-certificates libssl3 git
 COPY testworkflow-toolkit /toolkit
 USER 1001
 ENTRYPOINT ["/toolkit"]

--- a/pkg/api/v1/testkube/model_test_workflow_output.go
+++ b/pkg/api/v1/testkube/model_test_workflow_output.go
@@ -15,5 +15,5 @@ type TestWorkflowOutput struct {
 	// output kind name
 	Name string `json:"name,omitempty"`
 	// value returned
-	Value *interface{} `json:"value,omitempty"`
+	Value map[string]interface{} `json:"value,omitempty"`
 }

--- a/pkg/api/v1/testkube/model_test_workflow_status_extended.go
+++ b/pkg/api/v1/testkube/model_test_workflow_status_extended.go
@@ -21,6 +21,7 @@ func (statuses TestWorkflowStatuses) ToMap() map[TestWorkflowStatus]struct{} {
 // ParseTestWorkflowStatusList parse a list of workflow execution statuses from string
 func ParseTestWorkflowStatusList(source, separator string) (statusList TestWorkflowStatuses, err error) {
 	statusMap := map[TestWorkflowStatus]struct{}{
+		ABORTED_TestWorkflowStatus: {},
 		FAILED_TestWorkflowStatus:  {},
 		PASSED_TestWorkflowStatus:  {},
 		QUEUED_TestWorkflowStatus:  {},

--- a/pkg/tcl/testworkflowstcl/testworkflowcontroller/logs.go
+++ b/pkg/tcl/testworkflowstcl/testworkflowcontroller/logs.go
@@ -39,9 +39,13 @@ func (i *Instruction) ToInternal() *testkube.TestWorkflowOutput {
 	if i == nil {
 		return nil
 	}
-	value := &i.Value
-	if i.Value == nil {
-		value = nil
+	value := map[string]interface{}(nil)
+	if i.Value != nil {
+		v, _ := json.Marshal(i.Value)
+		_ = json.Unmarshal(v, &value)
+	}
+	if v, ok := i.Value.(map[string]interface{}); ok {
+		value = v
 	}
 	return &testkube.TestWorkflowOutput{
 		Ref:   i.Ref,

--- a/pkg/tcl/testworkflowstcl/testworkflowcontroller/logs.go
+++ b/pkg/tcl/testworkflowstcl/testworkflowcontroller/logs.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/kubeshop/testkube/cmd/tcl/testworkflow-init/data"
 	"github.com/kubeshop/testkube/pkg/api/v1/testkube"
+	"github.com/kubeshop/testkube/pkg/log"
 	"github.com/kubeshop/testkube/pkg/utils"
 )
 
@@ -42,7 +43,10 @@ func (i *Instruction) ToInternal() *testkube.TestWorkflowOutput {
 	value := map[string]interface{}(nil)
 	if i.Value != nil {
 		v, _ := json.Marshal(i.Value)
-		_ = json.Unmarshal(v, &value)
+		e := json.Unmarshal(v, &value)
+		if e != nil {
+			log.DefaultLogger.Warnf("invalid output passed from TestWorfklow - %v", i.Value)
+		}
 	}
 	if v, ok := i.Value.(map[string]interface{}); ok {
 		value = v


### PR DESCRIPTION
## Pull request description 

`libssl1.1` is not available in our current Alpine - https://github.com/kubeshop/testkube/actions/runs/8201841833/job/22431395514

## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [ ] tested locally
- [ ] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Breaking changes

-

## Changes

-

## Fixes

-