### PR TITLE
fix: [TKC-2774] use default cloud url

### DIFF
--- a/.github/workflows/release-dev.yaml
+++ b/.github/workflows/release-dev.yaml
@@ -124,6 +124,9 @@ jobs:
   build_agent_image:
     name: Build a Docker image for Testkube Agent
     runs-on: ubuntu-latest
+    env:
+      TESTKUBE_CLOUD_URL: "agent.testkube.io:443"
+
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -163,6 +166,7 @@ jobs:
             ga_id=${{secrets.TESTKUBE_CLI_GA_MEASUREMENT_ID}}
             ga_secret=${{secrets.TESTKUBE_CLI_GA_MEASUREMENT_SECRET}}
             docker_image_version=${{steps.tag.outputs.tag}}
+            cloud_url=${{ env.TESTKUBE_CLOUD_URL }}
           context: build/kind
           file: build/kind/kind.Dockerfile
           platforms: linux/amd64,linux/arm64/v8

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -113,6 +113,8 @@ jobs:
   build_agent_image:
     name: Build a Docker image for Testkube Agent
     runs-on: ubuntu-latest
+    env:
+      TESTKUBE_CLOUD_URL: "agent.testkube.io:443"
 
     steps:
       - name: Checkout
@@ -155,6 +157,7 @@ jobs:
             ga_id=${{secrets.TESTKUBE_CLI_GA_MEASUREMENT_ID}}
             ga_secret=${{secrets.TESTKUBE_CLI_GA_MEASUREMENT_SECRET}}
             docker_image_version=${{steps.tag.outputs.tag}}
+            cloud_url=${{ env.TESTKUBE_CLOUD_URL }}
           context: build/kind
           file: build/kind/kind.Dockerfile
           platforms: linux/amd64,linux/arm64

--- a/build/kind/entrypoint.sh
+++ b/build/kind/entrypoint.sh
@@ -173,13 +173,6 @@ if [ -z "$AGENT_KEY" ]; then
   exit 1
 fi
 
-# Check if cloud url is provided
-if [ -z "$CLOUD_URL" ]; then
-  log "Testkube installation failed. Please provide CLOUD_URL env var"
-  send_telenetry "docker_installation_failed" "parameter_not_found" "cloud url is empty"
-  exit 1
-fi
-
 # Step 1: Start docker service in background
 /usr/local/bin/dockerd-entrypoint.sh &
 

--- a/build/kind/kind.Dockerfile
+++ b/build/kind/kind.Dockerfile
@@ -35,6 +35,8 @@ ARG ga_secret
 ENV GA_SECRET=$ga_secret
 ARG docker_image_version
 ENV DOCKER_IMAGE_VERSION=$docker_image_version
+ARG cloud_url
+ENV CLOUD_URL=$cloud_url
 
 # Step 8: Set Docker entry point for DIND (Docker-in-Docker)
 ENTRYPOINT ["tini", "--", "/usr/local/bin/entrypoint.sh"]

--- a/cmd/kubectl-testkube/commands/common/flags.go
+++ b/cmd/kubectl-testkube/commands/common/flags.go
@@ -59,7 +59,7 @@ func CreateVariables(cmd *cobra.Command, ignoreSecretVariable bool) (vars map[st
 	return
 }
 
-func PopulateMasterFlags(cmd *cobra.Command, opts *HelmOptions, optionalIds bool) {
+func PopulateMasterFlags(cmd *cobra.Command, opts *HelmOptions, isDockerCmd bool) {
 	var (
 		apiURIPrefix, uiURIPrefix, agentURIPrefix, cloudRootDomain, proRootDomain string
 		insecure                                                                  bool
@@ -85,11 +85,16 @@ func PopulateMasterFlags(cmd *cobra.Command, opts *HelmOptions, optionalIds bool
 	cmd.Flags().StringVar(&opts.Master.UiUrlPrefix, "ui-prefix", defaultUiPrefix, "usually don't need to be changed [required for custom cloud mode]")
 	cmd.Flags().StringVar(&opts.Master.RootDomain, "root-domain", defaultRootDomain, "usually don't need to be changed [required for custom cloud mode]")
 
-	cmd.Flags().StringVar(&opts.Master.URIs.Agent, "agent-uri", "", "Testkube Pro agent URI [required for centralized mode]")
+	agentURI := ""
+	if isDockerCmd {
+		agentURI = "agent.testkube.io:443"
+	}
+
+	cmd.Flags().StringVar(&opts.Master.URIs.Agent, "agent-uri", agentURI, "Testkube Pro agent URI [required for centralized mode]")
 	cmd.Flags().StringVar(&opts.Master.URIs.Logs, "logs-uri", "", "Testkube Pro logs URI [required for centralized mode]")
 	cmd.Flags().StringVar(&opts.Master.AgentToken, "agent-token", "", "Testkube Pro agent key [required for centralized mode]")
 	neededForLogin := ""
-	if optionalIds {
+	if isDockerCmd {
 		neededForLogin = ". It can be skipped for no login mode"
 	}
 


### PR DESCRIPTION
## Pull request description 

- add default cloud url to docker image
- use default value for agent uri in docker

## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [ ] tested locally
- [ ] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Breaking changes

-

## Changes

-

## Fixes

-