### PR TITLE
feat: [TKC-1740] remove dashboard from connect and disconnect commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,6 @@ Main Testkube components are:
   - [Ginkgo](https://docs.testkube.io/test-types/executor-ginkgo/) - Runs tests written in Go using Ginkgo ([@jdborneman-terminus](https://github.com/jdborneman-terminus))
   - [Executor Template](https://github.com/kubeshop/testkube-executor-template) - for creating your own executors
 - Results DB - for centralized test results aggregation and analysis
-- [Testkube Dashboard](https://github.com/kubeshop/testkube-dashboard) - standalone web application for viewing real-time Testkube test results
 
 
 ## Getting Started

--- a/cmd/kubectl-testkube/commands/common/helper.go
+++ b/cmd/kubectl-testkube/commands/common/helper.go
@@ -21,9 +21,9 @@ import (
 )
 
 type HelmOptions struct {
-	Name, Namespace, Chart, Values                  string
-	NoDashboard, NoMinio, NoMongo, NoConfirm        bool
-	MinioReplicas, MongoReplicas, DashboardReplicas int
+	Name, Namespace, Chart, Values           string
+	NoDashboard, NoMinio, NoMongo, NoConfirm bool
+	MinioReplicas, MongoReplicas             int
 
 	Master config.Master
 	// For debug
@@ -107,7 +107,6 @@ func HelmUpgradeOrInstallTestkubeCloud(options HelmOptions, cfg config.Data, isM
 
 	args = append(args, "--set", fmt.Sprintf("testkube-api.minio.replicas=%d", options.MinioReplicas))
 	args = append(args, "--set", fmt.Sprintf("mongodb.replicas=%d", options.MongoReplicas))
-	args = append(args, "--set", fmt.Sprintf("testkube-dashboard.replicas=%d", options.DashboardReplicas))
 
 	args = append(args, options.Name, options.Chart)
 

--- a/cmd/kubectl-testkube/commands/common/helper.go
+++ b/cmd/kubectl-testkube/commands/common/helper.go
@@ -21,9 +21,9 @@ import (
 )
 
 type HelmOptions struct {
-	Name, Namespace, Chart, Values           string
-	NoDashboard, NoMinio, NoMongo, NoConfirm bool
-	MinioReplicas, MongoReplicas             int
+	Name, Namespace, Chart, Values string
+	NoMinio, NoMongo, NoConfirm    bool
+	MinioReplicas, MongoReplicas   int
 
 	Master config.Master
 	// For debug
@@ -101,7 +101,6 @@ func HelmUpgradeOrInstallTestkubeCloud(options HelmOptions, cfg config.Data, isM
 
 	args = append(args, "--set", fmt.Sprintf("testkube-api.multinamespace.enabled=%t", options.MultiNamespace))
 	args = append(args, "--set", fmt.Sprintf("testkube-operator.enabled=%t", !options.NoOperator))
-	args = append(args, "--set", fmt.Sprintf("testkube-dashboard.enabled=%t", !options.NoDashboard))
 	args = append(args, "--set", fmt.Sprintf("mongodb.enabled=%t", !options.NoMongo))
 	args = append(args, "--set", fmt.Sprintf("testkube-api.minio.enabled=%t", !options.NoMinio))
 
@@ -146,7 +145,6 @@ func HelmUpgradeOrInstalTestkube(options HelmOptions) error {
 	args = []string{"upgrade", "--install", "--create-namespace", "--namespace", options.Namespace}
 	args = append(args, "--set", fmt.Sprintf("testkube-api.multinamespace.enabled=%t", options.MultiNamespace))
 	args = append(args, "--set", fmt.Sprintf("testkube-operator.enabled=%t", !options.NoOperator))
-	args = append(args, "--set", fmt.Sprintf("testkube-dashboard.enabled=%t", !options.NoDashboard))
 	args = append(args, "--set", fmt.Sprintf("mongodb.enabled=%t", !options.NoMongo))
 	args = append(args, "--set", fmt.Sprintf("testkube-api.minio.enabled=%t", !options.NoMinio))
 	if options.NoMinio {
@@ -177,7 +175,6 @@ func PopulateHelmFlags(cmd *cobra.Command, options *HelmOptions) {
 	cmd.Flags().StringVar(&options.Values, "values", "", "path to Helm values file")
 
 	cmd.Flags().BoolVar(&options.NoMinio, "no-minio", false, "don't install MinIO")
-	cmd.Flags().BoolVar(&options.NoDashboard, "no-dashboard", false, "don't install dashboard")
 	cmd.Flags().BoolVar(&options.NoMongo, "no-mongo", false, "don't install MongoDB")
 	cmd.Flags().BoolVar(&options.NoConfirm, "no-confirm", false, "don't ask for confirmation - unatended installation mode")
 	cmd.Flags().BoolVar(&options.DryRun, "dry-run", false, "dry run mode - only print commands that would be executed")

--- a/cmd/kubectl-testkube/commands/common/validator/cloudcontext.go
+++ b/cmd/kubectl-testkube/commands/common/validator/cloudcontext.go
@@ -12,11 +12,11 @@ func ValidateCloudContext(cfg config.Data) error {
 	}
 
 	if cfg.CloudContext.ApiUri == "" {
-		return errors.New("please provide Testkube Cloud URI")
+		return errors.New("please provide Testkube Pro URI")
 	}
 
 	if cfg.CloudContext.ApiKey == "" {
-		return errors.New("please provide Testkube Cloud API token")
+		return errors.New("please provide Testkube Pro API token")
 	}
 
 	if cfg.CloudContext.EnvironmentId == "" {

--- a/cmd/kubectl-testkube/commands/pro/connect.go
+++ b/cmd/kubectl-testkube/commands/pro/connect.go
@@ -153,11 +153,6 @@ func NewConnectCmd() *cobra.Command {
 				common.KubectlScaleDeployment(opts.Namespace, "testkube-minio-testkube", opts.MinioReplicas)
 				spinner.Success()
 			}
-			if opts.DashboardReplicas == 0 {
-				spinner = ui.NewSpinner("Scaling down Dashbaord")
-				common.KubectlScaleDeployment(opts.Namespace, "testkube-dashboard", opts.DashboardReplicas)
-				spinner.Success()
-			}
 
 			ui.H2("Testkube Pro is connected to your Testkube instance, saving local configuration")
 
@@ -187,7 +182,6 @@ func NewConnectCmd() *cobra.Command {
 
 	cmd.Flags().IntVar(&opts.MinioReplicas, "minio-replicas", 0, "MinIO replicas")
 	cmd.Flags().IntVar(&opts.MongoReplicas, "mongo-replicas", 0, "MongoDB replicas")
-	cmd.Flags().IntVar(&opts.DashboardReplicas, "dashboard-replicas", 0, "Dashboard replicas")
 	return cmd
 }
 

--- a/cmd/kubectl-testkube/commands/pro/disconnect.go
+++ b/cmd/kubectl-testkube/commands/pro/disconnect.go
@@ -23,7 +23,7 @@ func NewDisconnectCmd() *cobra.Command {
 		Run: func(cmd *cobra.Command, args []string) {
 
 			ui.H1("Disconnecting your Pro environment:")
-			ui.Paragraph("Rolling back to your clusters testkube OSS installation")
+			ui.Paragraph("Rolling back to your clusters Testkube OSS installation")
 			ui.Paragraph("If you need more details click into following link: " + docsUrl)
 			ui.H2("You can safely switch between connecting Pro and disconnecting without losing your data.")
 
@@ -39,7 +39,7 @@ func NewDisconnectCmd() *cobra.Command {
 			info, err := client.GetServerInfo()
 			firstInstall := err != nil && strings.Contains(err.Error(), "not found")
 			if err != nil && !firstInstall {
-				ui.Failf("Can't get testkube cluster information: %s", err.Error())
+				ui.Failf("Can't get Testkube cluster information: %s", err.Error())
 			}
 			var apiContext string
 			if actx, ok := contextDescription[info.Context]; ok {
@@ -49,7 +49,7 @@ func NewDisconnectCmd() *cobra.Command {
 			if cfg.ContextType == config.ContextTypeKubeconfig {
 				clusterContext, err = common.GetCurrentKubernetesContext()
 				if err != nil {
-					pterm.Error.Printfln("Failed to get current kubernetes context: %s", err.Error())
+					pterm.Error.Printfln("Failed to get current Kubernetes context: %s", err.Error())
 					return
 				}
 			}
@@ -94,11 +94,6 @@ func NewDisconnectCmd() *cobra.Command {
 				common.KubectlScaleDeployment(opts.Namespace, "testkube-minio-testkube", opts.MinioReplicas)
 				spinner.Success()
 			}
-			if opts.DashboardReplicas > 0 {
-				spinner = ui.NewSpinner("Scaling up Dashbaord")
-				common.KubectlScaleDeployment(opts.Namespace, "testkube-dashboard", opts.DashboardReplicas)
-				spinner.Success()
-			}
 
 			ui.NL()
 			ui.Success("Disconnect finished successfully")
@@ -110,6 +105,5 @@ func NewDisconnectCmd() *cobra.Command {
 	common.PopulateHelmFlags(cmd, &opts)
 	cmd.Flags().IntVar(&opts.MinioReplicas, "minio-replicas", 1, "MinIO replicas")
 	cmd.Flags().IntVar(&opts.MongoReplicas, "mongo-replicas", 1, "MongoDB replicas")
-	cmd.Flags().IntVar(&opts.DashboardReplicas, "dashboard-replicas", 1, "Dashboard replicas")
 	return cmd
 }

--- a/cmd/kubectl-testkube/commands/pro/disconnect.go
+++ b/cmd/kubectl-testkube/commands/pro/disconnect.go
@@ -78,7 +78,7 @@ func NewDisconnectCmd() *cobra.Command {
 
 			ui.NL(2)
 
-			spinner := ui.NewSpinner("Disonnecting from Testkube Pro")
+			spinner := ui.NewSpinner("Disconnecting from Testkube Pro")
 
 			err = common.HelmUpgradeOrInstalTestkube(opts)
 			ui.ExitOnError("Installing Testkube Pro", err)

--- a/cmd/kubectl-testkube/commands/pro/init.go
+++ b/cmd/kubectl-testkube/commands/pro/init.go
@@ -13,9 +13,8 @@ import (
 
 func NewInitCmd() *cobra.Command {
 	options := common.HelmOptions{
-		NoMinio:     true,
-		NoMongo:     true,
-		NoDashboard: true,
+		NoMinio: true,
+		NoMongo: true,
 	}
 
 	cmd := &cobra.Command{

--- a/docs/docs/articles/testkube-oss.md
+++ b/docs/docs/articles/testkube-oss.md
@@ -25,7 +25,6 @@ This command will set up the following components in your Kubernetes cluster:
 - Create a Testkube namespace.
 - Deploy the Testkube API.
 - Use MongoDB for test results and Minio for artifact storage (optional; disable with --no-minio). 
-- Testkube Dashboard to visually and manage all your tests (optional; disable with --no-dashboard flag).
 - Testkube will listen and manage all the CRDs for Tests, TestSuites, Executors, etc… inside the Testkube namespace.
 
 

--- a/docs/docs/cli/testkube_init.md
+++ b/docs/docs/cli/testkube_init.md
@@ -21,7 +21,6 @@ testkube init [flags]
       --name string           installation name (usually you don't need to change it) (default "testkube")
       --namespace string      namespace where to install (default "testkube")
       --no-confirm            don't ask for confirmation - unatended installation mode
-      --no-dashboard          don't install dashboard
       --no-minio              don't install MinIO
       --no-mongo              don't install MongoDB
       --org-id string         Testkube Cloud organization id [required for centralized mode]

--- a/docs/docs/cli/testkube_install.md
+++ b/docs/docs/cli/testkube_install.md
@@ -12,7 +12,6 @@ testkube install [flags]
       --chart string    chart name (default "kubeshop/testkube")
   -h, --help            help for install
       --name string     installation name (default "testkube")
-      --no-dashboard    don't install dashboard
       --no-minio        don't install MinIO
       --no-mongo        don't install MongoDB
       --values string   path to Helm values file

--- a/docs/docs/cli/testkube_pro_connect.md
+++ b/docs/docs/cli/testkube_pro_connect.md
@@ -24,7 +24,6 @@ testkube pro connect [flags]
       --name string              installation name (usually you don't need to change it) (default "testkube")
       --namespace string         namespace where to install (default "testkube")
       --no-confirm               don't ask for confirmation - unatended installation mode
-      --no-dashboard             don't install dashboard
       --no-minio                 don't install MinIO
       --no-mongo                 don't install MongoDB
       --org-id string            Testkube Cloud organization id [required for centralized mode]


### PR DESCRIPTION
## Pull request description 

This PR removes the dashboard operations from the `pro connect` and `pro disconnect` commands. Furthermore, it fixes the issue of the `pro disconnect` not updating the context properly, see TKC-1749

## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [x] tested locally
- [ ] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Breaking changes

-

## Changes

-

## Fixes

-