### PR TITLE
fix: make the Cloud connection from the Init Process lazy (connect only when needed)

### DIFF
--- a/cmd/testworkflow-init/data/client.go
+++ b/cmd/testworkflow-init/data/client.go
@@ -35,5 +35,5 @@ func CloudClient() cloud.TestKubeCloudAPIClient {
 
 func Credentials() credentials.CredentialRepository {
 	cfg := GetState().InternalConfig
-	return credentials.NewCredentialRepository(CloudClient(), cfg.Worker.Connection.ApiKey, cfg.Execution.Id)
+	return credentials.NewCredentialRepository(CloudClient, cfg.Worker.Connection.ApiKey, cfg.Execution.Id)
 }

--- a/pkg/credentials/repository.go
+++ b/pkg/credentials/repository.go
@@ -17,19 +17,19 @@ type CredentialRepository interface {
 }
 
 type credentialRepository struct {
-	client      cloud.TestKubeCloudAPIClient
+	getClient   func() cloud.TestKubeCloudAPIClient
 	apiKey      string
 	executionId string
 }
 
-func NewCredentialRepository(client cloud.TestKubeCloudAPIClient, apiKey, executionId string) CredentialRepository {
-	return &credentialRepository{client: client, apiKey: apiKey, executionId: executionId}
+func NewCredentialRepository(getClient func() cloud.TestKubeCloudAPIClient, apiKey, executionId string) CredentialRepository {
+	return &credentialRepository{getClient: getClient, apiKey: apiKey, executionId: executionId}
 }
 
 func (c *credentialRepository) Get(ctx context.Context, name string) ([]byte, error) {
 	ctx = agentclient.AddAPIKeyMeta(ctx, c.apiKey)
 	opts := []grpc.CallOption{grpc.UseCompressor(gzip.Name), grpc.MaxCallRecvMsgSize(math.MaxInt32)}
-	result, err := c.client.GetCredential(ctx, &cloud.CredentialRequest{Name: name, ExecutionId: c.executionId}, opts...)
+	result, err := c.getClient().GetCredential(ctx, &cloud.CredentialRequest{Name: name, ExecutionId: c.executionId}, opts...)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Pull request description 

* Otherwise, images that don't use `credential()`, but have incorrect certificates (i.e. in images) for Cloud connection, will fail)

## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [x] tested locally
- [x] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test