### PR TITLE
fix(TKC-3004): kill nested processes on timeout properly

### DIFF
--- a/pkg/api/v1/testkube/model_test_workflow_step_status_extended.go
+++ b/pkg/api/v1/testkube/model_test_workflow_step_status_extended.go
@@ -1,7 +1,7 @@
 package testkube
 
 func (s *TestWorkflowStepStatus) Finished() bool {
-	return s != nil && *s != "" && *s != QUEUED_TestWorkflowStepStatus && *s != PAUSED_TestWorkflowStepStatus && *s != RUNNING_TestWorkflowStepStatus && *s != TIMEOUT_TestWorkflowStepStatus
+	return s != nil && *s != "" && *s != QUEUED_TestWorkflowStepStatus && *s != PAUSED_TestWorkflowStepStatus && *s != RUNNING_TestWorkflowStepStatus
 }
 
 func (s *TestWorkflowStepStatus) Aborted() bool {


### PR DESCRIPTION
## Pull request description 

* Kill nested processes correctly
* Set properly Test Workflow Execution status when step timeout happens
* Make step timeout graceful - allow retries and continuing

## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [x] tested locally
- [x] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Fixes

- https://linear.app/kubeshop/issue/TKC-3004/step-timeout-the-execution-continues-after-timeout-workflow-is-stuck