### PR TITLE
fix: send Content-Length: 0 to the Object Storage when file is empty

### DIFF
--- a/cmd/testworkflow-toolkit/artifacts/cloud_uploader.go
+++ b/cmd/testworkflow-toolkit/artifacts/cloud_uploader.go
@@ -86,6 +86,10 @@ func (d *cloudUploader) getContentType(path string, size int64) string {
 func (d *cloudUploader) putObject(url string, path string, file io.Reader, size int64) error {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Minute)
 	defer cancel()
+	if size == 0 {
+		// http.Request won't send Content-Length: 0, if the body is non-nil
+		file = nil
+	}
 	req, err := http.NewRequestWithContext(ctx, http.MethodPut, url, file)
 	if err != nil {
 		return err


### PR DESCRIPTION
## Pull request description 

As per Golang's [**Request documentation**](https://pkg.go.dev/net/http#Request):

```go
	// For client requests, a value of 0 with a non-nil Body is
	// also treated as unknown.
	ContentLength int64
```

Because of that, we need to ensure the `request.Body` is `nil` when the `ContentLength` is `0` - otherwise `Content-Length` header won't be sent.

## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [ ] tested locally
- [ ] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Fixes

- https://linear.app/kubeshop/issue/TKC-2680/[canton-of-geneva]-error-if-an-artifact-is-empty