### PR TITLE
fix: keep the execution ID for getting next one

### DIFF
--- a/cmd/tcl/testworkflow-toolkit/commands/execute.go
+++ b/cmd/tcl/testworkflow-toolkit/commands/execute.go
@@ -209,8 +209,10 @@ func buildWorkflowExecution(workflow testworkflowsv1.StepExecuteWorkflow, async 
 		for {
 			time.Sleep(100 * time.Millisecond)
 			for i := 0; i < GetExecutionRetryOnFailureMaxAttempts; i++ {
-				exec, err = c.GetTestWorkflowExecution(exec.Id)
+				var nextExec testkube.TestWorkflowExecution
+				nextExec, err = c.GetTestWorkflowExecution(exec.Id)
 				if err == nil {
+					exec = nextExec
 					break
 				}
 				if i+1 < GetExecutionRetryOnFailureMaxAttempts {


### PR DESCRIPTION
## Pull request description 

* `exec` was cleared, so `exec.Id` was not pointing to the execution

## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [x] tested locally
- [x] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
