### PR TITLE
fix: add missing durationMs for TestWorkflowResult

### DIFF
--- a/pkg/api/v1/testkube/model_test_workflow_result_extended.go
+++ b/pkg/api/v1/testkube/model_test_workflow_result_extended.go
@@ -68,6 +68,7 @@ func (r *TestWorkflowResult) Clone() *TestWorkflowResult {
 		StartedAt:       r.StartedAt,
 		FinishedAt:      r.FinishedAt,
 		Duration:        r.Duration,
+		DurationMs:      r.DurationMs,
 		Initialization:  r.Initialization.Clone(),
 		Steps:           steps,
 	}


### PR DESCRIPTION
## Pull request description 

* add missing `durationMs` during cloning TestWorkflow's result

## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [x] tested locally
- [ ] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
