### PR TITLE
fix: provide workflow name to parallel workers, so it will properly build path for artifacts

### DIFF
--- a/cmd/tcl/testworkflow-toolkit/commands/parallel.go
+++ b/cmd/tcl/testworkflow-toolkit/commands/parallel.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	testworkflowsv1 "github.com/kubeshop/testkube-operator/api/testworkflows/v1"
 	commontcl "github.com/kubeshop/testkube/cmd/tcl/testworkflow-toolkit/common"
@@ -220,10 +221,10 @@ func NewParallelCmd() *cobra.Command {
 				result, err := spawn.ExecutionWorker().Execute(context.Background(), executionworkertypes.ExecuteRequest{
 					ResourceId:          cfg.Resource.Id,
 					Execution:           cfg.Execution,
-					Workflow:            testworkflowsv1.TestWorkflow{Spec: *spec},
+					Workflow:            testworkflowsv1.TestWorkflow{ObjectMeta: metav1.ObjectMeta{Name: cfg.Workflow.Name, Labels: cfg.Workflow.Labels}, Spec: *spec},
 					ScheduledAt:         &scheduledAt,
 					ControlPlane:        cfg.ControlPlane,
-					ArtifactsPathPrefix: cfg.Resource.FsPrefix,
+					ArtifactsPathPrefix: spawn.CreateResourceConfig("", index).FsPrefix, // Omit duplicated reference for FS prefix
 				})
 				if err != nil {
 					fmt.Printf("%d: failed to prepare resources: %s\n", index, err.Error())

--- a/cmd/tcl/testworkflow-toolkit/commands/services.go
+++ b/cmd/tcl/testworkflow-toolkit/commands/services.go
@@ -20,6 +20,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	testworkflowsv1 "github.com/kubeshop/testkube-operator/api/testworkflows/v1"
 	commontcl "github.com/kubeshop/testkube/cmd/tcl/testworkflow-toolkit/common"
@@ -271,7 +272,7 @@ func NewServicesCmd() *cobra.Command {
 					ResourceId:     cfg.Resource.Id,
 					GroupId:        groupRef,
 					Execution:      cfg.Execution,
-					Workflow:       testworkflowsv1.TestWorkflow{Spec: instance.Spec},
+					Workflow:       testworkflowsv1.TestWorkflow{ObjectMeta: metav1.ObjectMeta{Name: cfg.Workflow.Name, Labels: cfg.Workflow.Labels}, Spec: instance.Spec},
 					ScheduledAt:    &scheduledAt,
 					RestartPolicy:  string(instance.RestartPolicy),
 					ReadinessProbe: common.MapPtr(instance.ReadinessProbe, testworkflows.MapProbeKubeToAPI),

--- a/pkg/testworkflows/executionworker/registry/controllers.go
+++ b/pkg/testworkflows/executionworker/registry/controllers.go
@@ -67,7 +67,10 @@ func (r *controllersRegistry) unsafeGet(id string) (ctrl controller.Controller, 
 func (r *controllersRegistry) deregister(id string) {
 	r.mu.Lock()
 	r.controllerReservations[id]--
-	if r.controllerReservations[id] == 0 {
+	if r.controllerReservations[id] < 0 {
+		r.controllerReservations[id] = 0
+	}
+	if r.controllerReservations[id] == 0 && r.controllers[id] != nil {
 		podIp, err := r.controllers[id].PodIP()
 		if err == nil && podIp != "" {
 			r.ips.Register(id, podIp)


### PR DESCRIPTION
## Pull request description 

* Provide workflow name down
* Simplify artifacts path for parallel workers (`<ref>/<index>` instead of `<ref>/<ref>-<index>`)
* Ensure de-registering controllers in Execution Worker works fine (encountered issue once)

## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [x] tested locally
- [x] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
