### PR TITLE
feat: display abort reason for TestWorkflow execution

### DIFF
--- a/pkg/tcl/testworkflowstcl/testworkflowcontroller/controller.go
+++ b/pkg/tcl/testworkflowstcl/testworkflowcontroller/controller.go
@@ -379,6 +379,16 @@ func (c *controller) Watch(parentCtx context.Context) Watcher[Notification] {
 			// so it will get stuck there.
 			if status.Status == testkube.ABORTED_TestWorkflowStepStatus {
 				result.Recompute(sig, c.scheduledAt)
+				abortTs := result.Steps[container.Name].FinishedAt
+				if status.Details == "" {
+					status.Details = "Manual"
+				}
+
+				w.SendValue(Notification{
+					Timestamp: abortTs,
+					Ref:       container.Name,
+					Log:       fmt.Sprintf("\n%s Aborted (%s)", abortTs.Format(KubernetesLogTimeFormat), status.Details),
+				})
 				w.SendValue(Notification{Result: result.Clone()})
 				return
 			}

--- a/pkg/tcl/testworkflowstcl/testworkflowcontroller/logs.go
+++ b/pkg/tcl/testworkflowstcl/testworkflowcontroller/logs.go
@@ -73,6 +73,7 @@ type ContainerLog struct {
 
 type ContainerResult struct {
 	Status     testkube.TestWorkflowStepStatus
+	Details    string
 	ExitCode   int
 	FinishedAt time.Time
 }
@@ -94,7 +95,7 @@ func GetContainerResult(c corev1.ContainerStatus) ContainerResult {
 	// Workaround - GKE sends SIGKILL after the container is already terminated,
 	// and the pod gets stuck then.
 	if c.State.Terminated.Reason != "Completed" {
-		return ContainerResult{Status: testkube.ABORTED_TestWorkflowStepStatus, ExitCode: -1, FinishedAt: c.State.Terminated.FinishedAt.Time}
+		return ContainerResult{Status: testkube.ABORTED_TestWorkflowStepStatus, Details: c.State.Terminated.Reason, ExitCode: -1, FinishedAt: c.State.Terminated.FinishedAt.Time}
 	}
 
 	msg := c.State.Terminated.Message


### PR DESCRIPTION
## Pull request description 

* Display Termination reason

| <img width="984" alt="Zrzut ekranu 2024-03-14 o 12 32 36" src="https://github.com/kubeshop/testkube/assets/3843526/9f2c500b-464f-4715-a44b-601a6d60e8a1"> | <img width="1054" alt="Zrzut ekranu 2024-03-14 o 12 32 57" src="https://github.com/kubeshop/testkube/assets/3843526/396ab7ff-96cc-4da0-a1c1-3ddabc370f45"> |
|-|-|

## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [x] tested locally
- [x] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
