### PR TITLE
chore: Bump Go to 1.23

### DIFF
--- a/cmd/debug-server/Dockerfile
+++ b/cmd/debug-server/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1
-FROM golang:1.22
+FROM golang:1.23
 WORKDIR /build
 COPY . .
 ENV CGO_ENABLED=0

--- a/contrib/executor/ginkgo/build/agent/Dockerfile
+++ b/contrib/executor/ginkgo/build/agent/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1
-FROM golang:1.22-alpine as base
+FROM golang:1.23-alpine as base
 
 RUN apk update;
 RUN go install -mod=mod github.com/onsi/ginkgo/v2/ginkgo

--- a/contrib/executor/k6/build/agent/Dockerfile
+++ b/contrib/executor/k6/build/agent/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.22 as builder
+FROM golang:1.23 as builder
 # # build k6 0.36.0 with prometheus support
 ENV K6_VERSION=v0.48.0
 RUN go install go.k6.io/xk6/cmd/xk6@v0.10.0 && xk6 build $K6_VERSION --with github.com/grafana/xk6-output-prometheus-remote@latest

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kubeshop/testkube
 
-go 1.22.3
+go 1.23.2
 
 require (
 	github.com/99designs/gqlgen v0.17.27


### PR DESCRIPTION
## Pull request description 

Updates `go` to `1.23.2`.

Relates to https://github.com/kubeshop/testkube/issues/5905

## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [ ] tested locally
- [ ] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Breaking changes

-

## Changes

-

## Fixes

-