### PR TITLE
fix: use execution tags from request if provided

### DIFF
--- a/pkg/testworkflows/testworkflowexecutor/prepared.go
+++ b/pkg/testworkflows/testworkflowexecutor/prepared.go
@@ -164,8 +164,8 @@ func (e *IntermediateExecution) Execution() *testkube.TestWorkflowExecution {
 		if e.cr.Spec.Execution != nil {
 			// TODO: Should resolve the expressions? (`{{"{{"}}` becomes `{{`)
 			maps.Copy(e.execution.Tags, e.cr.Spec.Execution.Tags)
-			maps.Copy(e.execution.Tags, e.tags)
 		}
+		maps.Copy(e.execution.Tags, e.tags)
 	}
 	return e.execution
 }

--- a/pkg/testworkflows/testworkflowexecutor/prepared.go
+++ b/pkg/testworkflows/testworkflowexecutor/prepared.go
@@ -349,6 +349,7 @@ func (e *IntermediateExecution) Finished() bool {
 func (e *IntermediateExecution) Clone() *IntermediateExecution {
 	return &IntermediateExecution{
 		cr:            e.cr.DeepCopy(),
+		dirty:         e.dirty,
 		tags:          maps.Clone(e.tags),
 		execution:     e.execution.Clone(),
 		prepended:     e.prepended,


### PR DESCRIPTION
## Pull request description 

* Use tags from request even when there is none defined in the TestWorkflow's spec

## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [x] tested locally
- [x] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test