### PR TITLE
fix: do not finalize labels/annotations twice, breaking escaping

### DIFF
--- a/pkg/expressions/parse_test.go
+++ b/pkg/expressions/parse_test.go
@@ -358,3 +358,11 @@ func TestCompileImmutableNone(t *testing.T) {
 	assert.Same(t, None, NewValue(noneValue))
 	assert.Same(t, NewValue(noneValue), NewValue(noneValue))
 }
+
+func TestCompileEscapedTemplate(t *testing.T) {
+	input := `{{"{{"}}- with secret "internal/data/database/config" -}}{{"{{"}} .Data.data.username }}@{{"{{"}} .Data.data.password }}{{"{{"}}- end -}}`
+	output := `{{- with secret "internal/data/database/config" -}}{{ .Data.data.username }}@{{ .Data.data.password }}{{- end -}}`
+
+	assert.Equal(t, input, MustCompileTemplate(input).Template())
+	assert.Equal(t, output, must(MustCompileTemplate(input).Static().StringValue()))
+}


### PR DESCRIPTION
## Pull request description 

* the labels/annotations were finalized twice, so `{{"{{"}}` was resolved to `{{` and then executed once again, failing the parser.

## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [x] tested locally
- [x] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [x] added a test
