### PR TITLE
fix: avoid readable message for EvictionByEvictionAPI

### DIFF
--- a/pkg/testworkflows/testworkflowcontroller/podstate.go
+++ b/pkg/testworkflows/testworkflowcontroller/podstate.go
@@ -353,9 +353,7 @@ func (p *podState) containerResult(name string) (ContainerResult, error) {
 			result := UnknownContainerResult
 			for _, c := range p.pod.Status.Conditions {
 				if c.Type == corev1.DisruptionTarget && c.Status == corev1.ConditionTrue {
-					if c.Reason == "EvictionByEvictionAPI" {
-						result.Details = "Pod has been requested for deletion using the Kubernetes API"
-					} else if c.Message == "" {
+					if c.Message == "" {
 						result.Details = c.Reason
 					} else {
 						result.Details = fmt.Sprintf("%s: %s", c.Reason, c.Message)


### PR DESCRIPTION
## Pull request description 

* it's saying that the Pod has been requested for deletion by Kubernetes API, but seems like there are edge cases when situation is different
* googling it is enough for User for now

## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [x] tested locally
- [x] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
