### PR TITLE
fix(testworkflows): displaying events

### DIFF
--- a/pkg/testworkflows/testworkflowcontroller/utils.go
+++ b/pkg/testworkflows/testworkflowcontroller/utils.go
@@ -12,7 +12,7 @@ import (
 )
 
 const (
-	KubernetesLogTimeFormat         = "2006-01-02T15:04:05.999999999Z"
+	KubernetesLogTimeFormat         = "2006-01-02T15:04:05.000000000Z"
 	KubernetesTimezoneLogTimeFormat = KubernetesLogTimeFormat + "07:00"
 )
 


### PR DESCRIPTION
## Pull request description 

* `999999` in Golang time format is not displaying the nanoseconds in case they are 0; it leads to incorrect length while formatting the time for events in logs, so the UI is not able to display them correctly.

## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [x] tested locally
- [x] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
