### PR TITLE
fix: fix semantic errors in yaml and generate openapi files

### DIFF
--- a/api/v1/testkube.yaml
+++ b/api/v1/testkube.yaml
@@ -3574,6 +3574,8 @@ paths:
         - test-workflows
         - api
         - pro
+      parameters:
+        - $ref: "#/components/parameters/ID"
       summary: Execute test workflow
       description: Execute test workflow in the kubernetes cluster
       operationId: executeTestWorkflow
@@ -3845,7 +3847,7 @@ paths:
   /test-workflow-executions/{executionID}/artifacts:
     get:
       parameters:
-        - $ref: "#/components/parameters/ID"
+        - $ref: "#/components/parameters/executionID"
       tags:
         - test-workflows
         - artifacts
@@ -3892,7 +3894,7 @@ paths:
   /test-workflow-executions/{executionID}/artifacts/{filename}:
     get:
       parameters:
-        - $ref: "#/components/parameters/ID"
+        - $ref: "#/components/parameters/executionID"
         - $ref: "#/components/parameters/Filename"
       tags:
         - test-workflows
@@ -3939,7 +3941,7 @@ paths:
   /test-workflow-executions/{executionID}/artifact-archive:
     get:
       parameters:
-        - $ref: "#/components/parameters/ID"
+        - $ref: "#/components/parameters/executionID"
         - $ref: "#/components/parameters/Mask"
       tags:
         - test-workflows

--- a/pkg/api/v1/testkube/model_test_workflow_independent_service_spec.go
+++ b/pkg/api/v1/testkube/model_test_workflow_independent_service_spec.go
@@ -25,6 +25,12 @@ type TestWorkflowIndependentServiceSpec struct {
 	SecurityContext *SecurityContext       `json:"securityContext,omitempty"`
 	// volumes to mount to the container
 	VolumeMounts []VolumeMount `json:"volumeMounts,omitempty"`
+	Count        *BoxedString  `json:"count,omitempty"`
+	MaxCount     *BoxedString  `json:"maxCount,omitempty"`
+	// matrix of parameters to spawn instances
+	Matrix map[string]interface{} `json:"matrix,omitempty"`
+	// parameters that should be distributed across sharded instances
+	Shards map[string]interface{} `json:"shards,omitempty"`
 	// maximum time until reaching readiness
 	Timeout string `json:"timeout,omitempty"`
 	// list of files to send to parallel steps
@@ -34,10 +40,4 @@ type TestWorkflowIndependentServiceSpec struct {
 	Logs           *BoxedString                       `json:"logs,omitempty"`
 	RestartPolicy  string                             `json:"restartPolicy,omitempty"`
 	ReadinessProbe *Probe                             `json:"readinessProbe,omitempty"`
-	Count          *BoxedString                       `json:"count,omitempty"`
-	MaxCount       *BoxedString                       `json:"maxCount,omitempty"`
-	// matrix of parameters to spawn instances
-	Matrix map[string]interface{} `json:"matrix,omitempty"`
-	// parameters that should be distributed across sharded instances
-	Shards map[string]interface{} `json:"shards,omitempty"`
 }

--- a/pkg/api/v1/testkube/model_test_workflow_independent_step_parallel.go
+++ b/pkg/api/v1/testkube/model_test_workflow_independent_step_parallel.go
@@ -28,19 +28,10 @@ type TestWorkflowIndependentStepParallel struct {
 	// delay before the step
 	Delay string `json:"delay,omitempty"`
 	// script to run in a default shell for the container
-	Shell     string                     `json:"shell,omitempty"`
-	Run       *TestWorkflowStepRun       `json:"run,omitempty"`
-	Execute   *TestWorkflowStepExecute   `json:"execute,omitempty"`
-	Artifacts *TestWorkflowStepArtifacts `json:"artifacts,omitempty"`
-	// how many resources could be scheduled in parallel
-	Parallelism int32 `json:"parallelism,omitempty"`
-	// worker description to display
-	Description string       `json:"description,omitempty"`
-	Logs        *BoxedString `json:"logs,omitempty"`
-	// list of files to send to parallel steps
-	Transfer []TestWorkflowStepParallelTransfer `json:"transfer,omitempty"`
-	// list of files to fetch from parallel steps
-	Fetch     []TestWorkflowStepParallelFetch               `json:"fetch,omitempty"`
+	Shell     string                                        `json:"shell,omitempty"`
+	Run       *TestWorkflowStepRun                          `json:"run,omitempty"`
+	Execute   *TestWorkflowStepExecute                      `json:"execute,omitempty"`
+	Artifacts *TestWorkflowStepArtifacts                    `json:"artifacts,omitempty"`
 	Config    map[string]TestWorkflowParameterSchema        `json:"config,omitempty"`
 	Content   *TestWorkflowContent                          `json:"content,omitempty"`
 	Services  map[string]TestWorkflowIndependentServiceSpec `json:"services,omitempty"`
@@ -51,4 +42,13 @@ type TestWorkflowIndependentStepParallel struct {
 	Steps     []TestWorkflowIndependentStep                 `json:"steps,omitempty"`
 	After     []TestWorkflowIndependentStep                 `json:"after,omitempty"`
 	Events    []TestWorkflowEvent                           `json:"events,omitempty"`
+	// how many resources could be scheduled in parallel
+	Parallelism int32 `json:"parallelism,omitempty"`
+	// worker description to display
+	Description string       `json:"description,omitempty"`
+	Logs        *BoxedString `json:"logs,omitempty"`
+	// list of files to send to parallel steps
+	Transfer []TestWorkflowStepParallelTransfer `json:"transfer,omitempty"`
+	// list of files to fetch from parallel steps
+	Fetch []TestWorkflowStepParallelFetch `json:"fetch,omitempty"`
 }

--- a/pkg/api/v1/testkube/model_test_workflow_service_spec.go
+++ b/pkg/api/v1/testkube/model_test_workflow_service_spec.go
@@ -34,11 +34,11 @@ type TestWorkflowServiceSpec struct {
 	Logs           *BoxedString                       `json:"logs,omitempty"`
 	RestartPolicy  string                             `json:"restartPolicy,omitempty"`
 	ReadinessProbe *Probe                             `json:"readinessProbe,omitempty"`
-	Use            []TestWorkflowTemplateRef          `json:"use,omitempty"`
 	Count          *BoxedString                       `json:"count,omitempty"`
 	MaxCount       *BoxedString                       `json:"maxCount,omitempty"`
 	// matrix of parameters to spawn instances
 	Matrix map[string]interface{} `json:"matrix,omitempty"`
 	// parameters that should be distributed across sharded instances
-	Shards map[string]interface{} `json:"shards,omitempty"`
+	Shards map[string]interface{}    `json:"shards,omitempty"`
+	Use    []TestWorkflowTemplateRef `json:"use,omitempty"`
 }

--- a/pkg/api/v1/testkube/model_test_workflow_step_execute_test_ref.go
+++ b/pkg/api/v1/testkube/model_test_workflow_step_execute_test_ref.go
@@ -10,16 +10,16 @@
 package testkube
 
 type TestWorkflowStepExecuteTestRef struct {
-	// test name to schedule
-	Name string `json:"name,omitempty"`
-	// test execution description to display
-	Description      string                                       `json:"description,omitempty"`
-	Count            *BoxedString                                 `json:"count,omitempty"`
-	MaxCount         *BoxedString                                 `json:"maxCount,omitempty"`
-	ExecutionRequest *TestWorkflowStepExecuteTestExecutionRequest `json:"executionRequest,omitempty"`
-	Tarball          map[string]TestWorkflowTarballRequest        `json:"tarball,omitempty"`
+	Count    *BoxedString `json:"count,omitempty"`
+	MaxCount *BoxedString `json:"maxCount,omitempty"`
 	// matrix of parameters to spawn instances
 	Matrix map[string]interface{} `json:"matrix,omitempty"`
 	// parameters that should be distributed across sharded instances
 	Shards map[string]interface{} `json:"shards,omitempty"`
+	// test name to schedule
+	Name string `json:"name,omitempty"`
+	// test execution description to display
+	Description      string                                       `json:"description,omitempty"`
+	ExecutionRequest *TestWorkflowStepExecuteTestExecutionRequest `json:"executionRequest,omitempty"`
+	Tarball          map[string]TestWorkflowTarballRequest        `json:"tarball,omitempty"`
 }

--- a/pkg/api/v1/testkube/model_test_workflow_step_execute_test_workflow_ref.go
+++ b/pkg/api/v1/testkube/model_test_workflow_step_execute_test_workflow_ref.go
@@ -10,6 +10,12 @@
 package testkube
 
 type TestWorkflowStepExecuteTestWorkflowRef struct {
+	Count    *BoxedString `json:"count,omitempty"`
+	MaxCount *BoxedString `json:"maxCount,omitempty"`
+	// matrix of parameters to spawn instances
+	Matrix map[string]interface{} `json:"matrix,omitempty"`
+	// parameters that should be distributed across sharded instances
+	Shards map[string]interface{} `json:"shards,omitempty"`
 	// TestWorkflow name to include
 	Name string `json:"name,omitempty"`
 	// TestWorkflow execution description to display
@@ -18,10 +24,4 @@ type TestWorkflowStepExecuteTestWorkflowRef struct {
 	ExecutionName string                                `json:"executionName,omitempty"`
 	Tarball       map[string]TestWorkflowTarballRequest `json:"tarball,omitempty"`
 	Config        map[string]string                     `json:"config,omitempty"`
-	Count         *BoxedString                          `json:"count,omitempty"`
-	MaxCount      *BoxedString                          `json:"maxCount,omitempty"`
-	// matrix of parameters to spawn instances
-	Matrix map[string]interface{} `json:"matrix,omitempty"`
-	// parameters that should be distributed across sharded instances
-	Shards map[string]interface{} `json:"shards,omitempty"`
 }

--- a/pkg/api/v1/testkube/model_test_workflow_step_parallel.go
+++ b/pkg/api/v1/testkube/model_test_workflow_step_parallel.go
@@ -28,20 +28,10 @@ type TestWorkflowStepParallel struct {
 	// delay before the step
 	Delay string `json:"delay,omitempty"`
 	// script to run in a default shell for the container
-	Shell     string                     `json:"shell,omitempty"`
-	Run       *TestWorkflowStepRun       `json:"run,omitempty"`
-	Execute   *TestWorkflowStepExecute   `json:"execute,omitempty"`
-	Artifacts *TestWorkflowStepArtifacts `json:"artifacts,omitempty"`
-	// how many resources could be scheduled in parallel
-	Parallelism int32 `json:"parallelism,omitempty"`
-	// worker description to display
-	Description string       `json:"description,omitempty"`
-	Logs        *BoxedString `json:"logs,omitempty"`
-	// list of files to send to parallel steps
-	Transfer []TestWorkflowStepParallelTransfer `json:"transfer,omitempty"`
-	// list of files to fetch from parallel steps
-	Fetch     []TestWorkflowStepParallelFetch        `json:"fetch,omitempty"`
-	Template  *TestWorkflowTemplateRef               `json:"template,omitempty"`
+	Shell     string                                 `json:"shell,omitempty"`
+	Run       *TestWorkflowStepRun                   `json:"run,omitempty"`
+	Execute   *TestWorkflowStepExecute               `json:"execute,omitempty"`
+	Artifacts *TestWorkflowStepArtifacts             `json:"artifacts,omitempty"`
 	Use       []TestWorkflowTemplateRef              `json:"use,omitempty"`
 	Config    map[string]TestWorkflowParameterSchema `json:"config,omitempty"`
 	Content   *TestWorkflowContent                   `json:"content,omitempty"`
@@ -53,4 +43,14 @@ type TestWorkflowStepParallel struct {
 	Steps     []TestWorkflowStep                     `json:"steps,omitempty"`
 	After     []TestWorkflowStep                     `json:"after,omitempty"`
 	Events    []TestWorkflowEvent                    `json:"events,omitempty"`
+	// how many resources could be scheduled in parallel
+	Parallelism int32 `json:"parallelism,omitempty"`
+	// worker description to display
+	Description string       `json:"description,omitempty"`
+	Logs        *BoxedString `json:"logs,omitempty"`
+	// list of files to send to parallel steps
+	Transfer []TestWorkflowStepParallelTransfer `json:"transfer,omitempty"`
+	// list of files to fetch from parallel steps
+	Fetch    []TestWorkflowStepParallelFetch `json:"fetch,omitempty"`
+	Template *TestWorkflowTemplateRef        `json:"template,omitempty"`
 }


### PR DESCRIPTION
## Pull request description 

OpenAPI definition had errors. This PR fixes those.

```
Semantic error at paths./test-workflows/{id}/executions
Declared path parameter "id" needs to be defined within every operation in the path (missing in "post"), or moved to the path-level parameters object
Jump to line 3525
Semantic error at paths./test-workflow-executions/{executionID}/artifacts
Declared path parameter "executionID" needs to be defined as a path parameter at either the path or operation level
Jump to line 3845
Semantic error at paths./test-workflow-executions/{executionID}/artifacts/{filename}
Declared path parameter "executionID" needs to be defined as a path parameter at either the path or operation level
Jump to line 3892
Semantic error at paths./test-workflow-executions/{executionID}/artifact-archive
Declared path parameter "executionID" needs to be defined as a path parameter at either the path or operation level
Jump to line 3939
```

## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [ ] tested locally
- [ ] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Breaking changes

-

## Changes

-

## Fixes

-