### PR TITLE
fix: clean completed migration job before reinitialize on-prem demo

### DIFF
--- a/cmd/api-server/main.go
+++ b/cmd/api-server/main.go
@@ -122,7 +122,7 @@ func runMigrations() (err error) {
 	return migrations.Migrator.Run(version.Version, migrator.MigrationTypeServer)
 }
 
-func runMongoMigrations(ctx context.Context, db *mongo.Database, migrationsDir string) error {
+func runMongoMigrations(ctx context.Context, db *mongo.Database, _ string) error {
 	migrationsCollectionName := "__migrations"
 	activeMigrations, err := dbmigrator.GetDbMigrationsFromFs(dbmigrations.MongoMigrationsFs)
 	if err != nil {

--- a/cmd/kubectl-testkube/commands/common/errors.go
+++ b/cmd/kubectl-testkube/commands/common/errors.go
@@ -34,6 +34,9 @@ const (
 	TKErrHelmCommandFailed ErrorCode = "TKERR-1301"
 	// TKErrKubectlCommandFailed is returned when a kubectl command fail.
 	TKErrKubectlCommandFailed ErrorCode = "TKERR-1302"
+
+	// TKErrCleanOldMigrationJobFailed is returned in case of issues with old migration jobs.
+	TKErrCleanOldMigrationJobFailed ErrorCode = "TKERR-1401"
 )
 
 const helpUrl = "https://testkubeworkspace.slack.com"

--- a/cmd/kubectl-testkube/commands/init.go
+++ b/cmd/kubectl-testkube/commands/init.go
@@ -214,6 +214,17 @@ func NewInitCmdDemo() *cobra.Command {
 				DemoValuesURL: demoValuesUrl,
 				DryRun:        dryRun,
 			}
+
+			cliErr = common.CleanExistingCompletedMigrationJobs(options.Namespace)
+			if cliErr != nil {
+				spinner.Fail("Failed to install Testkube On-Prem Demo")
+				if cfg.TelemetryEnabled {
+					cliErr.AddTelemetry(cmd, "installing", "install_failed", license)
+					_, _ = telemetry.HandleCLIErrorTelemetry(common.Version, cliErr)
+				}
+				common.HandleCLIError(cliErr)
+			}
+
 			cliErr = common.HelmUpgradeOrInstallTestkubeOnPremDemo(options)
 			if cliErr != nil {
 				spinner.Fail("Failed to install Testkube On-Prem Demo")

--- a/cmd/testworkflow-init/obfuscator/obfuscator.go
+++ b/cmd/testworkflow-init/obfuscator/obfuscator.go
@@ -135,7 +135,7 @@ func (s *obfuscator) Write(p []byte) (n int, err error) {
 
 	// Write the rest of data
 	if len(p) > 0 {
-		nn, err = s.dst.Write(p)
+		_, err = s.dst.Write(p)
 		return size, err
 	}
 	return size, nil

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -378,7 +378,7 @@ func (ag *Agent) runWorkers(ctx context.Context, numWorkers int) error {
 	return g.Wait()
 }
 
-func (ag *Agent) executeCommand(ctx context.Context, cmd *cloud.ExecuteRequest) *cloud.ExecuteResponse {
+func (ag *Agent) executeCommand(_ context.Context, cmd *cloud.ExecuteRequest) *cloud.ExecuteResponse {
 	switch {
 	case cmd.Url == healthcheckCommand:
 		return &cloud.ExecuteResponse{MessageId: cmd.MessageId, Status: 0}


### PR DESCRIPTION
## Pull request description 

The idea is to clean long TTL migration jobs when they exist and we're trying to recreate them. 

## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [ ] tested locally
- [ ] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Breaking changes

-

## Changes

-

## Fixes

-