### PR TITLE
fix: help text refers to invalid option for --output flag

### DIFF
--- a/cmd/kubectl-testkube/commands/get.go
+++ b/cmd/kubectl-testkube/commands/get.go
@@ -54,7 +54,7 @@ func NewGetCmd() *cobra.Command {
 	cmd.AddCommand(testworkflows.NewGetTestWorkflowExecutionsCmd())
 	cmd.AddCommand(testworkflowtemplates.NewGetTestWorkflowTemplatesCmd())
 
-	cmd.PersistentFlags().StringP("output", "o", "pretty", "output type can be one of json|yaml|pretty|go-template")
+	cmd.PersistentFlags().StringP("output", "o", "pretty", "output type can be one of json|yaml|pretty|go")
 	cmd.PersistentFlags().StringP("go-template", "", "{{.}}", "go template to render")
 
 	return cmd


### PR DESCRIPTION
## Pull request description 

The help text for the --output flag in the CLI suggest that there is type "go-template", when in fact it is just "go".

Compare:
- Flag defined: [cmd/kubectl-testkube/commands/get.go](https://github.com/kubeshop/testkube/blob/develop/cmd/kubectl-testkube/commands/get.go#L57)
- Flag used: https://github.com/kubeshop/testkube/blob/develop/cmd/kubectl-testkube/commands/common/render/obj.go#L13

## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [ ] tested locally
- [ ] tested on cluster
- [ ] added new dependencies
- [x] updated the docs
- [ ] added a test

## Breaking changes

-

## Changes

-

## Fixes

- misleading help text for --output flag in Testkube CLI