### PR TITLE
feat(installer): minor improvements

### DIFF
--- a/cmd/kubectl-testkube/commands/init.go
+++ b/cmd/kubectl-testkube/commands/init.go
@@ -2,6 +2,8 @@ package commands
 
 import (
 	"fmt"
+	"io"
+	"net/http"
 	"os/exec"
 	"strings"
 
@@ -9,6 +11,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/kubeshop/testkube/cmd/kubectl-testkube/commands/common"
+	"github.com/kubeshop/testkube/cmd/kubectl-testkube/commands/pro"
 	"github.com/kubeshop/testkube/cmd/kubectl-testkube/config"
 	"github.com/kubeshop/testkube/pkg/process"
 	"github.com/kubeshop/testkube/pkg/telemetry"
@@ -19,15 +22,18 @@ const (
 	defaultNamespace       = "testkube"
 	standaloneAgentProfile = "standalone-agent"
 	demoProfile            = "demo"
+	demoValuesUrl          = "https://raw.githubusercontent.com/kubeshop/testkube-cloud-charts/main/charts/testkube-enterprise/profiles/values.demo.yaml"
 	agentProfile           = "agent"
 
 	standaloneInstallationName = "Testkube OSS"
 	demoInstallationName       = "Testkube On-Prem demo"
 	agentInstallationName      = "Testkube Agent"
 	licenseFormat              = "XXXXXX-XXXXXX-XXXXXX-XXXXXX-XXXXXX-V3"
+	helpUrl                    = "https://testkubeworkspace.slack.com"
 )
 
 func NewInitCmd() *cobra.Command {
+	var export bool
 	standaloneCmd := NewInitCmdStandalone()
 
 	cmd := &cobra.Command{
@@ -39,24 +45,36 @@ func NewInitCmd() *cobra.Command {
 			"\t" + demoProfile + " -> " + demoInstallationName + "\n" +
 			"\t" + agentProfile + " -> " + agentInstallationName,
 		Run: func(cmd *cobra.Command, args []string) {
+			if export {
+				ui.Failf("export is unavailable for this profile")
+				return
+			}
 			standaloneCmd.Run(cmd, args)
 		},
 	}
 
 	cmd.AddCommand(standaloneCmd)
 	cmd.AddCommand(NewInitCmdDemo())
+	cmd.AddCommand(pro.NewInitCmd())
+	cmd.Flags().BoolVarP(&export, "export", "", false, "Export the values.yaml")
 
 	return cmd
 }
 
 func NewInitCmdStandalone() *cobra.Command {
+	var export bool
 	var options common.HelmOptions
 
 	cmd := &cobra.Command{
 		Use:     standaloneAgentProfile,
 		Short:   "Install " + standaloneInstallationName + " in your current context",
-		Aliases: []string{"install"},
+		Aliases: []string{"oss", "standalone"},
 		Run: func(cmd *cobra.Command, args []string) {
+			if export {
+				ui.Failf("export is unavailable for this profile")
+				return
+			}
+
 			ui.Logo()
 			ui.Info("Welcome to the installer for " + standaloneInstallationName + ".")
 			ui.NL()
@@ -82,6 +100,7 @@ func NewInitCmdStandalone() *cobra.Command {
 		},
 	}
 
+	cmd.Flags().BoolVarP(&export, "export", "", false, "Export the values.yaml")
 	common.PopulateHelmFlags(cmd, &options)
 	common.PopulateMasterFlags(cmd, &options)
 
@@ -89,14 +108,25 @@ func NewInitCmdStandalone() *cobra.Command {
 }
 
 func NewInitCmdDemo() *cobra.Command {
-	var noConfirm, dryRun bool
+	var noConfirm, dryRun, export bool
 	var license, namespace string
 
 	cmd := &cobra.Command{
 		Use:     demoProfile,
-		Short:   "Install " + demoInstallationName + " Helm chart registry in current kubectl context and update dependencies",
+		Short:   "Install " + demoInstallationName + " in your current context",
 		Aliases: []string{"on-premise-demo", "on-prem-demo", "enterprise-demo"},
 		Run: func(cmd *cobra.Command, args []string) {
+			if export {
+				valuesResp, err := http.Get(demoValuesUrl)
+				ui.ExitOnError("cannot fetch values", err)
+				valuesBytes, err := io.ReadAll(valuesResp.Body)
+				ui.ExitOnError("cannot fetch values", err)
+				values := string(valuesBytes)
+				_, err = fmt.Println(values)
+				ui.ExitOnError("cannot print values", err)
+				return
+			}
+
 			ui.Logo()
 			ui.Info("Welcome to the installer for " + demoInstallationName + ".")
 			ui.NL()
@@ -138,17 +168,24 @@ func NewInitCmdDemo() *cobra.Command {
 			ui.Warn("- Testkube CRDs and cluster roles will be applied to your cluster.")
 			ui.NL()
 
-			if ok := ui.Confirm("Do you want to continue"); !ok {
-				sendErrTelemetry(cmd, cfg, "install_cancelled", license, err)
-				return
+			if !noConfirm {
+				if ok := ui.Confirm("Do you want to continue"); !ok {
+					sendErrTelemetry(cmd, cfg, "install_cancelled", license, err)
+					return
+				}
 			}
 
 			sendAttemptTelemetry(cmd, cfg, license)
 			err = helmInstallDemo(license, namespace, dryRun)
 			if err != nil {
 				sendErrTelemetry(cmd, cfg, "install_failed", license, err)
+				ui.NL()
+				ui.Info(fmt.Sprint(err))
+				ui.NL()
+				ui.Info("Let us help you!")
+				ui.Info("Come say hi on Slack:", helpUrl)
+				return
 			}
-			ui.ExitOnError("Cannot install Testkube", err)
 
 			if err == nil {
 				cfg.Namespace = namespace
@@ -178,7 +215,7 @@ func NewInitCmdDemo() *cobra.Command {
 		},
 	}
 
-	cmd.Flags().BoolVarP(&noConfirm, "export", "", false, "Export the values.yaml")
+	cmd.Flags().BoolVarP(&export, "export", "", false, "Export the values.yaml")
 	cmd.Flags().BoolVarP(&noConfirm, "no-confirm", "y", false, "Skip confirmation")
 	cmd.Flags().StringVarP(&license, "license", "l", "", "License key")
 	cmd.Flags().BoolVarP(&dryRun, "dry-run", "", false, "Dry run")
@@ -208,21 +245,25 @@ func isContextApproved(isNoConfirm bool, installedComponent string) bool {
 }
 
 func helmInstallDemo(license, namespace string, dryRun bool) error {
+	spinner := ui.NewSpinner("Installing Testkube… ")
+
 	helmPath, err := exec.LookPath("helm")
 	if err != nil {
+		spinner.Fail("Failed to install Testkube")
 		return err
 	}
-
-	ui.Info("Installing Testkube… ")
 
 	args := []string{"repo", "add", "testkubeenterprise", "https://kubeshop.github.io/testkube-cloud-charts"}
 	_, err = process.ExecuteWithOptions(process.Options{Command: helmPath, Args: args, DryRun: dryRun})
 	if err != nil && !strings.Contains(err.Error(), "Error: repository name (kubeshop) already exists, please specify a different name") {
+		spinner.Fail("Failed to install Testkube")
 		return err
 	}
 
 	_, err = process.ExecuteWithOptions(process.Options{Command: helmPath, Args: []string{"repo", "update"}, DryRun: dryRun})
+
 	if err != nil {
+		spinner.Fail("Failed to install Testkube")
 		return err
 	}
 
@@ -230,15 +271,19 @@ func helmInstallDemo(license, namespace string, dryRun bool) error {
 		"--create-namespace",
 		"--namespace", namespace,
 		"--set", "global.enterpriseLicenseKey=" + license,
-		"--values", "https://raw.githubusercontent.com/kubeshop/testkube-cloud-charts/main/charts/testkube-enterprise/profiles/values.demo.yaml",
+		"--values", demoValuesUrl,
 		"--wait",
 		"testkube", "testkubeenterprise/testkube-enterprise"}
 
 	ui.Debug("Helm command: ", helmPath+" "+strings.Join(args, " "))
+
 	out, err := process.ExecuteWithOptions(process.Options{Command: helmPath, Args: args, DryRun: dryRun})
 	if err != nil {
+		spinner.Fail("Failed to install Testkube")
 		return err
 	}
+	spinner.Success()
+
 	ui.Debug("Helm command output: ", string(out))
 	ui.NL()
 	return nil

--- a/cmd/kubectl-testkube/commands/pro/init.go
+++ b/cmd/kubectl-testkube/commands/pro/init.go
@@ -12,6 +12,7 @@ import (
 )
 
 func NewInitCmd() *cobra.Command {
+	var export bool
 	options := common.HelmOptions{
 		NoMinio: true,
 		NoMongo: true,
@@ -20,8 +21,13 @@ func NewInitCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "init",
 		Short:   "Install Testkube Pro Agent and connect to Testkube Pro environment",
-		Aliases: []string{"install"},
+		Aliases: []string{"install", "agent"},
 		Run: func(cmd *cobra.Command, args []string) {
+			if export {
+				ui.Failf("export is unavailable for this profile")
+				return
+			}
+
 			ui.Info("WELCOME TO")
 			ui.Logo()
 
@@ -85,6 +91,7 @@ func NewInitCmd() *cobra.Command {
 	common.PopulateHelmFlags(cmd, &options)
 	common.PopulateMasterFlags(cmd, &options)
 
+	cmd.Flags().BoolVarP(&export, "export", "", false, "Export the values.yaml")
 	cmd.Flags().BoolVar(&options.MultiNamespace, "multi-namespace", false, "multi namespace mode")
 	cmd.Flags().BoolVar(&options.NoOperator, "no-operator", false, "should operator be installed (for more instances in multi namespace mode it should be set to true)")
 

--- a/cmd/kubectl-testkube/commands/purge.go
+++ b/cmd/kubectl-testkube/commands/purge.go
@@ -16,11 +16,14 @@ func NewPurgeCmd() *cobra.Command {
 		Long:    `Uninstall Testkube from your current kubectl context`,
 		Aliases: []string{"uninstall"},
 		Run: func(cmd *cobra.Command, args []string) {
-
+			originalVerbose := ui.Verbose
 			ui.Verbose = true
 
 			_, err := process.Execute("helm", "uninstall", "--namespace", namespace, name)
 			ui.PrintOnError("uninstalling testkube", err)
+
+			ui.Verbose = originalVerbose
+
 		},
 	}
 


### PR DESCRIPTION
This PR tackles multiple minor issues and polishing in the installer:

- `testkube init demo` during Installing Testkube… should give interactive spinner
- `testkube init --list-profiles` does not exist yet -> Changed to --help
- `testkube init agent` does not exist yet -> Alias for testkube pro init
- `testkube dashboard port-forward` -> testkube dashboard 
- `testkube init <profile> --export` does not exist yet -> Supports only demo profile for now
- 🐛 testkube uninstall does not work for some weird reason. All it does it wrap helm uninstall which gives different output. Need to check if "middleware" is running.
- Give help / instructions when Helm install fails. Where to go? What to do?