### PR TITLE
fix: adjust GoReleaser configuration for CLI

### DIFF
--- a/.goreleaser-dev.yml
+++ b/.goreleaser-dev.yml
@@ -25,9 +25,6 @@ archives:
 checksum:
   name_template: "checksums.txt"
 
-source:
-  rlcp: true
-
 sboms:
   - artifacts: archive
   - id: source 
@@ -59,7 +56,7 @@ release:
   prerelease: auto
 
 brews:
-  - tap:
+  - repository:
       owner: kubeshop
       name: homebrew-testkube-dev
     description: Testkube - your somewhat opinionated and friendly Kubernetes testing framework!

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -25,9 +25,6 @@ archives:
 checksum:
   name_template: "checksums.txt"
 
-source:
-  rlcp: true
-
 sboms:
   - artifacts: archive
   - id: source
@@ -88,7 +85,7 @@ release:
   prerelease: auto
 
 brews:
-  - tap:
+  - repository:
       owner: kubeshop
       name: homebrew-testkube
     description: Testkube - your somewhat opinionated and friendly Kubernetes testing framework!


### PR DESCRIPTION
## Pull request description 

* `brews[].tap` is replaced with brews[].repository - https://goreleaser.com/deprecations/#brewstap
* `source.rlcp` is now deleted and default - https://goreleaser.com/deprecations/#sourcerlcp

## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [ ] tested locally
- [ ] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
