### PR TITLE
feat(performance): improve Log Processing performance

### DIFF
--- a/pkg/testworkflows/testworkflowcontroller/channel.go
+++ b/pkg/testworkflows/testworkflowcontroller/channel.go
@@ -20,6 +20,7 @@ type Channel[T any] interface {
 	Channel() <-chan ChannelMessage[T]
 	Close()
 	Done() <-chan struct{}
+	CtxErr() error
 }
 
 type channel[T any] struct {
@@ -167,4 +168,8 @@ func (c *channel[T]) Close() {
 
 func (c *channel[T]) Done() <-chan struct{} {
 	return c.ctx.Done()
+}
+
+func (c *channel[T]) CtxErr() error {
+	return c.ctx.Err()
 }

--- a/pkg/testworkflows/testworkflowcontroller/logs.go
+++ b/pkg/testworkflows/testworkflowcontroller/logs.go
@@ -23,6 +23,7 @@ import (
 
 const (
 	FlushLogMaxSize = 100_000
+	FlushBufferSize = 65_536
 	FlushLogTime    = 100 * time.Millisecond
 )
 
@@ -218,7 +219,7 @@ func WatchContainerLogs(parentCtx context.Context, clientSet kubernetes.Interfac
 		defer flushLogBuffer()
 
 		// Parse and return the logs
-		reader := bufio.NewReader(stream)
+		reader := bufio.NewReaderSize(stream, FlushBufferSize)
 		tsReader := newTimestampReader()
 		isNewLine := false
 		isStarted := false

--- a/pkg/testworkflows/testworkflowcontroller/logs_test.go
+++ b/pkg/testworkflows/testworkflowcontroller/logs_test.go
@@ -10,26 +10,58 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func Test_ReadTimestamp_UTC(t *testing.T) {
+func Test_ReadTimestamp_UTC_Initial(t *testing.T) {
+	reader := newTimestampReader()
 	prefix := "2024-06-07T12:41:49.037275300Z "
 	message := "some-message"
 	buf := bufio.NewReader(bytes.NewBufferString(prefix + message))
-	ts, byt, err := ReadTimestamp(buf)
+	err := reader.Read(buf)
 	rest, _ := io.ReadAll(buf)
 	assert.NoError(t, err)
-	assert.Equal(t, []byte(prefix), byt)
+	assert.Equal(t, []byte(prefix), reader.Prefix())
 	assert.Equal(t, []byte(message), rest)
-	assert.Equal(t, time.Date(2024, 6, 7, 12, 41, 49, 37275300, time.UTC), ts)
+	assert.Equal(t, time.Date(2024, 6, 7, 12, 41, 49, 37275300, time.UTC), reader.ts)
 }
 
-func Test_ReadTimestamp_NonUTC(t *testing.T) {
+func Test_ReadTimestamp_NonUTC_Initial(t *testing.T) {
+	reader := newTimestampReader()
 	prefix := "2024-06-07T15:41:49.037275300+03:00 "
 	message := "some-message"
 	buf := bufio.NewReader(bytes.NewBufferString(prefix + message))
-	ts, byt, err := ReadTimestamp(buf)
+	err := reader.Read(buf)
 	rest, _ := io.ReadAll(buf)
 	assert.NoError(t, err)
-	assert.Equal(t, []byte(prefix), byt)
+	assert.Equal(t, []byte(prefix), reader.Prefix())
 	assert.Equal(t, []byte(message), rest)
-	assert.Equal(t, time.Date(2024, 6, 7, 12, 41, 49, 37275300, time.UTC), ts)
+	assert.Equal(t, time.Date(2024, 6, 7, 12, 41, 49, 37275300, time.UTC), reader.ts)
+}
+
+func Test_ReadTimestamp_UTC_Recurring(t *testing.T) {
+	reader := newTimestampReader()
+	prefix := "2024-06-07T12:41:49.037275300Z "
+	message := "some-message"
+	buf := bufio.NewReader(bytes.NewBufferString(prefix + prefix + message))
+	err1 := reader.Read(buf)
+	err2 := reader.Read(buf)
+	rest, _ := io.ReadAll(buf)
+	assert.NoError(t, err1)
+	assert.NoError(t, err2)
+	assert.Equal(t, []byte(prefix), reader.Prefix())
+	assert.Equal(t, []byte(message), rest)
+	assert.Equal(t, time.Date(2024, 6, 7, 12, 41, 49, 37275300, time.UTC), reader.ts)
+}
+
+func Test_ReadTimestamp_NonUTC_Recurring(t *testing.T) {
+	reader := newTimestampReader()
+	prefix := "2024-06-07T15:41:49.037275300+03:00 "
+	message := "some-message"
+	buf := bufio.NewReader(bytes.NewBufferString(prefix + prefix + message))
+	err1 := reader.Read(buf)
+	err2 := reader.Read(buf)
+	rest, _ := io.ReadAll(buf)
+	assert.NoError(t, err1)
+	assert.NoError(t, err2)
+	assert.Equal(t, []byte(prefix), reader.Prefix())
+	assert.Equal(t, []byte(message), rest)
+	assert.Equal(t, time.Date(2024, 6, 7, 12, 41, 49, 37275300, time.UTC), reader.ts)
 }

--- a/pkg/testworkflows/testworkflowcontroller/notifier.go
+++ b/pkg/testworkflows/testworkflowcontroller/notifier.go
@@ -3,6 +3,7 @@ package testworkflowcontroller
 import (
 	"context"
 	"fmt"
+	"sync"
 	"time"
 
 	"github.com/kubeshop/testkube/cmd/testworkflow-init/data"
@@ -12,12 +13,21 @@ import (
 	"github.com/kubeshop/testkube/pkg/ui"
 )
 
+const (
+	FlushResultTime    = 50 * time.Millisecond
+	FlushResultMaxTime = 100 * time.Millisecond
+)
+
 type notifier struct {
 	watcher     *channel[Notification]
 	result      testkube.TestWorkflowResult
 	sig         []testkube.TestWorkflowSignature
 	scheduledAt time.Time
 	lastTs      map[string]time.Time
+
+	resultMu        sync.Mutex
+	resultCh        chan struct{}
+	resultScheduled bool
 }
 
 func (n *notifier) GetLastTimestamp(ref string) time.Time {
@@ -40,12 +50,68 @@ func (n *notifier) RegisterTimestamp(ref string, t time.Time) {
 	}
 }
 
+func (n *notifier) Flush() {
+	n.resultMu.Lock()
+	defer n.resultMu.Unlock()
+	if !n.resultScheduled {
+		return
+	}
+	n.watcher.Send(Notification{Timestamp: n.result.LatestTimestamp(), Result: n.result.Clone()})
+	n.resultScheduled = false
+}
+
+func (n *notifier) scheduleFlush() {
+	n.resultMu.Lock()
+	defer n.resultMu.Unlock()
+
+	// Inform existing scheduler about the next result
+	if n.resultScheduled {
+		select {
+		case n.resultCh <- struct{}{}:
+		default:
+		}
+		return
+	}
+
+	// Run the scheduler
+	n.resultScheduled = true
+	go func() {
+		flushTimer := time.NewTimer(FlushResultMaxTime)
+		flushTimerEnabled := false
+
+		for {
+			if n.watcher.CtxErr() != nil {
+				return
+			}
+
+			select {
+			case <-n.watcher.Done():
+				n.Flush()
+				return
+			case <-flushTimer.C:
+				n.Flush()
+				flushTimerEnabled = false
+			case <-time.After(FlushResultTime):
+				n.Flush()
+				flushTimerEnabled = false
+			case <-n.resultCh:
+				if !flushTimerEnabled {
+					flushTimerEnabled = true
+					flushTimer.Reset(FlushResultMaxTime)
+				}
+				continue
+			}
+		}
+	}()
+}
+
 func (n *notifier) Raw(ref string, ts time.Time, message string, temporary bool) {
 	if message != "" {
 		if ref == InitContainerName {
 			ref = ""
 		}
 		// TODO: use timestamp from the message too for lastTs?
+		n.Flush()
 		n.watcher.Send(Notification{
 			Timestamp: ts.UTC(),
 			Log:       message,
@@ -92,7 +158,7 @@ func (n *notifier) recompute() {
 
 func (n *notifier) emit() {
 	n.recompute()
-	n.watcher.Send(Notification{Timestamp: n.result.LatestTimestamp(), Result: n.result.Clone()})
+	n.scheduleFlush()
 }
 
 func (n *notifier) queue(ts time.Time) {
@@ -184,6 +250,7 @@ func (n *notifier) Output(ref string, ts time.Time, output *data.Instruction) {
 		return
 	}
 	n.RegisterTimestamp(ref, ts)
+	n.Flush()
 	n.watcher.Send(Notification{Timestamp: ts.UTC(), Ref: ref, Output: output})
 }
 
@@ -276,5 +343,7 @@ func newNotifier(ctx context.Context, signature []testworkflowprocessor.Signatur
 		scheduledAt: scheduledAt,
 		result:      result,
 		lastTs:      make(map[string]time.Time),
+
+		resultCh: make(chan struct{}, 1),
 	}
 }

--- a/pkg/testworkflows/testworkflowcontroller/utils.go
+++ b/pkg/testworkflows/testworkflowcontroller/utils.go
@@ -12,7 +12,7 @@ import (
 )
 
 const (
-	KubernetesLogTimeFormat         = "2006-01-02T15:04:05.000000000Z"
+	KubernetesLogTimeFormat         = "2006-01-02T15:04:05.999999999Z"
 	KubernetesTimezoneLogTimeFormat = KubernetesLogTimeFormat + "07:00"
 )
 

--- a/pkg/testworkflows/testworkflowcontroller/watchinstrumentedpod.go
+++ b/pkg/testworkflows/testworkflowcontroller/watchinstrumentedpod.go
@@ -27,7 +27,7 @@ type WatchInstrumentedPodOptions struct {
 	Follow    *bool
 }
 
-func WatchInstrumentedPod(parentCtx context.Context, clientSet kubernetes.Interface, signature []testworkflowprocessor.Signature, scheduledAt time.Time, pod Channel[*corev1.Pod], podEvents Channel[*corev1.Event], opts WatchInstrumentedPodOptions) (Channel[Notification], error) {
+func WatchInstrumentedPod(parentCtx context.Context, clientSet kubernetes.Interface, signature []testworkflowprocessor.Signature, scheduledAt time.Time, pod Channel[*corev1.Pod], podEvents Channel[*corev1.Event], opts WatchInstrumentedPodOptions) (<-chan ChannelMessage[Notification], error) {
 	// Avoid missing data
 	if pod == nil {
 		return nil, errors.New("pod watcher is required")
@@ -180,7 +180,7 @@ func WatchInstrumentedPod(parentCtx context.Context, clientSet kubernetes.Interf
 		}
 	}()
 
-	return s.watcher, nil
+	return s.ch, nil
 }
 
 func maxTime(times ...time.Time) time.Time {

--- a/pkg/testworkflows/testworkflowcontroller/watchinstrumentedpod.go
+++ b/pkg/testworkflows/testworkflowcontroller/watchinstrumentedpod.go
@@ -42,7 +42,10 @@ func WatchInstrumentedPod(parentCtx context.Context, clientSet kubernetes.Interf
 
 	// Start watching
 	go func() {
-		defer ctxCancel()
+		defer func() {
+			s.Flush()
+			ctxCancel()
+		}()
 
 		// Watch for the basic initialization warnings
 		for v := range state.PreStart("") {

--- a/pkg/testworkflows/testworkflowcontroller/watchinstrumentedpod.go
+++ b/pkg/testworkflows/testworkflowcontroller/watchinstrumentedpod.go
@@ -102,7 +102,7 @@ func WatchInstrumentedPod(parentCtx context.Context, clientSet kubernetes.Interf
 
 			// Watch the container logs
 			follow := common.ResolvePtr(opts.Follow, true) && !state.IsFinished(ref)
-			for v := range WatchContainerLogs(ctx, clientSet, podObj.Namespace, podObj.Name, ref, 10, follow, pod).Channel() {
+			for v := range WatchContainerLogs(ctx, clientSet, podObj.Namespace, podObj.Name, ref, 10, pod).Channel() {
 				if v.Error != nil {
 					s.Error(v.Error)
 				} else if v.Value.Output != nil {

--- a/pkg/testworkflows/testworkflowexecutor/executor.go
+++ b/pkg/testworkflows/testworkflowexecutor/executor.go
@@ -314,7 +314,7 @@ func (e *executor) Control(ctx context.Context, testWorkflow *testworkflowsv1.Te
 
 	e.metrics.IncAndObserveExecuteTestWorkflow(*execution, e.dashboardURI)
 
-	e.updateStatus(testWorkflow, execution, testWorkflowExecution)
+	e.updateStatus(testWorkflow, execution, testWorkflowExecution) // TODO: Consider if it is needed
 	err = testworkflowcontroller.Cleanup(ctx, e.clientSet, execution.GetNamespace(e.namespace), execution.Id)
 	if err != nil {
 		log.DefaultLogger.Errorw("failed to cleanup TestWorkflow resources", "id", execution.Id, "error", err)


### PR DESCRIPTION
## Pull request description 

* Batch the log messages, so we don't send a JSON message for every single line
* Batch the results, so we don't save data in MongoDB/Cloud/Kubernetes every time there is a result update

The batching works as follows:
* Wait 50ms after receiving update/log to flush it to User
* Reset the timer on consecutive message, but wait no longer than 100ms to send any update to User
* **Logs only:** it flushes immediately if there is already 64KiB of logs buffered

In the result, the Test Workflows with significant amount of logs are working much better - both the real-time stream is faster, as well as the result computation (so the Test Workflow is marked done almost immediately after it's finished, even when there is a lot of logs).

## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [x] tested locally
- [x] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test