### PR TITLE
fix: allow custom URLs and auth connector to support our Skaffold setup

### DIFF
--- a/cmd/kubectl-testkube/commands/common/client.go
+++ b/cmd/kubectl-testkube/commands/common/client.go
@@ -100,7 +100,7 @@ func GetClient(cmd *cobra.Command) (client.Client, string, error) {
 			token, refreshToken, err = cloudlogin.CheckAndRefreshToken(context.Background(), authURI, cfg.CloudContext.ApiKey, cfg.CloudContext.RefreshToken)
 			if err != nil {
 				// Error: failed refreshing, go thru login flow
-				token, refreshToken, err = LoginUser(authURI)
+				token, refreshToken, err = LoginUser(authURI, cfg.CloudContext.CustomAuth)
 				if err != nil {
 					return nil, "", fmt.Errorf("error logging in: %w", err)
 				}

--- a/cmd/kubectl-testkube/commands/common/flags.go
+++ b/cmd/kubectl-testkube/commands/common/flags.go
@@ -84,6 +84,14 @@ func PopulateMasterFlags(cmd *cobra.Command, opts *HelmOptions, isDockerCmd bool
 	cmd.Flags().StringVar(&opts.Master.LogsUrlPrefix, "logs-prefix", defaultLogsPrefix, "usually don't need to be changed [required for custom cloud mode]")
 	cmd.Flags().StringVar(&opts.Master.UiUrlPrefix, "ui-prefix", defaultUiPrefix, "usually don't need to be changed [required for custom cloud mode]")
 	cmd.Flags().StringVar(&opts.Master.RootDomain, "root-domain", defaultRootDomain, "usually don't need to be changed [required for custom cloud mode]")
+	cmd.Flags().BoolVar(&opts.Master.CustomAuth, "custom-auth", false, "usually don't need to be changed [required for custom cloud mode]")
+
+	// allow to override default values of all URIs
+	cmd.Flags().String("api-uri-override", "", "api uri override")
+	cmd.Flags().String("ui-uri-override", "", "ui uri override")
+	cmd.Flags().String("auth-uri-override", "", "auth uri override")
+	cmd.Flags().String("agent-uri-override", "", "agent uri override")
+	cmd.Flags().String("logs-uri-override", "", "logs service uri override")
 
 	agentURI := ""
 	if isDockerCmd {
@@ -165,6 +173,10 @@ func ProcessMasterFlags(cmd *cobra.Command, opts *HelmOptions, cfg *config.Data)
 		opts.Master.LogsUrlPrefix = cmd.Flag("logs-prefix").Value.String()
 	}
 
+	if cmd.Flags().Changed("custom-auth") {
+		opts.Master.CustomAuth = cmd.Flag("custom-auth").Value.String() == "true"
+	}
+
 	uris := NewMasterUris(opts.Master.ApiUrlPrefix,
 		opts.Master.UiUrlPrefix,
 		opts.Master.AgentUrlPrefix,
@@ -189,6 +201,10 @@ func ProcessMasterFlags(cmd *cobra.Command, opts *HelmOptions, cfg *config.Data)
 
 	if cmd.Flag("ui-uri-override") != nil && cmd.Flags().Changed("ui-uri-override") {
 		uris.WithUiURI(cmd.Flag("ui-uri-override").Value.String())
+	}
+
+	if cmd.Flag("auth-uri-override") != nil && cmd.Flags().Changed("auth-uri-override") {
+		uris.WithAuthURI(cmd.Flag("auth-uri-override").Value.String())
 	}
 
 	opts.Master.URIs = uris

--- a/cmd/kubectl-testkube/commands/common/helper.go
+++ b/cmd/kubectl-testkube/commands/common/helper.go
@@ -446,9 +446,12 @@ func PopulateCloudConfig(cfg config.Data, apiKey string, dockerContainerName *st
 	return cfg
 }
 
-func LoginUser(authUri string) (string, string, error) {
+func LoginUser(authUri string, customConnector bool) (string, string, error) {
 	ui.H1("Login")
-	connectorID := ui.Select("Choose your login method", []string{github, gitlab})
+	connectorID := ""
+	if !customConnector {
+		connectorID = ui.Select("Choose your login method", []string{github, gitlab})
+	}
 
 	authUrl, tokenChan, err := cloudlogin.CloudLogin(context.Background(), authUri, strings.ToLower(connectorID))
 	if err != nil {

--- a/cmd/kubectl-testkube/commands/context/set.go
+++ b/cmd/kubectl-testkube/commands/context/set.go
@@ -98,10 +98,6 @@ func NewSetContextCmd() *cobra.Command {
 	cmd.Flags().StringVarP(&apiKey, "api-key", "k", "", "API Key for Testkube Pro")
 
 	// allow to override default values of all URIs
-	cmd.Flags().String("api-uri-override", "", "api uri override")
-	cmd.Flags().String("ui-uri-override", "", "ui uri override")
-	cmd.Flags().String("agent-uri-override", "", "agnet uri override")
-	cmd.Flags().String("logs-uri-override", "", "logs service uri override")
 	cmd.Flags().StringVar(&dockerContainerName, "docker-container", "testkube-agent", "Docker container name for Testkube Docker Agent")
 
 	common.PopulateMasterFlags(cmd, &opts, false)

--- a/cmd/kubectl-testkube/commands/dashboard.go
+++ b/cmd/kubectl-testkube/commands/dashboard.go
@@ -34,8 +34,8 @@ func NewDashboardCmd() *cobra.Command {
 			cfg, err := config.Load()
 			ui.ExitOnError("loading config file", err)
 
-			if namespace == "" {
-				namespace = cfg.Namespace
+			if namespace != "" {
+				cfg.Namespace = namespace
 			}
 
 			if cfg.ContextType != config.ContextTypeCloud {
@@ -43,7 +43,7 @@ func NewDashboardCmd() *cobra.Command {
 				if isDashboardRunning {
 					openOnPremDashboard(cmd, cfg, verbose, skipBrowser, "")
 				} else {
-					ui.Warn("No dashboard found. Is it running in the " + namespace + " namespace?")
+					ui.Warn("No dashboard found. Is it running in the " + cfg.Namespace + " namespace?")
 				}
 			} else {
 				openCloudDashboard(cfg)

--- a/cmd/kubectl-testkube/commands/docker/init.go
+++ b/cmd/kubectl-testkube/commands/docker/init.go
@@ -117,7 +117,7 @@ func NewInitCmd() *cobra.Command {
 			ui.H2("Saving Testkube CLI Pro context")
 			var token, refreshToken string
 			if !common.IsUserLoggedIn(cfg, options) {
-				token, refreshToken, err = common.LoginUser(options.Master.URIs.Auth)
+				token, refreshToken, err = common.LoginUser(options.Master.URIs.Auth, options.Master.CustomAuth)
 				sendErrTelemetry(cmd, cfg, "login", err)
 				ui.ExitOnError("user login", err)
 			}

--- a/cmd/kubectl-testkube/commands/pro/connect.go
+++ b/cmd/kubectl-testkube/commands/pro/connect.go
@@ -80,7 +80,7 @@ func NewConnectCmd() *cobra.Command {
 			)
 			// if no agent is passed create new environment and get its token
 			if opts.Master.AgentToken == "" && opts.Master.OrgId == "" && opts.Master.EnvId == "" {
-				token, refreshToken, err = common.LoginUser(opts.Master.URIs.Auth)
+				token, refreshToken, err = common.LoginUser(opts.Master.URIs.Auth, opts.Master.CustomAuth)
 				ui.ExitOnError("login", err)
 
 				orgId, orgName, err := common.UiGetOrganizationId(opts.Master.URIs.Api, token)
@@ -162,7 +162,7 @@ func NewConnectCmd() *cobra.Command {
 
 			ui.H2("Saving Testkube CLI Pro context")
 			if token == "" && !common.IsUserLoggedIn(cfg, opts) {
-				token, refreshToken, err = common.LoginUser(opts.Master.URIs.Auth)
+				token, refreshToken, err = common.LoginUser(opts.Master.URIs.Auth, opts.Master.CustomAuth)
 				ui.ExitOnError("user login", err)
 			}
 			err = common.PopulateLoginDataToContext(opts.Master.OrgId, opts.Master.EnvId, token, refreshToken, "", opts, cfg)

--- a/cmd/kubectl-testkube/commands/pro/init.go
+++ b/cmd/kubectl-testkube/commands/pro/init.go
@@ -98,7 +98,7 @@ func NewInitCmd() *cobra.Command {
 			ui.H2("Saving Testkube CLI Pro context")
 			var token, refreshToken string
 			if !common.IsUserLoggedIn(cfg, options) {
-				token, refreshToken, err = common.LoginUser(options.Master.URIs.Auth)
+				token, refreshToken, err = common.LoginUser(options.Master.URIs.Auth, options.Master.CustomAuth)
 				sendErrTelemetry(cmd, cfg, "login", err)
 				ui.ExitOnError("user login", err)
 			}

--- a/cmd/kubectl-testkube/commands/pro/login.go
+++ b/cmd/kubectl-testkube/commands/pro/login.go
@@ -21,7 +21,7 @@ func NewLoginCmd() *cobra.Command {
 
 			common.ProcessMasterFlags(cmd, &opts, &cfg)
 
-			token, refreshToken, err := common.LoginUser(opts.Master.URIs.Auth)
+			token, refreshToken, err := common.LoginUser(opts.Master.URIs.Auth, opts.Master.CustomAuth)
 			ui.ExitOnError("getting token", err)
 
 			orgID := opts.Master.OrgId

--- a/cmd/kubectl-testkube/config/data.go
+++ b/cmd/kubectl-testkube/config/data.go
@@ -30,6 +30,7 @@ type CloudContext struct {
 	UiUri               string `json:"uiUri,omitempty"`
 	TokenType           string `json:"tokenType,omitempty"`
 	DockerContainerName string `json:"dockerContainerName,omitempty"`
+	CustomAuth          bool   `json:"customConnector,omitempty"`
 }
 
 type Data struct {

--- a/cmd/kubectl-testkube/config/master.go
+++ b/cmd/kubectl-testkube/config/master.go
@@ -13,6 +13,7 @@ type Master struct {
 	LogsUrlPrefix  string                    `json:"logsUrlPrefix,omitempty"`
 	ApiUrlPrefix   string                    `json:"apiUrlPrefix,omitempty"`
 	RootDomain     string                    `json:"rootDomain,omitempty"`
+	CustomAuth     bool                      `json:"customAuth,omitempty"`
 	Features       featureflags.FeatureFlags `json:"features,omitempty"`
 
 	URIs MasterURIs `json:"uris,omitempty"`
@@ -50,5 +51,11 @@ func (m *MasterURIs) WithLogsURI(uri string) *MasterURIs {
 // WithUi sets whole ui URI
 func (m *MasterURIs) WithUiURI(uri string) *MasterURIs {
 	m.Ui = uri
+	return m
+}
+
+// WithUi sets whole auth URI
+func (m *MasterURIs) WithAuthURI(uri string) *MasterURIs {
+	m.Auth = uri
 	return m
 }

--- a/cmd/tcl/kubectl-testkube/devbox/README.md
+++ b/cmd/tcl/kubectl-testkube/devbox/README.md
@@ -18,7 +18,7 @@ This utility is used to help with development of the Agent features (like Test W
 ## Usage
 
 * Login to Testkube CLI, like `testkube login`
-* Run `go run cmd/kubectl-testkube/main.go devbox`
+  * For local development Testkube Enterprise (Skaffold), consider `testkube login --api-uri-override=http://localhost:8099 --agent-uri-override=http://testkube-enterprise-api.tk-dev.svc.local:8089 --auth-uri-override=http://localhost:5556 --custom-auth`
   * It's worth to create alias for that in own `.bashrc` or `.bash_profile`
   * It's worth to pass a devbox name, like `-n dawid`, so it's not using random name
 

--- a/pkg/cloudlogin/login.go
+++ b/pkg/cloudlogin/login.go
@@ -47,7 +47,11 @@ func CloudLogin(ctx context.Context, providerURL, connectorID string) (string, c
 	go http.ListenAndServe(":8090", nil)
 
 	// Redirect the user to the OIDC provider's login page.
-	authURL := oauth2Config.AuthCodeURL("state", oauth2.AccessTypeOffline, oauth2.SetAuthURLParam("connector_id", connectorID))
+	opts := []oauth2.AuthCodeOption{oauth2.AccessTypeOffline}
+	if connectorID != "" {
+		opts = append(opts, oauth2.SetAuthURLParam("connector_id", connectorID))
+	}
+	authURL := oauth2Config.AuthCodeURL("state", opts...)
 
 	respCh := make(chan Tokens)
 


### PR DESCRIPTION
## Pull request description 

* Allow custom auth connector (with `--custom-auth`) and all the URLs
* Fix overriding namespace in `testkube dashboard` command

## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [x] tested locally
- [x] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Fixes

- https://linear.app/kubeshop/issue/TKC-2792/[on-prem-demo]-real-time-logs-and-artifacts-download-not-working