### PR TITLE
fix(testworkflows): mount tarballs when needed (i.e. content.tarball or transfer)

### DIFF
--- a/pkg/tcl/testworkflowstcl/testworkflowprocessor/operations.go
+++ b/pkg/tcl/testworkflowstcl/testworkflowprocessor/operations.go
@@ -311,14 +311,14 @@ func ProcessContentTarball(_ InternalProcessor, layer Intermediate, container Co
 		args[i] = fmt.Sprintf("%s=%s", t.Path, t.Url)
 		needsMount := t.Mount != nil && *t.Mount
 		if !needsMount {
-			needsMount = selfContainer.HasVolumeAt(t.Path)
+			needsMount = !selfContainer.HasVolumeAt(t.Path)
 		}
 
 		if needsMount && t.Mount != nil && !*t.Mount {
 			return nil, fmt.Errorf("content.tarball[%d]: %s: is not part of any volume: should be mounted", i, t.Path)
 		}
 
-		if (needsMount && t.Mount == nil) || (t.Mount == nil && *t.Mount) {
+		if needsMount {
 			volumeMount := layer.AddEmptyDirVolume(nil, t.Path)
 			container.AppendVolumeMounts(volumeMount)
 		}


### PR DESCRIPTION
## Pull request description 

* when tarball content is requested (i.e. by `transfer` clause) there should be mounted EmptyDir volume at that place, if there is no volume yet.

## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [x] tested locally
- [x] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
