### PR TITLE
feat: [TKC-3016] fix defaultConfigs for TestWorkflow executions

### DIFF
--- a/pkg/repository/testworkflow/mongo_integration_test.go
+++ b/pkg/repository/testworkflow/mongo_integration_test.go
@@ -562,4 +562,76 @@ func TestNewMongoRepository_Get_Integration(t *testing.T) {
 	assert.Equal(t, "default", result.ConfigParams["param1"].DefaultValue)
 	assert.Equal(t, false, result.ConfigParams["param1"].Truncated)
 
+	execution2 := testkube.TestWorkflowExecution{
+		Id:   "test-id-2",
+		Name: "test-name-2",
+		Workflow: &testkube.TestWorkflow{
+			Name: "test-workflow-2",
+			Spec: &testkube.TestWorkflowSpec{},
+		},
+		ResolvedWorkflow: &testkube.TestWorkflow{
+			Name: "test-workflow-2",
+			Spec: &testkube.TestWorkflowSpec{
+				Config: map[string]testkube.TestWorkflowParameterSchema{
+					"param2": {
+						Default_: &testkube.BoxedString{
+							Value: "default",
+						},
+					},
+					"param1": {
+						Default_: &testkube.BoxedString{
+							Value: "default",
+						},
+						Sensitive: true,
+					},
+				},
+			},
+		},
+	}
+	err = repo.Insert(ctx, execution2)
+	assert.NoError(t, err)
+
+	result, err = repo.Get(ctx, "test-id-2")
+	assert.NoError(t, err)
+
+	assert.Equal(t, execution2.Id, result.Id)
+	assert.Equal(t, execution2.Name, result.Name)
+	assert.Nil(t, result.ConfigParams)
+
+	execution3 := testkube.TestWorkflowExecution{
+		Id:   "test-id-3",
+		Name: "test-name-3",
+		Workflow: &testkube.TestWorkflow{
+			Name: "test-workflow-3",
+			Spec: &testkube.TestWorkflowSpec{},
+		},
+		ResolvedWorkflow: &testkube.TestWorkflow{
+			Name: "test-workflow-2",
+			Spec: &testkube.TestWorkflowSpec{
+				Config: map[string]testkube.TestWorkflowParameterSchema{
+					"param2": {
+						Default_: &testkube.BoxedString{
+							Value: "default",
+						},
+					},
+					"param1": {
+						Default_: &testkube.BoxedString{
+							Value: "default",
+						},
+						Sensitive: true,
+					},
+				},
+			},
+		},
+		ConfigParams: map[string]testkube.TestWorkflowExecutionConfigValue{},
+	}
+	err = repo.Insert(ctx, execution3)
+	assert.NoError(t, err)
+
+	result, err = repo.Get(ctx, "test-id-3")
+	assert.NoError(t, err)
+
+	assert.Equal(t, execution3.Id, result.Id)
+	assert.Equal(t, execution3.Name, result.Name)
+	assert.Nil(t, result.ConfigParams)
 }


### PR DESCRIPTION
## Pull request description 

When request.Config is empty we don't provide defaultValues.

This fixes that, but also keeps so when sensitive is provided no values are returned

## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [ ] tested locally
- [ ] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Breaking changes

-

## Changes

-

## Fixes

-