### PR TITLE
feat: avoid getting image metadata from container registry when it is not needed

### DIFF
--- a/pkg/testworkflows/testworkflowprocessor/stage/containerstage.go
+++ b/pkg/testworkflows/testworkflowprocessor/stage/containerstage.go
@@ -52,8 +52,8 @@ func (s *containerStage) ContainerStages() []ContainerStage {
 	return []ContainerStage{s}
 }
 
-func (s *containerStage) GetImages() map[string]struct{} {
-	return map[string]struct{}{s.container.Image(): {}}
+func (s *containerStage) GetImages(isGroupNeeded bool) map[string]bool {
+	return map[string]bool{s.container.Image(): s.container.NeedsImageData(isGroupNeeded)}
 }
 
 func (s *containerStage) Flatten() []Stage {

--- a/pkg/testworkflows/testworkflowprocessor/stage/groupstage.go
+++ b/pkg/testworkflows/testworkflowprocessor/stage/groupstage.go
@@ -1,8 +1,6 @@
 package stage
 
 import (
-	"maps"
-
 	"github.com/pkg/errors"
 
 	"github.com/kubeshop/testkube/pkg/expressions"
@@ -100,10 +98,12 @@ func (s *groupStage) RecursiveChildren() []Stage {
 	return res
 }
 
-func (s *groupStage) GetImages() map[string]struct{} {
-	v := make(map[string]struct{})
+func (s *groupStage) GetImages(isGroupNeeded bool) map[string]bool {
+	v := make(map[string]bool)
 	for _, ch := range s.children {
-		maps.Copy(v, ch.GetImages())
+		for name, needsMetadata := range ch.GetImages(isGroupNeeded) {
+			v[name] = v[name] || needsMetadata
+		}
 	}
 	return v
 }

--- a/pkg/testworkflows/testworkflowprocessor/stage/mock_container.go
+++ b/pkg/testworkflows/testworkflowprocessor/stage/mock_container.go
@@ -287,6 +287,20 @@ func (mr *MockContainerMockRecorder) IsToolkit() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsToolkit", reflect.TypeOf((*MockContainer)(nil).IsToolkit))
 }
 
+// NeedsImageData mocks base method.
+func (m *MockContainer) NeedsImageData(arg0 bool) bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "NeedsImageData", arg0)
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// NeedsImageData indicates an expected call of NeedsImageData.
+func (mr *MockContainerMockRecorder) NeedsImageData(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NeedsImageData", reflect.TypeOf((*MockContainer)(nil).NeedsImageData), arg0)
+}
+
 // Parent mocks base method.
 func (m *MockContainer) Parent() Container {
 	m.ctrl.T.Helper()

--- a/pkg/testworkflows/testworkflowprocessor/stage/mock_stage.go
+++ b/pkg/testworkflows/testworkflowprocessor/stage/mock_stage.go
@@ -5,13 +5,12 @@
 package stage
 
 import (
-	"reflect"
+	reflect "reflect"
 
-	"github.com/golang/mock/gomock"
-
+	gomock "github.com/golang/mock/gomock"
 	v1 "github.com/kubeshop/testkube-operator/api/testworkflows/v1"
-	"github.com/kubeshop/testkube/pkg/expressions"
-	"github.com/kubeshop/testkube/pkg/imageinspector"
+	expressions "github.com/kubeshop/testkube/pkg/expressions"
+	imageinspector "github.com/kubeshop/testkube/pkg/imageinspector"
 )
 
 // MockStage is a mock of Stage interface.
@@ -126,17 +125,17 @@ func (mr *MockStageMockRecorder) Flatten() *gomock.Call {
 }
 
 // GetImages mocks base method.
-func (m *MockStage) GetImages() map[string]struct{} {
+func (m *MockStage) GetImages(arg0 bool) map[string]bool {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetImages")
-	ret0, _ := ret[0].(map[string]struct{})
+	ret := m.ctrl.Call(m, "GetImages", arg0)
+	ret0, _ := ret[0].(map[string]bool)
 	return ret0
 }
 
 // GetImages indicates an expected call of GetImages.
-func (mr *MockStageMockRecorder) GetImages() *gomock.Call {
+func (mr *MockStageMockRecorder) GetImages(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetImages", reflect.TypeOf((*MockStage)(nil).GetImages))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetImages", reflect.TypeOf((*MockStage)(nil).GetImages), arg0)
 }
 
 // HasPause mocks base method.

--- a/pkg/testworkflows/testworkflowprocessor/stage/stage.go
+++ b/pkg/testworkflows/testworkflowprocessor/stage/stage.go
@@ -14,7 +14,7 @@ type Stage interface {
 	Signature() Signature
 	Resolve(m ...expressions.Machine) error
 	ContainerStages() []ContainerStage
-	GetImages() map[string]struct{}
+	GetImages(isGroupNeeded bool) map[string]bool
 	ApplyImages(images map[string]*imageinspector.Info, imageNameResolutions map[string]string) error
 	Flatten() []Stage
 }


### PR DESCRIPTION
## Pull request description 

* When there is information about working directory, user group and command/shell provided for each of the steps, avoid calling the Container Registry for additional metadata.
   * additionally `image.command`, `image.args` and `image.workingDir` variables should not be used

## Example Test Workflow

```yaml
kind: TestWorkflow
apiVersion: testworkflows.testkube.io/v1
metadata:
  name: workflow-without-inspecting-images
spec:
  container:
    workingDir: /data
    securityContext:
      runAsGroup: 1000
  job:
    activeDeadlineSeconds: 60
  steps:
  - run:
      image: busybox
      shell: pwd && tree /data
  - run:
      image: busybox
      command:
      - /bin/sh
      - -c
      args:
      - echo 'hello'
  - run:
      image: busybox
      command:
      - /bin/sh
      - -c
      - echo 'hello again'
  - run:
      image: blah-unknown-image:1234
      shell: echo not executed because of unknown image
```

## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [x] tested locally
- [x] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test