### PR TITLE
fix: support git@github.com:kubeshop/testkube.git syntax support for cloning repositories

### DIFF
--- a/cmd/testworkflow-toolkit/commands/clone.go
+++ b/cmd/testworkflow-toolkit/commands/clone.go
@@ -5,6 +5,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 
 	"github.com/kballard/go-shellquote"
@@ -13,6 +14,10 @@ import (
 
 	"github.com/kubeshop/testkube/pkg/testworkflows/testworkflowprocessor/constants"
 	"github.com/kubeshop/testkube/pkg/ui"
+)
+
+var (
+	protocolRe = regexp.MustCompile(`^[^:]+://`)
 )
 
 func NewCloneCmd() *cobra.Command {
@@ -31,6 +36,10 @@ func NewCloneCmd() *cobra.Command {
 		Args:  cobra.ExactArgs(2),
 
 		Run: func(cmd *cobra.Command, args []string) {
+			// Append SSH protocol if there is missing one and it looks like that (git@github.com:kubeshop/testkube.git)
+			if !protocolRe.MatchString(args[0]) && strings.ContainsRune(args[0], ':') && !strings.ContainsRune(args[0], '\\') {
+				args[0] = "ssh://" + strings.Replace(args[0], ":", "/", 1)
+			}
 			uri, err := url.Parse(args[0])
 			ui.ExitOnError("repository uri", err)
 			destinationPath, err := filepath.Abs(args[1])


### PR DESCRIPTION
## Pull request description 

* Added support for `git@github.com:kubeshop/testkube.git` syntax (by converting it to SSH protocol)

## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [x] tested locally
- [x] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test