### PR TITLE
fix(testworkflows): don't resolve environment variables if they are dynamic (i.e. from secrets)

### DIFF
--- a/pkg/tcl/testworkflowstcl/testworkflowprocessor/container.go
+++ b/pkg/tcl/testworkflowstcl/testworkflowprocessor/container.go
@@ -467,7 +467,7 @@ func (c *container) Resolve(m ...expressionstcl.Machine) error {
 			env := c.Env()
 			name = name[4:]
 			for i := range env {
-				if env[i].Name == name {
+				if env[i].Name == name && env[i].ValueFrom == nil {
 					value, err := expressionstcl.EvalTemplate(env[i].Value)
 					if err == nil {
 						return value, true


### PR DESCRIPTION
## Pull request description 

* Because of that, i.e. cloning private repositories was not working

## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [x] tested locally
- [x] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
