### PR TITLE
fix: register all mounted directories for the artifacts scrapping

### DIFF
--- a/pkg/testworkflows/testworkflowprocessor/operations.go
+++ b/pkg/testworkflows/testworkflowprocessor/operations.go
@@ -3,6 +3,7 @@ package testworkflowprocessor
 import (
 	"fmt"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/pkg/errors"
@@ -296,10 +297,18 @@ func ProcessArtifacts(_ InternalProcessor, layer Intermediate, container stage.C
 	// Allow to combine it within other containers
 	stage.SetPure(true)
 
+	cmd := []string{constants.DefaultToolkitPath, "artifacts"}
+	for _, mount := range container.VolumeMounts() {
+		if mount.MountPath == constants.DefaultInternalPath {
+			continue
+		}
+		cmd = append(cmd, "-m", strings.TrimRight(mount.MountPath, `/\`))
+	}
+
 	selfContainer.
 		SetImage(constants.DefaultToolkitImage).
 		SetImagePullPolicy(corev1.PullIfNotPresent).
-		SetCommand(constants.DefaultToolkitPath, "artifacts", "-m", constants.DefaultDataPath).
+		SetCommand(cmd...).
 		EnableToolkit(stage.Ref())
 
 	args := make([]string, 0)


### PR DESCRIPTION
## Pull request description 

* allow fetching artifacts from all mounted volumes, not only `/data`

## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [x] tested locally
- [x] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
