### PR TITLE
fix(testworkflows): displaying log on parallel step status change

### DIFF
--- a/cmd/tcl/testworkflow-toolkit/commands/parallel.go
+++ b/cmd/tcl/testworkflow-toolkit/commands/parallel.go
@@ -283,12 +283,12 @@ func NewParallelCmd() *cobra.Command {
 
 					// Handle result change
 					if v.Status != prevStatus || v.Current != prevStep {
-						updates <- Update{index: index, result: v.Result}
-						prevStep = v.Current
-						prevStatus = v.Status
 						if v.Status != prevStatus {
 							log(string(v.Status))
 						}
+						updates <- Update{index: index, result: v.Result}
+						prevStep = v.Current
+						prevStatus = v.Status
 						if v.Result.IsFinished() {
 							data.PrintOutput(env.Ref(), "parallel", ParallelStatus{Index: int(index), Status: v.Status, Result: v.Result})
 							ctxCancel()


### PR DESCRIPTION
## Pull request description 

* it was comparing wrong values to decide if the status should be surfaced

| <img width="1040" alt="Zrzut ekranu 2024-05-21 o 11 23 34" src="https://github.com/kubeshop/testkube/assets/3843526/798d5cfb-c83d-4c7c-ad19-c0b227b538cd"> |
|-|

## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [x] tested locally
- [x] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
