### PR TITLE
fix(docs:deploying-in-aws): correct api path from /results/v1 to /v1

### DIFF
--- a/docs/docs/articles/deploying-in-aws.md
+++ b/docs/docs/articles/deploying-in-aws.md
@@ -49,7 +49,7 @@ uiIngress:
     alb.ingress.kubernetes.io/healthcheck-port: "8088"
     alb.ingress.kubernetes.io/ssl-redirect: "443"
     alb.ingress.kubernetes.io/certificate-arn: "arn:aws:acm:us-east-1:*******:certificate/*****"
-  path: /results/v1
+  path: /v1
   hosts:
     - test-api.aws.testkube.io
 ```
@@ -77,7 +77,7 @@ path: /
 
 :::caution
 
-Do not forget to add `apiServerEndpoint` to the `values.yaml` for `testkube-dashboard`, e.g.: `apiServerEndpoint: "test-api.aws.testkube.io/results/v1"`.
+Do not forget to add `apiServerEndpoint` to the `values.yaml` for `testkube-dashboard`, e.g.: `apiServerEndpoint: "test-api.aws.testkube.io/v1"`.
 
 :::
 
@@ -134,7 +134,7 @@ spec:
     - host: test-api.aws.testkube.io
       http:
         paths:
-          - path: /results/v1
+          - path: /v1
             pathType: Prefix
             backend:
               service:
@@ -169,7 +169,7 @@ service:
 
 :::caution
 
-Do not forget to add `apiServerEndpoint` to the values.yaml for `testkube-dashboard`, e.g.: `apiServerEndpoint: "test-api.aws.testkube.io/results/v1"`.
+Do not forget to add `apiServerEndpoint` to the values.yaml for `testkube-dashboard`, e.g.: `apiServerEndpoint: "test-api.aws.testkube.io/v1"`.
 
 :::
 


### PR DESCRIPTION
## Pull request description 
I would like contribute to prevent other users from wasting their time.

Turns out ingress setup documentation is not up to date - I couldn't setup testkube with ALB without going through closed tickets - https://github.com/kubeshop/testkube/issues/4850. At some point You have updated api path but probably forgot about documentation. 


## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [ ] tested locally
- [ ] tested on cluster
- [ ] added new dependencies
- [x] updated the docs
- [ ] added a test

## Breaking changes

-

## Changes

-

## Fixes

- updated documentation referencing api path from /results/v1 to /v1 in deploying-in-aws.md 