### PR TITLE
fix: passing secret as sensitive config

### DIFF
--- a/pkg/expressions/generic.go
+++ b/pkg/expressions/generic.go
@@ -212,11 +212,6 @@ func resolve(v reflect.Value, t tagData, m []Machine, force bool, finalize bool)
 				vv, _ = expr2.Static().StringValue()
 			} else {
 				vv = expr.Template()
-				if t.value == "template" && !IsTemplateStringWithoutExpressions(str) {
-					if IsTemplateStringWithInternalFnCall(vv) {
-						vv = CleanTemplateStringInternalFnCall(vv)
-					}
-				}
 			}
 			changed = vv != str
 			if ptr.Kind() == reflect.String {

--- a/pkg/expressions/parse.go
+++ b/pkg/expressions/parse.go
@@ -255,11 +255,3 @@ func CompileAndResolveTemplate(tpl string, m ...Machine) (Expression, error) {
 func IsTemplateStringWithoutExpressions(tpl string) bool {
 	return !strings.Contains(tpl, "{{")
 }
-
-func IsTemplateStringWithInternalFnCall(tpl string) bool {
-	return strings.Contains(tpl, "{{\"{{\"}}"+InternalFnCall)
-}
-
-func CleanTemplateStringInternalFnCall(tpl string) string {
-	return strings.ReplaceAll(tpl, "{{\"{{\"}}"+InternalFnCall, "{{")
-}

--- a/pkg/expressions/stdlib.go
+++ b/pkg/expressions/stdlib.go
@@ -17,8 +17,7 @@ import (
 )
 
 const (
-	RFC3339Millis  = "2006-01-02T15:04:05.000Z07:00"
-	InternalFnCall = "__internal__fn__call__"
+	RFC3339Millis = "2006-01-02T15:04:05.000Z07:00"
 )
 
 type StdFunction struct {

--- a/pkg/testworkflows/testworkflowprocessor/processor.go
+++ b/pkg/testworkflows/testworkflowprocessor/processor.go
@@ -166,7 +166,7 @@ func (p *processor) Bundle(ctx context.Context, workflow *testworkflowsv1.TestWo
 	secrets := append(layer.Secrets(), options.Secrets...)
 	for i := range secrets {
 		AnnotateControlledBy(&secrets[i], options.Config.Resource.RootId, options.Config.Resource.Id)
-		err = expressions.FinalizeForce(&secrets[i], machines...)
+		err = expressions.SimplifyForce(&secrets[i], machines...)
 		if err != nil {
 			return nil, errors.Wrap(err, "finalizing Secret")
 		}

--- a/pkg/testworkflows/testworkflowprocessor/secretmachine.go
+++ b/pkg/testworkflows/testworkflowprocessor/secretmachine.go
@@ -48,8 +48,8 @@ func createSecretMachine(mapEnvs map[string]corev1.EnvVarSource) expressions.Mac
 					Key: keyName,
 				},
 			}
-
-			return expressions.NewValue(fmt.Sprintf("{{%senv.%s}}", expressions.InternalFnCall, envName)), true, nil
+			v, err := expressions.Compile("env." + envName)
+			return v, true, err
 		})
 
 }

--- a/pkg/testworkflows/testworkflowprocessor/secretmachine_test.go
+++ b/pkg/testworkflows/testworkflowprocessor/secretmachine_test.go
@@ -12,7 +12,9 @@ import (
 func TestSecret(t *testing.T) {
 	mapEnvs := make(map[string]corev1.EnvVarSource)
 	machine := createSecretMachine(mapEnvs)
-	assert.Equal(t, "{{env.name_0_one_1_two_K_key_0_three_1_four}}", expressions.MustCall(machine, "secret", "name-one.two", "key-three.four"))
+	call, err := expressions.CompileAndResolve(`secret("name-one.two", "key-three.four")`, machine)
+	assert.NoError(t, err)
+	assert.Equal(t, "env.name_0_one_1_two_K_key_0_three_1_four", call.String())
 	assert.EqualValues(t, map[string]corev1.EnvVarSource{
 		"_02S_name_0_one_1_two_K_key_0_three_1_four": {
 			SecretKeyRef: &corev1.SecretKeySelector{
@@ -28,7 +30,9 @@ func TestSecret(t *testing.T) {
 func TestSecretComputed(t *testing.T) {
 	mapEnvs := make(map[string]corev1.EnvVarSource)
 	machine := createSecretMachine(mapEnvs)
-	assert.Equal(t, "{{env.name_0_one_1_two_K_key_0_three_1_four}}", expressions.MustCall(machine, "secret", "name-one.two", "key-three.four", true))
+	call, err := expressions.CompileAndResolve(`secret("name-one.two", "key-three.four", true)`, machine)
+	assert.NoError(t, err)
+	assert.Equal(t, "env.name_0_one_1_two_K_key_0_three_1_four", call.String())
 	assert.EqualValues(t, map[string]corev1.EnvVarSource{
 		"_02CS_name_0_one_1_two_K_key_0_three_1_four": {
 			SecretKeyRef: &corev1.SecretKeySelector{

--- a/pkg/testworkflows/testworkflowprocessor/secretmachine_test.go
+++ b/pkg/testworkflows/testworkflowprocessor/secretmachine_test.go
@@ -12,7 +12,7 @@ import (
 func TestSecret(t *testing.T) {
 	mapEnvs := make(map[string]corev1.EnvVarSource)
 	machine := createSecretMachine(mapEnvs)
-	assert.Equal(t, "{{"+expressions.InternalFnCall+"env.name_0_one_1_two_K_key_0_three_1_four}}", expressions.MustCall(machine, "secret", "name-one.two", "key-three.four"))
+	assert.Equal(t, "{{env.name_0_one_1_two_K_key_0_three_1_four}}", expressions.MustCall(machine, "secret", "name-one.two", "key-three.four"))
 	assert.EqualValues(t, map[string]corev1.EnvVarSource{
 		"_02S_name_0_one_1_two_K_key_0_three_1_four": {
 			SecretKeyRef: &corev1.SecretKeySelector{
@@ -28,7 +28,7 @@ func TestSecret(t *testing.T) {
 func TestSecretComputed(t *testing.T) {
 	mapEnvs := make(map[string]corev1.EnvVarSource)
 	machine := createSecretMachine(mapEnvs)
-	assert.Equal(t, "{{"+expressions.InternalFnCall+"env.name_0_one_1_two_K_key_0_three_1_four}}", expressions.MustCall(machine, "secret", "name-one.two", "key-three.four", true))
+	assert.Equal(t, "{{env.name_0_one_1_two_K_key_0_three_1_four}}", expressions.MustCall(machine, "secret", "name-one.two", "key-three.four", true))
 	assert.EqualValues(t, map[string]corev1.EnvVarSource{
 		"_02CS_name_0_one_1_two_K_key_0_three_1_four": {
 			SecretKeyRef: &corev1.SecretKeySelector{

--- a/pkg/testworkflows/testworkflowresolver/config.go
+++ b/pkg/testworkflows/testworkflowresolver/config.go
@@ -83,7 +83,7 @@ func getSecretCallExpression(expr expressions.Expression, k string, externalize 
 		return nil, errors.Wrap(err, "config."+k)
 	}
 	if envVar.SecretKeyRef != nil {
-		expr = expressions.NewValue(fmt.Sprintf("{{%ssecret(\"%s\", \"%s\", true)}}", expressions.InternalFnCall,
+		return expressions.Compile(fmt.Sprintf("secret(\"%s\", \"%s\", true)",
 			envVar.SecretKeyRef.Name, envVar.SecretKeyRef.Key))
 	}
 


### PR DESCRIPTION
## Pull request description 

```yaml
kind: TestWorkflow
apiVersion: testworkflows.testkube.io/v1
metadata:
  name: example-workflow
spec:
  steps:
  - name: Run tests
    template:
      name: example-template
      config:
        something: '{{ secret("some-secret", "key") }}'
---
kind: TestWorkflowTemplate
apiVersion: testworkflows.testkube.io/v1
metadata:
  name: example-template
spec:
  config:
    something:
      type: string
      sensitive: true
  steps:
  - shell: echo {{ config.something }}
```

<img width="1676" alt="Zrzut ekranu 2024-11-5 o 16 16 35" src="https://github.com/user-attachments/assets/8bb75c90-ec6f-478d-acfd-a54b6ecdda58">

## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [x] tested locally
- [x] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
