### PR TITLE
fix: downgrade GoReleaser Pro to v2.3.2, as it fails to build in v2.4.4

### DIFF
--- a/.github/workflows/release-dev.yaml
+++ b/.github/workflows/release-dev.yaml
@@ -73,7 +73,7 @@ jobs:
         uses: goreleaser/goreleaser-action@v6
         with:
           distribution: goreleaser-pro
-          version: latest
+          version: 'v2.3.2' # 2.4.4 fails with "no such file or directory"
           args: release -f ${{ matrix.path }} --skip=publish
         env:
           GITHUB_TOKEN: ${{ secrets.CI_BOT_TOKEN }}
@@ -222,7 +222,7 @@ jobs:
         uses: goreleaser/goreleaser-action@v6
         with:
           distribution: goreleaser-pro
-          version: latest
+          version: 'v2.3.2' # 2.4.4 fails with "no such file or directory"
           args: release -f .goreleaser-dev.yml
         env:
           GITHUB_TOKEN: ${{ secrets.CI_BOT_TOKEN }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -74,7 +74,7 @@ jobs:
         uses: goreleaser/goreleaser-action@v6
         with:
           distribution: goreleaser-pro
-          version: latest
+          version: 'v2.3.2' # 2.4.4 fails with "no such file or directory"
           args: release -f ${{ matrix.path }} --skip=publish
         env:
           GITHUB_TOKEN: ${{ secrets.CI_BOT_TOKEN }}
@@ -214,7 +214,7 @@ jobs:
         uses: goreleaser/goreleaser-action@v6
         with:
           distribution: goreleaser-pro
-          version: latest
+          version: 'v2.3.2' # 2.4.4 fails with "no such file or directory"
           args: release -f .goreleaser.yml
         env:
           GITHUB_TOKEN: ${{ secrets.CI_BOT_TOKEN }}


### PR DESCRIPTION
## Pull request description 

seems like GoReleaser fails to build kubectl-testkube binary now ([job](https://github.com/kubeshop/testkube/actions/runs/11681561402/job/32527400173)). There are no noticeable changes though compared to previous tag ([here](https://github.com/kubeshop/testkube/compare/v2.1.56...v2.1.57)) - except it's now GoReleaser v2.4.4-pro, when earlier it was v2.3.2-pro.
```
/opt/hostedtoolcache/goreleaser-action/2.4.4-pro/x64/goreleaser release -f .goreleaser.yml
  • by using this software you agree with its EULA, available at https://goreleaser.com/eula
  • running goreleaser v2.4.4-pro
  • loading environment variables
    • using token from $GITHUB_TOKEN
  • getting and validating git state
    • git state                                      commit=130be440378c16d656017003c3adbea59834385c branch=HEAD current_tag=v2.1.57 previous_tag=v2.1.56 dirty=false
  • parsing tag
  • setting defaults
  • ensuring distribution directory
  • setting up metadata
  • writing release metadata
  • loading go mod information
  • build prerequisites
  • building binaries
    • building                                       binary=dist/testkube_linux_arm64_v8.0/kubectl-testkube
    • building                                       binary=dist/testkube_linux_386_sse2/kubectl-testkube
    • building                                       binary=dist/testkube_windows_amd64_v1/kubectl-testkube.exe
    • building                                       binary=dist/testkube_linux_amd64_v1/kubectl-testkube
    • building                                       binary=dist/testkube_windows_arm64_v8.0/kubectl-testkube.exe
    • building                                       binary=dist/testkube_windows_386_sse2/kubectl-testkube.exe
    • building                                       binary=dist/testkube_darwin_arm64_v8.0/kubectl-testkube
    • building                                       binary=dist/testkube_darwin_amd64_v1/kubectl-testkube
  ⨯ release failed after 0s                  error=could not import "linux/testkube_linux_arm64/kubectl-testkube": stat linux/testkube_linux_arm64/kubectl-testkube: no such file or directory
```

## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [ ] tested locally
- [ ] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
