### PR TITLE
fix: set correctly group statuses on fatal error

### DIFF
--- a/pkg/api/v1/testkube/model_test_workflow_result_extended.go
+++ b/pkg/api/v1/testkube/model_test_workflow_result_extended.go
@@ -536,6 +536,7 @@ func (r *TestWorkflowResult) HealAborted(sigSequence []TestWorkflowSignature, er
 		} else if anyAborted {
 			step.Status = common.Ptr(ABORTED_TestWorkflowStepStatus)
 		}
+		r.Steps[ref] = step
 	}
 
 	// The rest of steps is unrecognized, so just mark them as aborted with information about faulty state


### PR DESCRIPTION
## Pull request description 

* When there was "skipped" status determined, it was not persisted, but replaced by "aborted" with "unknown failure source" message

## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [x] tested locally
- [x] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
