### PR TITLE
fix: allow passing FSGroup to PodSecurityContext in OpenAPI

### DIFF
--- a/api/v1/testkube.yaml
+++ b/api/v1/testkube.yaml
@@ -9654,6 +9654,8 @@ components:
           $ref: "#/components/schemas/BoxedInteger"
         runAsNonRoot:
           $ref: "#/components/schemas/BoxedBoolean"
+        fsGroup:
+          $ref: "#/components/schemas/BoxedInteger"
 
     Toleration:
       type: object

--- a/pkg/api/v1/testkube/model_pod_security_context.go
+++ b/pkg/api/v1/testkube/model_pod_security_context.go
@@ -13,4 +13,5 @@ type PodSecurityContext struct {
 	RunAsUser    *BoxedInteger `json:"runAsUser,omitempty"`
 	RunAsGroup   *BoxedInteger `json:"runAsGroup,omitempty"`
 	RunAsNonRoot *BoxedBoolean `json:"runAsNonRoot,omitempty"`
+	FsGroup      *BoxedInteger `json:"fsGroup,omitempty"`
 }

--- a/pkg/mapper/testworkflows/kube_openapi.go
+++ b/pkg/mapper/testworkflows/kube_openapi.go
@@ -513,6 +513,7 @@ func MapPodSecurityContextKubeToAPI(v corev1.PodSecurityContext) testkube.PodSec
 		RunAsUser:    MapInt64ToBoxedInteger(v.RunAsUser),
 		RunAsGroup:   MapInt64ToBoxedInteger(v.RunAsGroup),
 		RunAsNonRoot: MapBoolToBoxedBoolean(v.RunAsNonRoot),
+		FsGroup:      MapInt64ToBoxedInteger(v.FSGroup),
 	}
 }
 

--- a/pkg/mapper/testworkflows/openapi_kube.go
+++ b/pkg/mapper/testworkflows/openapi_kube.go
@@ -544,6 +544,7 @@ func MapPodSecurityContextAPIToKube(v testkube.PodSecurityContext) corev1.PodSec
 		RunAsUser:    MapBoxedIntegerToInt64(v.RunAsUser),
 		RunAsGroup:   MapBoxedIntegerToInt64(v.RunAsGroup),
 		RunAsNonRoot: MapBoxedBooleanToBool(v.RunAsNonRoot),
+		FSGroup:      MapBoxedIntegerToInt64(v.FsGroup),
 	}
 }
 


### PR DESCRIPTION
## Pull request description 

* recognize `pod.securityContext.fsGroup` in OpenAPI
   * earlier it was used, but i.e. not displayed in the UI (as OpenAPI didn't recognize it)

## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [ ] tested locally
- [ ] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
