### PR TITLE
fix: cloud uploader should match content type

### DIFF
--- a/pkg/cloud/data/artifact/uploader.go
+++ b/pkg/cloud/data/artifact/uploader.go
@@ -71,7 +71,7 @@ func (u *CloudUploader) putObject(ctx context.Context, url string, data io.Reade
 		return err
 	}
 
-	req.Header.Set("Content-Type", "application/octet-stream")
+	req.Header.Set("Content-Type", getContentType(url))
 	tr := http.DefaultTransport.(*http.Transport).Clone()
 	tr.TLSClientConfig = &tls.Config{InsecureSkipVerify: u.skipVerify}
 	client := &http.Client{Transport: tr}


### PR DESCRIPTION
## Pull request description 

fix use get content type function for cloud uploader

## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [ ] tested locally
- [ ] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Breaking changes

-

## Changes

-

## Fixes

-