### PR TITLE
feat: [TKC-2063] Delete testworkflow output when workflow is deleted

### DIFF
--- a/cmd/api-server/main.go
+++ b/cmd/api-server/main.go
@@ -298,7 +298,7 @@ func main() {
 		}
 		storageClient = minioClient
 		// Pro edition only (tcl protected code)
-		testWorkflowOutputRepository = testworkflow.NewMinioOutputRepository(storageClient, cfg.LogsBucket)
+		testWorkflowOutputRepository = testworkflow.NewMinioOutputRepository(storageClient, db.Collection(testworkflow.CollectionName), cfg.LogsBucket)
 		artifactStorage = minio.NewMinIOArtifactClient(storageClient)
 		// init storage
 		isMinioStorage := cfg.LogsStorage == "minio"

--- a/pkg/tcl/apitcl/v1/testworkflows.go
+++ b/pkg/tcl/apitcl/v1/testworkflows.go
@@ -69,6 +69,10 @@ func (s *apiTCL) DeleteTestWorkflowHandler() fiber.Handler {
 		}
 		skipExecutions := c.Query("skipDeleteExecutions", "")
 		if skipExecutions != "true" {
+			err = s.TestWorkflowOutput.DeleteOutputByTestWorkflow(context.Background(), name)
+			if err != nil {
+				return s.ClientError(c, "deleting executions output", err)
+			}
 			err = s.TestWorkflowResults.DeleteByTestWorkflow(context.Background(), name)
 			if err != nil {
 				return s.ClientError(c, "deleting executions", err)

--- a/pkg/tcl/cloudtcl/data/testworkflow/execution_models.go
+++ b/pkg/tcl/cloudtcl/data/testworkflow/execution_models.go
@@ -114,6 +114,13 @@ type ExecutionDeleteByWorkflowRequest struct {
 type ExecutionDeleteByWorkflowResponse struct {
 }
 
+type ExecutionDeleteOutputByWorkflowRequest struct {
+	WorkflowName string `json:"workflowName"`
+}
+
+type ExecutionDeleteOutputByWorkflowResponse struct {
+}
+
 type ExecutionDeleteAllRequest struct {
 }
 

--- a/pkg/tcl/cloudtcl/data/testworkflow/output.go
+++ b/pkg/tcl/cloudtcl/data/testworkflow/output.go
@@ -105,3 +105,9 @@ func (r *CloudOutputRepository) HasLog(ctx context.Context, id, workflowName str
 	}
 	return pass(r.executor, ctx, req, process)
 }
+
+// DeleteByTestWorkflow deletes execution results by workflow
+func (r *CloudOutputRepository) DeleteOutputByTestWorkflow(ctx context.Context, workflowName string) (err error) {
+	req := ExecutionDeleteOutputByWorkflowRequest{WorkflowName: workflowName}
+	return passNoContent(r.executor, ctx, req)
+}

--- a/pkg/tcl/repositorytcl/testworkflow/interface.go
+++ b/pkg/tcl/repositorytcl/testworkflow/interface.go
@@ -86,4 +86,7 @@ type OutputRepository interface {
 	ReadLog(ctx context.Context, id, workflowName string) (io.Reader, error)
 	// HasLog checks if there is an output in Minio
 	HasLog(ctx context.Context, id, workflowName string) (bool, error)
+
+	// DeleteOutputByTestWorkflow deletes execution output by test workflow
+	DeleteOutputByTestWorkflow(ctx context.Context, testWorkflowName string) error
 }

--- a/pkg/tcl/repositorytcl/testworkflow/mock_output_repository.go
+++ b/pkg/tcl/repositorytcl/testworkflow/mock_output_repository.go
@@ -35,6 +35,20 @@ func (m *MockOutputRepository) EXPECT() *MockOutputRepositoryMockRecorder {
 	return m.recorder
 }
 
+// DeleteOutputByTestWorkflow mocks base method.
+func (m *MockOutputRepository) DeleteOutputByTestWorkflow(arg0 context.Context, arg1 string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteOutputByTestWorkflow", arg0, arg1)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DeleteOutputByTestWorkflow indicates an expected call of DeleteOutputByTestWorkflow.
+func (mr *MockOutputRepositoryMockRecorder) DeleteOutputByTestWorkflow(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteOutputByTestWorkflow", reflect.TypeOf((*MockOutputRepository)(nil).DeleteOutputByTestWorkflow), arg0, arg1)
+}
+
 // HasLog mocks base method.
 func (m *MockOutputRepository) HasLog(arg0 context.Context, arg1, arg2 string) (bool, error) {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
## Pull request description 

Currently when you delete testworkflow thru api it doesn't delete the logs for it. This should fix that

## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [ ] tested locally
- [ ] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Breaking changes

-

## Changes

-

## Fixes

-