### PR TITLE
fix: [main] cloud uploader should set content type

### DIFF
--- a/pkg/cloud/data/artifact/scraper_integration_test.go
+++ b/pkg/cloud/data/artifact/scraper_integration_test.go
@@ -67,6 +67,7 @@ func TestCloudScraper_ArchiveFilesystemExtractor_Integration(t *testing.T) {
 		ExecutionID:   "my-execution-id",
 		TestName:      "my-test",
 		TestSuiteName: "my-test-suite",
+		ContentType:   "application/gzip",
 	}
 	mockExecutor.
 		EXPECT().
@@ -77,6 +78,7 @@ func TestCloudScraper_ArchiveFilesystemExtractor_Integration(t *testing.T) {
 		ExecutionID:   "my-execution-id",
 		TestName:      "my-test",
 		TestSuiteName: "my-test-suite",
+		ContentType:   "text/plain",
 	}
 	mockExecutor.
 		EXPECT().
@@ -154,6 +156,7 @@ func TestCloudScraper_RecursiveFilesystemExtractor_Integration(t *testing.T) {
 		ExecutionID:   "my-execution-id",
 		TestName:      "my-test",
 		TestSuiteName: "my-test-suite",
+		ContentType:   "text/plain",
 	}
 	mockExecutor.
 		EXPECT().
@@ -165,6 +168,7 @@ func TestCloudScraper_RecursiveFilesystemExtractor_Integration(t *testing.T) {
 		ExecutionID:   "my-execution-id",
 		TestName:      "my-test",
 		TestSuiteName: "my-test-suite",
+		ContentType:   "text/plain",
 	}
 	mockExecutor.
 		EXPECT().
@@ -176,6 +180,7 @@ func TestCloudScraper_RecursiveFilesystemExtractor_Integration(t *testing.T) {
 		ExecutionID:   "my-execution-id",
 		TestName:      "my-test",
 		TestSuiteName: "my-test-suite",
+		ContentType:   "text/plain",
 	}
 	mockExecutor.
 		EXPECT().

--- a/pkg/cloud/data/artifact/uploader_test.go
+++ b/pkg/cloud/data/artifact/uploader_test.go
@@ -57,6 +57,7 @@ func TestCloudLoader_Load(t *testing.T) {
 					ExecutionID:   "my-execution-id",
 					TestName:      "my-test",
 					TestSuiteName: "my-test-suite",
+					ContentType:   "text/plain",
 				}
 
 				mockExecutor.EXPECT().Execute(gomock.Any(), cloudscraper.CmdScraperPutObjectSignedURL, gomock.Eq(req)).Return([]byte(`{"URL":"`+testServer.URL+`/dummy"}`), nil).Times(1)
@@ -79,6 +80,7 @@ func TestCloudLoader_Load(t *testing.T) {
 					ExecutionID:   "my-execution-id",
 					TestName:      "my-test",
 					TestSuiteName: "my-test-suite",
+					ContentType:   "text/plain",
 				}
 
 				mockExecutor.EXPECT().Execute(gomock.Any(), cloudscraper.CmdScraperPutObjectSignedURL, gomock.Eq(req)).Return(nil, errors.New("connection error")).Times(1)


### PR DESCRIPTION
## Pull request description 

cherry picking fixes for cloud uploader content type.

Tested using dev image.

## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [ ] tested locally
- [ ] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Breaking changes

-

## Changes

-

## Fixes

-