### PR TITLE
fix(testworkflows): support overriding repository files with `content.files`

### DIFF
--- a/cmd/tcl/testworkflow-toolkit/commands/clone.go
+++ b/cmd/tcl/testworkflow-toolkit/commands/clone.go
@@ -13,6 +13,9 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"strings"
+
+	"github.com/otiai10/copy"
 
 	"github.com/kballard/go-shellquote"
 	"github.com/spf13/cobra"
@@ -39,7 +42,7 @@ func NewCloneCmd() *cobra.Command {
 		Run: func(cmd *cobra.Command, args []string) {
 			uri, err := url.Parse(args[0])
 			ui.ExitOnError("repository uri", err)
-			outputPath, err := filepath.Abs(args[1])
+			destinationPath, err := filepath.Abs(args[1])
 			ui.ExitOnError("output path", err)
 
 			// Disable interactivity
@@ -74,6 +77,9 @@ func NewCloneCmd() *cobra.Command {
 				os.Setenv("GIT_SSH_COMMAND", shellquote.Join("ssh", "-o", "StrictHostKeyChecking=no", "-o", "UserKnownHostsFile=/dev/null", "-i", sshKeyPath))
 			}
 
+			// Keep the files in temporary directory
+			outputPath := constants.DefaultTmpDirPath
+
 			// Mark directory as safe
 			configArgs := []string{"-c", fmt.Sprintf("safe.directory=%s", outputPath), "-c", "advice.detachedHead=false"}
 
@@ -105,6 +111,21 @@ func NewCloneCmd() *cobra.Command {
 					ui.ExitOnError("fetching head", err)
 				}
 			}
+
+			// Copy files to the expected directory. Ignore errors, only inform warn about them.
+			err = copy.Copy(outputPath, destinationPath, copy.Options{
+				OnError: func(src, dest string, err error) error {
+					if err != nil {
+						if src == outputPath && strings.Contains(err.Error(), "chmod") {
+							// Ignore chmod error on mounted directory
+							return nil
+						}
+						fmt.Printf("warn: copying to %s: %s\n", dest, err.Error())
+					}
+					return nil
+				},
+			})
+			ui.ExitOnError("copying files to destination", err)
 		},
 	}
 

--- a/cmd/tcl/testworkflow-toolkit/commands/clone.go
+++ b/cmd/tcl/testworkflow-toolkit/commands/clone.go
@@ -78,7 +78,7 @@ func NewCloneCmd() *cobra.Command {
 			}
 
 			// Keep the files in temporary directory
-			outputPath := constants.DefaultTmpDirPath
+			outputPath := filepath.Join(constants.DefaultTmpDirPath, "repo")
 
 			// Mark directory as safe
 			configArgs := []string{"-c", fmt.Sprintf("safe.directory=%s", outputPath), "-c", "advice.detachedHead=false"}

--- a/pkg/tcl/testworkflowstcl/testworkflowprocessor/operations.go
+++ b/pkg/tcl/testworkflowstcl/testworkflowprocessor/operations.go
@@ -238,6 +238,10 @@ func ProcessContentGit(_ InternalProcessor, layer Intermediate, container Contai
 		mountPath = filepath.Join(constants.DefaultDataPath, "repo")
 	}
 
+	// Build a temporary volume to clone the repository initially.
+	// This will allow mounting files in the destination at the same level (i.e. overriding the configuration).
+	container.AppendVolumeMounts(layer.AddEmptyDirVolume(nil, constants.DefaultTmpDirPath))
+
 	// Build volume pair and share with all siblings
 	volumeMount := layer.AddEmptyDirVolume(nil, mountPath)
 	container.AppendVolumeMounts(volumeMount)
@@ -273,11 +277,6 @@ func ProcessContentGit(_ InternalProcessor, layer Intermediate, container Contai
 		args = append(args, "-s", "{{env.TK_SSH_KEY}}")
 	} else if step.Content.Git.SshKey != "" {
 		args = append(args, "-s", step.Content.Git.SshKey)
-	}
-
-	// Provide temporary directory for SSH key to avoid issues with permissions
-	if step.Content.Git.SshKeyFrom != nil || step.Content.Git.SshKey != "" {
-		container.AppendVolumeMounts(layer.AddEmptyDirVolume(nil, constants.DefaultTmpDirPath))
 	}
 
 	// Provide auth type


### PR DESCRIPTION
## Pull request description 

* Allow cloning into non-empty directory (where are files mounted)
   * Clone to temporary directory, and then copy to the expected one
   * Any other solution won't work, as we are not able to stash read-only mounted files, to clone the repository at the same place

## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [x] tested locally
- [x] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test