### PR TITLE
fix: read correctly parallel template

### DIFF
--- a/pkg/testworkflows/testworkflowresolver/analyze.go
+++ b/pkg/testworkflows/testworkflowresolver/analyze.go
@@ -39,7 +39,7 @@ func listStepTemplates(cr testworkflowsv1.Step) map[string]struct{} {
 	if cr.Parallel != nil {
 		maps.Copy(v, listSpecTemplates(cr.Parallel.TestWorkflowSpec))
 		if cr.Parallel.Template != nil {
-			v[GetInternalTemplateName(cr.Template.Name)] = struct{}{}
+			v[GetInternalTemplateName(cr.Parallel.Template.Name)] = struct{}{}
 		}
 	}
 	for i := range cr.Setup {


### PR DESCRIPTION
## Pull request description 

Panic occurred, because of reading incorrect field of:

```yaml
    parallel:
      matrix:
        workflowName: ['postman-workflow-smoke', 'k6-workflow-smoke']
      description: '{{ matrix.workflowName }} workflow'
      template:
        name: template-trigger-remote-workflow
        config:
          apiToken: tkcapi_5b81e9e470b5154ddea1cb4390163b
          environmentId: tkcenv_84019fff03aac934
          organizationId: tkcorg_539cb664a4446f37
          rootDomain: testkube.io
          workflowToRun: '{{ matrix.workflowName }}'
```

## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [x] tested locally
- [x] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
