### PR TITLE
fix: detecting service IPs and fetching logs

### DIFF
--- a/cmd/tcl/testworkflow-toolkit/commands/services.go
+++ b/cmd/tcl/testworkflow-toolkit/commands/services.go
@@ -269,6 +269,7 @@ func NewServicesCmd() *cobra.Command {
 				scheduledAt := time.Now()
 				result, err := spawn.ExecutionWorker().Service(context.Background(), executionworkertypes.ServiceRequest{
 					ResourceId:     cfg.Resource.Id,
+					GroupId:        groupRef,
 					Execution:      cfg.Execution,
 					Workflow:       testworkflowsv1.TestWorkflow{Spec: instance.Spec},
 					ScheduledAt:    &scheduledAt,

--- a/cmd/testworkflow-init/main.go
+++ b/cmd/testworkflow-init/main.go
@@ -240,6 +240,10 @@ func main() {
 			}
 
 		case lite.ActionTypeExecute:
+			// Ensure the latest state before each execute,
+			// as it may refer to the state file (Toolkit).
+			data.SaveState()
+
 			// Ignore running when the step is already resolved (= skipped)
 			step := state.GetStep(action.Execute.Ref)
 			if step.IsFinished() {


### PR DESCRIPTION
## Pull request description 

* Add missing correlation group for services
  * So they can be gracefully cleaned up, and logs fetched
* Save the state file (with output) before execution
   * So Toolkit can always access service IPs

## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [x] tested locally
- [x] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
