### PR TITLE
fix: pulling from git servers using private ca

### DIFF
--- a/config/job-container-template.yml
+++ b/config/job-container-template.yml
@@ -21,12 +21,25 @@ spec:
         command:
           - "/bin/runner"
           - '{{ .Jsn }}'
+        {{- if .RunnerCustomCASecret }}
+        env:
+          - name: SSL_CERT_DIR
+            value: /etc/testkube/certs
+          - name: GIT_SSL_CAPATH
+            value: /etc/testkube/certs
+        {{- end }}
         volumeMounts:
         - name: data-volume
           mountPath: /data
         {{- if .CertificateSecret }}
         - name: {{ .CertificateSecret }}
           mountPath: /etc/certs
+        {{- end }}
+        {{- if .RunnerCustomCASecret }}
+        - name: {{ .RunnerCustomCASecret }}
+          mountPath: /etc/testkube/certs/testkube-custom-ca.pem
+          readOnly: true
+          subPath: ca.crt
         {{- end }}
         {{- if .ArtifactRequest }}
           {{- if and .ArtifactRequest.VolumeMountPath (or .ArtifactRequest.StorageClassName .ArtifactRequest.UseDefaultStorageClassName) }}
@@ -133,6 +146,12 @@ spec:
       - name: {{ .CertificateSecret }}
         secret:
           secretName: {{ .CertificateSecret }}
+      {{- end }}
+      {{- if .RunnerCustomCASecret }}
+      - name: {{ .RunnerCustomCASecret }}
+        secret:
+          secretName: {{ .RunnerCustomCASecret }}
+          defaultMode: 420
       {{- end }}
       {{- if .AgentAPITLSSecret }}
       - name: { { .AgentAPITLSSecret } }

--- a/config/job-scraper-template.yml
+++ b/config/job-scraper-template.yml
@@ -50,6 +50,8 @@ spec:
         env:
           - name: SSL_CERT_DIR
             value: /etc/testkube/certs
+          - name: GIT_SSL_CAPATH
+            value: /etc/testkube/certs
         {{- end }}
         volumeMounts:
         {{- if .RunnerCustomCASecret }}

--- a/config/job-template.yml
+++ b/config/job-template.yml
@@ -24,6 +24,8 @@ spec:
         env:
           - name: SSL_CERT_DIR
             value: /etc/testkube/certs
+          - name: GIT_SSL_CAPATH
+            value: /etc/testkube/certs
         {{- end }}
         volumeMounts:
         - name: data-volume
@@ -100,6 +102,8 @@ spec:
         {{- if .RunnerCustomCASecret }}
         env:
           - name: SSL_CERT_DIR
+            value: /etc/testkube/certs
+          - name: GIT_SSL_CAPATH
             value: /etc/testkube/certs
         {{- end }}
         volumeMounts:

--- a/config/slave-pod-template.yml
+++ b/config/slave-pod-template.yml
@@ -29,6 +29,8 @@ spec:
     env:
       - name: SSL_CERT_DIR
         value: /etc/testkube/certs
+      - name: GIT_SSL_CAPATH
+        value: /etc/testkube/certs
     {{- end }}
     volumeMounts:
     - name: data-volume

--- a/pkg/executor/containerexecutor/templates/job.tmpl
+++ b/pkg/executor/containerexecutor/templates/job.tmpl
@@ -26,6 +26,8 @@ spec:
         env:
           - name: SSL_CERT_DIR
             value: /etc/testkube/certs
+          - name: GIT_SSL_CAPATH
+            value: /etc/testkube/certs
         {{- end }}
         volumeMounts:
         - name: data-volume
@@ -98,6 +100,8 @@ spec:
         {{- if .RunnerCustomCASecret }}
         env:
           - name: SSL_CERT_DIR
+            value: /etc/testkube/certs
+          - name: GIT_SSL_CAPATH
             value: /etc/testkube/certs
         {{- end }}
         volumeMounts:


### PR DESCRIPTION
## Pull request description 



## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [ ] tested locally
- [x] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Breaking changes

-

## Changes

- Fix job templates to be able to pull from Git repositories using private-CAs. Covers prebuilt and container executors only, not workflows.

## Fixes

- TKC-1901
- TKC-1911