### PR TITLE
fix: handle gracefully OOMKilled errors on GKE

### DIFF
--- a/pkg/tcl/testworkflowstcl/testworkflowcontroller/controller.go
+++ b/pkg/tcl/testworkflowstcl/testworkflowcontroller/controller.go
@@ -372,6 +372,16 @@ func (c *controller) Watch(parentCtx context.Context) Watcher[Notification] {
 
 			// Update the last timestamp
 			lastTs = finishedAt
+
+			// Break the function if the step has been aborted.
+			// Breaking only to the loop is not enough,
+			// because due to GKE bug, the Job is still pending,
+			// so it will get stuck there.
+			if status.Status == testkube.ABORTED_TestWorkflowStepStatus {
+				result.Recompute(sig, c.scheduledAt)
+				w.SendValue(Notification{Result: result.Clone()})
+				return
+			}
 		}
 
 		// Read the pod finish time

--- a/pkg/tcl/testworkflowstcl/testworkflowcontroller/logs.go
+++ b/pkg/tcl/testworkflowstcl/testworkflowcontroller/logs.go
@@ -90,6 +90,13 @@ func GetContainerResult(c corev1.ContainerStatus) ContainerResult {
 		return ContainerResult{Status: testkube.RUNNING_TestWorkflowStepStatus, ExitCode: -1}
 	}
 	re := regexp.MustCompile(`^([^,]*),(0|[1-9]\d*)$`)
+
+	// Workaround - GKE sends SIGKILL after the container is already terminated,
+	// and the pod gets stuck then.
+	if c.State.Terminated.Reason != "Completed" {
+		return ContainerResult{Status: testkube.ABORTED_TestWorkflowStepStatus, ExitCode: -1, FinishedAt: c.State.Terminated.FinishedAt.Time}
+	}
+
 	msg := c.State.Terminated.Message
 	match := re.FindStringSubmatch(msg)
 	if match == nil {


### PR DESCRIPTION
## Pull request description 

- for some reason (bug?) GKE sends the SIGKILL when the container is already done successfully, and the Pod becomes stuck

## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [x] tested locally
- [x] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
