### PR TITLE
fix: CRD synchronisation in the development tool

### DIFF
--- a/cmd/tcl/kubectl-testkube/devbox/devutils/crdsync.go
+++ b/cmd/tcl/kubectl-testkube/devbox/devutils/crdsync.go
@@ -149,8 +149,8 @@ func (c *CRDSync) processTemplate(sourcePath string, template testworkflowsv1.Te
 			if !bytes.Equal(v1, v2) {
 				c.templates[i].Template = template
 				c.updates = append(c.updates, CRDSyncUpdate{Template: &template, Op: CRDSyncUpdateOpUpdate})
-				return nil
 			}
+			return nil
 		}
 	}
 	c.templates = append(c.templates, CRDSyncTemplate{SourcePath: sourcePath, Template: template})

--- a/cmd/tcl/kubectl-testkube/devbox/devutils/resources.go
+++ b/cmd/tcl/kubectl-testkube/devbox/devutils/resources.go
@@ -50,8 +50,14 @@ func (r *ossResourcesClient) CreateTestWorkflow(workflow testkube.TestWorkflow) 
 }
 
 func (r *ossResourcesClient) UpdateTestWorkflow(workflow testkube.TestWorkflow) (result testkube.TestWorkflow, err error) {
-	workflow.Namespace = r.namespace
-	v, err := r.testWorkflows.Update(testworkflows.MapAPIToKube(&workflow))
+	prev, err := r.testWorkflows.Get(workflow.Name)
+	if err != nil {
+		return r.CreateTestWorkflow(workflow)
+	}
+	cr := testworkflows.MapAPIToKube(&workflow)
+	cr.Namespace = r.namespace
+	cr.ResourceVersion = prev.ResourceVersion
+	v, err := r.testWorkflows.Update(cr)
 	if err != nil {
 		return
 	}
@@ -72,8 +78,14 @@ func (r *ossResourcesClient) CreateTestWorkflowTemplate(template testkube.TestWo
 }
 
 func (r *ossResourcesClient) UpdateTestWorkflowTemplate(template testkube.TestWorkflowTemplate) (result testkube.TestWorkflowTemplate, err error) {
-	template.Namespace = r.namespace
-	v, err := r.testWorkflowTemplates.Update(testworkflows.MapTemplateAPIToKube(&template))
+	prev, err := r.testWorkflowTemplates.Get(template.Name)
+	if err != nil {
+		return r.CreateTestWorkflowTemplate(template)
+	}
+	cr := testworkflows.MapTemplateAPIToKube(&template)
+	cr.Namespace = r.namespace
+	cr.ResourceVersion = prev.ResourceVersion
+	v, err := r.testWorkflowTemplates.Update(cr)
 	if err != nil {
 		return
 	}


### PR DESCRIPTION
## Pull request description 

* it was not working correctly for OSS, because `resourceVersion` was missing.
* also, template was marked as created when it exists but no changes detected

## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [x] tested locally
- [x] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
