### PR TITLE
fix: send Content-Type of TestWorkflow artifacts for signing URL

### DIFF
--- a/pkg/cloud/data/artifact/scraper_model.go
+++ b/pkg/cloud/data/artifact/scraper_model.go
@@ -8,6 +8,7 @@ const (
 
 type PutObjectSignedURLRequest struct {
 	Object           string `json:"object"`
+	ContentType      string `json:"contentType,omitempty"`
 	ExecutionID      string `json:"executionId"`
 	TestName         string `json:"testName"`
 	TestSuiteName    string `json:"testSuiteName"`


### PR DESCRIPTION
## Pull request description 

* Send `Content-Type` along with signed URL request, as the Signature V4 is also hashing the passed headers

Right now, the Minio works fine, but GCP revokes the Put request due to:
```
⨯ videos/smoke2.cy.js.mp4: failed: store file: failed saving file: status code: 403 / message: <?xml version='1.0' encoding='UTF-8'?><Error><Code>SignatureDoesNotMatch</Code><Message>Access denied.</Message><Details>The request signature we calculated does not match the signature you provided. Check your Google secret key and signing method.</Details><StringToSign>GOOG4-RSA-SHA256
20240311T214020Z
20240311/auto/storage/goog4_request
d751487ca00419b723ad665927825a21c80bdb1ded3debc283ab3cfe344e7833</StringToSign><CanonicalRequest>PUT
/testkube-cloud-outputs-edge/tkcorg_9deb42dda2197657/tkcenv_03e3ff499f13ccba/artifacts/testworkflows/cypress-workflow-smoke-13/65ef79f9b5bc3c7c7b67daa0/videos/smoke2.cy.js.mp4
X-Goog-Algorithm=GOOG4-RSA-SHA256&amp;X-Goog-Credential=edge-testkube-cloud-api%40testkube-328312.iam.gserviceaccount.com%2F20240311%2Fauto%2Fstorage%2Fgoog4_request&amp;X-Goog-Date=20240311T214020Z&amp;X-Goog-Expires=1799&amp;X-Goog-SignedHeaders=content-type%3Bhost
content-type:video/mp4
host:storage.googleapis.com

content-type;host
UNSIGNED-PAYLOAD</CanonicalRequest></Error>
```

## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [ ] tested locally
- [ ] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
