### PR TITLE
fix: avoid retrieving container logs again, when expected information is complete

### DIFF
--- a/pkg/testworkflows/testworkflowcontroller/watchinstrumentedpod.go
+++ b/pkg/testworkflows/testworkflowcontroller/watchinstrumentedpod.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/kubeshop/testkube/cmd/testworkflow-init/constants"
 	"github.com/kubeshop/testkube/cmd/testworkflow-init/data"
+	"github.com/kubeshop/testkube/cmd/testworkflow-init/instructions"
 	"github.com/kubeshop/testkube/pkg/api/v1/testkube"
 	"github.com/kubeshop/testkube/pkg/testworkflows/testworkflowcontroller/watchers"
 	"github.com/kubeshop/testkube/pkg/testworkflows/testworkflowprocessor/stage"
@@ -96,7 +97,7 @@ func WatchInstrumentedPod(parentCtx context.Context, clientSet kubernetes.Interf
 			notifier.Error(fmt.Errorf("cannot read execution instructions: %v", err))
 			return
 		}
-		refs, _ := ExtractRefsFromActionGroup(actions)
+		refs, endRefs := ExtractRefsFromActionGroup(actions)
 		initialRefs := make([]string, len(actions))
 		for i := range refs {
 			for j := range refs[i] {
@@ -118,6 +119,12 @@ func WatchInstrumentedPod(parentCtx context.Context, clientSet kubernetes.Interf
 		for containerIndex := 0; containerIndex < len(refs); containerIndex++ {
 			aborted := false
 			container := fmt.Sprintf("%d", containerIndex+1)
+
+			// Determine the last ref in this container, so we can confirm that the logs have been read until end
+			lastRef := endRefs[containerIndex][len(endRefs[containerIndex])-1]
+			if lastRef == "" && len(endRefs[containerIndex]) > 1 {
+				lastRef = endRefs[containerIndex][len(endRefs[containerIndex])-2]
+			}
 
 			// Wait until the Container is started
 			currentPodEventsIndex = 0
@@ -148,10 +155,13 @@ func WatchInstrumentedPod(parentCtx context.Context, clientSet kubernetes.Interf
 			lastStarted = refs[containerIndex][0]
 
 			// Read the Container logs
+			isLastHint := func(hint *instructions.Instruction) bool {
+				return hint != nil && hint.Ref == lastRef && hint.Name == constants.InstructionEnd
+			}
 			isDone := func() bool {
 				return opts.DisableFollow || watcher.State().ContainerFinished(container) || watcher.State().Completed()
 			}
-			for v := range WatchContainerLogs(ctx, clientSet, watcher.State().Namespace(), watcher.State().PodName(), container, 10, isDone) {
+			for v := range WatchContainerLogs(ctx, clientSet, watcher.State().Namespace(), watcher.State().PodName(), container, 10, isDone, isLastHint) {
 				if v.Error != nil {
 					notifier.Error(v.Error)
 					continue


### PR DESCRIPTION
## Pull request description 

* Earlier, for every container we were retrieving the logs twice - just to ensure that we haven't fall into log rotation
   * This fix will avoid additional retrieve, in most common case - when we have successfully received final step information

## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [x] tested locally
- [x] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
