### PR TITLE
fix: use cluster/environment ids for cli telemetry

### DIFF
--- a/api/v1/testkube.yaml
+++ b/api/v1/testkube.yaml
@@ -5840,6 +5840,10 @@ components:
           type: string
           description: server installaton namespace
           example: "my-testkube"
+        clusterId:
+          type: string
+          description: cluster id
+          example: "my-cluster-id"
         context:
           type: string
           description: currently configured testkube API context

--- a/internal/app/api/v1/handlers.go
+++ b/internal/app/api/v1/handlers.go
@@ -65,6 +65,7 @@ func (s *TestkubeAPI) InfoHandler() fiber.Handler {
 			Version:               version.Version,
 			Namespace:             s.Namespace,
 			Context:               apiContext,
+			ClusterId:             s.Config.ClusterID,
 			EnvId:                 envID,
 			OrgId:                 orgID,
 			HelmchartVersion:      s.helmchartVersion,

--- a/pkg/api/v1/testkube/model_server_info.go
+++ b/pkg/api/v1/testkube/model_server_info.go
@@ -17,6 +17,8 @@ type ServerInfo struct {
 	Commit string `json:"commit,omitempty"`
 	// server installaton namespace
 	Namespace string `json:"namespace,omitempty"`
+	// cluster id
+	ClusterId string `json:"clusterId,omitempty"`
 	// currently configured testkube API context
 	Context string `json:"context,omitempty"`
 	// cloud organization id

--- a/pkg/telemetry/payload.go
+++ b/pkg/telemetry/payload.go
@@ -97,7 +97,6 @@ type RunWorkflowParams struct {
 }
 
 func NewCLIPayload(context RunContext, id, name, version, category, clusterType string) Payload {
-	machineID := GetMachineID()
 	return Payload{
 		ClientID: id,
 		UserID:   id,
@@ -109,7 +108,7 @@ func NewCLIPayload(context RunContext, id, name, version, category, clusterType 
 					EventCategory:   category,
 					AppVersion:      version,
 					AppName:         "kubectl-testkube",
-					MachineID:       machineID,
+					MachineID:       GetMachineID(),
 					OperatingSystem: runtime.GOOS,
 					Architecture:    runtime.GOARCH,
 					Context:         context,

--- a/pkg/telemetry/telemetry.go
+++ b/pkg/telemetry/telemetry.go
@@ -11,6 +11,7 @@ import (
 	"github.com/spf13/cobra"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	"github.com/kubeshop/testkube/cmd/kubectl-testkube/commands/common"
 	"github.com/kubeshop/testkube/cmd/kubectl-testkube/config"
 	httpclient "github.com/kubeshop/testkube/pkg/http"
 	"github.com/kubeshop/testkube/pkg/k8sclient"
@@ -42,7 +43,7 @@ func SendCmdEvent(cmd *cobra.Command, version string) (string, error) {
 		command = "root"
 	}
 
-	payload := NewCLIPayload(getCurrentContext(), GetMachineID(), command, version, "cli_command_execution", GetClusterType())
+	payload := NewCLIPayload(getCurrentContext(), getUserID(cmd), command, version, "cli_command_execution", GetClusterType())
 	return sendData(senders, payload)
 }
 
@@ -89,13 +90,13 @@ func SendCmdAttemptEvent(cmd *cobra.Command, version string) (string, error) {
 
 	command += "_attempt"
 	// TODO pass error
-	payload := NewCLIPayload(getCurrentContext(), GetMachineID(), command, version, "cli_command_execution", GetClusterType())
+	payload := NewCLIPayload(getCurrentContext(), getUserID(cmd), command, version, "cli_command_execution", GetClusterType())
 	return sendData(senders, payload)
 }
 
 // SendCmdInitEvent will send CLI event to GA
 func SendCmdInitEvent(cmd *cobra.Command, version string) (string, error) {
-	payload := NewCLIPayload(getCurrentContext(), GetMachineID(), "init", version, "cli_command_execution", GetClusterType())
+	payload := NewCLIPayload(getCurrentContext(), getUserID(cmd), "init", version, "cli_command_execution", GetClusterType())
 	return sendData(senders, payload)
 }
 
@@ -162,6 +163,22 @@ func getCurrentContext() RunContext {
 		OrganizationId: data.CloudContext.OrganizationId,
 		EnvironmentId:  data.CloudContext.EnvironmentId,
 	}
+}
+
+func getUserID(cmd *cobra.Command) string {
+	id := "command-cli-user"
+	client, _, err := common.GetClient(cmd)
+	if err == nil && client != nil {
+		info, err := client.GetServerInfo()
+		if err == nil && info.ClusterId != "" {
+			id = info.ClusterId
+		}
+	}
+	data, err := config.Load()
+	if err != nil || data.CloudContext.EnvironmentId == "" {
+		return id
+	}
+	return data.CloudContext.EnvironmentId
 }
 
 func GetClusterType() string {


### PR DESCRIPTION
## Pull request description 

https://linear.app/kubeshop/issue/TKC-1571/use-fixed-user-id-for-cli-telemetry

## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [ ] tested locally
- [ ] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Breaking changes

-

## Changes

-

## Fixes

-