### PR TITLE
fix(testworkflows): storing logs for the services

### DIFF
--- a/pkg/testworkflows/testworkflowcontroller/utils.go
+++ b/pkg/testworkflows/testworkflowcontroller/utils.go
@@ -12,7 +12,7 @@ import (
 )
 
 const (
-	KubernetesLogTimeFormat         = "2006-01-02T15:04:05.999999999Z"
+	KubernetesLogTimeFormat         = "2006-01-02T15:04:05.000000000Z"
 	KubernetesTimezoneLogTimeFormat = KubernetesLogTimeFormat + "07:00"
 )
 

--- a/pkg/testworkflows/testworkflowcontroller/watchinstrumentedpod.go
+++ b/pkg/testworkflows/testworkflowcontroller/watchinstrumentedpod.go
@@ -102,7 +102,7 @@ func WatchInstrumentedPod(parentCtx context.Context, clientSet kubernetes.Interf
 
 			// Watch the container logs
 			follow := common.ResolvePtr(opts.Follow, true) && !state.IsFinished(ref)
-			for v := range WatchContainerLogs(ctx, clientSet, podObj.Namespace, podObj.Name, ref, 10, pod).Channel() {
+			for v := range WatchContainerLogs(ctx, clientSet, podObj.Namespace, podObj.Name, ref, follow, 10, pod).Channel() {
 				if v.Error != nil {
 					s.Error(v.Error)
 				} else if v.Value.Output != nil {

--- a/pkg/testworkflows/testworkflowprocessor/container.go
+++ b/pkg/testworkflows/testworkflowprocessor/container.go
@@ -468,7 +468,7 @@ func (c *container) Resolve(m ...expressions.Machine) error {
 			}
 			env := c.Env()
 			name = name[4:]
-			for i := range env {
+			for i := len(env) - 1; i >= 0; i-- {
 				if env[i].Name == name && env[i].ValueFrom == nil {
 					value, err := expressions.EvalTemplate(env[i].Value)
 					if err == nil {


### PR DESCRIPTION
## Pull request description 

* `TK_SVC_GROUP` (group of services to close) was incorrectly inherited (from lowest container), so the Kill Process worked incorrectly when multiple `services` clauses were used
* `WatchContainerLogs` always used `follow: true`, so for running services it was never finishing, blocking the workflow

## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [x] tested locally
- [x] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
