### PR TITLE
fix: (main) manual abort (improve deletion detection)

### DIFF
--- a/pkg/tcl/testworkflowstcl/testworkflowcontroller/cleanup.go
+++ b/pkg/tcl/testworkflowstcl/testworkflowcontroller/cleanup.go
@@ -40,7 +40,8 @@ func cleanupPods(ctx context.Context, clientSet kubernetes.Interface, namespace,
 
 func cleanupJobs(ctx context.Context, clientSet kubernetes.Interface, namespace, id string) error {
 	return clientSet.BatchV1().Jobs(namespace).DeleteCollection(ctx, metav1.DeleteOptions{
-		PropagationPolicy: common.Ptr(metav1.DeletePropagationBackground),
+		GracePeriodSeconds: common.Ptr(int64(0)),
+		PropagationPolicy:  common.Ptr(metav1.DeletePropagationBackground),
 	}, metav1.ListOptions{
 		LabelSelector: fmt.Sprintf("%s=%s", testworkflowprocessor.ExecutionIdLabelName, id),
 	})

--- a/pkg/tcl/testworkflowstcl/testworkflowcontroller/controller.go
+++ b/pkg/tcl/testworkflowstcl/testworkflowcontroller/controller.go
@@ -400,6 +400,13 @@ func (c *controller) Watch(parentCtx context.Context) Watcher[Notification] {
 				result.FinishedAt = v.Value.Status.CompletionTime.Time
 			}
 		}
+		if result.FinishedAt.IsZero() {
+			for v := range c.pod.Stream(ctx).Channel() {
+				if v.Value != nil && v.Value.ObjectMeta.DeletionTimestamp != nil {
+					result.FinishedAt = v.Value.ObjectMeta.DeletionTimestamp.Time
+				}
+			}
+		}
 
 		// Compute the TestWorkflow status and dates
 		result.Recompute(sig, c.scheduledAt)


### PR DESCRIPTION
## Pull request description 

* Kubernetes cluster will not necessarily send `DELETED` events for watch - it may send `MODIFIED` with `DeletionTimestamp`

## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [x] tested locally
- [x] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Breaking changes

-

## Changes

-

## Fixes

-