### PR TITLE
fix(testsuites): build execution filter properly

### DIFF
--- a/internal/app/api/deprecatedv1/testsuites.go
+++ b/internal/app/api/deprecatedv1/testsuites.go
@@ -624,8 +624,8 @@ func (s *DeprecatedTestkubeAPI) ListTestSuiteExecutionsHandler() fiber.Handler {
 		}
 		l.Debugw("got executions totals", "totals", executionsTotals, "time", time.Since(now))
 		filterAllTotals := *filter.(*testresult.FilterImpl)
-		filterAllTotals.WithPage(0).WithPageSize(math.MaxInt64)
-		allExecutionsTotals, err := s.DeprecatedRepositories.TestSuiteResults().GetExecutionsTotals(ctx, filterAllTotals)
+		filterAllTotals.WithPage(0).WithPageSize(math.MaxInt32)
+		allExecutionsTotals, err := s.DeprecatedRepositories.TestSuiteResults().GetExecutionsTotals(ctx, &filterAllTotals)
 		if err != nil {
 			return s.Error(c, http.StatusInternalServerError, fmt.Errorf("%s: client could not get all executions totals: %w", errPrefix, err))
 		}


### PR DESCRIPTION
## Pull request description 

* gRPC repository for Test Suites was trying to cast filter to pointer of one structure, while actual struct (not a pointer) was passed (https://github.com/kubeshop/testkube/commit/2d1757038ff415a11e8d58740f14086404fe4d45)
   * In Test Workflows we support both
   * In Tests we always use pointers
   * As the feature is deprecated anyway, just patched to send pointer instead

## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [x] tested locally
- [x] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test