### PR TITLE
chore: Add GitHub Actions to dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,7 +16,11 @@ updates:
       - "exu"
       - "vsukhin"
       - "nicufk"
-      - "vLia" 
+      - "vLia"
       - "povilasv"
       - "dejanzele"
-    
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: daily


### PR DESCRIPTION
## Pull request description 

Most of the GitHub Actions seem to be out of date. Use dependabot to keep them up to date.

## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [ ] tested locally
- [ ] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Breaking changes

-

## Changes

-

## Fixes

-