### PR TITLE
fix: update JMeter for integration to version which binary is provided by Apache

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -124,11 +124,11 @@ jobs:
           sudo apt-get update
           sudo apt-get install k6
 
-      - name: Set up JMeter@5.5
+      - name: Set up JMeter@5.6.3
         run: |
-          wget https://downloads.apache.org//jmeter/binaries/apache-jmeter-5.5.zip
-          unzip apache-jmeter-5.5.zip
-          mv apache-jmeter-5.5 jmeter
+          wget https://downloads.apache.org//jmeter/binaries/apache-jmeter-5.6.3.zip
+          unzip apache-jmeter-5.6.3.zip
+          mv apache-jmeter-5.6.3 jmeter
           sudo mv jmeter /opt
           echo "/opt/jmeter/bin" >> $GITHUB_PATH
 


### PR DESCRIPTION
## Pull request description 

Based on https://downloads.apache.org//jmeter/binaries listing, only 5.6.3 is available now

## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [ ] tested locally
- [ ] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
