### PR TITLE
fix: properly detect OOMKilled error on GKE

### DIFF
--- a/cmd/testworkflow-init/orchestration/executions.go
+++ b/cmd/testworkflow-init/orchestration/executions.go
@@ -167,17 +167,18 @@ func (e *execution) Run() (*executionResult, error) {
 
 	// Initialize local state
 	var exitCode uint8
+	var aborted bool
 
 	// Run the command
 	err := e.cmd.Start()
 	if err == nil {
 		e.group.pauseMu.Unlock()
 		e.cmdMu.Unlock()
-		_, exitCode = getProcessStatus(e.cmd.Wait())
+		aborted, exitCode = getProcessStatus(e.cmd.Wait())
 	} else {
 		e.group.pauseMu.Unlock()
 		e.cmdMu.Unlock()
-		_, exitCode = getProcessStatus(err)
+		aborted, exitCode = getProcessStatus(err)
 		e.cmd.Stderr.Write(append([]byte(err.Error()), '\n'))
 	}
 
@@ -185,6 +186,12 @@ func (e *execution) Run() (*executionResult, error) {
 	e.cmdMu.Lock()
 	e.cmd = nil
 	e.cmdMu.Unlock()
+
+	// Mark the execution group as aborted when this process was aborted.
+	// In Kubernetes, when that child process is killed, it may mean OOM Kill.
+	if aborted && !e.group.aborted.Load() {
+		e.group.Abort()
+	}
 
 	// Fail when aborted
 	if e.group.aborted.Load() {
@@ -196,11 +203,11 @@ func (e *execution) Run() (*executionResult, error) {
 
 func getProcessStatus(err error) (bool, uint8) {
 	if err == nil {
-		return true, 0
+		return false, 0
 	}
 	if e, ok := err.(*exec.ExitError); ok {
 		if e.ProcessState != nil {
-			return false, uint8(e.ProcessState.ExitCode())
+			return e.ProcessState.String() == "signal: killed", uint8(e.ProcessState.ExitCode())
 		}
 		return false, 1
 	}


### PR DESCRIPTION
## Pull request description 

* detect Killed Process/Container based on Killed Child Processes
   * GKE for some reason is not signaling nor killing the Init Process
* avoid reading step statuses from termination log in case of abort
   * Automated heuristics in that case are better

## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [x] tested locally
- [x] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
