### PR TITLE
fix(TKC-3212): avoid failing the artifacts save when JUnit processing failed

### DIFF
--- a/cmd/testworkflow-toolkit/artifacts/junit_post_processor.go
+++ b/cmd/testworkflow-toolkit/artifacts/junit_post_processor.go
@@ -53,8 +53,16 @@ func (p *JUnitPostProcessor) Start() error {
 	return nil
 }
 
-// Add checks if the file is a JUnit report and sends it to the cloud.
 func (p *JUnitPostProcessor) Add(path string) error {
+	err := p.add(path)
+	if err != nil {
+		fmt.Printf("warn: JUnit processing: %s: %s\n", path, err)
+	}
+	return nil
+}
+
+// Add checks if the file is a JUnit report and sends it to the cloud.
+func (p *JUnitPostProcessor) add(path string) error {
 	uploadPath := path
 	if p.pathPrefix != "" {
 		uploadPath = filepath.Join(p.pathPrefix, uploadPath)


### PR DESCRIPTION
## Pull request description 

* do not fail the artifacts save when JUnit processing fails

## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [ ] tested locally
- [ ] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Fixes

- https://linear.app/kubeshop/issue/TKC-3212/junit-report-parsing-failure-prevents-artifact-saving