### PR TITLE
feat: calibrate TestWorkflow clock for more precise step durations

### DIFF
--- a/cmd/tcl/testworkflow-init/data/state.go
+++ b/cmd/tcl/testworkflow-init/data/state.go
@@ -161,6 +161,9 @@ func Finish() {
 		_ = Step.Cmd.Process.Kill()
 	}
 
+	// Emit end hint to allow exporting the timestamp
+	PrintHint(Step.Ref, "end")
+
 	// The init process needs to finish with zero exit code,
 	// to continue with the next container.
 	os.Exit(0)

--- a/pkg/tcl/testworkflowstcl/testworkflowprocessor/processor.go
+++ b/pkg/tcl/testworkflowstcl/testworkflowprocessor/processor.go
@@ -254,7 +254,7 @@ func (p *processor) Bundle(ctx context.Context, workflow *testworkflowsv1.TestWo
 		Image:           defaultInitImage,
 		ImagePullPolicy: corev1.PullIfNotPresent,
 		Command:         []string{"/bin/sh", "-c"},
-		Args:            []string{fmt.Sprintf("cp /init %s && touch %s && chmod 777 %s && (echo -n ',0' > %s && exit 0) || (echo -n 'failed,1' > %s && exit 1)", defaultInitPath, defaultStatePath, defaultStatePath, "/dev/termination-log", "/dev/termination-log")},
+		Args:            []string{fmt.Sprintf("cp /init %s && touch %s && chmod 777 %s && (echo -n ',0' > %s && echo 'Done' && exit 0) || (echo -n 'failed,1' > %s && exit 1)", defaultInitPath, defaultStatePath, defaultStatePath, "/dev/termination-log", "/dev/termination-log")},
 		VolumeMounts:    layer.ContainerDefaults().VolumeMounts(),
 	}
 	err = expressionstcl.FinalizeForce(&initContainer, machines...)

--- a/pkg/tcl/testworkflowstcl/testworkflowprocessor/processor_test.go
+++ b/pkg/tcl/testworkflowstcl/testworkflowprocessor/processor_test.go
@@ -93,7 +93,7 @@ func TestProcessBasic(t *testing.T) {
 							Image:           defaultInitImage,
 							ImagePullPolicy: corev1.PullIfNotPresent,
 							Command:         []string{"/bin/sh", "-c"},
-							Args:            []string{"cp /init /.tktw/init && touch /.tktw/state && chmod 777 /.tktw/state && (echo -n ',0' > /dev/termination-log && exit 0) || (echo -n 'failed,1' > /dev/termination-log && exit 1)"},
+							Args:            []string{"cp /init /.tktw/init && touch /.tktw/state && chmod 777 /.tktw/state && (echo -n ',0' > /dev/termination-log && echo 'Done' && exit 0) || (echo -n 'failed,1' > /dev/termination-log && exit 1)"},
 							VolumeMounts:    volumeMounts,
 						},
 					},
@@ -168,7 +168,7 @@ func TestProcessBasicEnvReference(t *testing.T) {
 				Image:           defaultInitImage,
 				ImagePullPolicy: corev1.PullIfNotPresent,
 				Command:         []string{"/bin/sh", "-c"},
-				Args:            []string{"cp /init /.tktw/init && touch /.tktw/state && chmod 777 /.tktw/state && (echo -n ',0' > /dev/termination-log && exit 0) || (echo -n 'failed,1' > /dev/termination-log && exit 1)"},
+				Args:            []string{"cp /init /.tktw/init && touch /.tktw/state && chmod 777 /.tktw/state && (echo -n ',0' > /dev/termination-log && echo 'Done' && exit 0) || (echo -n 'failed,1' > /dev/termination-log && exit 1)"},
 				VolumeMounts:    volumeMounts,
 			},
 		},
@@ -232,7 +232,7 @@ func TestProcessMultipleSteps(t *testing.T) {
 				Image:           defaultInitImage,
 				ImagePullPolicy: corev1.PullIfNotPresent,
 				Command:         []string{"/bin/sh", "-c"},
-				Args:            []string{"cp /init /.tktw/init && touch /.tktw/state && chmod 777 /.tktw/state && (echo -n ',0' > /dev/termination-log && exit 0) || (echo -n 'failed,1' > /dev/termination-log && exit 1)"},
+				Args:            []string{"cp /init /.tktw/init && touch /.tktw/state && chmod 777 /.tktw/state && (echo -n ',0' > /dev/termination-log && echo 'Done' && exit 0) || (echo -n 'failed,1' > /dev/termination-log && exit 1)"},
 				VolumeMounts:    volumeMounts,
 			},
 			{
@@ -314,7 +314,7 @@ func TestProcessNestedSteps(t *testing.T) {
 				Image:           defaultInitImage,
 				ImagePullPolicy: corev1.PullIfNotPresent,
 				Command:         []string{"/bin/sh", "-c"},
-				Args:            []string{"cp /init /.tktw/init && touch /.tktw/state && chmod 777 /.tktw/state && (echo -n ',0' > /dev/termination-log && exit 0) || (echo -n 'failed,1' > /dev/termination-log && exit 1)"},
+				Args:            []string{"cp /init /.tktw/init && touch /.tktw/state && chmod 777 /.tktw/state && (echo -n ',0' > /dev/termination-log && echo 'Done' && exit 0) || (echo -n 'failed,1' > /dev/termination-log && exit 1)"},
 				VolumeMounts:    volumeMounts,
 			},
 			{
@@ -438,7 +438,7 @@ func TestProcessOptionalSteps(t *testing.T) {
 				Image:           defaultInitImage,
 				ImagePullPolicy: corev1.PullIfNotPresent,
 				Command:         []string{"/bin/sh", "-c"},
-				Args:            []string{"cp /init /.tktw/init && touch /.tktw/state && chmod 777 /.tktw/state && (echo -n ',0' > /dev/termination-log && exit 0) || (echo -n 'failed,1' > /dev/termination-log && exit 1)"},
+				Args:            []string{"cp /init /.tktw/init && touch /.tktw/state && chmod 777 /.tktw/state && (echo -n ',0' > /dev/termination-log && echo 'Done' && exit 0) || (echo -n 'failed,1' > /dev/termination-log && exit 1)"},
 				VolumeMounts:    volumeMounts,
 			},
 			{
@@ -560,7 +560,7 @@ func TestProcessNegativeSteps(t *testing.T) {
 				Image:           defaultInitImage,
 				ImagePullPolicy: corev1.PullIfNotPresent,
 				Command:         []string{"/bin/sh", "-c"},
-				Args:            []string{"cp /init /.tktw/init && touch /.tktw/state && chmod 777 /.tktw/state && (echo -n ',0' > /dev/termination-log && exit 0) || (echo -n 'failed,1' > /dev/termination-log && exit 1)"},
+				Args:            []string{"cp /init /.tktw/init && touch /.tktw/state && chmod 777 /.tktw/state && (echo -n ',0' > /dev/termination-log && echo 'Done' && exit 0) || (echo -n 'failed,1' > /dev/termination-log && exit 1)"},
 				VolumeMounts:    volumeMounts,
 			},
 			{
@@ -679,7 +679,7 @@ func TestProcessNegativeContainerStep(t *testing.T) {
 				Image:           defaultInitImage,
 				ImagePullPolicy: corev1.PullIfNotPresent,
 				Command:         []string{"/bin/sh", "-c"},
-				Args:            []string{"cp /init /.tktw/init && touch /.tktw/state && chmod 777 /.tktw/state && (echo -n ',0' > /dev/termination-log && exit 0) || (echo -n 'failed,1' > /dev/termination-log && exit 1)"},
+				Args:            []string{"cp /init /.tktw/init && touch /.tktw/state && chmod 777 /.tktw/state && (echo -n ',0' > /dev/termination-log && echo 'Done' && exit 0) || (echo -n 'failed,1' > /dev/termination-log && exit 1)"},
 				VolumeMounts:    volumeMounts,
 			},
 			{
@@ -755,7 +755,7 @@ func TestProcessOptionalContainerStep(t *testing.T) {
 				Image:           defaultInitImage,
 				ImagePullPolicy: corev1.PullIfNotPresent,
 				Command:         []string{"/bin/sh", "-c"},
-				Args:            []string{"cp /init /.tktw/init && touch /.tktw/state && chmod 777 /.tktw/state && (echo -n ',0' > /dev/termination-log && exit 0) || (echo -n 'failed,1' > /dev/termination-log && exit 1)"},
+				Args:            []string{"cp /init /.tktw/init && touch /.tktw/state && chmod 777 /.tktw/state && (echo -n ',0' > /dev/termination-log && echo 'Done' && exit 0) || (echo -n 'failed,1' > /dev/termination-log && exit 1)"},
 				VolumeMounts:    volumeMounts,
 			},
 			{
@@ -840,7 +840,7 @@ func TestProcessLocalContent(t *testing.T) {
 				Image:           defaultInitImage,
 				ImagePullPolicy: corev1.PullIfNotPresent,
 				Command:         []string{"/bin/sh", "-c"},
-				Args:            []string{"cp /init /.tktw/init && touch /.tktw/state && chmod 777 /.tktw/state && (echo -n ',0' > /dev/termination-log && exit 0) || (echo -n 'failed,1' > /dev/termination-log && exit 1)"},
+				Args:            []string{"cp /init /.tktw/init && touch /.tktw/state && chmod 777 /.tktw/state && (echo -n ',0' > /dev/termination-log && echo 'Done' && exit 0) || (echo -n 'failed,1' > /dev/termination-log && exit 1)"},
 				VolumeMounts:    volumeMounts,
 			},
 			{
@@ -932,7 +932,7 @@ func TestProcessGlobalContent(t *testing.T) {
 				Image:           defaultInitImage,
 				ImagePullPolicy: corev1.PullIfNotPresent,
 				Command:         []string{"/bin/sh", "-c"},
-				Args:            []string{"cp /init /.tktw/init && touch /.tktw/state && chmod 777 /.tktw/state && (echo -n ',0' > /dev/termination-log && exit 0) || (echo -n 'failed,1' > /dev/termination-log && exit 1)"},
+				Args:            []string{"cp /init /.tktw/init && touch /.tktw/state && chmod 777 /.tktw/state && (echo -n ',0' > /dev/termination-log && echo 'Done' && exit 0) || (echo -n 'failed,1' > /dev/termination-log && exit 1)"},
 				VolumeMounts:    volumeMounts,
 			},
 			{


### PR DESCRIPTION
## Pull request description 

* Use log timestamps to calibrate the step timestamps
   * Thanks to that, we are able to go down to millisecond precision (although it's still not always working, but it's far more accurate than depending on Kubernetes event timestamps, with second precision)

## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [x] tested locally
- [x] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
