### PR TITLE
fix(testworkflows): handle TestWorkflow status correctly on immediate kill

### DIFF
--- a/pkg/tcl/testworkflowstcl/testworkflowcontroller/controller.go
+++ b/pkg/tcl/testworkflowstcl/testworkflowcontroller/controller.go
@@ -277,6 +277,16 @@ func (c *controller) Logs(parentCtx context.Context, follow bool) io.Reader {
 	go func() {
 		defer writer.Close()
 		ref := ""
+		// Wait until there will be events fetched first
+		alignTimeoutCh := time.After(alignmentTimeout)
+		select {
+		case <-c.jobEvents.Peek(parentCtx):
+		case <-alignTimeoutCh:
+		}
+		select {
+		case <-c.podEvents.Peek(parentCtx):
+		case <-alignTimeoutCh:
+		}
 		w, err := WatchInstrumentedPod(parentCtx, c.clientSet, c.signature, c.scheduledAt, c.pod, c.podEvents, WatchInstrumentedPodOptions{
 			JobEvents: c.jobEvents,
 			Job:       c.job,

--- a/pkg/tcl/testworkflowstcl/testworkflowcontroller/notifier.go
+++ b/pkg/tcl/testworkflowstcl/testworkflowcontroller/notifier.go
@@ -50,6 +50,9 @@ func (n *notifier) RegisterTimestamp(ref string, t time.Time) {
 
 func (n *notifier) Raw(ref string, ts time.Time, message string) {
 	if message != "" {
+		if ref == InitContainerName {
+			ref = ""
+		}
 		// TODO: use timestamp from the message too for lastTs?
 		n.watcher.Send(Notification{
 			Timestamp: ts.UTC(),

--- a/pkg/tcl/testworkflowstcl/testworkflowcontroller/watchers.go
+++ b/pkg/tcl/testworkflowstcl/testworkflowcontroller/watchers.go
@@ -148,8 +148,6 @@ func WatchPodEventsByPodWatcher(ctx context.Context, clientSet kubernetes.Interf
 	w := newChannel[*corev1.Event](ctx, bufferSize)
 
 	go func() {
-		defer w.Close()
-
 		v, ok := <-pod.PeekMessage(ctx)
 		if !ok {
 			return


### PR DESCRIPTION
## Pull request description 

* When the execution is killed before it's actually started executing, that was locked
* Now, when it receives finish information before start/end, it will wait for 2s for Kubernetes events / other data, and stop otherwise

## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [x] tested locally
- [x] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
