### PR TITLE
fix: image pull secrets registry always being empty when checking reg…

### DIFF
--- a/pkg/skopeo/client_test.go
+++ b/pkg/skopeo/client_test.go
@@ -102,3 +102,30 @@ func TestParseSecretData(t *testing.T) {
 	})
 
 }
+
+// TestExtractRegistry uses table-driven tests to validate the extractRegistry function.
+func TestExtractRegistry(t *testing.T) {
+	tests := []struct {
+		name     string
+		image    string
+		expected string
+	}{
+		{"DockerHub short", "nginx:latest", "https://index.docker.io/v1/"},
+		{"DockerHub long", "library/nginx:latest", "https://index.docker.io/v1/"},
+		{"GCR", "gcr.io/google-containers/busybox:latest", "gcr.io"},
+		{"ECR", "123456789012.dkr.ecr.us-east-1.amazonaws.com/my-application:latest", "123456789012.dkr.ecr.us-east-1.amazonaws.com"},
+		{"MCR", "mcr.microsoft.com/dotnet/core/sdk:3.1", "mcr.microsoft.com"},
+		{"Quay", "quay.io/bitnami/nginx:latest", "quay.io"},
+		{"Custom port", "localhost:5000/myimage:latest", "localhost:5000"},
+		{"No tag", "myregistry.com/myimage", "myregistry.com"},
+		{"Only image", "myimage", "https://index.docker.io/v1/"},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			got := extractRegistry(tc.image)
+			assert.Equal(t, tc.expected, got)
+		})
+	}
+}


### PR DESCRIPTION
…i… (#5289)

* fix image pull secrets registry always being empty when checking registry map and nil pointer dereference in cli

* revert changes to testworkflowmetrics

## Pull request description 



## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [ ] tested locally
- [ ] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Breaking changes

-

## Changes

-

## Fixes

-