### PR TITLE
fix: allow to fully override URIs in CLI

### DIFF
--- a/cmd/kubectl-testkube/commands/common/flags.go
+++ b/cmd/kubectl-testkube/commands/common/flags.go
@@ -139,7 +139,23 @@ func ProcessMasterFlags(cmd *cobra.Command, opts *HelmOptions, cfg *config.Data)
 		}
 	}
 
-	opts.Master.URIs = NewMasterUris(opts.Master.ApiUrlPrefix,
+	if cmd.Flag("insecure").Value.String() == "true" {
+		opts.Master.Insecure = true
+	}
+
+	if cmd.Flags().Changed("api-prefix") {
+		opts.Master.ApiUrlPrefix = cmd.Flag("api-prefix").Value.String()
+	}
+
+	if cmd.Flags().Changed("ui-prefix") {
+		opts.Master.ApiUrlPrefix = cmd.Flag("api-prefix").Value.String()
+	}
+
+	if cmd.Flags().Changed("logs-prefix") {
+		opts.Master.ApiUrlPrefix = cmd.Flag("api-prefix").Value.String()
+	}
+
+	uris := NewMasterUris(opts.Master.ApiUrlPrefix,
 		opts.Master.UiUrlPrefix,
 		opts.Master.AgentUrlPrefix,
 		opts.Master.LogsUrlPrefix,
@@ -147,4 +163,24 @@ func ProcessMasterFlags(cmd *cobra.Command, opts *HelmOptions, cfg *config.Data)
 		opts.Master.URIs.Logs,
 		opts.Master.RootDomain,
 		opts.Master.Insecure)
+
+	// override whole URIs usually composed from prefix - host parts
+	if cmd.Flags().Changed("agent-uri-override") {
+		uris.WithAgentURI(cmd.Flag("agent-uri-override").Value.String())
+	}
+
+	if cmd.Flags().Changed("logs-uri-override") {
+		uris.WithLogsURI(cmd.Flag("logs-uri-override").Value.String())
+	}
+
+	if cmd.Flags().Changed("api-uri-override") {
+		uris.WithApiURI(cmd.Flag("api-uri-override").Value.String())
+	}
+
+	if cmd.Flags().Changed("ui-uri-override") {
+		uris.WithUiURI(cmd.Flag("ui-uri-override").Value.String())
+	}
+
+	opts.Master.URIs = uris
+
 }

--- a/cmd/kubectl-testkube/commands/common/flags.go
+++ b/cmd/kubectl-testkube/commands/common/flags.go
@@ -139,19 +139,19 @@ func ProcessMasterFlags(cmd *cobra.Command, opts *HelmOptions, cfg *config.Data)
 		}
 	}
 
-	if cmd.Flag("insecure").Value.String() == "true" {
+	if cmd.Flag("insecure") != nil && cmd.Flag("insecure").Value.String() == "true" {
 		opts.Master.Insecure = true
 	}
 
-	if cmd.Flags().Changed("api-prefix") {
+	if cmd.Flag("api-prefix") != nil && cmd.Flags().Changed("api-prefix") {
 		opts.Master.ApiUrlPrefix = cmd.Flag("api-prefix").Value.String()
 	}
 
-	if cmd.Flags().Changed("ui-prefix") {
+	if cmd.Flag("ui-prefix") != nil && cmd.Flags().Changed("ui-prefix") {
 		opts.Master.ApiUrlPrefix = cmd.Flag("api-prefix").Value.String()
 	}
 
-	if cmd.Flags().Changed("logs-prefix") {
+	if cmd.Flag("logs-prefix") != nil && cmd.Flags().Changed("logs-prefix") {
 		opts.Master.ApiUrlPrefix = cmd.Flag("api-prefix").Value.String()
 	}
 
@@ -165,19 +165,19 @@ func ProcessMasterFlags(cmd *cobra.Command, opts *HelmOptions, cfg *config.Data)
 		opts.Master.Insecure)
 
 	// override whole URIs usually composed from prefix - host parts
-	if cmd.Flags().Changed("agent-uri-override") {
+	if cmd.Flag("agent-uri-override") != nil && cmd.Flags().Changed("agent-uri-override") {
 		uris.WithAgentURI(cmd.Flag("agent-uri-override").Value.String())
 	}
 
-	if cmd.Flags().Changed("logs-uri-override") {
+	if cmd.Flag("logs-uri-override") != nil && cmd.Flags().Changed("logs-uri-override") {
 		uris.WithLogsURI(cmd.Flag("logs-uri-override").Value.String())
 	}
 
-	if cmd.Flags().Changed("api-uri-override") {
+	if cmd.Flag("api-uri-override") != nil && cmd.Flags().Changed("api-uri-override") {
 		uris.WithApiURI(cmd.Flag("api-uri-override").Value.String())
 	}
 
-	if cmd.Flags().Changed("ui-uri-override") {
+	if cmd.Flag("ui-uri-override") != nil && cmd.Flags().Changed("ui-uri-override") {
 		uris.WithUiURI(cmd.Flag("ui-uri-override").Value.String())
 	}
 

--- a/cmd/kubectl-testkube/commands/context/set.go
+++ b/cmd/kubectl-testkube/commands/context/set.go
@@ -1,6 +1,8 @@
 package context
 
 import (
+	"fmt"
+
 	"github.com/spf13/cobra"
 
 	"github.com/kubeshop/testkube/cmd/kubectl-testkube/commands/common"
@@ -25,6 +27,7 @@ func NewSetContextCmd() *cobra.Command {
 			cfg, err := config.Load()
 			ui.ExitOnError("loading config file", err)
 			common.ProcessMasterFlags(cmd, &opts, &cfg)
+			fmt.Printf("%+v\n", opts.Master)
 
 			if cmd.Flags().Changed("org") {
 				opts.Master.OrgId = org
@@ -80,6 +83,12 @@ func NewSetContextCmd() *cobra.Command {
 	cmd.Flags().MarkDeprecated("env", "use --env-id instead")
 	cmd.Flags().StringVarP(&namespace, "namespace", "n", "", "Testkube namespace to use for CLI commands")
 	cmd.Flags().StringVarP(&apiKey, "api-key", "k", "", "API Key for Testkube Pro")
+
+	// allow to override default values of all URIs
+	cmd.Flags().String("api-uri-override", "", "api uri override")
+	cmd.Flags().String("ui-uri-override", "", "ui uri override")
+	cmd.Flags().String("agent-uri-override", "", "agnet uri override")
+	cmd.Flags().String("logs-uri-override", "", "logs service uri override")
 
 	common.PopulateMasterFlags(cmd, &opts)
 	return cmd

--- a/cmd/kubectl-testkube/commands/context/set.go
+++ b/cmd/kubectl-testkube/commands/context/set.go
@@ -1,8 +1,6 @@
 package context
 
 import (
-	"fmt"
-
 	"github.com/spf13/cobra"
 
 	"github.com/kubeshop/testkube/cmd/kubectl-testkube/commands/common"
@@ -27,7 +25,6 @@ func NewSetContextCmd() *cobra.Command {
 			cfg, err := config.Load()
 			ui.ExitOnError("loading config file", err)
 			common.ProcessMasterFlags(cmd, &opts, &cfg)
-			fmt.Printf("%+v\n", opts.Master)
 
 			if cmd.Flags().Changed("org") {
 				opts.Master.OrgId = org

--- a/cmd/kubectl-testkube/config/master.go
+++ b/cmd/kubectl-testkube/config/master.go
@@ -30,25 +30,25 @@ type MasterURIs struct {
 }
 
 // WithApi sets whole api URI
-func (m *MasterURIs) WithApiURI(api string) *MasterURIs {
-	m.Api = api
+func (m *MasterURIs) WithApiURI(uri string) *MasterURIs {
+	m.Api = uri
 	return m
 }
 
 // WithAgent sets whole agent URI
-func (m *MasterURIs) WithAgentURI(agent string) *MasterURIs {
-	m.Agent = agent
+func (m *MasterURIs) WithAgentURI(uri string) *MasterURIs {
+	m.Agent = uri
 	return m
 }
 
 // WithLogs sets whole logs URI
-func (m *MasterURIs) WithLogsURI(logs string) *MasterURIs {
-	m.Logs = logs
+func (m *MasterURIs) WithLogsURI(uri string) *MasterURIs {
+	m.Logs = uri
 	return m
 }
 
 // WithUi sets whole ui URI
-func (m *MasterURIs) WithUiURI(ui string) *MasterURIs {
-	m.Ui = ui
+func (m *MasterURIs) WithUiURI(uri string) *MasterURIs {
+	m.Ui = uri
 	return m
 }

--- a/cmd/kubectl-testkube/config/master.go
+++ b/cmd/kubectl-testkube/config/master.go
@@ -28,3 +28,27 @@ type MasterURIs struct {
 	Ui         string `json:"ui,omitempty"`
 	Auth       string `json:"auth,omitempty"`
 }
+
+// WithApi sets whole api URI
+func (m *MasterURIs) WithApiURI(api string) *MasterURIs {
+	m.Api = api
+	return m
+}
+
+// WithAgent sets whole agent URI
+func (m *MasterURIs) WithAgentURI(agent string) *MasterURIs {
+	m.Agent = agent
+	return m
+}
+
+// WithLogs sets whole logs URI
+func (m *MasterURIs) WithLogsURI(logs string) *MasterURIs {
+	m.Logs = logs
+	return m
+}
+
+// WithUi sets whole ui URI
+func (m *MasterURIs) WithUiURI(ui string) *MasterURIs {
+	m.Ui = ui
+	return m
+}


### PR DESCRIPTION
## Pull request description 

Fixes CLI in enterprise - currently composing URIs logic don't fit enterprise use cases. 
It's combersome to mess with localhost based installation 
I've introduced possibility to fully control uris without any logic 


## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [ ] tested locally
- [ ] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Breaking changes

-

## Changes

-

## Fixes

-