### PR TITLE
fix: don't fetch logs for timed out services

### DIFF
--- a/pkg/testworkflows/testworkflowcontroller/watchinstrumentedpod.go
+++ b/pkg/testworkflows/testworkflowcontroller/watchinstrumentedpod.go
@@ -67,7 +67,7 @@ func WatchInstrumentedPod(parentCtx context.Context, clientSet kubernetes.Interf
 				}
 			}
 
-			if watcher.State().PodStarted() || watcher.State().Completed() {
+			if watcher.State().PodStarted() || watcher.State().Completed() || opts.DisableFollow {
 				break
 			}
 		}
@@ -78,7 +78,7 @@ func WatchInstrumentedPod(parentCtx context.Context, clientSet kubernetes.Interf
 		}
 
 		// Handle the case when it has been complete without pod start
-		if !watcher.State().PodStarted() && watcher.State().Completed() {
+		if !watcher.State().PodStarted() && (watcher.State().Completed() || opts.DisableFollow) {
 			notifier.Align(watcher.State())
 			return
 		}
@@ -141,7 +141,7 @@ func WatchInstrumentedPod(parentCtx context.Context, clientSet kubernetes.Interf
 				}
 
 				// Determine if the container should be already accessible
-				if watcher.State().ContainerStarted(container) || watcher.State().Completed() {
+				if watcher.State().ContainerStarted(container) || watcher.State().Completed() || opts.DisableFollow {
 					break
 				}
 			}
@@ -191,7 +191,7 @@ func WatchInstrumentedPod(parentCtx context.Context, clientSet kubernetes.Interf
 			// Wait until the Container is terminated
 			for ok := true; ok; _, ok = <-updatesCh {
 				// Determine if the container should be already stopped
-				if watcher.State().ContainerFinished(container) || watcher.State().Completed() {
+				if watcher.State().ContainerFinished(container) || watcher.State().Completed() || opts.DisableFollow {
 					break
 				}
 			}


### PR DESCRIPTION
## Pull request description 

* when the service has `timeout: 1s` and it fails, "Stop Services" was getting stuck
  * modified to not hang depending on the state

## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [x] tested locally
- [x] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test