### PR TITLE
feat(testworkflows): add Pod/Agent output on initialization step

### DIFF
--- a/pkg/tcl/testworkflowstcl/testworkflowcontroller/notifier.go
+++ b/pkg/tcl/testworkflowstcl/testworkflowcontroller/notifier.go
@@ -178,7 +178,10 @@ func (n *notifier) Start(ref string, ts time.Time) {
 }
 
 func (n *notifier) Output(ref string, ts time.Time, output *data.Instruction) {
-	if _, ok := n.result.Steps[ref]; !ok {
+	if ref == InitContainerName {
+		ref = ""
+	}
+	if _, ok := n.result.Steps[ref]; !ok && ref != "" {
 		return
 	}
 	n.RegisterTimestamp(ref, ts)

--- a/pkg/tcl/testworkflowstcl/testworkflowprocessor/processor.go
+++ b/pkg/tcl/testworkflowstcl/testworkflowprocessor/processor.go
@@ -335,6 +335,20 @@ func (p *processor) Bundle(ctx context.Context, workflow *testworkflowsv1.TestWo
 		Command:         []string{"/bin/sh", "-c"},
 		Args:            []string{constants.InitScript},
 		VolumeMounts:    layer.ContainerDefaults().VolumeMounts(),
+		Env: []corev1.EnvVar{
+			{Name: "TK_DEBUG_NODE", ValueFrom: &corev1.EnvVarSource{
+				FieldRef: &corev1.ObjectFieldSelector{FieldPath: "spec.nodeName"},
+			}},
+			{Name: "TK_DEBUG_POD", ValueFrom: &corev1.EnvVarSource{
+				FieldRef: &corev1.ObjectFieldSelector{FieldPath: "metadata.name"},
+			}},
+			{Name: "TK_DEBUG_NS", ValueFrom: &corev1.EnvVarSource{
+				FieldRef: &corev1.ObjectFieldSelector{FieldPath: "metadata.namespace"},
+			}},
+			{Name: "TK_DEBUG_SVC", ValueFrom: &corev1.EnvVarSource{
+				FieldRef: &corev1.ObjectFieldSelector{FieldPath: "spec.serviceAccountName"},
+			}},
+		},
 		SecurityContext: &corev1.SecurityContext{
 			RunAsGroup: fsGroup,
 		},

--- a/pkg/tcl/testworkflowstcl/testworkflowprocessor/processor_test.go
+++ b/pkg/tcl/testworkflowstcl/testworkflowprocessor/processor_test.go
@@ -38,6 +38,20 @@ var (
 	execMachine = expressionstcl.NewMachine().
 			Register("resource.root", "dummy-id").
 			Register("resource.id", "dummy-id-abc")
+	initEnvs = []corev1.EnvVar{
+		{Name: "TK_DEBUG_NODE", ValueFrom: &corev1.EnvVarSource{
+			FieldRef: &corev1.ObjectFieldSelector{FieldPath: "spec.nodeName"},
+		}},
+		{Name: "TK_DEBUG_POD", ValueFrom: &corev1.EnvVarSource{
+			FieldRef: &corev1.ObjectFieldSelector{FieldPath: "metadata.name"},
+		}},
+		{Name: "TK_DEBUG_NS", ValueFrom: &corev1.EnvVarSource{
+			FieldRef: &corev1.ObjectFieldSelector{FieldPath: "metadata.namespace"},
+		}},
+		{Name: "TK_DEBUG_SVC", ValueFrom: &corev1.EnvVarSource{
+			FieldRef: &corev1.ObjectFieldSelector{FieldPath: "spec.serviceAccountName"},
+		}},
+	}
 )
 
 func TestProcessEmpty(t *testing.T) {
@@ -99,6 +113,7 @@ func TestProcessBasic(t *testing.T) {
 							ImagePullPolicy: corev1.PullIfNotPresent,
 							Command:         []string{"/bin/sh", "-c"},
 							Args:            []string{constants.InitScript},
+							Env:             initEnvs,
 							VolumeMounts:    volumeMounts,
 							SecurityContext: &corev1.SecurityContext{
 								RunAsGroup: common.Ptr(constants.DefaultFsGroup),
@@ -183,6 +198,7 @@ func TestProcessBasicEnvReference(t *testing.T) {
 				ImagePullPolicy: corev1.PullIfNotPresent,
 				Command:         []string{"/bin/sh", "-c"},
 				Args:            []string{constants.InitScript},
+				Env:             initEnvs,
 				VolumeMounts:    volumeMounts,
 				SecurityContext: &corev1.SecurityContext{
 					RunAsGroup: common.Ptr(constants.DefaultFsGroup),
@@ -255,6 +271,7 @@ func TestProcessMultipleSteps(t *testing.T) {
 				ImagePullPolicy: corev1.PullIfNotPresent,
 				Command:         []string{"/bin/sh", "-c"},
 				Args:            []string{constants.InitScript},
+				Env:             initEnvs,
 				VolumeMounts:    volumeMounts,
 				SecurityContext: &corev1.SecurityContext{
 					RunAsGroup: common.Ptr(constants.DefaultFsGroup),
@@ -347,6 +364,7 @@ func TestProcessNestedSteps(t *testing.T) {
 				ImagePullPolicy: corev1.PullIfNotPresent,
 				Command:         []string{"/bin/sh", "-c"},
 				Args:            []string{constants.InitScript},
+				Env:             initEnvs,
 				VolumeMounts:    volumeMounts,
 				SecurityContext: &corev1.SecurityContext{
 					RunAsGroup: common.Ptr(constants.DefaultFsGroup),
@@ -486,6 +504,7 @@ func TestProcessOptionalSteps(t *testing.T) {
 				ImagePullPolicy: corev1.PullIfNotPresent,
 				Command:         []string{"/bin/sh", "-c"},
 				Args:            []string{constants.InitScript},
+				Env:             initEnvs,
 				VolumeMounts:    volumeMounts,
 				SecurityContext: &corev1.SecurityContext{
 					RunAsGroup: common.Ptr(constants.DefaultFsGroup),
@@ -623,6 +642,7 @@ func TestProcessNegativeSteps(t *testing.T) {
 				ImagePullPolicy: corev1.PullIfNotPresent,
 				Command:         []string{"/bin/sh", "-c"},
 				Args:            []string{constants.InitScript},
+				Env:             initEnvs,
 				VolumeMounts:    volumeMounts,
 				SecurityContext: &corev1.SecurityContext{
 					RunAsGroup: common.Ptr(constants.DefaultFsGroup),
@@ -756,6 +776,7 @@ func TestProcessNegativeContainerStep(t *testing.T) {
 				ImagePullPolicy: corev1.PullIfNotPresent,
 				Command:         []string{"/bin/sh", "-c"},
 				Args:            []string{constants.InitScript},
+				Env:             initEnvs,
 				VolumeMounts:    volumeMounts,
 				SecurityContext: &corev1.SecurityContext{
 					RunAsGroup: common.Ptr(constants.DefaultFsGroup),
@@ -843,6 +864,7 @@ func TestProcessOptionalContainerStep(t *testing.T) {
 				ImagePullPolicy: corev1.PullIfNotPresent,
 				Command:         []string{"/bin/sh", "-c"},
 				Args:            []string{constants.InitScript},
+				Env:             initEnvs,
 				VolumeMounts:    volumeMounts,
 				SecurityContext: &corev1.SecurityContext{
 					RunAsGroup: common.Ptr(constants.DefaultFsGroup),
@@ -939,6 +961,7 @@ func TestProcessLocalContent(t *testing.T) {
 				ImagePullPolicy: corev1.PullIfNotPresent,
 				Command:         []string{"/bin/sh", "-c"},
 				Args:            []string{constants.InitScript},
+				Env:             initEnvs,
 				VolumeMounts:    volumeMounts,
 				SecurityContext: &corev1.SecurityContext{
 					RunAsGroup: common.Ptr(constants.DefaultFsGroup),
@@ -1041,6 +1064,7 @@ func TestProcessGlobalContent(t *testing.T) {
 				ImagePullPolicy: corev1.PullIfNotPresent,
 				Command:         []string{"/bin/sh", "-c"},
 				Args:            []string{constants.InitScript},
+				Env:             initEnvs,
 				VolumeMounts:    volumeMounts,
 				SecurityContext: &corev1.SecurityContext{
 					RunAsGroup: common.Ptr(constants.DefaultFsGroup),
@@ -1155,6 +1179,7 @@ func TestProcessRunShell(t *testing.T) {
 							ImagePullPolicy: corev1.PullIfNotPresent,
 							Command:         []string{"/bin/sh", "-c"},
 							Args:            []string{constants.InitScript},
+							Env:             initEnvs,
 							VolumeMounts:    volumeMounts,
 							SecurityContext: &corev1.SecurityContext{
 								RunAsGroup: common.Ptr(constants.DefaultFsGroup),


### PR DESCRIPTION
## Pull request description 

* Expose `pod` output for all Test Workflows, that contains Pod information, Agent version, and Toolkit/Init Process images

## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [x] tested locally
- [x] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test