### PR TITLE
fix: direct client uri fix

### DIFF
--- a/pkg/api/v1/client/uploads.go
+++ b/pkg/api/v1/client/uploads.go
@@ -9,6 +9,7 @@ import (
 	"mime/multipart"
 	"net/http"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"k8s.io/client-go/kubernetes"
@@ -81,7 +82,7 @@ func (c CopyFileDirectClient) UploadFile(parentName string, parentType TestingTy
 }
 
 func (c CopyFileDirectClient) getUri() string {
-	return c.apiPathPrefix + uri
+	return strings.Join([]string{c.apiPathPrefix, c.apiURI, "/", Version, uri}, "")
 }
 
 // UploadFile uploads a copy file to the API server


### PR DESCRIPTION
## Pull request description 

Direct client for copy files did not take all parts of the URI into account when creating a connection

https://github.com/kubeshop/testkube/issues/5118

## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [x] tested locally
- [ ] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Breaking changes

-

## Changes

-

## Fixes

-