### PR TITLE
fix: clean up TestWorkflow jobs after finish

### DIFF
--- a/pkg/tcl/testworkflowstcl/testworkflowexecutor/executor.go
+++ b/pkg/tcl/testworkflowstcl/testworkflowexecutor/executor.go
@@ -119,6 +119,8 @@ func (e *executor) Control(ctx context.Context, execution testkube.TestWorkflowE
 	wg := sync.WaitGroup{}
 	wg.Add(1)
 	go func() {
+		defer wg.Done()
+
 		for v := range ctrl.Watch(ctx).Stream(ctx).Channel() {
 			if v.Error != nil {
 				continue


### PR DESCRIPTION
## Pull request description 

* Clean up TestWorkflow jobs after finish

## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [x] tested locally
- [x] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
