### PR TITLE
fix: use log artifact path w/o prefix in minio

### DIFF
--- a/pkg/storage/minio/minio.go
+++ b/pkg/storage/minio/minio.go
@@ -259,7 +259,7 @@ func (c *Client) downloadFile(ctx context.Context, bucket, bucketFolder, file st
 		return nil, ErrArtifactsNotFound
 	}
 
-	if bucketFolder != "" {
+	if bucketFolder != "" && bucketFolder != file {
 		file = strings.Trim(bucketFolder, "/") + "/" + file
 	}
 


### PR DESCRIPTION
## Pull request description 
When listing artifacts in MinIO, objects with the execution ID as a prefix are searched. For example, when the prefix is `660fb2ff8358704f8a3f1d07`, the list of objects is as follows: `660fb2ff8358704f8a3f1d07/artifact` and `660fb2ff8358704f8a3f1d07`.
When downloading artifacts, `downloadFile()` is assumed that all files are in the specific directory.
This assumption is not correct because the log artifact name itself is also execution ID.

## Checklist (choose whats happened)
- [ ] breaking change! (describe)
- [ ] tested locally
- [x] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Breaking changes
-

## Changes
-

## Fixes
- https://github.com/kubeshop/testkube/issues/5279