### PR TITLE
fix: correctly handle consecutive condition: always steps

### DIFF
--- a/pkg/testworkflows/testworkflowprocessor/processor.go
+++ b/pkg/testworkflows/testworkflowprocessor/processor.go
@@ -74,7 +74,12 @@ func (p *processor) process(layer Intermediate, container stage.Container, step 
 		if err != nil {
 			return nil, err
 		}
-		self.Add(stage)
+		if stage != nil {
+			if step.Condition != "" {
+				stage.SetCondition(step.Condition)
+			}
+			self.Add(stage)
+		}
 	}
 
 	// Add virtual pause step in case no other is there


### PR DESCRIPTION
## Pull request description 

Test Workflows like:

```yaml
kind: TestWorkflow
apiVersion: testworkflows.testkube.io/v1
metadata:
  name: demo-consecutive-always
spec:
  steps:
  - condition: always
    shell: echo hello
  - condition: always
    shell: exit 1
  - condition: always
    shell: echo hello
```

were not running the `condition: always` steps in case they are after failure

## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [x] tested locally
- [x] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [x] added a test