### PR TITLE
fix(expressions): simplifying math and enums, expose common expressions machine for steps

### DIFF
--- a/cmd/tcl/testworkflow-init/data/expressions.go
+++ b/cmd/tcl/testworkflow-init/data/expressions.go
@@ -97,12 +97,12 @@ var wd, _ = os.Getwd()
 var FileMachine = libs.NewFsMachine(os.DirFS("/"), wd)
 
 func Template(tpl string, m ...expressionstcl.Machine) (string, error) {
-	m = append(m, AliasMachine, EnvMachine, StateMachine, FileMachine)
+	m = append(m, AliasMachine, baseTestWorkflowMachine)
 	return expressionstcl.EvalTemplate(tpl, m...)
 }
 
 func Expression(expr string, m ...expressionstcl.Machine) (expressionstcl.StaticValue, error) {
-	m = append(m, AliasMachine, EnvMachine, StateMachine, FileMachine)
+	m = append(m, AliasMachine, baseTestWorkflowMachine)
 	return expressionstcl.EvalExpression(expr, m...)
 }
 

--- a/cmd/tcl/testworkflow-init/data/global.go
+++ b/cmd/tcl/testworkflow-init/data/global.go
@@ -1,0 +1,18 @@
+// Copyright 2024 Testkube.
+//
+// Licensed as a Testkube Pro file under the Testkube Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+//	https://github.com/kubeshop/testkube/blob/main/licenses/TCL.txt
+
+package data
+
+import "github.com/kubeshop/testkube/pkg/tcl/expressionstcl"
+
+var baseTestWorkflowMachine = expressionstcl.CombinedMachines(EnvMachine, StateMachine, FileMachine)
+
+func GetBaseTestWorkflowMachine() expressionstcl.Machine {
+	LoadState()
+	return baseTestWorkflowMachine
+}

--- a/cmd/tcl/testworkflow-init/data/state.go
+++ b/cmd/tcl/testworkflow-init/data/state.go
@@ -14,6 +14,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sync"
 
 	"github.com/kubeshop/testkube/pkg/tcl/expressionstcl"
 )
@@ -146,8 +147,16 @@ func persistStatus(filePath string) {
 	}
 }
 
+var loadStateMu sync.Mutex
+var loadedState bool
+
 func LoadState() {
-	readState(filepath.Join(defaultInternalPath, "state"))
+	defer loadStateMu.Unlock()
+	loadStateMu.Lock()
+	if !loadedState {
+		readState(filepath.Join(defaultInternalPath, "state"))
+		loadedState = true
+	}
 }
 
 func Finish() {

--- a/pkg/tcl/expressionstcl/generic.go
+++ b/pkg/tcl/expressionstcl/generic.go
@@ -209,7 +209,9 @@ func resolve(v reflect.Value, t tagData, m []Machine, force bool, finalize bool)
 			if ptr.Kind() == reflect.String {
 				v.SetString(vv)
 			} else {
-				ptr.Set(reflect.ValueOf(&vv))
+				instance := reflect.New(v.Type())
+				instance.Elem().SetString(vv)
+				ptr.Set(instance)
 			}
 		}
 		return

--- a/pkg/tcl/expressionstcl/generic_test.go
+++ b/pkg/tcl/expressionstcl/generic_test.go
@@ -54,6 +54,18 @@ type testObjNested struct {
 	Dummy corev1.Volume
 }
 
+type testEnum string
+
+type testObjWithStringEnums struct {
+	Value testEnum `expr:"force"`
+	Dummy testEnum
+}
+
+type testObjWithStringEnumPointers struct {
+	Value *testEnum `expr:"force"`
+	Dummy *testEnum
+}
+
 var testMachine = NewMachine().
 	Register("dummy", "test").
 	Register("ten", 10)
@@ -217,6 +229,38 @@ func TestGenericForceSimplifyNested(t *testing.T) {
 				},
 			},
 		},
+	}
+
+	assert.NoError(t, err)
+	assert.Equal(t, want, got)
+}
+
+func TestGenericSimplifyWithStringEnums(t *testing.T) {
+	got := testObjWithStringEnums{
+		Value: "{{ 3 + 2 }}{{ 5 }}",
+		Dummy: "{{ 4433 }}",
+	}
+	err := Simplify(&got)
+
+	want := testObjWithStringEnums{
+		Value: "55",
+		Dummy: "{{ 4433 }}",
+	}
+
+	assert.NoError(t, err)
+	assert.Equal(t, want, got)
+}
+
+func TestGenericSimplifyWithStringEnumPointers(t *testing.T) {
+	got := testObjWithStringEnumPointers{
+		Value: common.Ptr[testEnum]("{{ 3 + 2 }}{{ 5 }}"),
+		Dummy: common.Ptr[testEnum]("{{ 4433 }}"),
+	}
+	err := Simplify(&got)
+
+	want := testObjWithStringEnumPointers{
+		Value: common.Ptr[testEnum]("55"),
+		Dummy: common.Ptr[testEnum]("{{ 4433 }}"),
 	}
 
 	assert.NoError(t, err)

--- a/pkg/tcl/expressionstcl/math.go
+++ b/pkg/tcl/expressionstcl/math.go
@@ -210,7 +210,7 @@ func (s *math) Type() Type {
 
 func (s *math) itemString(v Expression) string {
 	if vv, ok := v.(*math); ok {
-		if getOperatorPriority(vv.operator) >= getOperatorPriority(s.operator) {
+		if getOperatorPriority(vv.operator) >= getOperatorPriority(s.operator) && (vv.operator != operatorAdd || v.Type() == vv.left.Type()) {
 			return v.String()
 		}
 	}

--- a/pkg/tcl/expressionstcl/parse_test.go
+++ b/pkg/tcl/expressionstcl/parse_test.go
@@ -40,6 +40,8 @@ func TestCompileMath(t *testing.T) {
 	assert.Equal(t, true, must(MustCompile(`3 != 5`).Static().BoolValue()))
 	assert.Equal(t, false, must(MustCompile(`3 == 5`).Static().BoolValue()))
 	assert.Equal(t, false, must(MustCompile(`3 = 5`).Static().BoolValue()))
+	assert.Equal(t, `"3/5:"+(a+b)+"/"+5`, MustCompile(`3 + "/" + 5 + ":" + (a + b) + "/" + 5`).String())
+	assert.Equal(t, `(a+"/")+b+":"+(a+1)+"/"+b`, MustCompile(`a + "/" + b + ":" + (a + 1) + "/" + b`).String())
 }
 
 func TestCompileLogical(t *testing.T) {
@@ -97,7 +99,7 @@ func TestCompileMathOperationsPrecedence(t *testing.T) {
 	assert.Equal(t, true, must(MustCompile(`!0 && 500`).Static().BoolValue()))
 	assert.Equal(t, false, must(MustCompile(`!5 && 500`).Static().BoolValue()))
 
-	assert.Equal(t, "A+B*(C+D)/E*F+G<>H**I*J**K", MustCompile(`A + B * (C + D) / E * F + G <> H ** I * J ** K`).String())
+	assert.Equal(t, "(A+B*(C+D)/E*F)+G<>H**I*J**K", MustCompile(`A + B * (C + D) / E * F + G <> H ** I * J ** K`).String())
 }
 
 func TestBuildTemplate(t *testing.T) {


### PR DESCRIPTION
## Pull request description 

* Fix simplifying string enum values (instead of panic)
* Fix simplifying math (as it could result in different equation before)
* Expose expressions machine with internal state, so it can be used by Toolkit

## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [x] tested locally
- [ ] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [x] added a test