### PR TITLE
fix: merge general-use steps properly

### DIFF
--- a/pkg/testworkflows/testworkflowprocessor/action/containerize.go
+++ b/pkg/testworkflows/testworkflowprocessor/action/containerize.go
@@ -39,11 +39,15 @@ func CreateContainer(groupId int, defaultContainer stage2.Container, actions []a
 	// Find the highest priority container configuration
 	var bestContainerConfig *actiontypes.Action
 	var bestIsToolkit = false
+	var bestIsDefaultImage = true
 	for i := range containerConfigs {
 		if executable[containerConfigs[i].Container.Ref] {
-			if bestContainerConfig == nil || bestIsToolkit {
+			image := containerConfigs[i].Container.Config.Image
+			isDefaultImage := image == "" || image == constants.DefaultInitImage || image == constants.DefaultToolkitImage
+			if bestContainerConfig == nil || bestIsToolkit || (bestIsDefaultImage && !isDefaultImage) {
 				bestContainerConfig = containerConfigs[i]
 				bestIsToolkit = toolkit[bestContainerConfig.Container.Ref]
+				bestIsDefaultImage = isDefaultImage
 			}
 		}
 	}

--- a/pkg/testworkflows/testworkflowprocessor/action/containerize_test.go
+++ b/pkg/testworkflows/testworkflowprocessor/action/containerize_test.go
@@ -1,0 +1,61 @@
+package action
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	testworkflowsv1 "github.com/kubeshop/testkube-operator/api/testworkflows/v1"
+	"github.com/kubeshop/testkube/internal/common"
+	"github.com/kubeshop/testkube/pkg/testworkflows/testworkflowprocessor/action/actiontypes"
+	"github.com/kubeshop/testkube/pkg/testworkflows/testworkflowprocessor/constants"
+	"github.com/kubeshop/testkube/pkg/testworkflows/testworkflowprocessor/stage"
+)
+
+func TestCreateContainer_MergingDefaultStepBefore(t *testing.T) {
+	input := actiontypes.NewActionList().
+		MutateContainer("ref1", testworkflowsv1.ContainerConfig{
+			Command: common.Ptr([]string{"sleep"}),
+		}).
+		Start("ref1").
+		Execute("ref1", false, true).
+		End("ref1").
+		CurrentStatus("ref1").
+		MutateContainer("ref2", testworkflowsv1.ContainerConfig{
+			Image:   "custom-image:1.2.3",
+			Command: common.Ptr([]string{"my-test"}),
+		}).
+		Start("ref2").
+		Execute("ref2", false, false).
+		End("ref2").
+		End(constants.RootOperationName).
+		End("")
+	result, _, err := CreateContainer(1, stage.NewContainer(), input, false)
+
+	assert.NoError(t, err)
+	assert.Equal(t, result.Image, "custom-image:1.2.3")
+}
+
+func TestCreateContainer_MergingDefaultStepAfter(t *testing.T) {
+	input := actiontypes.NewActionList().
+		MutateContainer("ref1", testworkflowsv1.ContainerConfig{
+			Image:   "custom-image:1.2.3",
+			Command: common.Ptr([]string{"my-test"}),
+		}).
+		Start("ref1").
+		Execute("ref1", false, false).
+		End("ref1").
+		CurrentStatus("ref1").
+		MutateContainer("ref2", testworkflowsv1.ContainerConfig{
+			Command: common.Ptr([]string{"sleep"}),
+		}).
+		Start("ref2").
+		Execute("ref2", false, true).
+		End("ref2").
+		End(constants.RootOperationName).
+		End("")
+	result, _, err := CreateContainer(1, stage.NewContainer(), input, false)
+
+	assert.NoError(t, err)
+	assert.Equal(t, result.Image, "custom-image:1.2.3")
+}


### PR DESCRIPTION
## Pull request description 

* It was incorrectly using default image when the container had pure operation merged forward

```yaml
kind: TestWorkflow
apiVersion: testworkflows.testkube.io/v1
metadata:
  name: example
spec:
  steps:
  - delay: 1s
    run:
      image: curlimages/curl:latest
      shell: curl -XGET http://testkube.io/
```

It will run both commands with the default init image, instead of `curlimages/curl:latest`

## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [x] tested locally
- [x] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [x] added a test