### PR TITLE
fix: handle optional steps

### DIFF
--- a/pkg/api/v1/testkube/model_test_workflow_result_extended.go
+++ b/pkg/api/v1/testkube/model_test_workflow_result_extended.go
@@ -352,8 +352,7 @@ func (r *TestWorkflowResult) healPredictedStatus(sigSequence []TestWorkflowSigna
 
 	// Determine if there are some steps failed
 	for ref := range r.Steps {
-		optional := isStepOptional(sigSequence, ref)
-		if r.Steps[ref].Status.Aborted() || (!optional && r.Steps[ref].Status.AnyError()) {
+		if r.Steps[ref].Status.Aborted() || (r.Steps[ref].Status.AnyError() && !isStepOptional(sigSequence, ref)) {
 			r.PredictedStatus = common.Ptr(FAILED_TestWorkflowStatus)
 			return
 		}

--- a/pkg/api/v1/testkube/model_test_workflow_result_extended.go
+++ b/pkg/api/v1/testkube/model_test_workflow_result_extended.go
@@ -334,7 +334,16 @@ func (r *TestWorkflowResult) HealMissingPauseStatuses() {
 	}
 }
 
-func (r *TestWorkflowResult) healPredictedStatus() {
+func isStepOptional(sigSequence []TestWorkflowSignature, ref string) bool {
+	for i := range sigSequence {
+		if sigSequence[i].Ref == ref {
+			return sigSequence[i].Optional
+		}
+	}
+	return false
+}
+
+func (r *TestWorkflowResult) healPredictedStatus(sigSequence []TestWorkflowSignature) {
 	// Mark as aborted, when any step is aborted
 	if r.IsAnyStepAborted() || r.Initialization.Status.AnyError() {
 		r.PredictedStatus = common.Ptr(ABORTED_TestWorkflowStatus)
@@ -343,7 +352,8 @@ func (r *TestWorkflowResult) healPredictedStatus() {
 
 	// Determine if there are some steps failed
 	for ref := range r.Steps {
-		if r.Steps[ref].Status != nil && r.Steps[ref].Status.AnyError() {
+		optional := isStepOptional(sigSequence, ref)
+		if r.Steps[ref].Status.Aborted() || (!optional && r.Steps[ref].Status.AnyError()) {
 			r.PredictedStatus = common.Ptr(FAILED_TestWorkflowStatus)
 			return
 		}
@@ -361,8 +371,8 @@ func (r *TestWorkflowResult) healStatus() {
 	}
 }
 
-func (r *TestWorkflowResult) HealStatus() {
-	r.healPredictedStatus()
+func (r *TestWorkflowResult) HealStatus(sigSequence []TestWorkflowSignature) {
+	r.healPredictedStatus(sigSequence)
 	r.healStatus()
 }
 

--- a/pkg/testworkflows/testworkflowcontroller/notifier.go
+++ b/pkg/testworkflows/testworkflowcontroller/notifier.go
@@ -358,7 +358,7 @@ func (n *notifier) reconcile() {
 	n.result.HealTimestamps(n.sigSequence, n.scheduledAt, containerStartTs, completionTs, n.ended)
 	n.result.HealDuration()
 	n.result.HealMissingPauseStatuses()
-	n.result.HealStatus()
+	n.result.HealStatus(n.sigSequence)
 }
 
 // TODO: Optimize memory


### PR DESCRIPTION
## Pull request description 

Failure of optional steps is now marking the whole execution to fail.

* It should not fail execution, if optional step fails

```yaml
kind: TestWorkflow
apiVersion: testworkflows.testkube.io/v1
metadata:
  name: optional-failure
spec:
  steps:
  - optional: true
    shell: exit 1
```

## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [x] tested locally
- [x] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
