### PR TITLE
feat(expressions): add more functionalities

### DIFF
--- a/cmd/tcl/testworkflow-init/data/expressions.go
+++ b/cmd/tcl/testworkflow-init/data/expressions.go
@@ -9,13 +9,11 @@
 package data
 
 import (
-	"fmt"
 	"os"
 	"strings"
 
-	"github.com/pkg/errors"
-
 	"github.com/kubeshop/testkube/pkg/tcl/expressionstcl"
+	"github.com/kubeshop/testkube/pkg/tcl/expressionstcl/libs"
 )
 
 var aliases = map[string]string{
@@ -95,21 +93,8 @@ var RefStatusMachine = expressionstcl.NewMachine().
 		return string(State.GetStep(ref).Status), true
 	})
 
-var FileMachine = expressionstcl.NewMachine().
-	RegisterFunction("file", func(values ...expressionstcl.StaticValue) (interface{}, bool, error) {
-		if len(values) != 1 {
-			return nil, true, errors.New("file() function takes a single argument")
-		}
-		if !values[0].IsString() {
-			return nil, true, fmt.Errorf("file() function expects a string argument, provided: %v", values[0].String())
-		}
-		filePath, _ := values[0].StringValue()
-		file, err := os.ReadFile(filePath)
-		if err != nil {
-			return nil, true, fmt.Errorf("reading file(%s): %s", filePath, err.Error())
-		}
-		return string(file), true, nil
-	})
+var wd, _ = os.Getwd()
+var FileMachine = libs.NewFsMachine(os.DirFS("/"), wd)
 
 func Template(tpl string, m ...expressionstcl.Machine) (string, error) {
 	m = append(m, AliasMachine, EnvMachine, StateMachine, FileMachine)

--- a/cmd/tcl/testworkflow-toolkit/artifacts/walker.go
+++ b/cmd/tcl/testworkflow-toolkit/artifacts/walker.go
@@ -27,9 +27,13 @@ func mapSlice[T any, U any](s []T, fn func(T) U) []U {
 
 func deduplicateRoots(paths []string) []string {
 	result := make([]string, 0)
+	unique := make(map[string]struct{})
+	for _, p := range paths {
+		unique[p] = struct{}{}
+	}
 loop:
-	for _, path := range paths {
-		for _, path2 := range paths {
+	for path := range unique {
+		for path2 := range unique {
 			if strings.HasPrefix(path, path2+"/") {
 				continue loop
 			}
@@ -176,6 +180,7 @@ func (w *walker) Patterns() []string {
 	return w.patterns
 }
 
+// TODO: Support negative patterns
 func (w *walker) matches(filePath string) bool {
 	for _, p := range w.patterns {
 		v, _ := doublestar.PathMatch(p, filePath)

--- a/go.mod
+++ b/go.mod
@@ -25,6 +25,7 @@ require (
 	github.com/gookit/color v1.5.3
 	github.com/gorilla/websocket v1.5.0
 	github.com/h2non/filetype v1.1.3
+	github.com/itchyny/gojq v0.12.14
 	github.com/joshdk/go-junit v1.0.0
 	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51
 	github.com/kelseyhightower/envconfig v1.4.0
@@ -95,7 +96,6 @@ require (
 	github.com/gorilla/css v1.0.1 // indirect
 	github.com/hashicorp/golang-lru/v2 v2.0.1 // indirect
 	github.com/henvic/httpretty v0.1.0 // indirect
-	github.com/itchyny/gojq v0.12.14 // indirect
 	github.com/itchyny/timefmt-go v0.1.5 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/klauspost/cpuid/v2 v2.2.3 // indirect

--- a/pkg/tcl/expressionstcl/accessor.go
+++ b/pkg/tcl/expressionstcl/accessor.go
@@ -22,9 +22,9 @@ func newAccessor(name string) Expression {
 	// Map values based on wildcard
 	segments := strings.Split(name, ".*")
 	if len(segments) > 1 {
-		return newCall("map", []Expression{
-			newAccessor(strings.Join(segments[0:len(segments)-1], ".*")),
-			NewStringValue("_.value" + segments[len(segments)-1]),
+		return newCall("map", []callArgument{
+			{expr: newAccessor(strings.Join(segments[0:len(segments)-1], ".*"))},
+			{expr: NewStringValue("_.value" + segments[len(segments)-1])},
 		})
 	}
 

--- a/pkg/tcl/expressionstcl/accessor.go
+++ b/pkg/tcl/expressionstcl/accessor.go
@@ -10,14 +10,36 @@ package expressionstcl
 
 import (
 	"fmt"
+	"strings"
 )
 
 type accessor struct {
-	name string
+	name     string
+	fallback *Expression
 }
 
 func newAccessor(name string) Expression {
-	return &accessor{name: name}
+	// Map values based on wildcard
+	segments := strings.Split(name, ".*")
+	if len(segments) > 1 {
+		return newCall("map", []Expression{
+			newAccessor(strings.Join(segments[0:len(segments)-1], ".*")),
+			NewStringValue("_.value" + segments[len(segments)-1]),
+		})
+	}
+
+	// Prepare fallback based on the segments
+	segments = strings.Split(name, ".")
+	var fallback *Expression
+	if len(segments) > 1 {
+		f := newPropertyAccessor(
+			newAccessor(strings.Join(segments[0:len(segments)-1], ".")),
+			segments[len(segments)-1],
+		)
+		fallback = &f
+	}
+
+	return &accessor{name: name, fallback: fallback}
 }
 
 func (s *accessor) Type() Type {
@@ -43,11 +65,18 @@ func (s *accessor) SafeResolve(m ...Machine) (v Expression, changed bool, err er
 
 	for i := range m {
 		result, ok, err := m[i].Get(s.name)
+		if ok && err == nil {
+			return result, true, nil
+		}
+		if s.fallback != nil {
+			var err2 error
+			result, ok, err2 = (*s.fallback).SafeResolve(m...)
+			if ok && err2 == nil {
+				return result, true, nil
+			}
+		}
 		if err != nil {
 			return nil, false, fmt.Errorf("error while accessing %s: %s", s.String(), err.Error())
-		}
-		if ok {
-			return result, true, nil
 		}
 	}
 	return s, false, nil

--- a/pkg/tcl/expressionstcl/convert.go
+++ b/pkg/tcl/expressionstcl/convert.go
@@ -117,6 +117,16 @@ func toMap(s interface{}) (map[string]interface{}, error) {
 		return nil, nil
 	}
 	// Convert
+	if isStruct(s) {
+		v, err := json.Marshal(s)
+		if err != nil {
+			return nil, fmt.Errorf("error while marshaling value: %v: %v", s, err)
+		}
+		err = json.Unmarshal(v, &s)
+		if err != nil {
+			return nil, fmt.Errorf("error while unmarshaling value: %v: %v", s, err)
+		}
+	}
 	if isMap(s) {
 		value := reflect.ValueOf(s)
 		res := make(map[string]interface{}, value.Len())

--- a/pkg/tcl/expressionstcl/libs/fs.go
+++ b/pkg/tcl/expressionstcl/libs/fs.go
@@ -1,0 +1,166 @@
+// Copyright 2024 Testkube.
+//
+// Licensed as a Testkube Pro file under the Testkube Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+//     https://github.com/kubeshop/testkube/blob/main/licenses/TCL.txt
+
+package libs
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"io/fs"
+	"path/filepath"
+	"strings"
+
+	"github.com/bmatcuk/doublestar/v4"
+
+	"github.com/kubeshop/testkube/pkg/tcl/expressionstcl"
+)
+
+func absPath(p, workingDir string) string {
+	if !filepath.IsAbs(p) {
+		p = filepath.Join(workingDir, p)
+	}
+	v, err := filepath.Abs(p)
+	if err != nil {
+		v = p
+	}
+	v = strings.TrimRight(filepath.ToSlash(v), "/")
+	if v == "" {
+		return "/"
+	}
+	return v
+}
+
+func findSearchRoot(pattern, workingDir string) string {
+	path, _ := doublestar.SplitPattern(pattern + "/")
+	path = strings.TrimRight(path, "/")
+	if path == "." {
+		return strings.TrimLeft(absPath("", workingDir), "/")
+	}
+	return strings.TrimLeft(path, "/")
+}
+
+func mapSlice[T any, U any](s []T, fn func(T) U) []U {
+	result := make([]U, len(s))
+	for i := range s {
+		result[i] = fn(s[i])
+	}
+	return result
+}
+
+func deduplicateRoots(paths []string) []string {
+	result := make([]string, 0)
+	unique := make(map[string]struct{})
+	for _, p := range paths {
+		unique[p] = struct{}{}
+	}
+loop:
+	for path := range unique {
+		for path2 := range unique {
+			if strings.HasPrefix(path, path2+"/") {
+				continue loop
+			}
+		}
+		result = append(result, path)
+	}
+	return result
+}
+
+func readFile(fsys fs.FS, workingDir string, values ...expressionstcl.StaticValue) (interface{}, error) {
+	if len(values) != 1 {
+		return nil, errors.New("file() function takes a single argument")
+	}
+	if !values[0].IsString() {
+		return nil, fmt.Errorf("file() function expects a string argument, provided: %v", values[0].String())
+	}
+	filePath, _ := values[0].StringValue()
+	file, err := fsys.Open(strings.TrimLeft(absPath(filePath, workingDir), "/"))
+	if err != nil {
+		return nil, fmt.Errorf("opening file(%s): %s", filePath, err.Error())
+	}
+	content, err := io.ReadAll(file)
+	if err != nil {
+		return nil, fmt.Errorf("reading file(%s): %s", filePath, err.Error())
+	}
+	return string(content), nil
+}
+
+func createGlobMatcher(patterns []string) func(string) bool {
+	return func(filePath string) bool {
+		for _, p := range patterns {
+			v, _ := doublestar.PathMatch(p, filePath)
+			if v {
+				return true
+			}
+		}
+		return false
+	}
+}
+
+func globFs(fsys fs.FS, workingDir string, values ...expressionstcl.StaticValue) (interface{}, error) {
+	if len(values) == 0 {
+		return nil, errors.New("glob() function takes at least one argument")
+	}
+
+	// Read all the patterns
+	ignorePatterns := make([]string, 0)
+	patterns := make([]string, 0)
+	for i := 0; i < len(values); i++ {
+		v, _ := values[i].StringValue()
+		if strings.HasPrefix(v, "!") {
+			ignorePatterns = append(ignorePatterns, absPath(v[1:], workingDir))
+		} else {
+			patterns = append(patterns, absPath(v, workingDir))
+		}
+	}
+	if len(patterns) == 0 {
+		return nil, errors.New("glob() function needs at least one matching pattern")
+	}
+	matchesPositive := createGlobMatcher(patterns)
+	matchesIgnore := createGlobMatcher(ignorePatterns)
+
+	// Determine roots for searching, to avoid scanning whole FS
+	findRoot := func(pattern string) string {
+		return findSearchRoot(pattern, workingDir)
+	}
+	roots := deduplicateRoots(mapSlice(patterns, findRoot))
+	result := make([]string, 0)
+	for _, root := range roots {
+		err := fs.WalkDir(fsys, root, func(path string, d fs.DirEntry, err error) error {
+			if path == "." || err != nil || d.IsDir() {
+				return nil
+			}
+			path = "/" + path
+			if !matchesPositive(path) || matchesIgnore(path) {
+				return nil
+			}
+			result = append(result, path)
+			return nil
+		})
+		if err != nil {
+			return nil, fmt.Errorf("glob() error: %v", err)
+		}
+	}
+
+	return result, nil
+}
+
+func NewFsMachine(fsys fs.FS, workingDir string) expressionstcl.Machine {
+	if workingDir == "" {
+		workingDir = "/"
+	}
+	return expressionstcl.NewMachine().
+		RegisterFunction("file", func(values ...expressionstcl.StaticValue) (interface{}, bool, error) {
+			v, err := readFile(fsys, workingDir, values...)
+			return v, true, err
+		}).
+		RegisterFunction("glob", func(values ...expressionstcl.StaticValue) (interface{}, bool, error) {
+			v, err := globFs(fsys, workingDir, values...)
+			return v, true, err
+		})
+}

--- a/pkg/tcl/expressionstcl/libs/fs_test.go
+++ b/pkg/tcl/expressionstcl/libs/fs_test.go
@@ -1,0 +1,63 @@
+// Copyright 2024 Testkube.
+//
+// Licensed as a Testkube Pro file under the Testkube Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+//     https://github.com/kubeshop/testkube/blob/main/licenses/TCL.txt
+
+package libs
+
+import (
+	"testing"
+
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/kubeshop/testkube/pkg/tcl/expressionstcl"
+)
+
+func MustCall(m expressionstcl.Machine, name string, args ...interface{}) interface{} {
+	list := make([]expressionstcl.StaticValue, len(args))
+	for i, v := range args {
+		if vv, ok := v.(expressionstcl.StaticValue); ok {
+			list[i] = vv
+		} else {
+			list[i] = expressionstcl.NewValue(v)
+		}
+	}
+	v, ok, err := m.Call(name, list...)
+	if err != nil {
+		panic(err)
+	}
+	if !ok {
+		panic("not recognized")
+	}
+	return v.Static().Value()
+}
+
+func TestFsLibGlob(t *testing.T) {
+	fsys := &afero.IOFS{Fs: afero.NewMemMapFs()}
+	_ = afero.WriteFile(fsys.Fs, "etc/file1.txt", nil, 0644)
+	_ = afero.WriteFile(fsys.Fs, "else/file1.txt", nil, 0644)
+	_ = afero.WriteFile(fsys.Fs, "another-file.txt", nil, 0644)
+	_ = afero.WriteFile(fsys.Fs, "etc/nested/file2.json", nil, 0644)
+	machine := NewFsMachine(fsys, "/etc")
+	assert.Equal(t, []string{"/etc/file1.txt", "/etc/nested/file2.json"}, MustCall(machine, "glob", "**/*"))
+	assert.Equal(t, []string{"/etc/file1.txt"}, MustCall(machine, "glob", "*"))
+	assert.Equal(t, []string{"/etc/nested/file2.json"}, MustCall(machine, "glob", "**/*.json"))
+	assert.Equal(t, []string{"/etc/file1.txt", "/etc/nested/file2.json"}, MustCall(machine, "glob", "**/*.json", "*.txt"))
+	assert.Equal(t, []string{"/another-file.txt", "/else/file1.txt", "/etc/file1.txt"}, MustCall(machine, "glob", "/**/*.txt"))
+	assert.Equal(t, []string{"/another-file.txt", "/etc/file1.txt"}, MustCall(machine, "glob", "/**/*.txt", "!/else/**/*"))
+}
+
+func TestFsLibRead(t *testing.T) {
+	fsys := &afero.IOFS{Fs: afero.NewMemMapFs()}
+	_ = afero.WriteFile(fsys.Fs, "etc/file1.txt", []byte("foo"), 0644)
+	_ = afero.WriteFile(fsys.Fs, "another-file.txt", []byte("bar"), 0644)
+	machine := NewFsMachine(fsys, "/etc")
+	assert.Equal(t, "foo", MustCall(machine, "file", "file1.txt"))
+	assert.Equal(t, "foo", MustCall(machine, "file", "/etc/file1.txt"))
+	assert.Equal(t, "bar", MustCall(machine, "file", "../another-file.txt"))
+	assert.Equal(t, "bar", MustCall(machine, "file", "/another-file.txt"))
+}

--- a/pkg/tcl/expressionstcl/parse.go
+++ b/pkg/tcl/expressionstcl/parse.go
@@ -114,7 +114,7 @@ func getNextSegment(t []token) (e Expression, i int, err error) {
 
 	// Call - abc(a, b, c)
 	if t[0].Type == tokenTypeAccessor && len(t) > 1 && t[1].Type == tokenTypeOpen {
-		args := make([]Expression, 0)
+		args := make([]callArgument, 0)
 		index := 2
 		for {
 			// Ensure there is another token (for call close or next argument)
@@ -139,7 +139,12 @@ func getNextSegment(t []token) (e Expression, i int, err error) {
 			if err != nil {
 				return nil, index, err
 			}
-			args = append(args, next)
+			if len(t) > index && t[index].Type == tokenTypeSpread {
+				args = append(args, callArgument{expr: next, spread: true})
+				index++
+			} else {
+				args = append(args, callArgument{expr: next})
+			}
 		}
 		return newCall(t[0].Value.(string), args), index + 1, nil
 	}

--- a/pkg/tcl/expressionstcl/parse.go
+++ b/pkg/tcl/expressionstcl/parse.go
@@ -62,6 +62,9 @@ func parseNextExpression(t []token, priority int) (e Expression, i int, err erro
 				return nil, i, nerr
 			}
 			e = newMath(op, e, ne)
+		case tokenTypePropertyAccessor:
+			e = newPropertyAccessor(e, t[i].Value.(string))
+			i += 1
 		default:
 			return e, i, err
 		}

--- a/pkg/tcl/expressionstcl/parse.go
+++ b/pkg/tcl/expressionstcl/parse.go
@@ -30,6 +30,9 @@ func parseNextExpression(t []token, priority int) (e Expression, i int, err erro
 
 		switch t[i].Type {
 		case tokenTypeTernary:
+			if priority >= 0 {
+				return e, i, nil
+			}
 			i += 1
 			te, ti, terr := parseNextExpression(t[i:], 0)
 			i += ti

--- a/pkg/tcl/expressionstcl/parse_test.go
+++ b/pkg/tcl/expressionstcl/parse_test.go
@@ -263,6 +263,9 @@ a:
 	assert.Equal(t, `5`, MustCompile(`at([1,2,3,4,5], 4)`).String())
 	assert.Equal(t, `"value"`, MustCompile(`at({"x": "value"}, "x")`).String())
 	assert.Equal(t, `null`, MustCompile(`at({"x": "value"}, "unknown-key")`).String())
+	assert.Equal(t, `"abc"`, MustCompile(`eval("\"abc\"")`).String())
+	assert.Equal(t, `50`, MustCompile(`eval("5 * 10")`).String())
+	assert.Equal(t, `50*something`, MustCompile(`eval("5 * 10 * something")`).String())
 }
 
 func TestCompileDetectAccessors(t *testing.T) {

--- a/pkg/tcl/expressionstcl/parse_test.go
+++ b/pkg/tcl/expressionstcl/parse_test.go
@@ -232,6 +232,7 @@ func TestCompileStandardLib(t *testing.T) {
 	assert.Equal(t, `"'a b c'"`, MustCompile(`shellquote("a b c")`).String())
 	assert.Equal(t, `"'a b c' 'd e f'"`, MustCompile(`shellquote("a b c", "d e f")`).String())
 	assert.Equal(t, `"''"`, MustCompile(`shellquote(null)`).String())
+	assert.Equal(t, `["a","b","c","a b c"]`, MustCompile(`shellargs("a b c 'a b c'")`).String())
 	assert.Equal(t, `"abc  d"`, MustCompile(`trim("   abc  d  \n  ")`).String())
 	assert.Equal(t, `"abc"`, MustCompile(`yaml("\"abc\"")`).String())
 	assert.Equal(t, `{"foo":{"bar":"baz"}}`, MustCompile(`yaml("foo:\n  bar: 'baz'")`).String())
@@ -279,6 +280,7 @@ func TestCompileWildcard_Unknown(t *testing.T) {
 
 func TestCompileSpread(t *testing.T) {
 	assert.Equal(t, `"a b c 'a b c'"`, MustCompile(`shellquote(["a", "b", "c", "a b c"]...)`).String())
+	assert.Equal(t, `"a b c 'a b c'"`, MustCompile("shellquote(shellargs(\"a b c\n'a b c'\")...)").String())
 	assert.Equal(t, `"axb"`, MustCompile(`join([["a", "b"], "x"]...)`).String())
 }
 

--- a/pkg/tcl/expressionstcl/parse_test.go
+++ b/pkg/tcl/expressionstcl/parse_test.go
@@ -246,6 +246,11 @@ a:
 	assert.Equal(t, `5`, MustCompile(`len("abcde")`).String())
 	assert.Equal(t, `2`, MustCompile(`len(["a", "b"])`).String())
 	assert.Equal(t, `2`, MustCompile(`len({"a": "b", "b": "c"})`).String())
+	assert.Equal(t, `2`, MustCompile(`floor(2.6)`).String())
+	assert.Equal(t, `2`, MustCompile(`ceil(1.6)`).String())
+	assert.Equal(t, `2`, MustCompile(`round(1.6)`).String())
+	assert.Equal(t, `2`, MustCompile(`round(1.5)`).String())
+	assert.Equal(t, `1`, MustCompile(`round(1.4)`).String())
 }
 
 func TestCompileDetectAccessors(t *testing.T) {

--- a/pkg/tcl/expressionstcl/parse_test.go
+++ b/pkg/tcl/expressionstcl/parse_test.go
@@ -273,6 +273,11 @@ func TestCompileWildcard_Unknown(t *testing.T) {
 	assert.Equal(t, `map(map(a.b.c,"_.value"),"_.value.d.e")`, MustCompile("a.b.c.*.*.d.e").String())
 }
 
+func TestCompileSpread(t *testing.T) {
+	assert.Equal(t, `"a b c 'a b c'"`, MustCompile(`shellquote(["a", "b", "c", "a b c"]...)`).String())
+	assert.Equal(t, `"axb"`, MustCompile(`join([["a", "b"], "x"]...)`).String())
+}
+
 func TestCompileWildcard_Map(t *testing.T) {
 	vm := NewMachine().Register("a.b.c", []map[string]interface{}{
 		{"d": map[string]string{"e": "v1"}},

--- a/pkg/tcl/expressionstcl/parse_test.go
+++ b/pkg/tcl/expressionstcl/parse_test.go
@@ -260,6 +260,9 @@ a:
 	assert.Equal(t, `[5]`, MustCompile(`jq([1,2,3,4,5], ". | max")`).String())
 	assert.Equal(t, `[{"b":{"v":2}}]`, MustCompile(`jq([{"a":{"v": 1}},{"b":{"v": 2}}], ". | max_by(.v)")`).String())
 	assert.Equal(t, `[[3,4,5]]`, MustCompile(`jq([1,2,3,4,5], "map(select(. > 2))")`).String())
+	assert.Equal(t, `5`, MustCompile(`at([1,2,3,4,5], 4)`).String())
+	assert.Equal(t, `"value"`, MustCompile(`at({"x": "value"}, "x")`).String())
+	assert.Equal(t, `null`, MustCompile(`at({"x": "value"}, "unknown-key")`).String())
 }
 
 func TestCompileDetectAccessors(t *testing.T) {

--- a/pkg/tcl/expressionstcl/parse_test.go
+++ b/pkg/tcl/expressionstcl/parse_test.go
@@ -243,6 +243,9 @@ a:
 	assert.Equal(t, `[""]`, MustCompile(`split(null)`).String())
 	assert.Equal(t, `["a","b","c"]`, MustCompile(`split("a,b,c")`).String())
 	assert.Equal(t, `["a","b","c"]`, MustCompile(`split("a---b---c", "---")`).String())
+	assert.Equal(t, `5`, MustCompile(`len("abcde")`).String())
+	assert.Equal(t, `2`, MustCompile(`len(["a", "b"])`).String())
+	assert.Equal(t, `2`, MustCompile(`len({"a": "b", "b": "c"})`).String())
 }
 
 func TestCompileDetectAccessors(t *testing.T) {

--- a/pkg/tcl/expressionstcl/parse_test.go
+++ b/pkg/tcl/expressionstcl/parse_test.go
@@ -254,6 +254,9 @@ a:
 	assert.Equal(t, `[[1,2],[3,4],[5]]`, MustCompile(`chunk([1,2,3,4,5], 2)`).String())
 	assert.Equal(t, `[2,4,6,8,10]`, MustCompile(`map([1,2,3,4,5], "_.value * 2")`).String())
 	assert.Equal(t, `[0,2,4,6,8]`, MustCompile(`map([10,20,30,40,50], "_.index * 2")`).String())
+	assert.Equal(t, `[2,4,6,8,10]`, MustCompile(`map([1,2,3,4,5], "_.value * 2")`).String())
+	assert.Equal(t, `[0,2,4,6,8]`, MustCompile(`map([10,20,30,40,50], "_.index * 2")`).String())
+	assert.Equal(t, `[3,4,5]`, MustCompile(`filter([1,2,3,4,5], "_.value > 2")`).String())
 }
 
 func TestCompileDetectAccessors(t *testing.T) {

--- a/pkg/tcl/expressionstcl/parse_test.go
+++ b/pkg/tcl/expressionstcl/parse_test.go
@@ -251,6 +251,7 @@ a:
 	assert.Equal(t, `2`, MustCompile(`round(1.6)`).String())
 	assert.Equal(t, `2`, MustCompile(`round(1.5)`).String())
 	assert.Equal(t, `1`, MustCompile(`round(1.4)`).String())
+	assert.Equal(t, `[[1,2],[3,4],[5]]`, MustCompile(`chunk([1,2,3,4,5], 2)`).String())
 }
 
 func TestCompileDetectAccessors(t *testing.T) {

--- a/pkg/tcl/expressionstcl/parse_test.go
+++ b/pkg/tcl/expressionstcl/parse_test.go
@@ -24,6 +24,10 @@ func TestCompileBasic(t *testing.T) {
 func TestCompileTernary(t *testing.T) {
 	assert.Equal(t, "value", must(MustCompile(`true ? "value" : "another"`).Static().StringValue()))
 	assert.Equal(t, "another", must(MustCompile(`false ? "value" : "another"`).Static().StringValue()))
+	assert.Equal(t, "another", must(MustCompile(`5 == 3 ? "value" : "another"`).Static().StringValue()))
+	assert.Equal(t, "another", must(MustCompile(`5 == 3 && 2 == 4 ? "value" : "another"`).Static().StringValue()))
+	assert.Equal(t, "another", must(MustCompile(`5 == 3 || 2 == 4 ? "value" : "another"`).Static().StringValue()))
+	assert.Equal(t, "value", must(MustCompile(`3 == 3 || 2 == 4 ? "value" : "another"`).Static().StringValue()))
 	assert.Equal(t, "xyz", must(MustCompile(`false ? "value" : true ? "xyz" :"another"`).Static().StringValue()))
 	assert.Equal(t, "xyz", must(MustCompile(`false ? "value" : (true ? "xyz" :"another")`).Static().StringValue()))
 	assert.Equal(t, 5.78, must(MustCompile(`false ? 3 : (true ? 5.78 : 2)`).Static().FloatValue()))

--- a/pkg/tcl/expressionstcl/parse_test.go
+++ b/pkg/tcl/expressionstcl/parse_test.go
@@ -257,6 +257,9 @@ a:
 	assert.Equal(t, `[2,4,6,8,10]`, MustCompile(`map([1,2,3,4,5], "_.value * 2")`).String())
 	assert.Equal(t, `[0,2,4,6,8]`, MustCompile(`map([10,20,30,40,50], "_.index * 2")`).String())
 	assert.Equal(t, `[3,4,5]`, MustCompile(`filter([1,2,3,4,5], "_.value > 2")`).String())
+	assert.Equal(t, `[5]`, MustCompile(`jq([1,2,3,4,5], ". | max")`).String())
+	assert.Equal(t, `[{"b":{"v":2}}]`, MustCompile(`jq([{"a":{"v": 1}},{"b":{"v": 2}}], ". | max_by(.v)")`).String())
+	assert.Equal(t, `[[3,4,5]]`, MustCompile(`jq([1,2,3,4,5], "map(select(. > 2))")`).String())
 }
 
 func TestCompileDetectAccessors(t *testing.T) {

--- a/pkg/tcl/expressionstcl/parse_test.go
+++ b/pkg/tcl/expressionstcl/parse_test.go
@@ -252,6 +252,8 @@ a:
 	assert.Equal(t, `2`, MustCompile(`round(1.5)`).String())
 	assert.Equal(t, `1`, MustCompile(`round(1.4)`).String())
 	assert.Equal(t, `[[1,2],[3,4],[5]]`, MustCompile(`chunk([1,2,3,4,5], 2)`).String())
+	assert.Equal(t, `[2,4,6,8,10]`, MustCompile(`map([1,2,3,4,5], "_.value * 2")`).String())
+	assert.Equal(t, `[0,2,4,6,8]`, MustCompile(`map([10,20,30,40,50], "_.index * 2")`).String())
 }
 
 func TestCompileDetectAccessors(t *testing.T) {

--- a/pkg/tcl/expressionstcl/propertyaccessor.go
+++ b/pkg/tcl/expressionstcl/propertyaccessor.go
@@ -1,0 +1,74 @@
+// Copyright 2024 Testkube.
+//
+// Licensed as a Testkube Pro file under the Testkube Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+//     https://github.com/kubeshop/testkube/blob/main/licenses/TCL.txt
+
+package expressionstcl
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/pkg/errors"
+)
+
+type propertyAccessor struct {
+	value Expression
+	path  []string
+}
+
+func newPropertyAccessor(value Expression, path string) Expression {
+	return &propertyAccessor{value: value, path: strings.Split(path, ".")}
+}
+
+func (s *propertyAccessor) Type() Type {
+	return TypeUnknown
+}
+
+func (s *propertyAccessor) String() string {
+	return fmt.Sprintf("%s.%s", s.value.SafeString(), strings.Join(s.path, "."))
+}
+
+func (s *propertyAccessor) SafeString() string {
+	return s.String()
+}
+
+func (s *propertyAccessor) Template() string {
+	return "{{" + s.String() + "}}"
+}
+
+func (s *propertyAccessor) SafeResolve(m ...Machine) (v Expression, changed bool, err error) {
+	if s.value.Static() == nil {
+		s.value, changed, err = s.value.SafeResolve(m...)
+		if !changed || err != nil || s.value.Static() == nil {
+			return s, changed, err
+		}
+	}
+	current := s.value
+	for i := 0; i < len(s.path); i++ {
+		current, err = CallStdFunction("at", current, s.path[i])
+		if err != nil {
+			return nil, changed, errors.Wrap(err, strings.Join(s.path[:i+1], "."))
+		}
+	}
+	return current, true, nil
+}
+
+func (s *propertyAccessor) Resolve(m ...Machine) (v Expression, err error) {
+	return deepResolve(s, m...)
+}
+
+func (s *propertyAccessor) Static() StaticValue {
+	return nil
+}
+
+func (s *propertyAccessor) Accessors() map[string]struct{} {
+	return nil
+}
+
+func (s *propertyAccessor) Functions() map[string]struct{} {
+	return nil
+}

--- a/pkg/tcl/expressionstcl/static.go
+++ b/pkg/tcl/expressionstcl/static.go
@@ -113,7 +113,7 @@ func (s *static) IsNumber() bool {
 }
 
 func (s *static) IsMap() bool {
-	return !s.IsNone() && isMap(s.value)
+	return !s.IsNone() && (isMap(s.value) || isStruct(s.value))
 }
 
 func (s *static) IsSlice() bool {

--- a/pkg/tcl/expressionstcl/stdlib.go
+++ b/pkg/tcl/expressionstcl/stdlib.go
@@ -268,6 +268,34 @@ var stdFunctions = map[string]StdFunction{
 			return NewValue(int64(math2.Round(f))), nil
 		},
 	},
+	"chunk": {
+		Handler: func(value ...StaticValue) (Expression, error) {
+			if len(value) != 2 {
+				return nil, fmt.Errorf(`"chunk" function expects 2 arguments, %d provided`, len(value))
+			}
+			list, err := value[0].SliceValue()
+			if err != nil {
+				return nil, fmt.Errorf(`"chunk" function expects 1st argument to be a list, %s provided: %v`, value[0], err)
+			}
+			size, err := value[1].IntValue()
+			if err != nil {
+				return nil, fmt.Errorf(`"chunk" function expects 2nd argument to be integer, %s provided: %v`, value[1], err)
+			}
+			if size <= 0 {
+				return nil, fmt.Errorf(`"chunk" function expects 2nd argument to be >= 1, %s provided: %v`, value[1], err)
+			}
+			chunks := make([][]interface{}, 0)
+			l := int64(len(list))
+			for i := int64(0); i < l; i += size {
+				end := i + size
+				if end > l {
+					end = l
+				}
+				chunks = append(chunks, list[i:end])
+			}
+			return NewValue(chunks), nil
+		},
+	},
 }
 
 const (

--- a/pkg/tcl/expressionstcl/stdlib.go
+++ b/pkg/tcl/expressionstcl/stdlib.go
@@ -300,6 +300,45 @@ var stdFunctions = map[string]StdFunction{
 			return NewValue(chunks), nil
 		},
 	},
+	"at": {
+		Handler: func(value ...StaticValue) (Expression, error) {
+			if len(value) != 2 {
+				return nil, fmt.Errorf(`"at" function expects 2 arguments, %d provided`, len(value))
+			}
+			if value[0].IsSlice() {
+				v, _ := value[0].SliceValue()
+				k, err := value[1].IntValue()
+				if err != nil {
+					return nil, fmt.Errorf(`"at" function expects 2nd argument to be number for list, %s provided`, value[1])
+				}
+				if k >= 0 && k < int64(len(v)) {
+					return NewValue(v[int(k)]), nil
+				}
+				return nil, fmt.Errorf(`"at" function: error: out of bounds (length=%d, index=%d)`, len(v), k)
+			}
+			if value[0].IsMap() {
+				v, _ := value[0].MapValue()
+				k, _ := value[1].StringValue()
+				item, ok := v[k]
+				if ok {
+					return NewValue(item), nil
+				}
+				return None, nil
+			}
+			if value[0].IsString() {
+				v, _ := value[0].StringValue()
+				k, err := value[1].IntValue()
+				if err != nil {
+					return nil, fmt.Errorf(`"at" function expects 2nd argument to be number for string, %s provided`, value[1])
+				}
+				if k >= 0 && k < int64(len(v)) {
+					return NewValue(v[int(k)]), nil
+				}
+				return nil, fmt.Errorf(`"at" function: error: out of bounds (length=%d, index=%d)`, len(v), k)
+			}
+			return nil, fmt.Errorf(`"at" function can be performed only on lists, maps and strings: %s provided`, value[0])
+		},
+	},
 	"map": {
 		Handler: func(value ...StaticValue) (Expression, error) {
 			if len(value) != 2 {

--- a/pkg/tcl/expressionstcl/stdlib.go
+++ b/pkg/tcl/expressionstcl/stdlib.go
@@ -207,6 +207,27 @@ var stdFunctions = map[string]StdFunction{
 			return NewValue(strings.TrimSpace(str)), nil
 		},
 	},
+	"len": {
+		ReturnType: TypeInt64,
+		Handler: func(value ...StaticValue) (Expression, error) {
+			if len(value) != 1 {
+				return nil, fmt.Errorf(`"len" function expects 1 argument, %d provided`, len(value))
+			}
+			if value[0].IsSlice() {
+				v, err := value[0].SliceValue()
+				return NewValue(int64(len(v))), err
+			}
+			if value[0].IsString() {
+				v, err := value[0].StringValue()
+				return NewValue(int64(len(v))), err
+			}
+			if value[0].IsMap() {
+				v, err := value[0].MapValue()
+				return NewValue(int64(len(v))), err
+			}
+			return nil, fmt.Errorf(`"len" function expects string, slice or map, %v provided`, value[0])
+		},
+	},
 }
 
 const (

--- a/pkg/tcl/expressionstcl/stdlib.go
+++ b/pkg/tcl/expressionstcl/stdlib.go
@@ -401,6 +401,19 @@ var stdFunctions = map[string]StdFunction{
 			return NewValue(result), nil
 		},
 	},
+	"eval": {
+		Handler: func(value ...StaticValue) (Expression, error) {
+			if len(value) != 1 {
+				return nil, fmt.Errorf(`"eval" function expects 1 argument, %d provided`, len(value))
+			}
+			exprStr, _ := value[0].StringValue()
+			expr, err := Compile(exprStr)
+			if err != nil {
+				return nil, fmt.Errorf(`"eval" function: %s: error: %v`, value[0], err)
+			}
+			return expr, nil
+		},
+	},
 	"jq": {
 		Handler: func(value ...StaticValue) (Expression, error) {
 			if len(value) != 2 {

--- a/pkg/tcl/expressionstcl/stdlib.go
+++ b/pkg/tcl/expressionstcl/stdlib.go
@@ -199,6 +199,16 @@ var stdFunctions = map[string]StdFunction{
 			return NewValue(shellquote.Join(args...)), nil
 		},
 	},
+	"shellargs": {
+		Handler: func(value ...StaticValue) (Expression, error) {
+			if len(value) != 1 {
+				return nil, fmt.Errorf(`"shellargs" function expects 1 arguments, %d provided`, len(value))
+			}
+			v, _ := value[0].StringValue()
+			words, err := shellquote.Split(v)
+			return NewValue(words), err
+		},
+	},
 	"trim": {
 		ReturnType: TypeString,
 		Handler: func(value ...StaticValue) (Expression, error) {

--- a/pkg/tcl/expressionstcl/stdlib.go
+++ b/pkg/tcl/expressionstcl/stdlib.go
@@ -11,6 +11,7 @@ package expressionstcl
 import (
 	"encoding/json"
 	"fmt"
+	math2 "math"
 	"strings"
 
 	"github.com/kballard/go-shellquote"
@@ -226,6 +227,45 @@ var stdFunctions = map[string]StdFunction{
 				return NewValue(int64(len(v))), err
 			}
 			return nil, fmt.Errorf(`"len" function expects string, slice or map, %v provided`, value[0])
+		},
+	},
+	"floor": {
+		ReturnType: TypeInt64,
+		Handler: func(value ...StaticValue) (Expression, error) {
+			if len(value) != 1 {
+				return nil, fmt.Errorf(`"floor" function expects 1 argument, %d provided`, len(value))
+			}
+			f, err := value[0].FloatValue()
+			if err != nil {
+				return nil, fmt.Errorf(`"floor" function expects a number, %s provided: %v`, value[0], err)
+			}
+			return NewValue(int64(math2.Floor(f))), nil
+		},
+	},
+	"ceil": {
+		ReturnType: TypeInt64,
+		Handler: func(value ...StaticValue) (Expression, error) {
+			if len(value) != 1 {
+				return nil, fmt.Errorf(`"ceil" function expects 1 argument, %d provided`, len(value))
+			}
+			f, err := value[0].FloatValue()
+			if err != nil {
+				return nil, fmt.Errorf(`"ceil" function expects a number, %s provided: %v`, value[0], err)
+			}
+			return NewValue(int64(math2.Ceil(f))), nil
+		},
+	},
+	"round": {
+		ReturnType: TypeInt64,
+		Handler: func(value ...StaticValue) (Expression, error) {
+			if len(value) != 1 {
+				return nil, fmt.Errorf(`"round" function expects 1 argument, %d provided`, len(value))
+			}
+			f, err := value[0].FloatValue()
+			if err != nil {
+				return nil, fmt.Errorf(`"round" function expects a number, %s provided: %v`, value[0], err)
+			}
+			return NewValue(int64(math2.Round(f))), nil
 		},
 	},
 }

--- a/pkg/tcl/expressionstcl/stdlib.go
+++ b/pkg/tcl/expressionstcl/stdlib.go
@@ -466,28 +466,28 @@ func CastToString(v Expression) Expression {
 	} else if v.Type() == TypeString {
 		return v
 	}
-	return newCall(stringCastStdFn, []Expression{v})
+	return newCall(stringCastStdFn, []callArgument{{expr: v}})
 }
 
 func CastToBool(v Expression) Expression {
 	if v.Type() == TypeBool {
 		return v
 	}
-	return newCall(boolCastStdFn, []Expression{v})
+	return newCall(boolCastStdFn, []callArgument{{expr: v}})
 }
 
 func CastToInt(v Expression) Expression {
 	if v.Type() == TypeInt64 {
 		return v
 	}
-	return newCall(intCastStdFn, []Expression{v})
+	return newCall(intCastStdFn, []callArgument{{expr: v}})
 }
 
 func CastToFloat(v Expression) Expression {
 	if v.Type() == TypeFloat64 {
 		return v
 	}
-	return newCall(intCastStdFn, []Expression{v})
+	return newCall(intCastStdFn, []callArgument{{expr: v}})
 }
 
 func IsStdFunction(name string) bool {

--- a/pkg/tcl/expressionstcl/tokenize.go
+++ b/pkg/tcl/expressionstcl/tokenize.go
@@ -21,6 +21,7 @@ var noneRe = regexp.MustCompile(`^null(?:[^a-zA-Z\d_.]|$)`)
 var jsonValueRe = regexp.MustCompile(`^(?:["{\[\d]|((?:true|false)(?:[^a-zA-Z\d_.]|$)))`)
 var accessorRe = regexp.MustCompile(`^[a-zA-Z\d_]+(?:\s*\.\s*([a-zA-Z\d_]+|\*))*`)
 var propertyAccessorRe = regexp.MustCompile(`^\.\s*([a-zA-Z\d_]+|\*)`)
+var spreadRe = regexp.MustCompile(`^\.\.\.`)
 var spaceRe = regexp.MustCompile(`^\s+`)
 
 func tokenizeNext(exp string, i int) (token, int, error) {
@@ -46,6 +47,8 @@ func tokenizeNext(exp string, i int) (token, int, error) {
 			i += len(space)
 		case noneRe.MatchString(exp[i:]):
 			return tokenJson(noneValue), i + 4, nil
+		case spreadRe.MatchString(exp[i:]):
+			return tokenSpread, i + 3, nil
 		case jsonValueRe.MatchString(exp[i:]):
 			// Allow multi-line string with literal \n
 			// TODO: Optimize, and allow deeper in the tree

--- a/pkg/tcl/expressionstcl/tokenize.go
+++ b/pkg/tcl/expressionstcl/tokenize.go
@@ -19,7 +19,8 @@ import (
 var mathOperatorRe = regexp.MustCompile(`^(?:!=|<>|==|>=|<=|&&|\*\*|\|\||[+\-*/><=%])`)
 var noneRe = regexp.MustCompile(`^null(?:[^a-zA-Z\d_.]|$)`)
 var jsonValueRe = regexp.MustCompile(`^(?:["{\[\d]|((?:true|false)(?:[^a-zA-Z\d_.]|$)))`)
-var accessorRe = regexp.MustCompile(`^[a-zA-Z\d_](?:[a-zA-Z\d_.]*[a-zA-Z\d_])?`)
+var accessorRe = regexp.MustCompile(`^[a-zA-Z\d_]+(?:\s*\.\s*([a-zA-Z\d_]+|\*))*`)
+var propertyAccessorRe = regexp.MustCompile(`^\.\s*([a-zA-Z\d_]+|\*)`)
 var spaceRe = regexp.MustCompile(`^\s+`)
 
 func tokenizeNext(exp string, i int) (token, int, error) {
@@ -75,6 +76,9 @@ func tokenizeNext(exp string, i int) (token, int, error) {
 		case accessorRe.MatchString(exp[i:]):
 			acc := accessorRe.FindString(exp[i:])
 			return tokenAccessor(acc), i + len(acc), nil
+		case propertyAccessorRe.MatchString(exp[i:]):
+			acc := propertyAccessorRe.FindString(exp[i:])
+			return tokenPropertyAccessor(acc[1:]), i + len(acc), nil
 		default:
 			return token{}, i, fmt.Errorf("unknown character at index %d in expression: %s", i, exp)
 		}

--- a/pkg/tcl/expressionstcl/tokenize_test.go
+++ b/pkg/tcl/expressionstcl/tokenize_test.go
@@ -29,6 +29,12 @@ func TestTokenizeSimple(t *testing.T) {
 	assert.Equal(t, []token{tokenAccessor("a"), tokenOpen, tokenAccessor("b"), tokenComma, tokenJson(true), tokenClose}, mustTokenize(`a(b, true)`))
 	assert.Equal(t, []token{tokenJson(noneValue)}, mustTokenize("null"))
 	assert.Equal(t, []token{tokenJson(noneValue), tokenMath("+"), tokenJson(4.0)}, mustTokenize("null + 4"))
+	assert.Equal(t, []token{tokenJson([]interface{}{1.0}), tokenPropertyAccessor("0")}, mustTokenize("[1].0"))
+}
+
+func TestTokenizeWildcard(t *testing.T) {
+	assert.Equal(t, []token{tokenAccessor("a.b.c.*.d.e")}, mustTokenize(`a.b.c.*.d.e`))
+	assert.Equal(t, []token{tokenAccessor("a.b.c.0.d.e")}, mustTokenize(`a.b.c.0.d.e`))
 }
 
 func TestTokenizeJson(t *testing.T) {

--- a/pkg/tcl/expressionstcl/tokens.go
+++ b/pkg/tcl/expressionstcl/tokens.go
@@ -28,6 +28,7 @@ const (
 
 	// Functions
 	tokenTypeComma
+	tokenTypeSpread
 )
 
 type token struct {
@@ -42,6 +43,7 @@ var (
 	tokenTernary          = token{Type: tokenTypeTernary}
 	tokenTernarySeparator = token{Type: tokenTypeTernarySeparator}
 	tokenComma            = token{Type: tokenTypeComma}
+	tokenSpread           = token{Type: tokenTypeSpread}
 )
 
 func tokenMath(op string) token {

--- a/pkg/tcl/expressionstcl/tokens.go
+++ b/pkg/tcl/expressionstcl/tokens.go
@@ -13,6 +13,7 @@ type tokenType uint8
 const (
 	// Primitives
 	tokenTypeAccessor tokenType = iota
+	tokenTypePropertyAccessor
 	tokenTypeJson
 
 	// Math
@@ -53,4 +54,8 @@ func tokenJson(value interface{}) token {
 
 func tokenAccessor(value interface{}) token {
 	return token{Type: tokenTypeAccessor, Value: value}
+}
+
+func tokenPropertyAccessor(value interface{}) token {
+	return token{Type: tokenTypePropertyAccessor, Value: value}
 }

--- a/pkg/tcl/expressionstcl/typechecking.go
+++ b/pkg/tcl/expressionstcl/typechecking.go
@@ -53,6 +53,10 @@ func isMap(s interface{}) bool {
 	return reflect.ValueOf(s).Kind() == reflect.Map
 }
 
+func isStruct(s interface{}) bool {
+	return reflect.ValueOf(s).Kind() == reflect.Struct
+}
+
 func isSlice(s interface{}) bool {
 	return reflect.ValueOf(s).Kind() == reflect.Slice
 }

--- a/pkg/tcl/expressionstcl/utils.go
+++ b/pkg/tcl/expressionstcl/utils.go
@@ -44,7 +44,7 @@ func EvalTemplate(tpl string, machines ...Machine) (string, error) {
 	return expr.Static().StringValue()
 }
 
-func EvalExpression(str string, machines ...Machine) (StaticValue, error) {
+func EvalExpressionPartial(str string, machines ...Machine) (Expression, error) {
 	expr, err := Compile(str)
 	if err != nil {
 		return nil, errors.Wrap(err, "compiling")
@@ -52,6 +52,14 @@ func EvalExpression(str string, machines ...Machine) (StaticValue, error) {
 	expr, err = expr.Resolve(machines...)
 	if err != nil {
 		return nil, errors.Wrap(err, "resolving")
+	}
+	return expr, err
+}
+
+func EvalExpression(str string, machines ...Machine) (StaticValue, error) {
+	expr, err := EvalExpressionPartial(str, machines...)
+	if err != nil {
+		return nil, err
 	}
 	if expr.Static() == nil {
 		return nil, fmt.Errorf("expression should be static: %s", expr.String())


### PR DESCRIPTION
## Pull request description 

Add more built-in functionalities for Expressions language - will be required/helpful for more complex queries in Distributed Tests.

### Syntax improvements

* Nested accessors (`a.b.c.d`) are more smart
  * Earlier: it was asking machine specifically about `a.b.c.d`,
  * Now: it tries to fallback to `a.b.c`, `a.b` and `a` and seeking for inner keys
  * Helpful for reading unknown schemas, like Pod schema in the struct
* Wildcard accessor implemented - `a.b.*.d`
  * It helps read different common values, like `spawn.slaves.*.ip`
* Spread argument operator implemented (`...`)
  * It helps to pass custom arguments, i.e. to sanitize results from another function
  * `shellquote(glob("**/*_test.go")...)`

### New built-in functions

* `glob(string...)`: to find files matching pattern
   * Will help take (and slice) list of tests to run, i.e. `glob("**/*_test.go")`
* `chunk([]any, int)`: slice list to N chunks
   * Will help to distribute tests across multiple pods, like `chunk(glob("**/*_test.go"), 5)` to split tests to run evenly across 5 pods
* `floor(number)`/`ceil(number)`/`round(number)`: basic math arithmetics
* `len(any)`: basic check of string/list/map length
* `at(any, any)`: get value of struct/map/list at specific index
  * Like `at([10,20], 0)` or `at({"a": "bar"}, "a")`
* `map(any, string)` - map values with an expression - the expression is passed as second parameter and has `_.value` and `_.key`/`_.index` accessors
  * To simply map list to another, like: `map([10, 20, 30], "_.value * 2")`
* `filter(any, string)` - filter values with an expression
  * in example: `filter([10, 20, 30], "_.value > 20")`
* `eval(string)` - unsafe evaluation of an expression - last resort option
* `jq(any, string)` - run [**jq**](https://github.com/itchyny/gojq) query against a value
  * like: `jq([1,2,3,4,5], ". | max")`
* `shellargs(string)` - parse shell arguments, and return list of them
  * useful for normalizing parameters, like `shellquote(shellargs(config.setup)...)` where `config.setup` is `"-f abc\n-c def"`

## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [x] tested locally
- [x] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [x] added a test
