### PR TITLE
fix: mark logs as saved properly

### DIFF
--- a/pkg/runner/executionlogswriter.go
+++ b/pkg/runner/executionlogswriter.go
@@ -110,9 +110,11 @@ func (e *executionLogsWriter) Save(ctx context.Context) error {
 func (e *executionLogsWriter) cleanup() {
 	if e.writer != nil {
 		e.writer.Close()
+		e.writer = nil
 	}
 	if e.buffer != nil {
 		e.buffer.Cleanup()
+		e.buffer = nil
 	}
 }
 


### PR DESCRIPTION
## Pull request description 

* On execution save error, the logs were tried to be saved multiple times (except they were successfully transferred already)

## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [x] tested locally
- [x] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test