### PR TITLE
fix(testworkflows): handle edge case of nullish event sent

### DIFF
--- a/pkg/tcl/testworkflowstcl/testworkflowcontroller/utils.go
+++ b/pkg/tcl/testworkflowstcl/testworkflowcontroller/utils.go
@@ -89,6 +89,9 @@ func WatchJob(ctx context.Context, clientSet kubernetes.Interface, namespace, na
 				switch event.Type {
 				case watch.Added, watch.Modified:
 					job := event.Object.(*batchv1.Job)
+					if job == nil {
+						continue
+					}
 					w.SendValue(job)
 					if IsJobDone(job) {
 						return
@@ -171,6 +174,9 @@ func watchPod(ctx context.Context, clientSet kubernetes.Interface, namespace str
 				switch event.Type {
 				case watch.Added, watch.Modified:
 					pod := event.Object.(*corev1.Pod)
+					if pod == nil {
+						continue
+					}
 					w.SendValue(pod)
 					if IsPodDone(pod) {
 						return
@@ -430,7 +436,10 @@ func watchEvents(clientSet kubernetes.Interface, namespace string, options ListO
 				}
 				switch event.Type {
 				case watch.Added, watch.Modified:
-					w.SendValue(event.Object.(*corev1.Event))
+					v := event.Object.(*corev1.Event)
+					if v != nil {
+						w.SendValue(v)
+					}
 				}
 			}
 		}


### PR DESCRIPTION
## Pull request description 

I don't have a clue how it can happen, but received panic error from @vsukhin:

```
panic: runtime error: invalid memory address or nil pointer dereference

[signal SIGSEGV: segmentation violation code=0x1 addr=0x180 pc=0x1fed8ea]

goroutine 316 [running]:
github.com/kubeshop/testkube/pkg/tcl/testworkflowstcl/testworkflowcontroller.WatchJobPreEvents.func1()
	/build/pkg/tcl/testworkflowstcl/testworkflowcontroller/utils.go:363 +0x1ea
created by github.com/kubeshop/testkube/pkg/tcl/testworkflowstcl/testworkflowcontroller.WatchJobPreEvents in goroutine 312
	/build/pkg/tcl/testworkflowstcl/testworkflowcontroller/utils.go:349 +0xe5
```

Assuming then that watch events may fall into faulty state, where the value is there, but it's nullish. In that case, we will ignore it waiting for a valid one.

## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [ ] tested locally
- [ ] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test