### PR TITLE
fix: set empty `reports` on Execution update too

### DIFF
--- a/pkg/repository/testworkflow/mongo.go
+++ b/pkg/repository/testworkflow/mongo.go
@@ -280,6 +280,9 @@ func (r *MongoRepository) Insert(ctx context.Context, result testkube.TestWorkfl
 
 func (r *MongoRepository) Update(ctx context.Context, result testkube.TestWorkflowExecution) (err error) {
 	result.EscapeDots()
+	if result.Reports == nil {
+		result.Reports = []testkube.TestWorkflowReport{}
+	}
 	_, err = r.Coll.ReplaceOne(ctx, bson.M{"id": result.Id}, result)
 	return
 }


### PR DESCRIPTION
## Pull request description 

* Earlier, it was putting empty array only on `Insert`, now it will add it in `Update` too
   * We haven't been using `repo.Update` before decoupling execution creation

## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [ ] tested locally
- [ ] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
