### PR TITLE
fix: avoid circular resolution across different resource patterns

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -52,3 +52,4 @@ jobs:
           version: latest
           args: --timeout=5m
           only-new-issues: true
+          verify: false


### PR DESCRIPTION
## Pull request description 

* Solve the problem when multiple GitOps Agents are based on the same data source (i.e. even rolling update) with different patterns (like `<name>` and `prefix-<name>` may go all forward through `prefix-prefix-<name>`, up to i.e. `prefix-prefix-prefix-prefix-prefix-prefix-prefix-prefix-<name>`

## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [x] tested locally
- [x] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [x] added a test