### PR TITLE
fix: add `workingDir` support for TestWorkflow artifacts step

### DIFF
--- a/api/v1/testkube.yaml
+++ b/api/v1/testkube.yaml
@@ -7965,6 +7965,8 @@ components:
     TestWorkflowStepArtifacts:
       type: object
       properties:
+        workingDir:
+          $ref: "#/components/schemas/BoxedString"
         compress:
           $ref: "#/components/schemas/TestWorkflowStepArtifactsCompression"
         paths:

--- a/go.mod
+++ b/go.mod
@@ -29,7 +29,7 @@ require (
 	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51
 	github.com/kelseyhightower/envconfig v1.4.0
 	github.com/kubepug/kubepug v1.7.1
-	github.com/kubeshop/testkube-operator v1.15.2-beta1.0.20240312153624-07cd5e8ce0be
+	github.com/kubeshop/testkube-operator v1.15.2-beta1.0.20240314074148-03a6d2dd1f3b
 	github.com/minio/minio-go/v7 v7.0.47
 	github.com/montanaflynn/stats v0.6.6
 	github.com/moogar0880/problems v0.1.1

--- a/go.sum
+++ b/go.sum
@@ -362,6 +362,8 @@ github.com/kubepug/kubepug v1.7.1 h1:LKhfSxS8Y5mXs50v+3Lpyec+cogErDLcV7CMUuiaisw
 github.com/kubepug/kubepug v1.7.1/go.mod h1:lv+HxD0oTFL7ZWjj0u6HKhMbbTIId3eG7aWIW0gyF8g=
 github.com/kubeshop/testkube-operator v1.15.2-beta1.0.20240312153624-07cd5e8ce0be h1:cs5m8bekmvEcyvFT37KgUEduv6XrdUfmX5WqZAbLUCY=
 github.com/kubeshop/testkube-operator v1.15.2-beta1.0.20240312153624-07cd5e8ce0be/go.mod h1:P47tw1nKQFufdsZndyq2HG2MSa0zK/lU0XpRfZtEmIk=
+github.com/kubeshop/testkube-operator v1.15.2-beta1.0.20240314074148-03a6d2dd1f3b h1:O41BWxgeUQJaBz4bcDlQhvHhiWLHPvsTxtvIKmwxjOs=
+github.com/kubeshop/testkube-operator v1.15.2-beta1.0.20240314074148-03a6d2dd1f3b/go.mod h1:P47tw1nKQFufdsZndyq2HG2MSa0zK/lU0XpRfZtEmIk=
 github.com/leodido/go-urn v1.2.1 h1:BqpAaACuzVSgi/VLzGZIobT2z4v53pjosyNd9Yv6n/w=
 github.com/leodido/go-urn v1.2.1/go.mod h1:zt4jvISO2HfUBqxjfIshjdMTYS56ZS/qv49ictyFfxY=
 github.com/lithammer/fuzzysearch v1.1.8 h1:/HIuJnjHuXS8bKaiTMeeDlW2/AyIWk2brx1V8LFgLN4=

--- a/pkg/api/v1/testkube/model_test_workflow_step_artifacts.go
+++ b/pkg/api/v1/testkube/model_test_workflow_step_artifacts.go
@@ -10,7 +10,8 @@
 package testkube
 
 type TestWorkflowStepArtifacts struct {
-	Compress *TestWorkflowStepArtifactsCompression `json:"compress,omitempty"`
+	WorkingDir *BoxedString                          `json:"workingDir,omitempty"`
+	Compress   *TestWorkflowStepArtifactsCompression `json:"compress,omitempty"`
 	// file paths to fetch from the container
 	Paths []string `json:"paths"`
 }

--- a/pkg/tcl/mapperstcl/testworkflows/kube_openapi.go
+++ b/pkg/tcl/mapperstcl/testworkflows/kube_openapi.go
@@ -493,8 +493,9 @@ func MapStepArtifactsCompressionKubeToAPI(v testworkflowsv1.ArtifactCompression)
 
 func MapStepArtifactsKubeToAPI(v testworkflowsv1.StepArtifacts) testkube.TestWorkflowStepArtifacts {
 	return testkube.TestWorkflowStepArtifacts{
-		Compress: common.MapPtr(v.Compress, MapStepArtifactsCompressionKubeToAPI),
-		Paths:    v.Paths,
+		WorkingDir: MapStringToBoxedString(v.WorkingDir),
+		Compress:   common.MapPtr(v.Compress, MapStepArtifactsCompressionKubeToAPI),
+		Paths:      v.Paths,
 	}
 }
 

--- a/pkg/tcl/mapperstcl/testworkflows/openapi_kube.go
+++ b/pkg/tcl/mapperstcl/testworkflows/openapi_kube.go
@@ -510,8 +510,9 @@ func MapStepArtifactsCompressionAPIToKube(v testkube.TestWorkflowStepArtifactsCo
 
 func MapStepArtifactsAPIToKube(v testkube.TestWorkflowStepArtifacts) testworkflowsv1.StepArtifacts {
 	return testworkflowsv1.StepArtifacts{
-		Compress: common.MapPtr(v.Compress, MapStepArtifactsCompressionAPIToKube),
-		Paths:    v.Paths,
+		WorkingDir: MapBoxedStringToString(v.WorkingDir),
+		Compress:   common.MapPtr(v.Compress, MapStepArtifactsCompressionAPIToKube),
+		Paths:      v.Paths,
 	}
 }
 

--- a/pkg/tcl/testworkflowstcl/testworkflowprocessor/operations.go
+++ b/pkg/tcl/testworkflowstcl/testworkflowprocessor/operations.go
@@ -280,7 +280,8 @@ func ProcessArtifacts(_ InternalProcessor, layer Intermediate, container Contain
 		return nil, errors.New("there needs to be at least one path to scrap for artifacts")
 	}
 
-	selfContainer := container.CreateChild()
+	selfContainer := container.CreateChild().
+		ApplyCR(&testworkflowsv1.ContainerConfig{WorkingDir: step.Artifacts.WorkingDir})
 	stage := NewContainerStage(layer.NextRef(), selfContainer)
 	stage.SetCondition("always")
 	stage.SetCategory("Upload artifacts")


### PR DESCRIPTION
## Pull request description 

* https://github.com/kubeshop/testkube-operator/pull/233

## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [x] tested locally
- [ ] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test