### PR TITLE
fix: ensure there is a service IP available before marking as started

### DIFF
--- a/cmd/tcl/testworkflow-toolkit/commands/services.go
+++ b/cmd/tcl/testworkflow-toolkit/commands/services.go
@@ -334,7 +334,7 @@ func NewServicesCmd() *cobra.Command {
 						instructions.PrintOutput(env.Ref(), "service", info)
 					}
 
-					if v.Current == mainRef {
+					if v.Current == mainRef && state[instance.Name][index].Ip != "" {
 						started = true
 						if instance.ReadinessProbe == nil {
 							log("container started")


### PR DESCRIPTION
## Pull request description 

* There was a race condition, where the container may be marked as started, while pod has not registered yet its IP in Testkube

## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [x] tested locally
- [x] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
