### PR TITLE
feat: add durationMs to the TestWorkflow's result

### DIFF
--- a/api/v1/testkube.yaml
+++ b/api/v1/testkube.yaml
@@ -7597,6 +7597,9 @@ components:
         duration:
           type: string
           description: Go-formatted (human-readable) duration
+        durationMs:
+          type: integer
+          description: Duration in milliseconds
       required:
         - status
         - predictedStatus
@@ -7655,6 +7658,9 @@ components:
         duration:
           type: string
           description: Go-formatted (human-readable) duration
+        durationMs:
+          type: integer
+          description: Duration in milliseconds
         initialization:
           $ref: "#/components/schemas/TestWorkflowStepResult"
         steps:

--- a/pkg/api/v1/testkube/model_test_workflow_result.go
+++ b/pkg/api/v1/testkube/model_test_workflow_result.go
@@ -23,7 +23,9 @@ type TestWorkflowResult struct {
 	// when the pod has been completed
 	FinishedAt time.Time `json:"finishedAt,omitempty"`
 	// Go-formatted (human-readable) duration
-	Duration       string                            `json:"duration,omitempty"`
+	Duration string `json:"duration,omitempty"`
+	// Duration in milliseconds
+	DurationMs     int32                             `json:"durationMs,omitempty"`
 	Initialization *TestWorkflowStepResult           `json:"initialization,omitempty"`
 	Steps          map[string]TestWorkflowStepResult `json:"steps,omitempty"`
 }

--- a/pkg/api/v1/testkube/model_test_workflow_result_extended.go
+++ b/pkg/api/v1/testkube/model_test_workflow_result_extended.go
@@ -97,6 +97,7 @@ func (r *TestWorkflowResult) Recompute(sig []TestWorkflowSignature) {
 	// Compute the duration
 	if !r.FinishedAt.IsZero() {
 		r.Duration = r.FinishedAt.Sub(r.QueuedAt).Round(time.Millisecond).String()
+		r.DurationMs = int32(r.FinishedAt.Sub(r.QueuedAt).Milliseconds())
 	}
 
 	// Build status on the internal failure

--- a/pkg/api/v1/testkube/model_test_workflow_result_summary.go
+++ b/pkg/api/v1/testkube/model_test_workflow_result_summary.go
@@ -24,4 +24,6 @@ type TestWorkflowResultSummary struct {
 	FinishedAt time.Time `json:"finishedAt,omitempty"`
 	// Go-formatted (human-readable) duration
 	Duration string `json:"duration,omitempty"`
+	// Duration in milliseconds
+	DurationMs int32 `json:"durationMs,omitempty"`
 }


### PR DESCRIPTION
## Pull request description 

* add `durationMs` (number) to TestWorkflow results

## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [x] tested locally
- [ ] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
