### PR TITLE
feat: add support for better error handling in CLI

### DIFF
--- a/cmd/kubectl-testkube/commands/common/errors.go
+++ b/cmd/kubectl-testkube/commands/common/errors.go
@@ -1,0 +1,79 @@
+package common
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/pterm/pterm"
+)
+
+const (
+	// TKERR-1xx errors are to issues when running testkube CLI commands.
+
+	// TKERR-11xx errors are related to missing dependencies.
+
+	// TKErrMissingDependencyHelm is returned when kubectl is not found in $PATH.
+	TKErrMissingDependencyHelm = "TKERR-1101"
+	// TKErrMissingDependencyKubectl is returned when kubectl is not found in $PATH.
+	TKErrMissingDependencyKubectl = "TKERR-1102"
+
+	// TKERR-12xx errors are related to configuration issues.
+
+	// TKErrConfigLoadingFailed is returned when configuration loading fails.
+	TKErrConfigLoadingFailed = "TKERR-1201"
+	// TKErrInvalidInstallConfig is returned when invalid configuration is supplied when installing or upgrading.
+	TKErrInvalidInstallConfig = "TKERR-1202"
+
+	// TKERR-13xx errors are related to install operations.
+
+	// TKErrHelmCommandFailed is returned when a helm command fails.
+	TKErrHelmCommandFailed = "TKERR-1301"
+	// TKErrKubectlCommandFailed is returned when a kubectl command fail.
+	TKErrKubectlCommandFailed = "TKERR-1302"
+)
+
+type CLIError struct {
+	Code        string
+	Title       string
+	Description string
+	ActualError error
+	StackTrace  string
+	MoreInfo    string
+}
+
+func (e *CLIError) Error() string {
+	return fmt.Sprintf("%s: %s", e.Code, e.Description)
+}
+
+func (e *CLIError) Print() {
+	pterm.DefaultHeader.Println("Testkube Init Error")
+
+	pterm.DefaultSection.Println("Error Details")
+
+	items := []pterm.BulletListItem{
+		{Level: 0, Text: pterm.Sprintf("[%s]: %s", e.Code, e.Title), TextStyle: pterm.NewStyle(pterm.FgRed)},
+		{Level: 0, Text: pterm.Sprintf("%s", e.Description), TextStyle: pterm.NewStyle(pterm.FgLightWhite)},
+	}
+	if e.MoreInfo != "" {
+		items = append(items, pterm.BulletListItem{Level: 0, Text: pterm.Sprintf("%s", e.MoreInfo), TextStyle: pterm.NewStyle(pterm.FgGray)})
+	}
+	pterm.DefaultBulletList.WithItems(items).Render()
+}
+
+func NewCLIError(code, title, moreInfoURL string, err error) *CLIError {
+	return &CLIError{
+		Code:        code,
+		Title:       title,
+		Description: err.Error(),
+		ActualError: err,
+		MoreInfo:    moreInfoURL,
+	}
+}
+
+// HandleCLIError checks does the error exist, and if it does, prints the error and exits the program.
+func HandleCLIError(err *CLIError) {
+	if err != nil {
+		err.Print()
+		os.Exit(1)
+	}
+}

--- a/cmd/kubectl-testkube/commands/init.go
+++ b/cmd/kubectl-testkube/commands/init.go
@@ -85,8 +85,7 @@ func NewInitCmdStandalone() *cobra.Command {
 
 			common.ProcessMasterFlags(cmd, &options, nil)
 
-			err := common.HelmUpgradeOrInstalTestkube(options)
-			ui.ExitOnError("Cannot install Testkube", err)
+			common.HandleCLIError(common.HelmUpgradeOrInstallTestkube(options))
 
 			ui.Info(`To help improve the quality of Testkube, we collect anonymous basic telemetry data. Head out to https://docs.testkube.io/articles/telemetry to read our policy or feel free to:`)
 
@@ -136,10 +135,10 @@ func NewInitCmdDemo() *cobra.Command {
 
 			sendTelemetry(cmd, cfg, license, "installation launched")
 
-			kubecontext, err := common.GetCurrentKubernetesContext()
-			if err != nil {
-				ui.Failf("kubeconfig not found")
+			kubecontext, cliErr := common.GetCurrentKubernetesContext()
+			if cliErr != nil {
 				sendErrTelemetry(cmd, cfg, "install_kubeconfig_not_found", license, "kubeconfig not found", err)
+				common.HandleCLIError(cliErr)
 			}
 			sendTelemetry(cmd, cfg, license, "kubeconfig found")
 
@@ -249,7 +248,8 @@ func isContextApproved(isNoConfirm bool, installedComponent string) bool {
 		ui.NL()
 
 		currentContext, err := common.GetCurrentKubernetesContext()
-		ui.ExitOnError("getting current context", err)
+		common.HandleCLIError(err)
+
 		ui.Alert("Current kubectl context:", currentContext)
 		ui.NL()
 

--- a/cmd/kubectl-testkube/commands/pro/connect.go
+++ b/cmd/kubectl-testkube/commands/pro/connect.go
@@ -52,9 +52,10 @@ func NewConnectCmd() *cobra.Command {
 			common.ProcessMasterFlags(cmd, &opts, &cfg)
 
 			var clusterContext string
+			var cliErr *common.CLIError
 			if cfg.ContextType == config.ContextTypeKubeconfig {
-				clusterContext, err = common.GetCurrentKubernetesContext()
-				ui.ExitOnError("getting current kubernetes context", err)
+				clusterContext, cliErr = common.GetCurrentKubernetesContext()
+				common.HandleCLIError(cliErr)
 			}
 
 			// TODO: implement context info
@@ -136,8 +137,11 @@ func NewConnectCmd() *cobra.Command {
 			}
 
 			spinner := ui.NewSpinner("Connecting Testkube Pro")
-			err = common.HelmUpgradeOrInstallTestkubeCloud(opts, cfg, true)
-			ui.ExitOnError("Installing Testkube Pro", err)
+			if cliErr = common.HelmUpgradeOrInstallTestkubeCloud(opts, cfg, true); cliErr != nil {
+				spinner.Fail()
+				common.HandleCLIError(cliErr)
+			}
+
 			spinner.Success()
 
 			ui.NL()

--- a/cmd/kubectl-testkube/commands/upgrade.go
+++ b/cmd/kubectl-testkube/commands/upgrade.go
@@ -1,6 +1,8 @@
 package commands
 
 import (
+	"os"
+
 	"github.com/spf13/cobra"
 
 	"github.com/kubeshop/testkube/cmd/kubectl-testkube/commands/common"
@@ -35,7 +37,9 @@ func NewUpgradeCmd() *cobra.Command {
 				ui.Warn("Please be sure you're on valid kubectl context before continuing!")
 				ui.NL()
 
-				currentContext, err := common.GetCurrentKubernetesContext()
+				currentContext, cliErr := common.GetCurrentKubernetesContext()
+				common.HandleCLIError(cliErr)
+
 				ui.ExitOnError("getting current context", err)
 				ui.Alert("Current kubectl context:", currentContext)
 				ui.NL()
@@ -70,8 +74,10 @@ func NewUpgradeCmd() *cobra.Command {
 					ui.Success("All agent migrations executed successfully")
 				}
 
-				err = common.HelmUpgradeOrInstalTestkube(options)
-				ui.ExitOnError("Upgrading Testkube", err)
+				if cliErr := common.HelmUpgradeOrInstallTestkube(options); cliErr != nil {
+					cliErr.Print()
+					os.Exit(1)
+				}
 			}
 
 		},

--- a/pkg/process/exec.go
+++ b/pkg/process/exec.go
@@ -17,7 +17,8 @@ type Options struct {
 	DryRun  bool
 }
 
-// Execute runs system command and returns whole output also in case of error
+// ExecuteWithOptions runs system command and returns whole output also in case of error.
+// It also supports dry-run mode, where it only prints the command to be executed.
 func ExecuteWithOptions(options Options) (out []byte, err error) {
 	if options.DryRun {
 		fmt.Println("$ " + strings.Join(append([]string{options.Command}, options.Args...), " "))


### PR DESCRIPTION
## Pull request description 

Define a better user-facing error structure.
Introduce error codes.
Add framework for better error handling in CLI.

Example returned error:
![image](https://github.com/user-attachments/assets/aa294c44-00e1-4768-b1cb-e0f0bad18e62)

Example code:
```
func lookupKubectlPath() (string, *CLIError) {
	kubectlPath, err := exec.LookPath("kubectl")
	if err != nil {
		return "", NewCLIError(
			TKErrMissingDependencyKubectl,
			"Required dependency not found: kubectl",
			"Install kubectl by following this guide: https://kubernetes.io/docs/tasks/tools/#kubectl",
			err,
		)
	}
	return kubectlPath, nil
}
```


## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [ ] tested locally
- [ ] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Breaking changes

-

## Changes

-

## Fixes

-