### PR TITLE
fix: load image metadata when needed / load platform-specific manifest with Crane fetcher

### DIFF
--- a/pkg/testworkflows/testworkflowprocessor/processor.go
+++ b/pkg/testworkflows/testworkflowprocessor/processor.go
@@ -212,7 +212,7 @@ func (p *processor) Bundle(ctx context.Context, workflow *testworkflowsv1.TestWo
 
 	// Load the image details when necessary
 	hasPodSecurityContextGroup := podConfig.SecurityContext != nil && podConfig.SecurityContext.RunAsGroup != nil
-	imageNames := root.GetImages(hasPodSecurityContextGroup)
+	imageNames := root.GetImages(!hasPodSecurityContextGroup)
 	images := make(map[string]*imageinspector.Info)
 	imageNameResolutions := map[string]string{}
 	for image, needsMetadata := range imageNames {


### PR DESCRIPTION
## Pull request description 

* load image metadata when needed
  * there was a typo: when there was group required to determine permissions, it was passing down as unneeded
* obtain image manifests in Crane for specific platform
  * it was not checking for the platform

## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [x] tested locally
- [x] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test