### PR TITLE
feat: add options to control Test Workflows orchestration

### DIFF
--- a/api/v1/testkube.yaml
+++ b/api/v1/testkube.yaml
@@ -8478,6 +8478,16 @@ components:
       required:
       - from
 
+    TestWorkflowSystem:
+      type: object
+      properties:
+        pureByDefault:
+          type: boolean
+          description: assume all the steps are pure by default
+        isolatedContainers:
+          type: boolean
+          description: disable the behavior of merging multiple operations in a single container
+
     TestWorkflowSpec:
       type: object
       properties:
@@ -8487,6 +8497,8 @@ components:
             $ref: "#/components/schemas/TestWorkflowTemplateRef"
         config:
           $ref: "#/components/schemas/TestWorkflowConfigSchema"
+        system:
+          $ref: "#/components/schemas/TestWorkflowSystem"
         content:
           $ref: "#/components/schemas/TestWorkflowContent"
         services:
@@ -8521,6 +8533,8 @@ components:
       properties:
         config:
           $ref: "#/components/schemas/TestWorkflowConfigSchema"
+        system:
+          $ref: "#/components/schemas/TestWorkflowSystem"
         content:
           $ref: "#/components/schemas/TestWorkflowContent"
         services:
@@ -8595,6 +8609,8 @@ components:
         condition:
           type: string
           description: expression to declare under which conditions the step should be run; defaults to "passed", except artifacts where it defaults to "always"
+        pure:
+          $ref: "#/components/schemas/BoxedBoolean"
         paused:
           type: boolean
           description: should the step be paused initially
@@ -8655,6 +8671,8 @@ components:
         condition:
           type: string
           description: expression to declare under which conditions the step should be run; defaults to "passed", except artifacts where it defaults to "always"
+        pure:
+          $ref: "#/components/schemas/BoxedBoolean"
         paused:
           type: boolean
           description: should the step be paused initially

--- a/cmd/testworkflow-init/orchestration/executions.go
+++ b/cmd/testworkflow-init/orchestration/executions.go
@@ -177,6 +177,7 @@ func (e *execution) Run() (*executionResult, error) {
 		e.group.pauseMu.Unlock()
 		e.cmdMu.Unlock()
 		_, exitCode = getProcessStatus(err)
+		e.cmd.Stderr.Write(append([]byte(err.Error()), '\n'))
 	}
 
 	// Clean up

--- a/go.mod
+++ b/go.mod
@@ -34,7 +34,7 @@ require (
 	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51
 	github.com/kelseyhightower/envconfig v1.4.0
 	github.com/kubepug/kubepug v1.7.1
-	github.com/kubeshop/testkube-operator v1.15.2-beta1.0.20240729112855-d7bd9c5f64a9
+	github.com/kubeshop/testkube-operator v1.15.2-beta1.0.20240807112434-ea57d26581dc
 	github.com/minio/minio-go/v7 v7.0.47
 	github.com/montanaflynn/stats v0.6.6
 	github.com/moogar0880/problems v0.1.1

--- a/go.sum
+++ b/go.sum
@@ -373,6 +373,8 @@ github.com/kubepug/kubepug v1.7.1 h1:LKhfSxS8Y5mXs50v+3Lpyec+cogErDLcV7CMUuiaisw
 github.com/kubepug/kubepug v1.7.1/go.mod h1:lv+HxD0oTFL7ZWjj0u6HKhMbbTIId3eG7aWIW0gyF8g=
 github.com/kubeshop/testkube-operator v1.15.2-beta1.0.20240729112855-d7bd9c5f64a9 h1:Zg+hTPkHi504Nwp3M9kM9+DPX7OdiYJBJL2hJCE5Jhg=
 github.com/kubeshop/testkube-operator v1.15.2-beta1.0.20240729112855-d7bd9c5f64a9/go.mod h1:P47tw1nKQFufdsZndyq2HG2MSa0zK/lU0XpRfZtEmIk=
+github.com/kubeshop/testkube-operator v1.15.2-beta1.0.20240807112434-ea57d26581dc h1:Fk8GhNpw5VHWUxyAQ/sPYAH2dKPGyQBVOvkA+VBPMYQ=
+github.com/kubeshop/testkube-operator v1.15.2-beta1.0.20240807112434-ea57d26581dc/go.mod h1:P47tw1nKQFufdsZndyq2HG2MSa0zK/lU0XpRfZtEmIk=
 github.com/leodido/go-urn v1.2.1 h1:BqpAaACuzVSgi/VLzGZIobT2z4v53pjosyNd9Yv6n/w=
 github.com/leodido/go-urn v1.2.1/go.mod h1:zt4jvISO2HfUBqxjfIshjdMTYS56ZS/qv49ictyFfxY=
 github.com/lithammer/fuzzysearch v1.1.8 h1:/HIuJnjHuXS8bKaiTMeeDlW2/AyIWk2brx1V8LFgLN4=

--- a/pkg/api/v1/testkube/model_test_workflow_independent_service_spec.go
+++ b/pkg/api/v1/testkube/model_test_workflow_independent_service_spec.go
@@ -25,12 +25,6 @@ type TestWorkflowIndependentServiceSpec struct {
 	SecurityContext *SecurityContext       `json:"securityContext,omitempty"`
 	// volumes to mount to the container
 	VolumeMounts []VolumeMount `json:"volumeMounts,omitempty"`
-	Count        *BoxedString  `json:"count,omitempty"`
-	MaxCount     *BoxedString  `json:"maxCount,omitempty"`
-	// matrix of parameters to spawn instances
-	Matrix map[string]interface{} `json:"matrix,omitempty"`
-	// parameters that should be distributed across sharded instances
-	Shards map[string]interface{} `json:"shards,omitempty"`
 	// service description to display
 	Description string `json:"description,omitempty"`
 	// maximum time until reaching readiness
@@ -42,4 +36,10 @@ type TestWorkflowIndependentServiceSpec struct {
 	Logs           *BoxedString                       `json:"logs,omitempty"`
 	RestartPolicy  string                             `json:"restartPolicy,omitempty"`
 	ReadinessProbe *Probe                             `json:"readinessProbe,omitempty"`
+	Count          *BoxedString                       `json:"count,omitempty"`
+	MaxCount       *BoxedString                       `json:"maxCount,omitempty"`
+	// matrix of parameters to spawn instances
+	Matrix map[string]interface{} `json:"matrix,omitempty"`
+	// parameters that should be distributed across sharded instances
+	Shards map[string]interface{} `json:"shards,omitempty"`
 }

--- a/pkg/api/v1/testkube/model_test_workflow_independent_step.go
+++ b/pkg/api/v1/testkube/model_test_workflow_independent_step.go
@@ -13,7 +13,8 @@ type TestWorkflowIndependentStep struct {
 	// readable name for the step
 	Name string `json:"name,omitempty"`
 	// expression to declare under which conditions the step should be run; defaults to \"passed\", except artifacts where it defaults to \"always\"
-	Condition string `json:"condition,omitempty"`
+	Condition string        `json:"condition,omitempty"`
+	Pure      *BoxedBoolean `json:"pure,omitempty"`
 	// should the step be paused initially
 	Paused bool `json:"paused,omitempty"`
 	// is the step expected to fail

--- a/pkg/api/v1/testkube/model_test_workflow_independent_step_parallel.go
+++ b/pkg/api/v1/testkube/model_test_workflow_independent_step_parallel.go
@@ -28,11 +28,21 @@ type TestWorkflowIndependentStepParallel struct {
 	// delay before the step
 	Delay string `json:"delay,omitempty"`
 	// script to run in a default shell for the container
-	Shell     string                                        `json:"shell,omitempty"`
-	Run       *TestWorkflowStepRun                          `json:"run,omitempty"`
-	Execute   *TestWorkflowStepExecute                      `json:"execute,omitempty"`
-	Artifacts *TestWorkflowStepArtifacts                    `json:"artifacts,omitempty"`
+	Shell     string                     `json:"shell,omitempty"`
+	Run       *TestWorkflowStepRun       `json:"run,omitempty"`
+	Execute   *TestWorkflowStepExecute   `json:"execute,omitempty"`
+	Artifacts *TestWorkflowStepArtifacts `json:"artifacts,omitempty"`
+	// how many resources could be scheduled in parallel
+	Parallelism int32 `json:"parallelism,omitempty"`
+	// worker description to display
+	Description string       `json:"description,omitempty"`
+	Logs        *BoxedString `json:"logs,omitempty"`
+	// list of files to send to parallel steps
+	Transfer []TestWorkflowStepParallelTransfer `json:"transfer,omitempty"`
+	// list of files to fetch from parallel steps
+	Fetch     []TestWorkflowStepParallelFetch               `json:"fetch,omitempty"`
 	Config    map[string]TestWorkflowParameterSchema        `json:"config,omitempty"`
+	System    *TestWorkflowSystem                           `json:"system,omitempty"`
 	Content   *TestWorkflowContent                          `json:"content,omitempty"`
 	Services  map[string]TestWorkflowIndependentServiceSpec `json:"services,omitempty"`
 	Container *TestWorkflowContainerConfig                  `json:"container,omitempty"`
@@ -42,13 +52,4 @@ type TestWorkflowIndependentStepParallel struct {
 	Steps     []TestWorkflowIndependentStep                 `json:"steps,omitempty"`
 	After     []TestWorkflowIndependentStep                 `json:"after,omitempty"`
 	Events    []TestWorkflowEvent                           `json:"events,omitempty"`
-	// how many resources could be scheduled in parallel
-	Parallelism int32 `json:"parallelism,omitempty"`
-	// worker description to display
-	Description string       `json:"description,omitempty"`
-	Logs        *BoxedString `json:"logs,omitempty"`
-	// list of files to send to parallel steps
-	Transfer []TestWorkflowStepParallelTransfer `json:"transfer,omitempty"`
-	// list of files to fetch from parallel steps
-	Fetch []TestWorkflowStepParallelFetch `json:"fetch,omitempty"`
 }

--- a/pkg/api/v1/testkube/model_test_workflow_service_spec.go
+++ b/pkg/api/v1/testkube/model_test_workflow_service_spec.go
@@ -36,11 +36,11 @@ type TestWorkflowServiceSpec struct {
 	Logs           *BoxedString                       `json:"logs,omitempty"`
 	RestartPolicy  string                             `json:"restartPolicy,omitempty"`
 	ReadinessProbe *Probe                             `json:"readinessProbe,omitempty"`
+	Use            []TestWorkflowTemplateRef          `json:"use,omitempty"`
 	Count          *BoxedString                       `json:"count,omitempty"`
 	MaxCount       *BoxedString                       `json:"maxCount,omitempty"`
 	// matrix of parameters to spawn instances
 	Matrix map[string]interface{} `json:"matrix,omitempty"`
 	// parameters that should be distributed across sharded instances
-	Shards map[string]interface{}    `json:"shards,omitempty"`
-	Use    []TestWorkflowTemplateRef `json:"use,omitempty"`
+	Shards map[string]interface{} `json:"shards,omitempty"`
 }

--- a/pkg/api/v1/testkube/model_test_workflow_spec.go
+++ b/pkg/api/v1/testkube/model_test_workflow_spec.go
@@ -12,6 +12,7 @@ package testkube
 type TestWorkflowSpec struct {
 	Use       []TestWorkflowTemplateRef              `json:"use,omitempty"`
 	Config    map[string]TestWorkflowParameterSchema `json:"config,omitempty"`
+	System    *TestWorkflowSystem                    `json:"system,omitempty"`
 	Content   *TestWorkflowContent                   `json:"content,omitempty"`
 	Services  map[string]TestWorkflowServiceSpec     `json:"services,omitempty"`
 	Container *TestWorkflowContainerConfig           `json:"container,omitempty"`

--- a/pkg/api/v1/testkube/model_test_workflow_step.go
+++ b/pkg/api/v1/testkube/model_test_workflow_step.go
@@ -13,7 +13,8 @@ type TestWorkflowStep struct {
 	// readable name for the step
 	Name string `json:"name,omitempty"`
 	// expression to declare under which conditions the step should be run; defaults to \"passed\", except artifacts where it defaults to \"always\"
-	Condition string `json:"condition,omitempty"`
+	Condition string        `json:"condition,omitempty"`
+	Pure      *BoxedBoolean `json:"pure,omitempty"`
 	// should the step be paused initially
 	Paused bool `json:"paused,omitempty"`
 	// is the step expected to fail

--- a/pkg/api/v1/testkube/model_test_workflow_step_execute_test_ref.go
+++ b/pkg/api/v1/testkube/model_test_workflow_step_execute_test_ref.go
@@ -10,16 +10,16 @@
 package testkube
 
 type TestWorkflowStepExecuteTestRef struct {
-	Count    *BoxedString `json:"count,omitempty"`
-	MaxCount *BoxedString `json:"maxCount,omitempty"`
-	// matrix of parameters to spawn instances
-	Matrix map[string]interface{} `json:"matrix,omitempty"`
-	// parameters that should be distributed across sharded instances
-	Shards map[string]interface{} `json:"shards,omitempty"`
 	// test name to schedule
 	Name string `json:"name,omitempty"`
 	// test execution description to display
 	Description      string                                       `json:"description,omitempty"`
+	Count            *BoxedString                                 `json:"count,omitempty"`
+	MaxCount         *BoxedString                                 `json:"maxCount,omitempty"`
 	ExecutionRequest *TestWorkflowStepExecuteTestExecutionRequest `json:"executionRequest,omitempty"`
 	Tarball          map[string]TestWorkflowTarballRequest        `json:"tarball,omitempty"`
+	// matrix of parameters to spawn instances
+	Matrix map[string]interface{} `json:"matrix,omitempty"`
+	// parameters that should be distributed across sharded instances
+	Shards map[string]interface{} `json:"shards,omitempty"`
 }

--- a/pkg/api/v1/testkube/model_test_workflow_step_execute_test_workflow_ref.go
+++ b/pkg/api/v1/testkube/model_test_workflow_step_execute_test_workflow_ref.go
@@ -10,12 +10,6 @@
 package testkube
 
 type TestWorkflowStepExecuteTestWorkflowRef struct {
-	Count    *BoxedString `json:"count,omitempty"`
-	MaxCount *BoxedString `json:"maxCount,omitempty"`
-	// matrix of parameters to spawn instances
-	Matrix map[string]interface{} `json:"matrix,omitempty"`
-	// parameters that should be distributed across sharded instances
-	Shards map[string]interface{} `json:"shards,omitempty"`
 	// TestWorkflow name to include
 	Name string `json:"name,omitempty"`
 	// TestWorkflow execution description to display
@@ -24,4 +18,10 @@ type TestWorkflowStepExecuteTestWorkflowRef struct {
 	ExecutionName string                                `json:"executionName,omitempty"`
 	Tarball       map[string]TestWorkflowTarballRequest `json:"tarball,omitempty"`
 	Config        map[string]string                     `json:"config,omitempty"`
+	Count         *BoxedString                          `json:"count,omitempty"`
+	MaxCount      *BoxedString                          `json:"maxCount,omitempty"`
+	// matrix of parameters to spawn instances
+	Matrix map[string]interface{} `json:"matrix,omitempty"`
+	// parameters that should be distributed across sharded instances
+	Shards map[string]interface{} `json:"shards,omitempty"`
 }

--- a/pkg/api/v1/testkube/model_test_workflow_step_parallel.go
+++ b/pkg/api/v1/testkube/model_test_workflow_step_parallel.go
@@ -28,12 +28,23 @@ type TestWorkflowStepParallel struct {
 	// delay before the step
 	Delay string `json:"delay,omitempty"`
 	// script to run in a default shell for the container
-	Shell     string                                 `json:"shell,omitempty"`
-	Run       *TestWorkflowStepRun                   `json:"run,omitempty"`
-	Execute   *TestWorkflowStepExecute               `json:"execute,omitempty"`
-	Artifacts *TestWorkflowStepArtifacts             `json:"artifacts,omitempty"`
+	Shell     string                     `json:"shell,omitempty"`
+	Run       *TestWorkflowStepRun       `json:"run,omitempty"`
+	Execute   *TestWorkflowStepExecute   `json:"execute,omitempty"`
+	Artifacts *TestWorkflowStepArtifacts `json:"artifacts,omitempty"`
+	// how many resources could be scheduled in parallel
+	Parallelism int32 `json:"parallelism,omitempty"`
+	// worker description to display
+	Description string       `json:"description,omitempty"`
+	Logs        *BoxedString `json:"logs,omitempty"`
+	// list of files to send to parallel steps
+	Transfer []TestWorkflowStepParallelTransfer `json:"transfer,omitempty"`
+	// list of files to fetch from parallel steps
+	Fetch     []TestWorkflowStepParallelFetch        `json:"fetch,omitempty"`
+	Template  *TestWorkflowTemplateRef               `json:"template,omitempty"`
 	Use       []TestWorkflowTemplateRef              `json:"use,omitempty"`
 	Config    map[string]TestWorkflowParameterSchema `json:"config,omitempty"`
+	System    *TestWorkflowSystem                    `json:"system,omitempty"`
 	Content   *TestWorkflowContent                   `json:"content,omitempty"`
 	Services  map[string]TestWorkflowServiceSpec     `json:"services,omitempty"`
 	Container *TestWorkflowContainerConfig           `json:"container,omitempty"`
@@ -43,14 +54,4 @@ type TestWorkflowStepParallel struct {
 	Steps     []TestWorkflowStep                     `json:"steps,omitempty"`
 	After     []TestWorkflowStep                     `json:"after,omitempty"`
 	Events    []TestWorkflowEvent                    `json:"events,omitempty"`
-	// how many resources could be scheduled in parallel
-	Parallelism int32 `json:"parallelism,omitempty"`
-	// worker description to display
-	Description string       `json:"description,omitempty"`
-	Logs        *BoxedString `json:"logs,omitempty"`
-	// list of files to send to parallel steps
-	Transfer []TestWorkflowStepParallelTransfer `json:"transfer,omitempty"`
-	// list of files to fetch from parallel steps
-	Fetch    []TestWorkflowStepParallelFetch `json:"fetch,omitempty"`
-	Template *TestWorkflowTemplateRef        `json:"template,omitempty"`
 }

--- a/pkg/api/v1/testkube/model_test_workflow_template_spec.go
+++ b/pkg/api/v1/testkube/model_test_workflow_template_spec.go
@@ -11,6 +11,7 @@ package testkube
 
 type TestWorkflowTemplateSpec struct {
 	Config    map[string]TestWorkflowParameterSchema        `json:"config,omitempty"`
+	System    *TestWorkflowSystem                           `json:"system,omitempty"`
 	Content   *TestWorkflowContent                          `json:"content,omitempty"`
 	Services  map[string]TestWorkflowIndependentServiceSpec `json:"services,omitempty"`
 	Container *TestWorkflowContainerConfig                  `json:"container,omitempty"`

--- a/pkg/mapper/testworkflows/kube_openapi.go
+++ b/pkg/mapper/testworkflows/kube_openapi.go
@@ -867,6 +867,7 @@ func MapStepParallelKubeToAPI(v testworkflowsv1.StepParallel) testkube.TestWorkf
 		Fetch:       common.MapSlice(v.Fetch, MapStepParallelFetchKubeToAPI),
 		Use:         common.MapSlice(v.Use, MapTemplateRefKubeToAPI),
 		Config:      common.MapMap(v.Config, MapParameterSchemaKubeToAPI),
+		System:      common.MapPtr(v.System, MapSystemKubeToAPI),
 		Content:     common.MapPtr(v.Content, MapContentKubeToAPI),
 		Container:   common.MapPtr(v.Container, MapContainerConfigKubeToAPI),
 		Job:         common.MapPtr(v.Job, MapJobConfigKubeToAPI),
@@ -900,6 +901,7 @@ func MapIndependentStepParallelKubeToAPI(v testworkflowsv1.IndependentStepParall
 		Transfer:    common.MapSlice(v.Transfer, MapStepParallelTransferKubeToAPI),
 		Fetch:       common.MapSlice(v.Fetch, MapStepParallelFetchKubeToAPI),
 		Config:      common.MapMap(v.Config, MapParameterSchemaKubeToAPI),
+		System:      common.MapPtr(v.System, MapSystemKubeToAPI),
 		Content:     common.MapPtr(v.Content, MapContentKubeToAPI),
 		Container:   common.MapPtr(v.Container, MapContainerConfigKubeToAPI),
 		Job:         common.MapPtr(v.Job, MapJobConfigKubeToAPI),
@@ -1036,6 +1038,7 @@ func MapStepKubeToAPI(v testworkflowsv1.Step) testkube.TestWorkflowStep {
 		Paused:     v.Paused,
 		Negative:   v.Negative,
 		Optional:   v.Optional,
+		Pure:       MapBoolToBoxedBoolean(v.Pure),
 		Use:        common.MapSlice(v.Use, MapTemplateRefKubeToAPI),
 		Template:   common.MapPtr(v.Template, MapTemplateRefKubeToAPI),
 		Retry:      common.MapPtr(v.Retry, MapRetryPolicyKubeToAPI),
@@ -1062,6 +1065,7 @@ func MapIndependentStepKubeToAPI(v testworkflowsv1.IndependentStep) testkube.Tes
 		Paused:     v.Paused,
 		Negative:   v.Negative,
 		Optional:   v.Optional,
+		Pure:       MapBoolToBoxedBoolean(v.Pure),
 		Retry:      common.MapPtr(v.Retry, MapRetryPolicyKubeToAPI),
 		Timeout:    v.Timeout,
 		Delay:      v.Delay,
@@ -1079,10 +1083,18 @@ func MapIndependentStepKubeToAPI(v testworkflowsv1.IndependentStep) testkube.Tes
 	}
 }
 
+func MapSystemKubeToAPI(v testworkflowsv1.TestWorkflowSystem) testkube.TestWorkflowSystem {
+	return testkube.TestWorkflowSystem{
+		PureByDefault:      v.PureByDefault,
+		IsolatedContainers: v.IsolatedContainers,
+	}
+}
+
 func MapSpecKubeToAPI(v testworkflowsv1.TestWorkflowSpec) testkube.TestWorkflowSpec {
 	return testkube.TestWorkflowSpec{
 		Use:       common.MapSlice(v.Use, MapTemplateRefKubeToAPI),
 		Config:    common.MapMap(v.Config, MapParameterSchemaKubeToAPI),
+		System:    common.MapPtr(v.System, MapSystemKubeToAPI),
 		Content:   common.MapPtr(v.Content, MapContentKubeToAPI),
 		Services:  common.MapMap(v.Services, MapServiceSpecKubeToAPI),
 		Container: common.MapPtr(v.Container, MapContainerConfigKubeToAPI),
@@ -1098,6 +1110,7 @@ func MapSpecKubeToAPI(v testworkflowsv1.TestWorkflowSpec) testkube.TestWorkflowS
 func MapTemplateSpecKubeToAPI(v testworkflowsv1.TestWorkflowTemplateSpec) testkube.TestWorkflowTemplateSpec {
 	return testkube.TestWorkflowTemplateSpec{
 		Config:    common.MapMap(v.Config, MapParameterSchemaKubeToAPI),
+		System:    common.MapPtr(v.System, MapSystemKubeToAPI),
 		Content:   common.MapPtr(v.Content, MapContentKubeToAPI),
 		Container: common.MapPtr(v.Container, MapContainerConfigKubeToAPI),
 		Job:       common.MapPtr(v.Job, MapJobConfigKubeToAPI),

--- a/pkg/mapper/testworkflows/openapi_kube.go
+++ b/pkg/mapper/testworkflows/openapi_kube.go
@@ -909,6 +909,7 @@ func MapStepParallelAPIToKube(v testkube.TestWorkflowStepParallel) testworkflows
 		TestWorkflowSpec: testworkflowsv1.TestWorkflowSpec{
 			TestWorkflowSpecBase: testworkflowsv1.TestWorkflowSpecBase{
 				Config:    common.MapMap(v.Config, MapParameterSchemaAPIToKube),
+				System:    common.MapPtr(v.System, MapSystemAPIToKube),
 				Content:   common.MapPtr(v.Content, MapContentAPIToKube),
 				Container: common.MapPtr(v.Container, MapContainerConfigAPIToKube),
 				Job:       common.MapPtr(v.Job, MapJobConfigAPIToKube),
@@ -953,6 +954,7 @@ func MapIndependentStepParallelAPIToKube(v testkube.TestWorkflowIndependentStepP
 		TestWorkflowTemplateSpec: testworkflowsv1.TestWorkflowTemplateSpec{
 			TestWorkflowSpecBase: testworkflowsv1.TestWorkflowSpecBase{
 				Config:    common.MapMap(v.Config, MapParameterSchemaAPIToKube),
+				System:    common.MapPtr(v.System, MapSystemAPIToKube),
 				Content:   common.MapPtr(v.Content, MapContentAPIToKube),
 				Container: common.MapPtr(v.Container, MapContainerConfigAPIToKube),
 				Job:       common.MapPtr(v.Job, MapJobConfigAPIToKube),
@@ -1109,6 +1111,7 @@ func MapStepAPIToKube(v testkube.TestWorkflowStep) testworkflowsv1.Step {
 		StepMeta: testworkflowsv1.StepMeta{
 			Name:      v.Name,
 			Condition: v.Condition,
+			Pure:      MapBoxedBooleanToBool(v.Pure),
 		},
 		StepControl: testworkflowsv1.StepControl{
 			Paused:   v.Paused,
@@ -1145,6 +1148,7 @@ func MapIndependentStepAPIToKube(v testkube.TestWorkflowIndependentStep) testwor
 		StepMeta: testworkflowsv1.StepMeta{
 			Name:      v.Name,
 			Condition: v.Condition,
+			Pure:      MapBoxedBooleanToBool(v.Pure),
 		},
 		StepControl: testworkflowsv1.StepControl{
 			Paused:   v.Paused,
@@ -1174,10 +1178,18 @@ func MapIndependentStepAPIToKube(v testkube.TestWorkflowIndependentStep) testwor
 	}
 }
 
+func MapSystemAPIToKube(v testkube.TestWorkflowSystem) testworkflowsv1.TestWorkflowSystem {
+	return testworkflowsv1.TestWorkflowSystem{
+		PureByDefault:      v.PureByDefault,
+		IsolatedContainers: v.IsolatedContainers,
+	}
+}
+
 func MapSpecAPIToKube(v testkube.TestWorkflowSpec) testworkflowsv1.TestWorkflowSpec {
 	return testworkflowsv1.TestWorkflowSpec{
 		TestWorkflowSpecBase: testworkflowsv1.TestWorkflowSpecBase{
 			Config:    common.MapMap(v.Config, MapParameterSchemaAPIToKube),
+			System:    common.MapPtr(v.System, MapSystemAPIToKube),
 			Content:   common.MapPtr(v.Content, MapContentAPIToKube),
 			Container: common.MapPtr(v.Container, MapContainerConfigAPIToKube),
 			Job:       common.MapPtr(v.Job, MapJobConfigAPIToKube),
@@ -1196,6 +1208,7 @@ func MapTemplateSpecAPIToKube(v testkube.TestWorkflowTemplateSpec) testworkflows
 	return testworkflowsv1.TestWorkflowTemplateSpec{
 		TestWorkflowSpecBase: testworkflowsv1.TestWorkflowSpecBase{
 			Config:    common.MapMap(v.Config, MapParameterSchemaAPIToKube),
+			System:    common.MapPtr(v.System, MapSystemAPIToKube),
 			Content:   common.MapPtr(v.Content, MapContentAPIToKube),
 			Container: common.MapPtr(v.Container, MapContainerConfigAPIToKube),
 			Job:       common.MapPtr(v.Job, MapJobConfigAPIToKube),

--- a/pkg/testworkflows/testworkflowprocessor/action/finalize.go
+++ b/pkg/testworkflows/testworkflowprocessor/action/finalize.go
@@ -6,7 +6,7 @@ import (
 	"github.com/kubeshop/testkube/pkg/testworkflows/testworkflowprocessor/constants"
 )
 
-func Finalize(groups actiontypes.ActionGroups) actiontypes.ActionGroups {
+func Finalize(groups actiontypes.ActionGroups, isolatedContainers bool) actiontypes.ActionGroups {
 	if len(groups) == 0 {
 		return actiontypes.ActionGroups{{{Setup: &lite.ActionSetup{
 			CopyInit:     false,
@@ -49,27 +49,29 @@ func Finalize(groups actiontypes.ActionGroups) actiontypes.ActionGroups {
 	}
 
 	// Determine if the setup step can be combined with the further group
-	canMergeSetup := true
+	canMergeSetup := !isolatedContainers
 	maybeCopyToolkit := false
-	for i := range groups[0] {
-		// Ignore non-transition actions
-		if groups[0][i].Type() != lite.ActionTypeContainerTransition {
-			continue
-		}
+	if canMergeSetup {
+		for i := range groups[0] {
+			// Ignore non-transition actions
+			if groups[0][i].Type() != lite.ActionTypeContainerTransition {
+				continue
+			}
 
-		// Disallow merging setup step for custom images
-		if groups[0][i].Container.Config.Image != constants.DefaultInitImage && groups[0][i].Container.Config.Image != constants.DefaultToolkitImage {
-			canMergeSetup = false
-			break
-		}
+			// Disallow merging setup step for custom images
+			if groups[0][i].Container.Config.Image != constants.DefaultInitImage && groups[0][i].Container.Config.Image != constants.DefaultToolkitImage {
+				canMergeSetup = false
+				break
+			}
 
-		// Allow merging setup step with toolkit image
-		if groups[0][i].Container.Config.Image == constants.DefaultToolkitImage {
-			maybeCopyToolkit = true
+			// Allow merging setup step with toolkit image
+			if groups[0][i].Container.Config.Image == constants.DefaultToolkitImage {
+				maybeCopyToolkit = true
+			}
 		}
-	}
-	if maybeCopyToolkit && canMergeSetup {
-		copyToolkit = true
+		if maybeCopyToolkit && canMergeSetup {
+			copyToolkit = true
+		}
 	}
 
 	// Avoid using /.tktw/toolkit when the toolkit is not copied

--- a/pkg/testworkflows/testworkflowprocessor/action/group.go
+++ b/pkg/testworkflows/testworkflowprocessor/action/group.go
@@ -62,7 +62,7 @@ func getContainerConfigs(actions actiontypes.ActionList) (configs []testworkflow
 	return
 }
 
-func Group(actions actiontypes.ActionList) (groups actiontypes.ActionGroups) {
+func Group(actions actiontypes.ActionList, isolatedContainers bool) (groups actiontypes.ActionGroups) {
 	// Detect "start" and "execute" instructions
 	startIndexes := make([]int, 0)
 	startInstructions := make(map[string]int)
@@ -110,6 +110,11 @@ func Group(actions actiontypes.ActionList) (groups actiontypes.ActionGroups) {
 	}
 	if len(actions) > 0 {
 		groups[0] = append(actions, groups[0]...)
+	}
+
+	// Do not try merging the containers
+	if isolatedContainers {
+		return groups
 	}
 
 	// Combine multiple operations in a single container if it's possible

--- a/pkg/testworkflows/testworkflowprocessor/action/group_test.go
+++ b/pkg/testworkflows/testworkflowprocessor/action/group_test.go
@@ -54,6 +54,6 @@ func TestGroup_Basic(t *testing.T) {
 		input[12:17],                 // ends before containerConfig("step3")
 		input[17:],
 	}
-	got := Finalize(Group(input))
+	got := Finalize(Group(input, false), false)
 	assert.Equal(t, want, got)
 }

--- a/pkg/testworkflows/testworkflowprocessor/action/process.go
+++ b/pkg/testworkflows/testworkflowprocessor/action/process.go
@@ -13,7 +13,7 @@ import (
 	stage2 "github.com/kubeshop/testkube/pkg/testworkflows/testworkflowprocessor/stage"
 )
 
-func process(currentStatus string, parents []string, stage stage2.Stage, machines ...expressions.Machine) (actions actiontypes.ActionList, err error) {
+func process(currentStatus string, parents []string, stage stage2.Stage, inheritedPure *bool, machines ...expressions.Machine) (actions actiontypes.ActionList, err error) {
 	// Store the init status
 	actions = append(actions, actiontypes.Action{
 		CurrentStatus: common.Ptr(currentStatus),
@@ -74,12 +74,17 @@ func process(currentStatus string, parents []string, stage stage2.Stage, machine
 
 	// Handle executable action
 	if exec, ok := stage.(stage2.ContainerStage); ok {
+		toolkit := exec.IsToolkit()
+		pure := exec.Pure()
+		if !toolkit && !pure && inheritedPure != nil {
+			pure = *inheritedPure
+		}
 		actions = append(actions, actiontypes.Action{
 			Execute: &lite.ActionExecute{
 				Ref:      exec.Ref(),
 				Negative: exec.Negative(),
-				Toolkit:  exec.IsToolkit(),
-				Pure:     exec.Pure(),
+				Toolkit:  toolkit,
+				Pure:     pure,
 			},
 		})
 	}
@@ -94,10 +99,15 @@ func process(currentStatus string, parents []string, stage stage2.Stage, machine
 		}
 		parents = append(parents, group.Ref())
 
+		// Adjust the inherited purity
+		if group.Pure() != nil {
+			inheritedPure = group.Pure()
+		}
+
 		// Handle children
 		refs := make([]string, 0)
 		for _, ch := range group.Children() {
-			sub, err := process(currentStatus, parents, ch, machines...)
+			sub, err := process(currentStatus, parents, ch, inheritedPure, machines...)
 			if err != nil {
 				return nil, errors.Wrap(err, "processing group children")
 			}
@@ -133,8 +143,8 @@ func process(currentStatus string, parents []string, stage stage2.Stage, machine
 	return
 }
 
-func Process(root stage2.Stage, machines ...expressions.Machine) (actiontypes.ActionList, error) {
-	actions, err := process("true", nil, root, machines...)
+func Process(root stage2.Stage, inheritedPure *bool, machines ...expressions.Machine) (actiontypes.ActionList, error) {
+	actions, err := process("true", nil, root, inheritedPure, machines...)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/testworkflows/testworkflowprocessor/action/process_test.go
+++ b/pkg/testworkflows/testworkflowprocessor/action/process_test.go
@@ -58,7 +58,7 @@ func TestProcess_BasicSteps(t *testing.T) {
 		End("")
 
 	// Assert
-	got, err := Process(root)
+	got, err := Process(root, nil)
 	assert.NoError(t, err)
 	assert.Equal(t, want, got)
 }
@@ -145,7 +145,7 @@ func TestProcess_Grouping(t *testing.T) {
 		End("")
 
 	// Assert
-	got, err := Process(root)
+	got, err := Process(root, nil)
 	assert.NoError(t, err)
 	assert.Equal(t, want, got)
 }
@@ -202,7 +202,7 @@ func TestProcess_Pause(t *testing.T) {
 		End("")
 
 	// Assert
-	got, err := Process(root)
+	got, err := Process(root, nil)
 	assert.NoError(t, err)
 	assert.Equal(t, want, got)
 }
@@ -256,7 +256,7 @@ func TestProcess_NegativeStep(t *testing.T) {
 		End("")
 
 	// Assert
-	got, err := Process(root)
+	got, err := Process(root, nil)
 	assert.NoError(t, err)
 	assert.Equal(t, want, got)
 }
@@ -309,7 +309,7 @@ func TestProcess_NegativeGroup(t *testing.T) {
 		End("")
 
 	// Assert
-	got, err := Process(root)
+	got, err := Process(root, nil)
 	assert.NoError(t, err)
 	assert.Equal(t, want, got)
 }
@@ -363,7 +363,7 @@ func TestProcess_OptionalStep(t *testing.T) {
 		End("")
 
 	// Assert
-	got, err := Process(root)
+	got, err := Process(root, nil)
 	assert.NoError(t, err)
 	assert.Equal(t, want, got)
 }
@@ -423,7 +423,7 @@ func TestProcess_OptionalGroup(t *testing.T) {
 		End("")
 
 	// Assert
-	got, err := Process(root)
+	got, err := Process(root, nil)
 	assert.NoError(t, err)
 	assert.Equal(t, want, got)
 }
@@ -472,7 +472,7 @@ func TestProcess_IgnoreExecutionOfStaticSkip(t *testing.T) {
 		End("")
 
 	// Assert
-	got, err := Process(root)
+	got, err := Process(root, nil)
 	assert.NoError(t, err)
 	assert.Equal(t, want, got)
 }
@@ -514,7 +514,7 @@ func TestProcess_IgnoreExecutionOfStaticSkipGroup(t *testing.T) {
 		End("")
 
 	// Assert
-	got, err := Process(root)
+	got, err := Process(root, nil)
 	assert.NoError(t, err)
 	assert.Equal(t, want, got)
 }
@@ -559,7 +559,7 @@ func TestProcess_IgnoreExecutionOfStaticSkipGroup_Pause(t *testing.T) {
 		End("")
 
 	// Assert
-	got, err := Process(root)
+	got, err := Process(root, nil)
 	assert.NoError(t, err)
 	assert.Equal(t, want, got)
 }
@@ -612,7 +612,7 @@ func TestProcess_IgnoreExecutionOfStaticSkip_PauseGroup(t *testing.T) {
 		End("")
 
 	// Assert
-	got, err := Process(root)
+	got, err := Process(root, nil)
 	assert.NoError(t, err)
 	assert.Equal(t, want, got)
 }

--- a/pkg/testworkflows/testworkflowprocessor/stage/containerstage.go
+++ b/pkg/testworkflows/testworkflowprocessor/stage/containerstage.go
@@ -34,7 +34,7 @@ type ContainerStage interface {
 	IsToolkit() bool
 
 	SetPure(pure bool) ContainerStage
-	Pure() bool // TODO: Consider purity level?
+	Pure() bool
 }
 
 func NewContainerStage(ref string, container Container) ContainerStage {

--- a/pkg/testworkflows/testworkflowresolver/apply.go
+++ b/pkg/testworkflows/testworkflowresolver/apply.go
@@ -64,6 +64,7 @@ func injectTemplateToSpec(spec *testworkflowsv1.TestWorkflowSpec, template testw
 	spec.Content = MergeContent(template.Spec.Content, spec.Content)
 	spec.Services = MergeMap(common.MapMap(template.Spec.Services, ConvertIndependentServiceToService), spec.Services)
 	spec.Container = MergeContainerConfig(template.Spec.Container, spec.Container)
+	spec.System = MergeSystem(template.Spec.System, spec.System)
 
 	// Include the steps from the template
 	setup := common.MapSlice(template.Spec.Setup, ConvertIndependentStepToStep)
@@ -91,6 +92,11 @@ func InjectStepTemplate(step *testworkflowsv1.Step, template testworkflowsv1.Tes
 	step.Content = MergeContent(template.Spec.Content, step.Content)
 	step.Services = MergeMap(common.MapMap(template.Spec.Services, ConvertIndependentServiceToService), step.Services)
 	step.Container = MergeContainerConfig(template.Spec.Container, step.Container)
+
+	// Define the step purity
+	if step.Pure != nil && template.Spec.System != nil && template.Spec.System.PureByDefault && !template.Spec.System.IsolatedContainers {
+		step.Pure = common.Ptr(true)
+	}
 
 	// Fast-track when the template doesn't contain any steps to run
 	if len(template.Spec.Setup) == 0 && len(template.Spec.Steps) == 0 && len(template.Spec.After) == 0 {

--- a/pkg/testworkflows/testworkflowresolver/merge.go
+++ b/pkg/testworkflows/testworkflowresolver/merge.go
@@ -301,6 +301,17 @@ func MergeResources(dst, include *testworkflowsv1.Resources) *testworkflowsv1.Re
 	return dst
 }
 
+func MergeSystem(dst, include *testworkflowsv1.TestWorkflowSystem) *testworkflowsv1.TestWorkflowSystem {
+	if dst == nil {
+		return include
+	} else if include == nil {
+		return dst
+	}
+	dst.IsolatedContainers = dst.IsolatedContainers || include.IsolatedContainers
+	dst.PureByDefault = dst.PureByDefault || include.PureByDefault
+	return dst
+}
+
 func MergeContainerConfig(dst, include *testworkflowsv1.ContainerConfig) *testworkflowsv1.ContainerConfig {
 	if dst == nil {
 		return include


### PR DESCRIPTION
## Pull request description 

As per https://github.com/kubeshop/testkube-operator/pull/293:

* add `system.pureByDefault`
   * make everything pure by default; may be useful as a Global Template
* add `system.isolatedContainers`
   * to opt-out from the new mechanics of merging the operations within containers
* add `pure` on the step level
   * to allow configuring "purity" for specific steps

## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [x] tested locally
- [x] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Fixes

- https://linear.app/kubeshop/issue/TKC-2372/workflows-istio-support-phase-2