### PR TITLE
fix: aborting execution via endpoint without test workflow name

### DIFF
--- a/pkg/tcl/apitcl/v1/testworkflowexecutions.go
+++ b/pkg/tcl/apitcl/v1/testworkflowexecutions.go
@@ -217,8 +217,13 @@ func (s *apiTCL) AbortTestWorkflowExecutionHandler() fiber.Handler {
 		executionID := c.Params("executionID")
 		errPrefix := fmt.Sprintf("failed to abort test workflow execution '%s'", executionID)
 
-		// TODO: Fetch execution from database
-		execution, err := s.TestWorkflowResults.GetByNameAndTestWorkflow(ctx, executionID, name)
+		var execution testkube.TestWorkflowExecution
+		var err error
+		if name == "" {
+			execution, err = s.TestWorkflowResults.Get(ctx, executionID)
+		} else {
+			execution, err = s.TestWorkflowResults.GetByNameAndTestWorkflow(ctx, executionID, name)
+		}
 		if err != nil {
 			return s.ClientError(c, errPrefix, err)
 		}


### PR DESCRIPTION
## Pull request description 

* `POST /test-workflow-executions/:executionID/abort` was searching by TestWorkflow name, while it didn't exist

## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [ ] tested locally
- [ ] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
