### PR TITLE
fix: propagate aborted status correctly on GKE's OOMKilled

### DIFF
--- a/pkg/testworkflows/testworkflowcontroller/logs.go
+++ b/pkg/testworkflows/testworkflowcontroller/logs.go
@@ -88,6 +88,9 @@ func getContainerLogsStream(ctx context.Context, clientSet kubernetes.Interface,
 			if !strings.Contains(err.Error(), "is waiting to start") {
 				return nil, err
 			}
+			if !follow {
+				return bytes.NewReader(nil), io.EOF
+			}
 			p := <-pod.Peek(ctx)
 			if p == nil {
 				return bytes.NewReader(nil), io.EOF


### PR DESCRIPTION
## Pull request description 



## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [x] tested locally
- [x] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Breaking changes

-

## Changes

-

## Fixes

-