### PR TITLE
fix(testworkflows): support non-UTC timezone in Kubernetes logs

### DIFF
--- a/pkg/tcl/testworkflowstcl/testworkflowcontroller/logs_test.go
+++ b/pkg/tcl/testworkflowstcl/testworkflowcontroller/logs_test.go
@@ -1,0 +1,43 @@
+// Copyright 2024 Testkube.
+//
+// Licensed as a Testkube Pro file under the Testkube Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+//	https://github.com/kubeshop/testkube/blob/main/licenses/TCL.txt
+
+package testworkflowcontroller
+
+import (
+	"bufio"
+	"bytes"
+	"io"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_ReadTimestamp_UTC(t *testing.T) {
+	prefix := "2024-06-07T12:41:49.037275300Z "
+	message := "some-message"
+	buf := bufio.NewReader(bytes.NewBufferString(prefix + message))
+	ts, byt, err := ReadTimestamp(buf)
+	rest, _ := io.ReadAll(buf)
+	assert.NoError(t, err)
+	assert.Equal(t, []byte(prefix), byt)
+	assert.Equal(t, []byte(message), rest)
+	assert.Equal(t, time.Date(2024, 6, 7, 12, 41, 49, 37275300, time.UTC), ts)
+}
+
+func Test_ReadTimestamp_NonUTC(t *testing.T) {
+	prefix := "2024-06-07T15:41:49.037275300+03:00 "
+	message := "some-message"
+	buf := bufio.NewReader(bytes.NewBufferString(prefix + message))
+	ts, byt, err := ReadTimestamp(buf)
+	rest, _ := io.ReadAll(buf)
+	assert.NoError(t, err)
+	assert.Equal(t, []byte(prefix), byt)
+	assert.Equal(t, []byte(message), rest)
+	assert.Equal(t, time.Date(2024, 6, 7, 12, 41, 49, 37275300, time.UTC), ts)
+}

--- a/pkg/tcl/testworkflowstcl/testworkflowcontroller/utils.go
+++ b/pkg/tcl/testworkflowstcl/testworkflowcontroller/utils.go
@@ -20,7 +20,8 @@ import (
 )
 
 const (
-	KubernetesLogTimeFormat = "2006-01-02T15:04:05.000000000Z"
+	KubernetesLogTimeFormat         = "2006-01-02T15:04:05.000000000Z"
+	KubernetesTimezoneLogTimeFormat = KubernetesLogTimeFormat + "07:00"
 )
 
 func GetEventContainerName(event *corev1.Event) string {


### PR DESCRIPTION
## Pull request description 

* fix: support non-UTC timezone in Kubernetes logs
   * Kubernetes may store the logs with `+03:00` timezone instead of UTC's `Z`

## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [x] tested locally
- [x] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [x] added a test
