### PR TITLE
fix(testworkflows): allow passing container settings for services

### DIFF
--- a/cmd/tcl/testworkflow-toolkit/commands/services.go
+++ b/cmd/tcl/testworkflow-toolkit/commands/services.go
@@ -68,7 +68,6 @@ type ServiceInfo struct {
 	Status      ServiceStatus `json:"status,omitempty"`
 }
 
-// TODO: Pass DEBUG=1 down / enable logs
 func NewServicesCmd() *cobra.Command {
 	var (
 		groupRef string

--- a/cmd/tcl/testworkflow-toolkit/commands/services.go
+++ b/cmd/tcl/testworkflow-toolkit/commands/services.go
@@ -68,6 +68,7 @@ type ServiceInfo struct {
 	Status      ServiceStatus `json:"status,omitempty"`
 }
 
+// TODO: Pass DEBUG=1 down / enable logs
 func NewServicesCmd() *cobra.Command {
 	var (
 		groupRef string
@@ -152,6 +153,7 @@ func NewServicesCmd() *cobra.Command {
 							{StepOperations: testworkflowsv1.StepOperations{Run: common2.Ptr(svcSpec.StepRun)}},
 						},
 					}
+					spec.Steps[0].Run.ContainerConfig = testworkflowsv1.ContainerConfig{}
 
 					// Transfer the data
 					if spec.Content == nil {


### PR DESCRIPTION
## Pull request description 

* in example `volumeMounts` were duplicated = failing pod spec

## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [x] tested locally
- [x] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Breaking changes

-

## Changes

-

## Fixes

-