### PR TITLE
fix(TKC-2310): expose expression variables for simple use of org, env and dashboard

### DIFF
--- a/cmd/tcl/testworkflow-toolkit/spawn/utils.go
+++ b/cmd/tcl/testworkflow-toolkit/spawn/utils.go
@@ -264,6 +264,11 @@ func CreateLogger(name, description string, index, count int64) func(...string) 
 }
 
 func CreateBaseMachine() expressions.Machine {
+	dashboardUrl := env.Config().System.DashboardUrl
+	if env.Config().Cloud.ApiKey != "" {
+		dashboardUrl = fmt.Sprintf("%s/organization/%s/environment/%s/dashboard",
+			env.Config().Cloud.UiUrl, env.Config().Cloud.OrgId, env.Config().Cloud.EnvId)
+	}
 	return expressions.CombinedMachines(
 		data.GetBaseTestWorkflowMachine(),
 		expressions.NewMachine().RegisterStringMap("internal", map[string]string{
@@ -303,7 +308,16 @@ func CreateBaseMachine() expressions.Machine {
 			"images.persistence.enabled": strconv.FormatBool(env.Config().Images.InspectorPersistenceEnabled),
 			"images.persistence.key":     env.Config().Images.InspectorPersistenceCacheKey,
 			"images.cache.ttl":           env.Config().Images.ImageCredentialsCacheTTL.String(),
-		}),
+		}).
+			Register("dashboard", map[string]string{
+				"url": dashboardUrl,
+			}).
+			Register("organization", map[string]string{
+				"id": env.Config().Cloud.OrgId,
+			}).
+			Register("environment", map[string]string{
+				"id": env.Config().Cloud.EnvId,
+			}),
 	)
 }
 


### PR DESCRIPTION
## Pull request description 

* Expose `dashboard.url` variable, that will either point to OSS URL prefix, or to the Environment's URL prefix
* Expose `organization.id` and `environment.id` (user-facing, not `internal`) variables

## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [ ] tested locally
- [ ] tested on cluster
- [ ] added new dependencies
- [x] updated the docs
- [ ] added a test

## Fixes

- https://linear.app/kubeshop/issue/TKC-2310/%5Bnorauto%5D-%5Bfeature-request%5D-new-workflow-environment-variables-for-org