### PR TITLE
feat(testworkflows): expose temporary log lines about the container status

### DIFF
--- a/api/v1/testkube.yaml
+++ b/api/v1/testkube.yaml
@@ -7743,6 +7743,9 @@ components:
           description: log content, if it's just a log. note, that it includes 30 chars timestamp + space
         output:
           $ref: "#/components/schemas/TestWorkflowOutput"
+        temporary:
+          type: boolean
+          description: should it be considered temporary only for execution time
 
     TestWorkflowOutput:
       type: object

--- a/cmd/testworkflow-init/data/emit.go
+++ b/cmd/testworkflow-init/data/emit.go
@@ -17,6 +17,9 @@ const (
 var instructionRe = regexp.MustCompile(fmt.Sprintf(`^%s(%s)?([^%s]+)%s([a-zA-Z0-9-_.]+)(?:%s([^\n]+))?%s$`,
 	InstructionPrefix, HintPrefix, InstructionSeparator, InstructionSeparator, InstructionValueSeparator, InstructionSeparator))
 
+var StartHintRe = regexp.MustCompile(fmt.Sprintf(`^%s%s([^%s]+)%sstart%s$`,
+	InstructionPrefix, HintPrefix, InstructionSeparator, InstructionSeparator, InstructionSeparator))
+
 type Instruction struct {
 	Ref   string
 	Name  string

--- a/pkg/api/v1/testkube/model_test_workflow_execution_notification.go
+++ b/pkg/api/v1/testkube/model_test_workflow_execution_notification.go
@@ -22,4 +22,6 @@ type TestWorkflowExecutionNotification struct {
 	// log content, if it's just a log. note, that it includes 30 chars timestamp + space
 	Log    string              `json:"log,omitempty"`
 	Output *TestWorkflowOutput `json:"output,omitempty"`
+	// should it be considered temporary only for execution time
+	Temporary bool `json:"temporary,omitempty"`
 }

--- a/pkg/testworkflows/testworkflowcontroller/controller.go
+++ b/pkg/testworkflows/testworkflowcontroller/controller.go
@@ -288,8 +288,8 @@ func (c *controller) Logs(parentCtx context.Context, follow bool) io.Reader {
 			return
 		}
 		for v := range w.Channel() {
-			if v.Error == nil && v.Value.Log != "" {
-				if ref != v.Value.Ref {
+			if v.Error == nil && v.Value.Log != "" && !v.Value.Temporary {
+				if ref != v.Value.Ref && v.Value.Ref != "" {
 					ref = v.Value.Ref
 					_, _ = writer.Write([]byte(data.SprintHint(ref, initconstants.InstructionStart)))
 				}

--- a/pkg/testworkflows/testworkflowcontroller/notification.go
+++ b/pkg/testworkflows/testworkflowcontroller/notification.go
@@ -15,15 +15,17 @@ type Notification struct {
 	Ref       string                       `json:"ref,omitempty"`
 	Log       string                       `json:"log,omitempty"`
 	Output    *data.Instruction            `json:"output,omitempty"`
+	Temporary bool                         `json:"temporary,omitempty"`
 }
 
 func (n *Notification) ToInternal() testkube.TestWorkflowExecutionNotification {
 	return testkube.TestWorkflowExecutionNotification{
-		Ts:     n.Timestamp,
-		Result: n.Result,
-		Ref:    n.Ref,
-		Log:    n.Log,
-		Output: InstructionToInternal(n.Output),
+		Ts:        n.Timestamp,
+		Result:    n.Result,
+		Ref:       n.Ref,
+		Log:       n.Log,
+		Output:    InstructionToInternal(n.Output),
+		Temporary: n.Temporary,
 	}
 }
 

--- a/pkg/testworkflows/testworkflowcontroller/podstate.go
+++ b/pkg/testworkflows/testworkflowcontroller/podstate.go
@@ -28,6 +28,7 @@ type podState struct {
 	started    map[string]time.Time
 	finished   map[string]time.Time
 	warnings   map[string][]*corev1.Event
+	events     map[string][]*corev1.Event
 	prestart   map[string]*channel[podStateUpdate]
 	finishedCh map[string]chan struct{}
 	mu         sync.RWMutex
@@ -39,6 +40,7 @@ type podStateUpdate struct {
 	Queued  *time.Time
 	Started *time.Time
 	Warning *corev1.Event
+	Event   *corev1.Event
 }
 
 func newPodState(parentCtx context.Context) *podState {
@@ -48,6 +50,7 @@ func newPodState(parentCtx context.Context) *podState {
 		started:    map[string]time.Time{},
 		finished:   map[string]time.Time{},
 		warnings:   map[string][]*corev1.Event{},
+		events:     map[string][]*corev1.Event{},
 		prestart:   map[string]*channel[podStateUpdate]{},
 		finishedCh: map[string]chan struct{}{},
 		ctx:        ctx,
@@ -167,19 +170,19 @@ func (p *podState) setFinishedAt(name string, ts time.Time) {
 	}
 }
 
-func (p *podState) unsafeAddWarning(name string, event *corev1.Event) {
-	if !slices.ContainsFunc(p.warnings[name], common.DeepEqualCmp(event)) {
-		p.warnings[name] = append(p.warnings[name], event)
-		p.preStartWatcher(name).Send(podStateUpdate{Warning: event})
+func (p *podState) unsafeAddEvent(name string, event *corev1.Event) {
+	if !slices.ContainsFunc(p.events[name], common.DeepEqualCmp(event)) {
+		p.events[name] = append(p.events[name], event)
+		p.preStartWatcher(name).Send(podStateUpdate{Event: event})
 	}
 }
 
-func (p *podState) addWarning(name string, event *corev1.Event) {
+func (p *podState) addEvent(name string, event *corev1.Event) {
 	p.mu.Lock()
 	defer p.mu.Unlock()
-	p.unsafeAddWarning(name, event)
+	p.unsafeAddEvent(name, event)
 	if name == "" {
-		p.unsafeAddWarning(InitContainerName, event)
+		p.unsafeAddEvent(InitContainerName, event)
 	}
 }
 
@@ -208,8 +211,8 @@ func (p *podState) RegisterEvent(event *corev1.Event) {
 	case "Scheduled", "Started":
 		p.setStartedAt(name, event.CreationTimestamp.Time)
 	}
-	if event.Type != "Normal" {
-		p.addWarning(name, event)
+	if p.StartedAt(name).IsZero() {
+		p.addEvent(name, event)
 	}
 }
 

--- a/pkg/testworkflows/testworkflowcontroller/podstate.go
+++ b/pkg/testworkflows/testworkflowcontroller/podstate.go
@@ -211,7 +211,7 @@ func (p *podState) RegisterEvent(event *corev1.Event) {
 	case "Scheduled", "Started":
 		p.setStartedAt(name, event.CreationTimestamp.Time)
 	}
-	if p.StartedAt(name).IsZero() {
+	if p.StartedAt(name).IsZero() && event.Reason != "Created" && event.Reason != "SuccessfulCreate" {
 		p.addEvent(name, event)
 	}
 }

--- a/pkg/testworkflows/testworkflowcontroller/podstate.go
+++ b/pkg/testworkflows/testworkflowcontroller/podstate.go
@@ -3,6 +3,7 @@ package testworkflowcontroller
 import (
 	"context"
 	"slices"
+	"strings"
 	"sync"
 	"time"
 
@@ -11,6 +12,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 
 	"github.com/kubeshop/testkube/internal/common"
+	"github.com/kubeshop/testkube/pkg/testworkflows/testworkflowprocessor/constants"
 )
 
 const (
@@ -211,7 +213,9 @@ func (p *podState) RegisterEvent(event *corev1.Event) {
 	case "Scheduled", "Started":
 		p.setStartedAt(name, event.CreationTimestamp.Time)
 	}
-	if p.StartedAt(name).IsZero() && event.Reason != "Created" && event.Reason != "SuccessfulCreate" {
+	if p.StartedAt(name).IsZero() &&
+		event.Reason != "Created" && event.Reason != "SuccessfulCreate" &&
+		(event.Reason != "Pulled" || (!strings.Contains(event.Message, constants.DefaultInitImage) && !strings.Contains(event.Message, constants.DefaultToolkitImage))) {
 		p.addEvent(name, event)
 	}
 }

--- a/pkg/testworkflows/testworkflowcontroller/watchinstrumentedpod.go
+++ b/pkg/testworkflows/testworkflowcontroller/watchinstrumentedpod.go
@@ -51,9 +51,9 @@ func WatchInstrumentedPod(parentCtx context.Context, clientSet kubernetes.Interf
 			} else if v.Value.Started != nil {
 				s.Queue("", state.QueuedAt(""))
 				s.Start("", state.StartedAt(""))
-			} else if v.Value.Warning != nil {
-				ts := maxTime(v.Value.Warning.CreationTimestamp.Time, v.Value.Warning.FirstTimestamp.Time, v.Value.Warning.LastTimestamp.Time)
-				s.Warning("", ts, v.Value.Warning.Reason, v.Value.Warning.Message)
+			} else if v.Value.Event != nil {
+				ts := maxTime(v.Value.Event.CreationTimestamp.Time, v.Value.Event.FirstTimestamp.Time, v.Value.Event.LastTimestamp.Time)
+				s.Event("", ts, v.Value.Event.Type, v.Value.Event.Reason, v.Value.Event.Message)
 			}
 		}
 
@@ -85,9 +85,9 @@ func WatchInstrumentedPod(parentCtx context.Context, clientSet kubernetes.Interf
 				} else if v.Value.Started != nil {
 					s.Queue(ref, state.QueuedAt(ref))
 					s.Start(ref, state.StartedAt(ref))
-				} else if v.Value.Warning != nil {
-					ts := maxTime(v.Value.Warning.CreationTimestamp.Time, v.Value.Warning.FirstTimestamp.Time, v.Value.Warning.LastTimestamp.Time)
-					s.Warning("", ts, v.Value.Warning.Reason, v.Value.Warning.Message)
+				} else if v.Value.Event != nil {
+					ts := maxTime(v.Value.Event.CreationTimestamp.Time, v.Value.Event.FirstTimestamp.Time, v.Value.Event.LastTimestamp.Time)
+					s.Event(ref, ts, v.Value.Event.Type, v.Value.Event.Reason, v.Value.Event.Message)
 				}
 			}
 
@@ -132,7 +132,7 @@ func WatchInstrumentedPod(parentCtx context.Context, clientSet kubernetes.Interf
 						s.Resume(ref, end)
 					}
 				} else {
-					s.Raw(ref, v.Value.Time, string(v.Value.Log))
+					s.Raw(ref, v.Value.Time, string(v.Value.Log), false)
 				}
 			}
 
@@ -164,7 +164,7 @@ func WatchInstrumentedPod(parentCtx context.Context, clientSet kubernetes.Interf
 				if status.Details == "" {
 					status.Details = "Manual"
 				}
-				s.Raw(ref, s.GetLastTimestamp(ref), fmt.Sprintf("\n%s Aborted (%s)", s.GetLastTimestamp(ref).Format(KubernetesLogTimeFormat), status.Details))
+				s.Raw(ref, s.GetLastTimestamp(ref), fmt.Sprintf("\n%s Aborted (%s)", s.GetLastTimestamp(ref).Format(KubernetesLogTimeFormat), status.Details), false)
 				break
 			}
 		}

--- a/pkg/testworkflows/testworkflowexecutor/executor.go
+++ b/pkg/testworkflows/testworkflowexecutor/executor.go
@@ -210,7 +210,9 @@ func (e *executor) Control(ctx context.Context, testWorkflow *testworkflowsv1.Te
 				continue
 			}
 			if v.Value.Output != nil {
-				execution.Output = append(execution.Output, *testworkflowcontroller.InstructionToInternal(v.Value.Output))
+				if !v.Value.Temporary {
+					execution.Output = append(execution.Output, *testworkflowcontroller.InstructionToInternal(v.Value.Output))
+				}
 			} else if v.Value.Result != nil {
 				execution.Result = v.Value.Result
 				if execution.Result.IsFinished() {
@@ -230,8 +232,8 @@ func (e *executor) Control(ctx context.Context, testWorkflow *testworkflowsv1.Te
 					wg.Done()
 				}()
 				wg.Wait()
-			} else {
-				if ref != v.Value.Ref {
+			} else if !v.Value.Temporary {
+				if ref != v.Value.Ref && v.Value.Ref != "" {
 					ref = v.Value.Ref
 					_, err := writer.Write([]byte(data.SprintHint(ref, initconstants.InstructionStart)))
 					if err != nil {


### PR DESCRIPTION
## Pull request description 

* Expose logs about the events like pulling images, temporarily during execution
  * They are not part of final logs (except `type: Warning`s, same as now)
* Fixed CLI logs, so they display that a bit better

In future we can hide them on the UI after step is started (`temporary` flag for that, but needs Cloud API update and minor FE changes)

## Screenshots

| <img width="1023" alt="Zrzut ekranu 2024-06-19 o 11 16 23" src="https://github.com/kubeshop/testkube/assets/3843526/6a031a87-b463-4baa-82f2-86ba2f0781b7"> | <img width="1012" alt="Zrzut ekranu 2024-06-19 o 11 16 41" src="https://github.com/kubeshop/testkube/assets/3843526/82f048ba-e7c1-477c-b510-aeee6f7642d0"> |
|-|-|

## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [x] tested locally
- [x] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test