### PR TITLE
fix(testworkflows): fetch logs properly for running services

### DIFF
--- a/cmd/tcl/testworkflow-toolkit/commands/services.go
+++ b/cmd/tcl/testworkflow-toolkit/commands/services.go
@@ -336,6 +336,7 @@ func NewServicesCmd() *cobra.Command {
 						break
 					}
 				}
+				ctrl.StopController()
 
 				// Fail if the container has not started
 				if !started {

--- a/cmd/tcl/testworkflow-toolkit/spawn/utils.go
+++ b/cmd/tcl/testworkflow-toolkit/spawn/utils.go
@@ -234,7 +234,8 @@ func SaveLogs(ctx context.Context, clientSet kubernetes.Interface, storage artif
 		Timeout: ControllerTimeout,
 	})
 	if err == nil {
-		err = storage.SaveStream(filePath, ctrl.Logs(ctx))
+		err = storage.SaveStream(filePath, ctrl.Logs(ctx, false))
+		ctrl.StopController()
 	}
 	return filePath, err
 }

--- a/pkg/tcl/testworkflowstcl/testworkflowcontroller/logs.go
+++ b/pkg/tcl/testworkflowstcl/testworkflowcontroller/logs.go
@@ -11,6 +11,7 @@ package testworkflowcontroller
 import (
 	"bufio"
 	"context"
+	"errors"
 	"io"
 	"strings"
 	"time"
@@ -36,7 +37,7 @@ type ContainerLog struct {
 	Output *data.Instruction
 }
 
-func WatchContainerLogs(ctx context.Context, clientSet kubernetes.Interface, namespace, podName, containerName string, bufferSize int, follow bool) Channel[ContainerLog] {
+func WatchContainerLogs(ctx context.Context, clientSet kubernetes.Interface, namespace, podName, containerName string, bufferSize int, follow bool, pod Channel[*corev1.Pod]) Channel[ContainerLog] {
 	w := newChannel[ContainerLog](ctx, bufferSize)
 
 	go func() {
@@ -57,6 +58,10 @@ func WatchContainerLogs(ctx context.Context, clientSet kubernetes.Interface, nam
 				if !strings.Contains(err.Error(), "is waiting to start") {
 					w.Error(err)
 					return
+				}
+				p := <-pod.Peek(ctx)
+				if p != nil && IsPodDone(p) {
+					w.Error(errors.New("pod is finished and there are no logs for this container"))
 				}
 				continue
 			}

--- a/pkg/tcl/testworkflowstcl/testworkflowcontroller/logs.go
+++ b/pkg/tcl/testworkflowstcl/testworkflowcontroller/logs.go
@@ -36,7 +36,7 @@ type ContainerLog struct {
 	Output *data.Instruction
 }
 
-func WatchContainerLogs(ctx context.Context, clientSet kubernetes.Interface, namespace, podName, containerName string, bufferSize int) Channel[ContainerLog] {
+func WatchContainerLogs(ctx context.Context, clientSet kubernetes.Interface, namespace, podName, containerName string, bufferSize int, follow bool) Channel[ContainerLog] {
 	w := newChannel[ContainerLog](ctx, bufferSize)
 
 	go func() {
@@ -45,7 +45,7 @@ func WatchContainerLogs(ctx context.Context, clientSet kubernetes.Interface, nam
 
 		// Create logs stream request
 		req := clientSet.CoreV1().Pods(namespace).GetLogs(podName, &corev1.PodLogOptions{
-			Follow:     true,
+			Follow:     follow,
 			Timestamps: true,
 			Container:  containerName,
 		})

--- a/pkg/tcl/testworkflowstcl/testworkflowcontroller/podstate.go
+++ b/pkg/tcl/testworkflowstcl/testworkflowcontroller/podstate.go
@@ -62,9 +62,11 @@ func newPodState(parentCtx context.Context) *podState {
 		<-ctx.Done()
 		state.mu.Lock()
 		defer state.mu.Unlock()
-		for _, c := range state.finishedCh {
+		for name, c := range state.finishedCh {
 			if c != nil {
+				state.finished[name] = time.Time{}
 				close(c)
+				delete(state.finishedCh, name)
 			}
 		}
 	}()

--- a/pkg/tcl/testworkflowstcl/testworkflowcontroller/watchinstrumentedpod.go
+++ b/pkg/tcl/testworkflowstcl/testworkflowcontroller/watchinstrumentedpod.go
@@ -26,6 +26,7 @@ import (
 
 const (
 	InitContainerName = "tktw-init"
+	IdleTimeout       = 100 * time.Millisecond
 )
 
 type WatchInstrumentedPodOptions struct {
@@ -147,7 +148,7 @@ func WatchInstrumentedPod(parentCtx context.Context, clientSet kubernetes.Interf
 			} else {
 				select {
 				case <-state.Finished(ref):
-				case <-time.After(100 * time.Millisecond):
+				case <-time.After(IdleTimeout):
 					return
 				}
 			}

--- a/pkg/tcl/testworkflowstcl/testworkflowcontroller/watchinstrumentedpod.go
+++ b/pkg/tcl/testworkflowstcl/testworkflowcontroller/watchinstrumentedpod.go
@@ -104,8 +104,8 @@ func WatchInstrumentedPod(parentCtx context.Context, clientSet kubernetes.Interf
 			}
 
 			// Watch the container logs
-			follow := common.ResolvePtr(opts.Follow, true)
-			for v := range WatchContainerLogs(ctx, clientSet, podObj.Namespace, podObj.Name, ref, 10, follow).Channel() {
+			follow := common.ResolvePtr(opts.Follow, true) && !state.IsFinished(ref)
+			for v := range WatchContainerLogs(ctx, clientSet, podObj.Namespace, podObj.Name, ref, 10, follow, pod).Channel() {
 				if v.Error != nil {
 					s.Error(v.Error)
 				} else if v.Value.Output != nil {

--- a/pkg/tcl/testworkflowstcl/testworkflowcontroller/watchinstrumentedpod.go
+++ b/pkg/tcl/testworkflowstcl/testworkflowcontroller/watchinstrumentedpod.go
@@ -19,6 +19,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 
 	"github.com/kubeshop/testkube/cmd/tcl/testworkflow-init/constants"
+	"github.com/kubeshop/testkube/internal/common"
 	"github.com/kubeshop/testkube/pkg/api/v1/testkube"
 	"github.com/kubeshop/testkube/pkg/tcl/testworkflowstcl/testworkflowprocessor"
 )
@@ -30,6 +31,7 @@ const (
 type WatchInstrumentedPodOptions struct {
 	JobEvents Channel[*corev1.Event]
 	Job       Channel[*batchv1.Job]
+	Follow    *bool
 }
 
 func WatchInstrumentedPod(parentCtx context.Context, clientSet kubernetes.Interface, signature []testworkflowprocessor.Signature, scheduledAt time.Time, pod Channel[*corev1.Pod], podEvents Channel[*corev1.Event], opts WatchInstrumentedPodOptions) (Channel[Notification], error) {
@@ -101,7 +103,8 @@ func WatchInstrumentedPod(parentCtx context.Context, clientSet kubernetes.Interf
 			}
 
 			// Watch the container logs
-			for v := range WatchContainerLogs(ctx, clientSet, podObj.Namespace, podObj.Name, ref, 10).Channel() {
+			follow := common.ResolvePtr(opts.Follow, true)
+			for v := range WatchContainerLogs(ctx, clientSet, podObj.Namespace, podObj.Name, ref, 10, follow).Channel() {
 				if v.Error != nil {
 					s.Error(v.Error)
 				} else if v.Value.Output != nil {
@@ -139,7 +142,15 @@ func WatchInstrumentedPod(parentCtx context.Context, clientSet kubernetes.Interf
 			}
 
 			// Get the final result
-			<-state.Finished(ref)
+			if follow {
+				<-state.Finished(ref)
+			} else {
+				select {
+				case <-state.Finished(ref):
+				case <-time.After(100 * time.Millisecond):
+					return
+				}
+			}
 			status, err := state.ContainerResult(ref)
 			if err != nil {
 				s.Error(err)

--- a/pkg/triggers/scraper.go
+++ b/pkg/triggers/scraper.go
@@ -188,6 +188,7 @@ func (s *Service) abortRunningTestWorkflowExecutions(ctx context.Context, status
 			// Pro edition only (tcl protected code)
 			// Abort the execution
 			err = ctrl.Abort(context.Background())
+			ctrl.StopController()
 			if err != nil {
 				s.logger.Errorf("trigger service: execution scraper component: error aborting test workflow execution: %v", err)
 				continue


### PR DESCRIPTION
## Pull request description 

* the Test Workflow was stuck, as it was trying to fetch logs of running service, while it was not finishing, so it was still waiting for logs continuation.

## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [x] tested locally
- [x] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
