### PR TITLE
fix: obfuscate secret() calls, resolve sensitive config

### DIFF
--- a/cmd/testworkflow-init/constants/commands.go
+++ b/cmd/testworkflow-init/constants/commands.go
@@ -3,6 +3,7 @@ package constants
 const (
 	EnvGroupActions = "01"
 	EnvGroupDebug   = "00"
+	EnvGroupSecrets = "02"
 
 	EnvNodeName           = "TKI_N"
 	EnvPodName            = "TKI_P"

--- a/cmd/testworkflow-init/orchestration/setup.go
+++ b/cmd/testworkflow-init/orchestration/setup.go
@@ -16,8 +16,12 @@ import (
 	"github.com/kubeshop/testkube/pkg/testworkflows/testworkflowprocessor/action/actiontypes/lite"
 )
 
+const (
+	GlobalSecretGroup = "02"
+)
+
 var (
-	scopedRegex              = regexp.MustCompile(`^_(00|01|\d|[1-9]\d*)(C)?(S?)_`)
+	scopedRegex              = regexp.MustCompile(`^_(00|01|02|\d|[1-9]\d*)(C)?(S?)_`)
 	Setup                    = newSetup()
 	defaultWorkingDir        = getWorkingDir()
 	commonSensitiveVariables = []string{
@@ -130,6 +134,16 @@ func (c *setup) GetSensitiveWords() []string {
 			words = append(words, value)
 		}
 	}
+	// TODO: Avoid adding the secrets to all the groups without isolation
+	for k := range c.envGroups[GlobalSecretGroup] {
+		value := os.Getenv(k)
+		if len(value) < c.minSensitiveWordLength {
+			continue
+		}
+		if _, ok := c.envGroupsSensitive[GlobalSecretGroup][k]; ok {
+			words = append(words, value)
+		}
+	}
 	return words
 }
 
@@ -153,6 +167,15 @@ func (c *setup) UseEnv(group string) {
 	envResolutions := map[string]expressions.Expression{}
 	for k, v := range c.envGroups[group] {
 		if _, ok := c.envGroupsComputed[group][k]; ok {
+			envTemplates[k] = v
+		} else {
+			os.Setenv(k, v)
+		}
+	}
+
+	// TODO: Avoid adding the secrets to all the groups without isolation
+	for k, v := range c.envGroups[GlobalSecretGroup] {
+		if _, ok := c.envGroupsComputed[GlobalSecretGroup][k]; ok {
 			envTemplates[k] = v
 		} else {
 			os.Setenv(k, v)

--- a/cmd/testworkflow-init/orchestration/setup.go
+++ b/cmd/testworkflow-init/orchestration/setup.go
@@ -130,7 +130,7 @@ func (c *setup) GetSensitiveWords() []string {
 			words = append(words, value)
 		}
 	}
-	// TODO: Avoid adding the secrets to all the groups without isolation
+	// TODO(TKC-2585): Avoid adding the secrets to all the groups without isolation
 	for k := range c.envGroups[constants.EnvGroupSecrets] {
 		value := os.Getenv(k)
 		if len(value) < c.minSensitiveWordLength {
@@ -169,7 +169,7 @@ func (c *setup) UseEnv(group string) {
 		}
 	}
 
-	// TODO: Avoid adding the secrets to all the groups without isolation
+	// TODO(TKC-2585): Avoid adding the secrets to all the groups without isolation
 	for k, v := range c.envGroups[constants.EnvGroupSecrets] {
 		if _, ok := c.envGroupsComputed[constants.EnvGroupSecrets][k]; ok {
 			envTemplates[k] = v

--- a/cmd/testworkflow-init/orchestration/setup.go
+++ b/cmd/testworkflow-init/orchestration/setup.go
@@ -16,10 +16,6 @@ import (
 	"github.com/kubeshop/testkube/pkg/testworkflows/testworkflowprocessor/action/actiontypes/lite"
 )
 
-const (
-	GlobalSecretGroup = "02"
-)
-
 var (
 	scopedRegex              = regexp.MustCompile(`^_(00|01|02|\d|[1-9]\d*)(C)?(S?)_`)
 	Setup                    = newSetup()
@@ -135,12 +131,12 @@ func (c *setup) GetSensitiveWords() []string {
 		}
 	}
 	// TODO: Avoid adding the secrets to all the groups without isolation
-	for k := range c.envGroups[GlobalSecretGroup] {
+	for k := range c.envGroups[constants.EnvGroupSecrets] {
 		value := os.Getenv(k)
 		if len(value) < c.minSensitiveWordLength {
 			continue
 		}
-		if _, ok := c.envGroupsSensitive[GlobalSecretGroup][k]; ok {
+		if _, ok := c.envGroupsSensitive[constants.EnvGroupSecrets][k]; ok {
 			words = append(words, value)
 		}
 	}
@@ -174,8 +170,8 @@ func (c *setup) UseEnv(group string) {
 	}
 
 	// TODO: Avoid adding the secrets to all the groups without isolation
-	for k, v := range c.envGroups[GlobalSecretGroup] {
-		if _, ok := c.envGroupsComputed[GlobalSecretGroup][k]; ok {
+	for k, v := range c.envGroups[constants.EnvGroupSecrets] {
+		if _, ok := c.envGroupsComputed[constants.EnvGroupSecrets][k]; ok {
 			envTemplates[k] = v
 		} else {
 			os.Setenv(k, v)

--- a/pkg/expressions/libs/fs_test.go
+++ b/pkg/expressions/libs/fs_test.go
@@ -9,25 +9,6 @@ import (
 	"github.com/kubeshop/testkube/pkg/expressions"
 )
 
-func MustCall(m expressions.Machine, name string, args ...interface{}) interface{} {
-	list := make([]expressions.StaticValue, len(args))
-	for i, v := range args {
-		if vv, ok := v.(expressions.StaticValue); ok {
-			list[i] = vv
-		} else {
-			list[i] = expressions.NewValue(v)
-		}
-	}
-	v, ok, err := m.Call(name, list...)
-	if err != nil {
-		panic(err)
-	}
-	if !ok {
-		panic("not recognized")
-	}
-	return v.Static().Value()
-}
-
 func TestFsLibGlob(t *testing.T) {
 	fsys := &afero.IOFS{Fs: afero.NewMemMapFs()}
 	_ = afero.WriteFile(fsys.Fs, "etc/file1.txt", nil, 0644)
@@ -35,12 +16,12 @@ func TestFsLibGlob(t *testing.T) {
 	_ = afero.WriteFile(fsys.Fs, "another-file.txt", nil, 0644)
 	_ = afero.WriteFile(fsys.Fs, "etc/nested/file2.json", nil, 0644)
 	machine := NewFsMachine(fsys, "/etc")
-	assert.Equal(t, []string{"/etc/file1.txt", "/etc/nested/file2.json"}, MustCall(machine, "glob", "**/*"))
-	assert.Equal(t, []string{"/etc/file1.txt"}, MustCall(machine, "glob", "*"))
-	assert.Equal(t, []string{"/etc/nested/file2.json"}, MustCall(machine, "glob", "**/*.json"))
-	assert.Equal(t, []string{"/etc/file1.txt", "/etc/nested/file2.json"}, MustCall(machine, "glob", "**/*.json", "*.txt"))
-	assert.Equal(t, []string{"/another-file.txt", "/else/file1.txt", "/etc/file1.txt"}, MustCall(machine, "glob", "/**/*.txt"))
-	assert.Equal(t, []string{"/another-file.txt", "/etc/file1.txt"}, MustCall(machine, "glob", "/**/*.txt", "!/else/**/*"))
+	assert.Equal(t, []string{"/etc/file1.txt", "/etc/nested/file2.json"}, expressions.MustCall(machine, "glob", "**/*"))
+	assert.Equal(t, []string{"/etc/file1.txt"}, expressions.MustCall(machine, "glob", "*"))
+	assert.Equal(t, []string{"/etc/nested/file2.json"}, expressions.MustCall(machine, "glob", "**/*.json"))
+	assert.Equal(t, []string{"/etc/file1.txt", "/etc/nested/file2.json"}, expressions.MustCall(machine, "glob", "**/*.json", "*.txt"))
+	assert.Equal(t, []string{"/another-file.txt", "/else/file1.txt", "/etc/file1.txt"}, expressions.MustCall(machine, "glob", "/**/*.txt"))
+	assert.Equal(t, []string{"/another-file.txt", "/etc/file1.txt"}, expressions.MustCall(machine, "glob", "/**/*.txt", "!/else/**/*"))
 }
 
 func TestFsLibRead(t *testing.T) {
@@ -48,8 +29,8 @@ func TestFsLibRead(t *testing.T) {
 	_ = afero.WriteFile(fsys.Fs, "etc/file1.txt", []byte("foo"), 0644)
 	_ = afero.WriteFile(fsys.Fs, "another-file.txt", []byte("bar"), 0644)
 	machine := NewFsMachine(fsys, "/etc")
-	assert.Equal(t, "foo", MustCall(machine, "file", "file1.txt"))
-	assert.Equal(t, "foo", MustCall(machine, "file", "/etc/file1.txt"))
-	assert.Equal(t, "bar", MustCall(machine, "file", "../another-file.txt"))
-	assert.Equal(t, "bar", MustCall(machine, "file", "/another-file.txt"))
+	assert.Equal(t, "foo", expressions.MustCall(machine, "file", "file1.txt"))
+	assert.Equal(t, "foo", expressions.MustCall(machine, "file", "/etc/file1.txt"))
+	assert.Equal(t, "bar", expressions.MustCall(machine, "file", "../another-file.txt"))
+	assert.Equal(t, "bar", expressions.MustCall(machine, "file", "/another-file.txt"))
 }

--- a/pkg/expressions/libs/secret.go
+++ b/pkg/expressions/libs/secret.go
@@ -9,6 +9,23 @@ import (
 	"github.com/kubeshop/testkube/pkg/expressions"
 )
 
+const (
+	GlobalSecretGroup = "02"
+)
+
+// FIXME: it's copied from actiontypes to avoid import cycle
+func EnvName(group string, computed bool, sensitive bool, name string) string {
+	suffix := ""
+	if computed {
+		suffix = "C"
+	}
+	if sensitive {
+		suffix += "S"
+	}
+	return fmt.Sprintf("_%s%s_%s", group, suffix, name)
+}
+
+// TODO: Probably it shouldn't be part of expressions lib, as it's actually workflow processing
 func NewSecretMachine(mapEnvs map[string]corev1.EnvVarSource) expressions.Machine {
 	return expressions.NewMachine().
 		RegisterFunction("secret", func(values ...expressions.StaticValue) (interface{}, bool, error) {
@@ -28,8 +45,10 @@ func NewSecretMachine(mapEnvs map[string]corev1.EnvVarSource) expressions.Machin
 				}
 			}
 
-			envName := fmt.Sprintf("S_N_%s_K_%s", strs[0], strs[1])
-			mapEnvs[envName] = corev1.EnvVarSource{
+			// TODO: Avoid adding the secrets to all the groups with virtual SN group
+			envName := fmt.Sprintf("%s_K_%s", strs[0], strs[1])
+			internalName := EnvName(GlobalSecretGroup, false, true, envName)
+			mapEnvs[internalName] = corev1.EnvVarSource{
 				SecretKeyRef: &corev1.SecretKeySelector{
 					LocalObjectReference: corev1.LocalObjectReference{
 						Name: secretName,

--- a/pkg/expressions/libs/secret_test.go
+++ b/pkg/expressions/libs/secret_test.go
@@ -12,9 +12,9 @@ import (
 func TestSecret(t *testing.T) {
 	mapEnvs := make(map[string]corev1.EnvVarSource)
 	machine := NewSecretMachine(mapEnvs)
-	assert.Equal(t, "{{"+expressions.InternalFnCall+"env.S_N_name_0_one_1_two_K_key_0_three_1_four}}", MustCall(machine, "secret", "name-one.two", "key-three.four"))
+	assert.Equal(t, "{{"+expressions.InternalFnCall+"env.name_0_one_1_two_K_key_0_three_1_four}}", MustCall(machine, "secret", "name-one.two", "key-three.four"))
 	assert.EqualValues(t, map[string]corev1.EnvVarSource{
-		"S_N_name_0_one_1_two_K_key_0_three_1_four": {
+		"_02S_name_0_one_1_two_K_key_0_three_1_four": {
 			SecretKeyRef: &corev1.SecretKeySelector{
 				LocalObjectReference: corev1.LocalObjectReference{
 					Name: "name-one.two",

--- a/pkg/expressions/libs/secret_test.go
+++ b/pkg/expressions/libs/secret_test.go
@@ -24,3 +24,19 @@ func TestSecret(t *testing.T) {
 		},
 	}, mapEnvs)
 }
+
+func TestSecretComputed(t *testing.T) {
+	mapEnvs := make(map[string]corev1.EnvVarSource)
+	machine := NewSecretMachine(mapEnvs)
+	assert.Equal(t, "{{"+expressions.InternalFnCall+"env.name_0_one_1_two_K_key_0_three_1_four}}", MustCall(machine, "secret", "name-one.two", "key-three.four", true))
+	assert.EqualValues(t, map[string]corev1.EnvVarSource{
+		"_02CS_name_0_one_1_two_K_key_0_three_1_four": {
+			SecretKeyRef: &corev1.SecretKeySelector{
+				LocalObjectReference: corev1.LocalObjectReference{
+					Name: "name-one.two",
+				},
+				Key: "key-three.four",
+			},
+		},
+	}, mapEnvs)
+}

--- a/pkg/expressions/utils.go
+++ b/pkg/expressions/utils.go
@@ -85,3 +85,22 @@ func Escape(str string) string {
 func EscapeLabelKeyForVarName(key string) string {
 	return strings.ReplaceAll(strings.ReplaceAll(strings.ReplaceAll(key, ".", "_"), "-", "_"), "/", "_")
 }
+
+func MustCall(m Machine, name string, args ...interface{}) interface{} {
+	list := make([]StaticValue, len(args))
+	for i, v := range args {
+		if vv, ok := v.(StaticValue); ok {
+			list[i] = vv
+		} else {
+			list[i] = NewValue(v)
+		}
+	}
+	v, ok, err := m.Call(name, list...)
+	if err != nil {
+		panic(err)
+	}
+	if !ok {
+		panic("not recognized")
+	}
+	return v.Static().Value()
+}

--- a/pkg/testworkflows/testworkflowprocessor/processor.go
+++ b/pkg/testworkflows/testworkflowprocessor/processor.go
@@ -395,6 +395,7 @@ func (p *processor) Bundle(ctx context.Context, workflow *testworkflowsv1.TestWo
 	}
 	jobSpec.Spec.Template = podSpec
 
+	// TODO: Avoid adding the secrets to all the groups without isolation
 	addEnvVarToContainerSpec(mapEnv, jobSpec.Spec.Template.Spec.InitContainers)
 	addEnvVarToContainerSpec(mapEnv, jobSpec.Spec.Template.Spec.Containers)
 

--- a/pkg/testworkflows/testworkflowprocessor/processor.go
+++ b/pkg/testworkflows/testworkflowprocessor/processor.go
@@ -15,7 +15,6 @@ import (
 	testworkflowsv1 "github.com/kubeshop/testkube-operator/api/testworkflows/v1"
 	"github.com/kubeshop/testkube/internal/common"
 	"github.com/kubeshop/testkube/pkg/expressions"
-	"github.com/kubeshop/testkube/pkg/expressions/libs"
 	"github.com/kubeshop/testkube/pkg/imageinspector"
 	"github.com/kubeshop/testkube/pkg/testworkflows/testworkflowprocessor/action"
 	"github.com/kubeshop/testkube/pkg/testworkflows/testworkflowprocessor/action/actiontypes"
@@ -112,7 +111,7 @@ func (p *processor) Bundle(ctx context.Context, workflow *testworkflowsv1.TestWo
 		AppendVolumeMounts(layer.AddEmptyDirVolume(nil, constants.DefaultDataPath))
 
 	mapEnv := make(map[string]corev1.EnvVarSource)
-	extendedMachines := append(machines, libs.NewSecretMachine(mapEnv))
+	extendedMachines := append(machines, createSecretMachine(mapEnv))
 
 	// Fetch resource root and resource ID
 	resourceRoot, err := expressions.EvalExpression("resource.root", extendedMachines...)

--- a/pkg/testworkflows/testworkflowprocessor/processor.go
+++ b/pkg/testworkflows/testworkflowprocessor/processor.go
@@ -394,7 +394,7 @@ func (p *processor) Bundle(ctx context.Context, workflow *testworkflowsv1.TestWo
 	}
 	jobSpec.Spec.Template = podSpec
 
-	// TODO: Avoid adding the secrets to all the groups without isolation
+	// TODO(TKC-2585): Avoid adding the secrets to all the groups without isolation
 	addEnvVarToContainerSpec(mapEnv, jobSpec.Spec.Template.Spec.InitContainers)
 	addEnvVarToContainerSpec(mapEnv, jobSpec.Spec.Template.Spec.Containers)
 

--- a/pkg/testworkflows/testworkflowprocessor/secretmachine.go
+++ b/pkg/testworkflows/testworkflowprocessor/secretmachine.go
@@ -37,7 +37,7 @@ func createSecretMachine(mapEnvs map[string]corev1.EnvVarSource) expressions.Mac
 				}
 			}
 
-			// TODO: Avoid adding the secrets to all the groups with virtual SN group
+			// TODO(TKC-2585): Avoid adding the secrets to all the groups with virtual 02 group
 			envName := fmt.Sprintf("%s_K_%s", strs[0], strs[1])
 			internalName := actiontypes.EnvName(constants.EnvGroupSecrets, computed, true, envName)
 			mapEnvs[internalName] = corev1.EnvVarSource{

--- a/pkg/testworkflows/testworkflowprocessor/secretmachine.go
+++ b/pkg/testworkflows/testworkflowprocessor/secretmachine.go
@@ -1,4 +1,4 @@
-package libs
+package testworkflowprocessor
 
 import (
 	"fmt"
@@ -6,27 +6,12 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 
+	"github.com/kubeshop/testkube/cmd/testworkflow-init/constants"
 	"github.com/kubeshop/testkube/pkg/expressions"
+	"github.com/kubeshop/testkube/pkg/testworkflows/testworkflowprocessor/action/actiontypes"
 )
 
-const (
-	GlobalSecretGroup = "02"
-)
-
-// FIXME: it's copied from actiontypes to avoid import cycle
-func EnvName(group string, computed bool, sensitive bool, name string) string {
-	suffix := ""
-	if computed {
-		suffix = "C"
-	}
-	if sensitive {
-		suffix += "S"
-	}
-	return fmt.Sprintf("_%s%s_%s", group, suffix, name)
-}
-
-// TODO: Probably it shouldn't be part of expressions lib, as it's actually workflow processing
-func NewSecretMachine(mapEnvs map[string]corev1.EnvVarSource) expressions.Machine {
+func createSecretMachine(mapEnvs map[string]corev1.EnvVarSource) expressions.Machine {
 	return expressions.NewMachine().
 		RegisterFunction("secret", func(values ...expressions.StaticValue) (interface{}, bool, error) {
 			computed := false
@@ -54,7 +39,7 @@ func NewSecretMachine(mapEnvs map[string]corev1.EnvVarSource) expressions.Machin
 
 			// TODO: Avoid adding the secrets to all the groups with virtual SN group
 			envName := fmt.Sprintf("%s_K_%s", strs[0], strs[1])
-			internalName := EnvName(GlobalSecretGroup, computed, true, envName)
+			internalName := actiontypes.EnvName(constants.EnvGroupSecrets, computed, true, envName)
 			mapEnvs[internalName] = corev1.EnvVarSource{
 				SecretKeyRef: &corev1.SecretKeySelector{
 					LocalObjectReference: corev1.LocalObjectReference{

--- a/pkg/testworkflows/testworkflowprocessor/secretmachine_test.go
+++ b/pkg/testworkflows/testworkflowprocessor/secretmachine_test.go
@@ -1,4 +1,4 @@
-package libs
+package testworkflowprocessor
 
 import (
 	"testing"
@@ -11,8 +11,8 @@ import (
 
 func TestSecret(t *testing.T) {
 	mapEnvs := make(map[string]corev1.EnvVarSource)
-	machine := NewSecretMachine(mapEnvs)
-	assert.Equal(t, "{{"+expressions.InternalFnCall+"env.name_0_one_1_two_K_key_0_three_1_four}}", MustCall(machine, "secret", "name-one.two", "key-three.four"))
+	machine := createSecretMachine(mapEnvs)
+	assert.Equal(t, "{{"+expressions.InternalFnCall+"env.name_0_one_1_two_K_key_0_three_1_four}}", expressions.MustCall(machine, "secret", "name-one.two", "key-three.four"))
 	assert.EqualValues(t, map[string]corev1.EnvVarSource{
 		"_02S_name_0_one_1_two_K_key_0_three_1_four": {
 			SecretKeyRef: &corev1.SecretKeySelector{
@@ -27,8 +27,8 @@ func TestSecret(t *testing.T) {
 
 func TestSecretComputed(t *testing.T) {
 	mapEnvs := make(map[string]corev1.EnvVarSource)
-	machine := NewSecretMachine(mapEnvs)
-	assert.Equal(t, "{{"+expressions.InternalFnCall+"env.name_0_one_1_two_K_key_0_three_1_four}}", MustCall(machine, "secret", "name-one.two", "key-three.four", true))
+	machine := createSecretMachine(mapEnvs)
+	assert.Equal(t, "{{"+expressions.InternalFnCall+"env.name_0_one_1_two_K_key_0_three_1_four}}", expressions.MustCall(machine, "secret", "name-one.two", "key-three.four", true))
 	assert.EqualValues(t, map[string]corev1.EnvVarSource{
 		"_02CS_name_0_one_1_two_K_key_0_three_1_four": {
 			SecretKeyRef: &corev1.SecretKeySelector{

--- a/pkg/testworkflows/testworkflowresolver/config.go
+++ b/pkg/testworkflows/testworkflowresolver/config.go
@@ -78,12 +78,12 @@ func createConfigMachine(cfg map[string]intstr.IntOrString, schema map[string]te
 
 func getSecretCallExpression(expr expressions.Expression, k string, externalize func(key, value string) (*corev1.EnvVarSource, error)) (
 	expressions.Expression, error) {
-	envVar, err := externalize(k, expr.String())
+	envVar, err := externalize(k, expr.Template())
 	if err != nil {
 		return nil, errors.Wrap(err, "config."+k)
 	}
 	if envVar.SecretKeyRef != nil {
-		expr = expressions.NewValue(fmt.Sprintf("{{%ssecret(\"%s\", \"%s\")}}", expressions.InternalFnCall,
+		expr = expressions.NewValue(fmt.Sprintf("{{%ssecret(\"%s\", \"%s\", true)}}", expressions.InternalFnCall,
 			envVar.SecretKeyRef.Name, envVar.SecretKeyRef.Key))
 	}
 


### PR DESCRIPTION
## Pull request description 

* Correctly resolve sensitive configuration (i.e. `something: 'foo'` became `"foo"` before, instead of unquoted `foo`)
* Include sensitive configuration and `secret()` calls as sensitive words

## Example workflow

```
kind: TestWorkflow
apiVersion: testworkflows.testkube.io/v1
metadata:
  name: example-sensitive
spec:
  config:
    something:
      type: string
      default: blah
      sensitive: true
  steps:
  - shell: echo '{{ secret("example-secret", "example-key") }} {{ config.something }}'
```

### Result Before

```
seeeensitve-value "blah"
```

### Result After

```
****ue ****ah
```

## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [x] tested locally
- [x] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Changes

-

## Fixes

-