### PR TITLE
fix: buffer the logs on the file system before sending them to Object Storage

### DIFF
--- a/pkg/bufferedstream/bufferedstream.go
+++ b/pkg/bufferedstream/bufferedstream.go
@@ -1,0 +1,76 @@
+package bufferedstream
+
+import (
+	"context"
+	"io"
+	"os"
+
+	"github.com/pkg/errors"
+)
+
+// bufferedStream is a mechanism to buffer data in FS instead of memory.
+type bufferedStream struct {
+	ctx  context.Context
+	end  context.CancelCauseFunc
+	file *os.File
+	size int
+}
+
+type BufferedStream interface {
+	io.Reader
+	Len() int
+	Cleanup() error
+	Err() error
+	Ready() <-chan struct{}
+}
+
+func newBufferedStream(file *os.File, source io.Reader) BufferedStream {
+	ctx, end := context.WithCancelCause(context.Background())
+	stream := &bufferedStream{ctx: ctx, end: end, file: file}
+
+	// Stream the data into file buffer
+	go func() {
+		size, err := io.Copy(file, source)
+		stream.size = int(size)
+		if err == nil || errors.Is(err, io.EOF) {
+			_, err = file.Seek(0, io.SeekStart)
+		}
+		if err == nil {
+			err = io.EOF
+		}
+		stream.end(err)
+	}()
+
+	return stream
+}
+
+func (b *bufferedStream) Read(p []byte) (n int, err error) {
+	<-b.ctx.Done()
+	return b.file.Read(p)
+}
+
+func (b *bufferedStream) Err() error {
+	return context.Cause(b.ctx)
+}
+
+func (b *bufferedStream) Ready() <-chan struct{} {
+	return b.ctx.Done()
+}
+
+func (b *bufferedStream) Len() int {
+	<-b.ctx.Done()
+	return b.size
+}
+
+func (b *bufferedStream) Cleanup() error {
+	b.end(nil)
+	return os.Remove(b.file.Name())
+}
+
+func NewBufferedStream(dirPath, prefix string, source io.Reader) (BufferedStream, error) {
+	file, err := os.CreateTemp(dirPath, prefix)
+	if err != nil {
+		return nil, err
+	}
+	return newBufferedStream(file, source), nil
+}

--- a/pkg/bufferedstream/bufferedstream_test.go
+++ b/pkg/bufferedstream/bufferedstream_test.go
@@ -1,0 +1,90 @@
+package bufferedstream
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBufferedStream(t *testing.T) {
+	inputStream := bytes.NewBuffer([]byte("test input stream"))
+	file, err := os.CreateTemp("", "testbuffer")
+	if err != nil {
+		t.Error("failed to create temp file")
+		return
+	}
+	stream := newBufferedStream(file, inputStream)
+	defer stream.Cleanup()
+	select {
+	case <-stream.Ready():
+	case <-time.After(1 * time.Second):
+		t.Error("timed out waiting for stream to be ready")
+		return
+	}
+
+	result, _ := io.ReadAll(stream)
+	assert.Equal(t, []byte("test input stream"), result)
+}
+
+func TestBufferedStream_Cleanup(t *testing.T) {
+	inputStream := bytes.NewBuffer([]byte("test input stream"))
+	file, err := os.CreateTemp("", "testbuffer")
+	if err != nil {
+		t.Error("failed to create temp file")
+		return
+	}
+	stream := newBufferedStream(file, inputStream)
+	select {
+	case <-stream.Ready():
+	case <-time.After(1 * time.Second):
+		stream.Cleanup()
+		t.Error("timed out waiting for stream to be ready")
+		return
+	}
+
+	statBefore, statBeforeErr := os.Stat(file.Name())
+
+	err = stream.Cleanup()
+	stat, statErr := os.Stat(file.Name())
+
+	assert.NoError(t, statBeforeErr)
+	assert.NotEqual(t, nil, statBefore)
+	assert.NoError(t, err)
+	assert.Equal(t, nil, stat)
+	assert.Error(t, statErr)
+}
+
+func TestBufferedStream_Len(t *testing.T) {
+	inputStream := bytes.NewBuffer([]byte("test input stream"))
+	inputStreamLen := inputStream.Len()
+	file, err := os.CreateTemp("", "testbuffer")
+	if err != nil {
+		t.Error("failed to create temp file")
+		return
+	}
+	stream := newBufferedStream(file, inputStream)
+	defer stream.Cleanup()
+
+	size := -1
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		size = stream.Len()
+		wg.Done()
+	}()
+
+	select {
+	case <-stream.Ready():
+	case <-time.After(1 * time.Second):
+		t.Error("timed out waiting for stream to be ready")
+		return
+	}
+
+	wg.Wait()
+	assert.Equal(t, inputStreamLen, size)
+}

--- a/pkg/repository/testworkflow/minio_output_repository.go
+++ b/pkg/repository/testworkflow/minio_output_repository.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/kubeshop/testkube/pkg/api/v1/testkube"
+	"github.com/kubeshop/testkube/pkg/bufferedstream"
 	"github.com/kubeshop/testkube/pkg/log"
 	"github.com/kubeshop/testkube/pkg/storage"
 
@@ -44,7 +45,12 @@ func (m *MinioRepository) PresignReadLog(ctx context.Context, id, workflowName s
 
 func (m *MinioRepository) SaveLog(ctx context.Context, id, workflowName string, reader io.Reader) error {
 	log.DefaultLogger.Debugw("inserting output", "id", id, "workflowName", workflowName)
-	return m.storage.UploadFileToBucket(ctx, m.bucket, bucketFolder, id, reader, -1)
+	buffer, err := bufferedstream.NewBufferedStream("", "log", reader)
+	if err != nil {
+		return nil
+	}
+	defer buffer.Cleanup()
+	return m.storage.UploadFileToBucket(ctx, m.bucket, bucketFolder, id, reader, int64(buffer.Len()))
 }
 
 func (m *MinioRepository) ReadLog(ctx context.Context, id, workflowName string) (io.Reader, error) {

--- a/pkg/storage/minio/minio.go
+++ b/pkg/storage/minio/minio.go
@@ -494,15 +494,10 @@ func (c *Client) uploadFile(ctx context.Context, bucket, bucketFolder, filePath 
 		filePath = strings.Trim(bucketFolder, "/") + "/" + filePath
 	}
 
-	var partSize uint64
-	if objectSize == -1 {
-		partSize = absMinPartSize
-	}
-
 	c.Log.Debugw("saving object in minio", "file", filePath, "bucket", bucket)
 	_, err = c.minioClient.PutObject(ctx, bucket, filePath, reader, objectSize, minio.PutObjectOptions{
 		ContentType: "application/octet-stream",
-		PartSize:    partSize})
+		PartSize:    absMinPartSize})
 	if err != nil {
 		return fmt.Errorf("minio saving file (%s) put object error: %w", filePath, err)
 	}

--- a/pkg/testworkflows/testworkflowprocessor/operations.go
+++ b/pkg/testworkflows/testworkflowprocessor/operations.go
@@ -173,10 +173,6 @@ func ProcessContentGit(_ InternalProcessor, layer Intermediate, container stage.
 		mountPath = filepath.Join(constants.DefaultDataPath, "repo")
 	}
 
-	// Build a temporary volume to clone the repository initially.
-	// This will allow mounting files in the destination at the same level (i.e. overriding the configuration).
-	container.AppendVolumeMounts(layer.AddEmptyDirVolume(nil, constants.DefaultTmpDirPath))
-
 	// Build volume pair and share with all siblings
 	volumeMount := layer.AddEmptyDirVolume(nil, mountPath)
 	container.AppendVolumeMounts(volumeMount)

--- a/pkg/testworkflows/testworkflowprocessor/processor.go
+++ b/pkg/testworkflows/testworkflowprocessor/processor.go
@@ -108,6 +108,7 @@ func (p *processor) Bundle(ctx context.Context, workflow *testworkflowsv1.TestWo
 	layer.ContainerDefaults().
 		ApplyCR(constants.DefaultContainerConfig.DeepCopy()).
 		AppendVolumeMounts(layer.AddEmptyDirVolume(nil, constants.DefaultInternalPath)).
+		AppendVolumeMounts(layer.AddEmptyDirVolume(nil, constants.DefaultTmpDirPath)).
 		AppendVolumeMounts(layer.AddEmptyDirVolume(nil, constants.DefaultDataPath))
 
 	mapEnv := make(map[string]corev1.EnvVarSource)


### PR DESCRIPTION
## Pull request description 

* Buffer the logs in the temporary file, so we know the total file size
   * We have encountered some issues when streaming the logs without Content-Length

## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [x] tested locally
- [x] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
