### PR TITLE
fix(testworkflows): pass dynamic machine for the matrix & shards in execute step

### DIFF
--- a/cmd/tcl/testworkflow-toolkit/commands/execute.go
+++ b/cmd/tcl/testworkflow-toolkit/commands/execute.go
@@ -237,7 +237,7 @@ func NewExecuteCmd() *cobra.Command {
 				}
 
 				// Resolve the params
-				params, err := common2.GetParamsSpec(t.Matrix, t.Shards, t.Count, t.MaxCount)
+				params, err := common2.GetParamsSpec(t.Matrix, t.Shards, t.Count, t.MaxCount, baseMachine)
 				if err != nil {
 					ui.Fail(errors.Wrap(err, "matrix and sharding"))
 				}
@@ -265,7 +265,7 @@ func NewExecuteCmd() *cobra.Command {
 				}
 
 				// Resolve the params
-				params, err := common2.GetParamsSpec(w.Matrix, w.Shards, w.Count, w.MaxCount)
+				params, err := common2.GetParamsSpec(w.Matrix, w.Shards, w.Count, w.MaxCount, baseMachine)
 				if err != nil {
 					ui.Fail(errors.Wrap(err, "matrix and sharding"))
 				}


### PR DESCRIPTION
## Pull request description 

* pass base Expressions machine for the `matrix` and `shards` computation in `execute` step

## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [x] tested locally
- [x] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
