### PR TITLE
feat: allow reading dynamically output of TestWorkflows

### DIFF
--- a/cmd/tcl/testworkflow-init/data/state.go
+++ b/cmd/tcl/testworkflow-init/data/state.go
@@ -11,6 +11,7 @@ package data
 import (
 	"bytes"
 	"encoding/gob"
+	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -49,6 +50,18 @@ func (s *state) GetOutput(name string) (expressionstcl.Expression, bool, error) 
 	}
 	expr, err := expressionstcl.Compile(v)
 	return expr, true, err
+}
+
+func (s *state) SetOutput(ref, name string, value interface{}) {
+	if s.Output == nil {
+		s.Output = make(map[string]string)
+	}
+	v, err := json.Marshal(value)
+	if err == nil {
+		s.Output[name] = string(v)
+	} else {
+		fmt.Printf("Warning: couldn't save '%s' (%s) output: %s\n", name, ref, err.Error())
+	}
 }
 
 func (s *state) GetSelfStatus() string {

--- a/cmd/tcl/testworkflow-init/run/run.go
+++ b/cmd/tcl/testworkflow-init/run/run.go
@@ -14,6 +14,7 @@ import (
 	"os/exec"
 
 	"github.com/kubeshop/testkube/cmd/tcl/testworkflow-init/data"
+	"github.com/kubeshop/testkube/cmd/tcl/testworkflow-init/utils"
 )
 
 const (
@@ -37,6 +38,8 @@ func getProcessStatus(err error) (bool, uint8) {
 // TODO: Obfuscate Stdout/Stderr streams
 func createCommand(cmd string, args ...string) (c *exec.Cmd) {
 	c = exec.Command(cmd, args...)
+	out := utils.NewOutputProcessor(data.Step.Ref, os.Stdout)
+	c.Stdout = out
 	c.Stdout = os.Stdout
 	c.Stderr = os.Stderr
 	c.Stdin = os.Stdin

--- a/cmd/tcl/testworkflow-init/utils/outputProcessor.go
+++ b/cmd/tcl/testworkflow-init/utils/outputProcessor.go
@@ -1,0 +1,56 @@
+// Licensed as a Testkube Pro file under the Testkube Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+//	https://github.com/kubeshop/testkube/blob/main/licenses/TCL.txt
+
+package utils
+
+import (
+	"bytes"
+	"errors"
+	"io"
+
+	"github.com/kubeshop/testkube/cmd/tcl/testworkflow-init/data"
+)
+
+type outputProcessor struct {
+	writer   io.Writer
+	ref      string
+	closed   bool
+	lastLine []byte
+}
+
+func NewOutputProcessor(ref string, writer io.Writer) io.WriteCloser {
+	return &outputProcessor{
+		writer: writer,
+		ref:    ref,
+	}
+}
+
+func (o *outputProcessor) Write(p []byte) (int, error) {
+	if o.closed {
+		return 0, errors.New("stream is already closed")
+	}
+
+	// Process to search for output
+	lines := bytes.Split(append(o.lastLine, p...), []byte("\n"))
+	o.lastLine = nil
+	for i := range lines {
+		instruction, _, _ := data.DetectInstruction(lines[i])
+		if instruction == nil && i == len(lines)-1 {
+			o.lastLine = lines[i]
+		}
+		if instruction != nil && instruction.Value != nil {
+			data.State.SetOutput(instruction.Ref, instruction.Name, instruction.Value)
+		}
+	}
+
+	// Pass the output down
+	return o.writer.Write(p)
+}
+
+func (o *outputProcessor) Close() error {
+	o.closed = true
+	return nil
+}

--- a/pkg/tcl/testworkflowstcl/testworkflowcontroller/cleanup.go
+++ b/pkg/tcl/testworkflowstcl/testworkflowcontroller/cleanup.go
@@ -21,19 +21,28 @@ import (
 )
 
 func cleanupConfigMaps(ctx context.Context, clientSet kubernetes.Interface, namespace, id string) error {
-	return clientSet.CoreV1().ConfigMaps(namespace).DeleteCollection(ctx, metav1.DeleteOptions{}, metav1.ListOptions{
+	return clientSet.CoreV1().ConfigMaps(namespace).DeleteCollection(ctx, metav1.DeleteOptions{
+		GracePeriodSeconds: common.Ptr(int64(0)),
+		PropagationPolicy:  common.Ptr(metav1.DeletePropagationBackground),
+	}, metav1.ListOptions{
 		LabelSelector: fmt.Sprintf("%s=%s", constants.ExecutionIdLabelName, id),
 	})
 }
 
 func cleanupSecrets(ctx context.Context, clientSet kubernetes.Interface, namespace, id string) error {
-	return clientSet.CoreV1().Secrets(namespace).DeleteCollection(ctx, metav1.DeleteOptions{}, metav1.ListOptions{
+	return clientSet.CoreV1().Secrets(namespace).DeleteCollection(ctx, metav1.DeleteOptions{
+		GracePeriodSeconds: common.Ptr(int64(0)),
+		PropagationPolicy:  common.Ptr(metav1.DeletePropagationBackground),
+	}, metav1.ListOptions{
 		LabelSelector: fmt.Sprintf("%s=%s", constants.ExecutionIdLabelName, id),
 	})
 }
 
 func cleanupPods(ctx context.Context, clientSet kubernetes.Interface, namespace, id string) error {
-	return clientSet.CoreV1().Pods(namespace).DeleteCollection(ctx, metav1.DeleteOptions{}, metav1.ListOptions{
+	return clientSet.CoreV1().Pods(namespace).DeleteCollection(ctx, metav1.DeleteOptions{
+		GracePeriodSeconds: common.Ptr(int64(0)),
+		PropagationPolicy:  common.Ptr(metav1.DeletePropagationBackground),
+	}, metav1.ListOptions{
 		LabelSelector: fmt.Sprintf("%s=%s", constants.ExecutionIdLabelName, id),
 	})
 }

--- a/pkg/tcl/testworkflowstcl/testworkflowcontroller/controller.go
+++ b/pkg/tcl/testworkflowstcl/testworkflowcontroller/controller.go
@@ -237,7 +237,7 @@ func (c *controller) Watch(parentCtx context.Context) Watcher[Notification] {
 			// TODO: Calibrate clock with v.Value.Hint or just first/last timestamp here
 			w.SendValue(Notification{
 				Timestamp: v.Value.Time,
-				Log:       fmt.Sprintf("%s %s\n", v.Value.Time.Format(KubernetesLogTimeFormat), string(v.Value.Log)),
+				Log:       string(v.Value.Log),
 			})
 		}
 

--- a/pkg/tcl/testworkflowstcl/testworkflowexecutor/executor.go
+++ b/pkg/tcl/testworkflowstcl/testworkflowexecutor/executor.go
@@ -140,7 +140,7 @@ func (e *executor) Control(ctx context.Context, execution testkube.TestWorkflowE
 				continue
 			}
 			if v.Value.Output != nil {
-				execution.Output = append(execution.Output, *v.Value.Output.ToInternal())
+				execution.Output = append(execution.Output, *testworkflowcontroller.InstructionToInternal(v.Value.Output))
 			} else if v.Value.Result != nil {
 				execution.Result = v.Value.Result
 				if execution.Result.IsFinished() {

--- a/pkg/tcl/testworkflowstcl/testworkflowprocessor/processor.go
+++ b/pkg/tcl/testworkflowstcl/testworkflowprocessor/processor.go
@@ -118,6 +118,10 @@ func (p *processor) Bundle(ctx context.Context, workflow *testworkflowsv1.TestWo
 		},
 		Steps: append(workflow.Spec.Setup, append(workflow.Spec.Steps, workflow.Spec.After...)...),
 	}
+	err = expressionstcl.Simplify(&workflow, machines...)
+	if err != nil {
+		return nil, errors.Wrap(err, "error while simplifying workflow instructions")
+	}
 	root, err := p.process(layer, layer.ContainerDefaults(), rootStep, "")
 	if err != nil {
 		return nil, errors.Wrap(err, "processing error")


### PR DESCRIPTION
## Pull request description 

* Expose the Output printed ([**PrintOutput**](https://github.com/kubeshop/testkube/blob/develop/cmd/tcl/testworkflow-init/data/emit.go#L74-L76)) from TestWorkflow steps into internal state, so it can be used across different steps
   * It will be used to pass pod data of services, like auto-created database IP
* Deduplicate empty lines when output appears
* Avoid grace period for deleting resources

## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [x] tested locally
- [ ] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test