### PR TITLE
ci: disable dev releases to the apt server

### DIFF
--- a/.github/workflows/release-dev.yaml
+++ b/.github/workflows/release-dev.yaml
@@ -270,43 +270,43 @@ jobs:
           asset_name: ${{steps.checksum.outputs.INSTALLER_NAME}}_checksum.txt
           asset_content_type: text/plain
 
-  build-and-publish-linux-installer:
-    needs: release
-    runs-on: ubuntu-latest
+  # build-and-publish-linux-installer:
+  #   needs: release
+  #   runs-on: ubuntu-latest
 
-    steps:
-      - name: Get Intermediate Artifacts
-        uses: actions/download-artifact@master
-        with:
-          name: bin-artifacts
-          path: dist
+  #   steps:
+  #     - name: Get Intermediate Artifacts
+  #       uses: actions/download-artifact@master
+  #       with:
+  #         name: bin-artifacts
+  #         path: dist
 
-      - name: Get tag
-        id: tag
-        uses: dawidd6/action-get-tag@v1
-        with:
-          strip_v: true
+  #     - name: Get tag
+  #       id: tag
+  #       uses: dawidd6/action-get-tag@v1
+  #       with:
+  #         strip_v: true
 
-      - name: Publish package
-        env:
-          USERNAME: "aptly"
-          PASSWORD: ${{ secrets.APTLY_PASSWORD }}
-          APTLY_URL: "repo.testkube.io:8080"
-          VERSION: ${{steps.tag.outputs.tag}}
-        run: |
-          ### Upload files
-          curl --fail-with-body -u ${USERNAME}:${PASSWORD} -X POST -F file=@dist/testkube_${VERSION}_linux_386.deb http://${APTLY_URL}/api/files/testkube
-          curl --fail-with-body -u ${USERNAME}:${PASSWORD} -X POST -F file=@dist/testkube_${VERSION}_linux_arm64.deb http://${APTLY_URL}/api/files/testkube
-          curl --fail-with-body -u ${USERNAME}:${PASSWORD} -X POST -F file=@dist/testkube_${VERSION}_linux_amd64.deb http://${APTLY_URL}/api/files/testkube
+  #     - name: Publish package
+  #       env:
+  #         USERNAME: "aptly"
+  #         PASSWORD: ${{ secrets.APTLY_PASSWORD }}
+  #         APTLY_URL: "repo.testkube.io:8080"
+  #         VERSION: ${{steps.tag.outputs.tag}}
+  #       run: |
+  #         ### Upload files
+  #         curl --fail-with-body -u ${USERNAME}:${PASSWORD} -X POST -F file=@dist/testkube_${VERSION}_linux_386.deb http://${APTLY_URL}/api/files/testkube
+  #         curl --fail-with-body -u ${USERNAME}:${PASSWORD} -X POST -F file=@dist/testkube_${VERSION}_linux_arm64.deb http://${APTLY_URL}/api/files/testkube
+  #         curl --fail-with-body -u ${USERNAME}:${PASSWORD} -X POST -F file=@dist/testkube_${VERSION}_linux_amd64.deb http://${APTLY_URL}/api/files/testkube
 
-          ### Add file to repo
-          curl --fail-with-body -u ${USERNAME}:${PASSWORD} -X POST http://${APTLY_URL}/api/repos/testkube/file/testkube?forceReplace=1
+  #         ### Add file to repo
+  #         curl --fail-with-body -u ${USERNAME}:${PASSWORD} -X POST http://${APTLY_URL}/api/repos/testkube/file/testkube?forceReplace=1
 
-          ### Create snapshot
-          curl --fail-with-body -u ${USERNAME}:${PASSWORD} -X POST -H 'Content-Type: application/json' --data '{"Name":"testkube-'${VERSION}'"}' http://${APTLY_URL}/api/repos/testkube/snapshots
+  #         ### Create snapshot
+  #         curl --fail-with-body -u ${USERNAME}:${PASSWORD} -X POST -H 'Content-Type: application/json' --data '{"Name":"testkube-'${VERSION}'"}' http://${APTLY_URL}/api/repos/testkube/snapshots
 
-          ### Publish repo
-          curl --fail-with-body -u ${USERNAME}:${PASSWORD} -X PUT -H 'Content-Type: application/json' --data '{"Snapshots": [{"Component": "main", "Name": "testkube-'${VERSION}'"}]}'}], http://repo.testkube.io:8080/api/publish/:linux/linux
+  #         ### Publish repo
+  #         curl --fail-with-body -u ${USERNAME}:${PASSWORD} -X PUT -H 'Content-Type: application/json' --data '{"Snapshots": [{"Component": "main", "Name": "testkube-'${VERSION}'"}]}'}], http://repo.testkube.io:8080/api/publish/:linux/linux
 
   trigger-deploy-to-dev-env:
     needs: release


### PR DESCRIPTION
## Pull request description 

The dev releases (with the suffix `-beta00*`) of testkube CLI are pushed to the same APT server the users are using, therefore increasing the risk of delivering broken executables. The purpose of this PR is to disable these.

See this thread: https://testkubeworkspace.slack.com/archives/C06D9EYTQ2J/p1711033378785719

## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [ ] tested locally
- [ ] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Breaking changes

-

## Changes

-

## Fixes

-