### PR TITLE
fix(testworkflows): identify sub-resources from parallel steps and services properly for destroying

### DIFF
--- a/cmd/tcl/testworkflow-toolkit/spawn/utils.go
+++ b/cmd/tcl/testworkflow-toolkit/spawn/utils.go
@@ -192,7 +192,7 @@ func CreateExecutionMachine(prefix string, index int64) (string, expressionstcl.
 			"name": env.WorkflowName(),
 		}).
 		Register("resource", map[string]string{
-			"rootId":   env.ExecutionId(),
+			"root":     env.ExecutionId(),
 			"id":       id,
 			"fsPrefix": fsPrefix,
 		}).


### PR DESCRIPTION
## Pull request description 

* `root` label was set incorrectly, so if the TestWorkflow has errored/aborted before end, the pods were left there

## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [x] tested locally
- [x] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test