### PR TITLE
fix(testworkflows): orchestration fixes

### DIFF
--- a/pkg/api/v1/testkube/model_test_workflow_execution_extended.go
+++ b/pkg/api/v1/testkube/model_test_workflow_execution_extended.go
@@ -38,3 +38,10 @@ func (e *TestWorkflowExecution) EscapeDots() *TestWorkflowExecution {
 func (e *TestWorkflowExecution) UnscapeDots() *TestWorkflowExecution {
 	return e.ConvertDots(utils.UnescapeDots)
 }
+
+func (e *TestWorkflowExecution) GetNamespace(defaultNamespace string) string {
+	if e.Namespace == "" {
+		return defaultNamespace
+	}
+	return e.Namespace
+}

--- a/pkg/tcl/apitcl/v1/testworkflowexecutions.go
+++ b/pkg/tcl/apitcl/v1/testworkflowexecutions.go
@@ -42,7 +42,7 @@ func (s *apiTCL) StreamTestWorkflowExecutionNotificationsHandler() fiber.Handler
 		}
 
 		// Check for the logs
-		ctrl, err := testworkflowcontroller.New(ctx, s.Clientset, execution.Namespace, execution.Id, execution.ScheduledAt)
+		ctrl, err := testworkflowcontroller.New(ctx, s.Clientset, execution.GetNamespace(s.Namespace), execution.Id, execution.ScheduledAt)
 		if err != nil {
 			return s.BadRequest(c, errPrefix, "fetching job", err)
 		}
@@ -91,7 +91,7 @@ func (s *apiTCL) StreamTestWorkflowExecutionNotificationsWebSocketHandler() fibe
 		}
 
 		// Check for the logs TODO: Load from the database if possible
-		ctrl, err := testworkflowcontroller.New(ctx, s.Clientset, execution.Namespace, execution.Id, execution.ScheduledAt)
+		ctrl, err := testworkflowcontroller.New(ctx, s.Clientset, execution.GetNamespace(s.Namespace), execution.Id, execution.ScheduledAt)
 		if err != nil {
 			return
 		}
@@ -233,7 +233,7 @@ func (s *apiTCL) AbortTestWorkflowExecutionHandler() fiber.Handler {
 		}
 
 		// Obtain the controller
-		ctrl, err := testworkflowcontroller.New(ctx, s.Clientset, execution.Namespace, execution.Id, execution.ScheduledAt)
+		ctrl, err := testworkflowcontroller.New(ctx, s.Clientset, execution.GetNamespace(s.Namespace), execution.Id, execution.ScheduledAt)
 		if err != nil {
 			return s.BadRequest(c, errPrefix, "fetching job", err)
 		}
@@ -273,7 +273,7 @@ func (s *apiTCL) PauseTestWorkflowExecutionHandler() fiber.Handler {
 		}
 
 		// Obtain the controller
-		ctrl, err := testworkflowcontroller.New(ctx, s.Clientset, execution.Namespace, execution.Id, execution.ScheduledAt)
+		ctrl, err := testworkflowcontroller.New(ctx, s.Clientset, execution.GetNamespace(s.Namespace), execution.Id, execution.ScheduledAt)
 		if err != nil {
 			return s.BadRequest(c, errPrefix, "fetching job", err)
 		}
@@ -313,8 +313,7 @@ func (s *apiTCL) ResumeTestWorkflowExecutionHandler() fiber.Handler {
 		}
 
 		// Obtain the controller
-		ctrl, err := testworkflowcontroller.New(ctx, s.Clientset, execution.Namespace, execution.Id, execution.ScheduledAt)
-		defer ctrl.StopController()
+		ctrl, err := testworkflowcontroller.New(ctx, s.Clientset, execution.GetNamespace(s.Namespace), execution.Id, execution.ScheduledAt)
 		if err != nil {
 			return s.BadRequest(c, errPrefix, "fetching job", err)
 		}
@@ -350,8 +349,7 @@ func (s *apiTCL) AbortAllTestWorkflowExecutionsHandler() fiber.Handler {
 
 		for _, execution := range executions {
 			// Obtain the controller
-			ctrl, err := testworkflowcontroller.New(ctx, s.Clientset, execution.Namespace, execution.Id, execution.ScheduledAt)
-			defer ctrl.StopController()
+			ctrl, err := testworkflowcontroller.New(ctx, s.Clientset, execution.GetNamespace(s.Namespace), execution.Id, execution.ScheduledAt)
 			if err != nil {
 				return s.BadRequest(c, errPrefix, "fetching job", err)
 			}
@@ -453,7 +451,7 @@ func (s *apiTCL) GetTestWorkflowNotificationsStream(ctx context.Context, executi
 	}
 
 	// Check for the logs
-	ctrl, err := testworkflowcontroller.New(ctx, s.Clientset, execution.Namespace, execution.Id, execution.ScheduledAt)
+	ctrl, err := testworkflowcontroller.New(ctx, s.Clientset, execution.GetNamespace(s.Namespace), execution.Id, execution.ScheduledAt)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/tcl/testworkflowstcl/testworkflowcontroller/controller.go
+++ b/pkg/tcl/testworkflowstcl/testworkflowcontroller/controller.go
@@ -22,7 +22,7 @@ import (
 )
 
 const (
-	DefaultInitTimeout = 1 * time.Second
+	DefaultInitTimeout = 5 * time.Second
 )
 
 var (

--- a/pkg/tcl/testworkflowstcl/testworkflowexecutor/executor.go
+++ b/pkg/tcl/testworkflowstcl/testworkflowexecutor/executor.go
@@ -142,7 +142,7 @@ func (e *executor) handleFatalError(execution *testkube.TestWorkflowExecution, e
 		log.DefaultLogger.Errorf("failed to save fatal error for execution %s: %v", execution.Id, err)
 	}
 	e.emitter.Notify(testkube.NewEventEndTestWorkflowFailed(execution))
-	go testworkflowcontroller.Cleanup(context.Background(), e.clientSet, execution.Namespace, execution.Id)
+	go testworkflowcontroller.Cleanup(context.Background(), e.clientSet, execution.GetNamespace(e.namespace), execution.Id)
 }
 
 func (e *executor) Recover(ctx context.Context) {
@@ -161,7 +161,7 @@ func (e *executor) Recover(ctx context.Context) {
 }
 
 func (e *executor) Control(ctx context.Context, execution *testkube.TestWorkflowExecution) error {
-	ctrl, err := testworkflowcontroller.New(ctx, e.clientSet, execution.Namespace, execution.Id, execution.ScheduledAt)
+	ctrl, err := testworkflowcontroller.New(ctx, e.clientSet, execution.GetNamespace(e.namespace), execution.Id, execution.ScheduledAt)
 	if err != nil {
 		log.DefaultLogger.Errorw("failed to control the TestWorkflow", "id", execution.Id, "error", err)
 		return err
@@ -224,7 +224,7 @@ func (e *executor) Control(ctx context.Context, execution *testkube.TestWorkflow
 			} else {
 				// Handle unknown state
 				ctrl.StopController()
-				ctrl, err = testworkflowcontroller.New(ctx, e.clientSet, execution.Namespace, execution.Id, execution.ScheduledAt)
+				ctrl, err = testworkflowcontroller.New(ctx, e.clientSet, execution.GetNamespace(e.namespace), execution.Id, execution.ScheduledAt)
 				if err == nil {
 					for v := range ctrl.Watch(ctx) {
 						if v.Error != nil || v.Value.Output == nil {
@@ -272,7 +272,7 @@ func (e *executor) Control(ctx context.Context, execution *testkube.TestWorkflow
 
 	wg.Wait()
 
-	err = testworkflowcontroller.Cleanup(ctx, e.clientSet, execution.Namespace, execution.Id)
+	err = testworkflowcontroller.Cleanup(ctx, e.clientSet, execution.GetNamespace(e.namespace), execution.Id)
 	if err != nil {
 		log.DefaultLogger.Errorw("failed to cleanup TestWorkflow resources", "id", execution.Id, "error", err)
 	}


### PR DESCRIPTION
## Pull request description 

* use default namespace if execution doesn't have it
   * old executions + executions when newest Agent is used with older Pro instance
* make `Channel.PeekMessage` non-blocking
   * so it successfully handles timeouts
* sort out `StopController` when it's not needed as context is passed

## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [x] tested locally
- [x] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test