### PR TITLE
fix(TKC-3318): auto-secrets creation

### DIFF
--- a/cmd/tcl/kubectl-testkube/devbox/command.go
+++ b/cmd/tcl/kubectl-testkube/devbox/command.go
@@ -55,6 +55,7 @@ func NewDevBoxCommand() *cobra.Command {
 		runnersCount        uint16
 		gitopsEnabled       bool
 		disableDefaultAgent bool
+		disableCloudStorage bool
 	)
 
 	cmd := &cobra.Command{
@@ -144,7 +145,7 @@ func NewDevBoxCommand() *cobra.Command {
 
 			// Initialize wrappers over cluster resources
 			interceptor := devutils.NewInterceptor(interceptorPod, baseInitImage, baseToolkitImage, interceptorBin)
-			agent := devutils.NewAgent(agentPod, cloud, baseAgentImage, baseInitImage, baseToolkitImage)
+			agent := devutils.NewAgent(agentPod, cloud, baseAgentImage, baseInitImage, baseToolkitImage, disableCloudStorage)
 			binaryStorage := devutils.NewBinaryStorage(binaryStoragePod, binaryStorageBin)
 			mongo := devutils.NewMongo(mongoPod)
 			minio := devutils.NewMinio(minioPod)
@@ -190,7 +191,7 @@ func NewDevBoxCommand() *cobra.Command {
 			// Create environment in the Cloud
 			if !oss {
 				fmt.Println("Creating environment in Cloud...")
-				env, err = cloud.CreateEnvironment(namespace.Name())
+				env, err = cloud.CreateEnvironment(namespace.Name(), disableCloudStorage)
 				if err != nil {
 					fail(errors.Wrap(err, "failed to create Cloud environment"))
 				}
@@ -874,6 +875,7 @@ func NewDevBoxCommand() *cobra.Command {
 	cmd.Flags().StringVar(&baseAgentImage, "agent-image", "kubeshop/testkube-api-server:latest", "base agent image")
 	cmd.Flags().Uint16Var(&runnersCount, "runners", 0, "additional runners count")
 	cmd.Flags().BoolVar(&disableDefaultAgent, "disable-agent", false, "should disable default agent")
+	cmd.Flags().BoolVar(&disableCloudStorage, "disable-cloud-storage", false, "should disable storage in Cloud")
 
 	return cmd
 }

--- a/cmd/tcl/kubectl-testkube/devbox/devutils/agent.go
+++ b/cmd/tcl/kubectl-testkube/devbox/devutils/agent.go
@@ -10,6 +10,7 @@ package devutils
 
 import (
 	"context"
+	"fmt"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -19,20 +20,22 @@ import (
 )
 
 type Agent struct {
-	pod              *PodObject
-	cloud            *CloudObject
-	agentImage       string
-	initProcessImage string
-	toolkitImage     string
+	pod                 *PodObject
+	cloud               *CloudObject
+	agentImage          string
+	initProcessImage    string
+	toolkitImage        string
+	disableCloudStorage bool
 }
 
-func NewAgent(pod *PodObject, cloud *CloudObject, agentImage, initProcessImage, toolkitImage string) *Agent {
+func NewAgent(pod *PodObject, cloud *CloudObject, agentImage, initProcessImage, toolkitImage string, disableCloudStorage bool) *Agent {
 	return &Agent{
-		pod:              pod,
-		cloud:            cloud,
-		agentImage:       agentImage,
-		initProcessImage: initProcessImage,
-		toolkitImage:     toolkitImage,
+		pod:                 pod,
+		cloud:               cloud,
+		agentImage:          agentImage,
+		initProcessImage:    initProcessImage,
+		toolkitImage:        toolkitImage,
+		disableCloudStorage: disableCloudStorage,
 	}
 }
 
@@ -53,7 +56,7 @@ func (r *Agent) Create(ctx context.Context, env *client.Environment) error {
 		{Name: "TESTKUBE_TW_TOOLKIT_IMAGE", Value: r.toolkitImage},
 		{Name: "TESTKUBE_TW_INIT_IMAGE", Value: r.initProcessImage},
 		{Name: "FEATURE_NEW_ARCHITECTURE", Value: "true"},
-		{Name: "FEATURE_CLOUD_STORAGE", Value: "true"},
+		{Name: "FEATURE_CLOUD_STORAGE", Value: fmt.Sprintf("%v", !r.disableCloudStorage)},
 	}
 	if env != nil {
 		tlsInsecure := "false"

--- a/cmd/tcl/kubectl-testkube/devbox/devutils/cloud.go
+++ b/cmd/tcl/kubectl-testkube/devbox/devutils/cloud.go
@@ -148,12 +148,12 @@ func (c *CloudObject) DashboardUrl(id, path string) string {
 	return strings.TrimSuffix(fmt.Sprintf("%s/organization/%s/environment/%s/", c.cfg.UiUri, c.cfg.OrganizationId, id)+strings.TrimPrefix(path, "/"), "/")
 }
 
-func (c *CloudObject) CreateEnvironment(name string) (*client.Environment, error) {
+func (c *CloudObject) CreateEnvironment(name string, disableCloudStorage bool) (*client.Environment, error) {
 	env, err := c.envClient.Create(client.Environment{
 		Name:            name,
 		Owner:           c.cfg.OrganizationId,
 		OrganizationId:  c.cfg.OrganizationId,
-		CloudStorage:    true,
+		CloudStorage:    !disableCloudStorage,
 		NewArchitecture: true,
 	})
 	if err != nil {

--- a/pkg/newclients/testworkflowclient/cloud.go
+++ b/pkg/newclients/testworkflowclient/cloud.go
@@ -3,6 +3,8 @@ package testworkflowclient
 import (
 	"context"
 
+	"k8s.io/apimachinery/pkg/types"
+
 	"github.com/kubeshop/testkube/internal/common"
 	"github.com/kubeshop/testkube/pkg/api/v1/testkube"
 	"github.com/kubeshop/testkube/pkg/cloud"
@@ -57,6 +59,10 @@ func (c *cloudTestWorkflowClient) Delete(ctx context.Context, environmentId stri
 
 func (c *cloudTestWorkflowClient) DeleteByLabels(ctx context.Context, environmentId string, labels map[string]string) (uint32, error) {
 	return c.client.DeleteTestWorkflowsByLabels(ctx, environmentId, labels)
+}
+
+func (c *cloudTestWorkflowClient) GetKubernetesObjectUID(ctx context.Context, environmentId string, name string) (types.UID, error) {
+	return "", nil
 }
 
 func (c *cloudTestWorkflowClient) WatchUpdates(ctx context.Context, environmentId string, includeInitialData bool) Watcher {

--- a/pkg/newclients/testworkflowclient/interface.go
+++ b/pkg/newclients/testworkflowclient/interface.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"time"
 
+	"k8s.io/apimachinery/pkg/types"
+
 	"github.com/kubeshop/testkube/pkg/api/v1/testkube"
 	"github.com/kubeshop/testkube/pkg/repository/channels"
 )
@@ -34,6 +36,7 @@ type Watcher channels.Watcher[Update]
 //go:generate mockgen -destination=./mock_interface.go -package=testworkflowclient "github.com/kubeshop/testkube/pkg/newclients/testworkflowclient" TestWorkflowClient
 type TestWorkflowClient interface {
 	Get(ctx context.Context, environmentId string, name string) (*testkube.TestWorkflow, error)
+	GetKubernetesObjectUID(ctx context.Context, environmentId string, name string) (types.UID, error)
 	List(ctx context.Context, environmentId string, options ListOptions) ([]testkube.TestWorkflow, error)
 	ListLabels(ctx context.Context, environmentId string) (map[string][]string, error)
 	Update(ctx context.Context, environmentId string, workflow testkube.TestWorkflow) error

--- a/pkg/newclients/testworkflowclient/kubernetes.go
+++ b/pkg/newclients/testworkflowclient/kubernetes.go
@@ -12,6 +12,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
 	"k8s.io/apimachinery/pkg/selection"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -81,6 +82,17 @@ func (c *k8sTestWorkflowClient) Get(ctx context.Context, environmentId string, n
 		return nil, err
 	}
 	return testworkflows.MapKubeToAPI(workflow), nil
+}
+
+func (c *k8sTestWorkflowClient) GetKubernetesObjectUID(ctx context.Context, environmentId string, name string) (types.UID, error) {
+	workflow, err := c.get(ctx, name)
+	if err != nil {
+		return "", err
+	}
+	if workflow != nil {
+		return workflow.UID, nil
+	}
+	return "", nil
 }
 
 func (c *k8sTestWorkflowClient) List(ctx context.Context, environmentId string, options ListOptions) ([]testkube.TestWorkflow, error) {

--- a/pkg/newclients/testworkflowclient/mock_interface.go
+++ b/pkg/newclients/testworkflowclient/mock_interface.go
@@ -10,6 +10,7 @@ import (
 
 	gomock "github.com/golang/mock/gomock"
 	testkube "github.com/kubeshop/testkube/pkg/api/v1/testkube"
+	types "k8s.io/apimachinery/pkg/types"
 )
 
 // MockTestWorkflowClient is a mock of TestWorkflowClient interface.
@@ -91,6 +92,21 @@ func (m *MockTestWorkflowClient) Get(arg0 context.Context, arg1, arg2 string) (*
 func (mr *MockTestWorkflowClientMockRecorder) Get(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Get", reflect.TypeOf((*MockTestWorkflowClient)(nil).Get), arg0, arg1, arg2)
+}
+
+// GetKubernetesObjectUID mocks base method.
+func (m *MockTestWorkflowClient) GetKubernetesObjectUID(arg0 context.Context, arg1, arg2 string) (types.UID, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetKubernetesObjectUID", arg0, arg1, arg2)
+	ret0, _ := ret[0].(types.UID)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetKubernetesObjectUID indicates an expected call of GetKubernetesObjectUID.
+func (mr *MockTestWorkflowClientMockRecorder) GetKubernetesObjectUID(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetKubernetesObjectUID", reflect.TypeOf((*MockTestWorkflowClient)(nil).GetKubernetesObjectUID), arg0, arg1, arg2)
 }
 
 // List mocks base method.

--- a/pkg/newclients/testworkflowtemplateclient/cloud.go
+++ b/pkg/newclients/testworkflowtemplateclient/cloud.go
@@ -3,6 +3,8 @@ package testworkflowtemplateclient
 import (
 	"context"
 
+	"k8s.io/apimachinery/pkg/types"
+
 	"github.com/kubeshop/testkube/internal/common"
 	"github.com/kubeshop/testkube/pkg/api/v1/testkube"
 	"github.com/kubeshop/testkube/pkg/cloud"
@@ -22,6 +24,10 @@ func NewCloudTestWorkflowTemplateClient(client controlplaneclient.TestWorkflowTe
 
 func (c *cloudTestWorkflowTemplateClient) Get(ctx context.Context, environmentId string, name string) (*testkube.TestWorkflowTemplate, error) {
 	return c.client.GetTestWorkflowTemplate(ctx, environmentId, name)
+}
+
+func (c *cloudTestWorkflowTemplateClient) GetKubernetesObjectUID(ctx context.Context, environmentId string, name string) (types.UID, error) {
+	return "", nil
 }
 
 func (c *cloudTestWorkflowTemplateClient) List(ctx context.Context, environmentId string, options ListOptions) ([]testkube.TestWorkflowTemplate, error) {

--- a/pkg/newclients/testworkflowtemplateclient/interface.go
+++ b/pkg/newclients/testworkflowtemplateclient/interface.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"time"
 
+	"k8s.io/apimachinery/pkg/types"
+
 	"github.com/kubeshop/testkube/pkg/api/v1/testkube"
 	"github.com/kubeshop/testkube/pkg/repository/channels"
 )
@@ -34,6 +36,7 @@ type Watcher channels.Watcher[Update]
 //go:generate mockgen -destination=./mock_interface.go -package=testworkflowtemplateclient "github.com/kubeshop/testkube/pkg/newclients/testworkflowtemplateclient" TestWorkflowTemplateClient
 type TestWorkflowTemplateClient interface {
 	Get(ctx context.Context, environmentId string, name string) (*testkube.TestWorkflowTemplate, error)
+	GetKubernetesObjectUID(ctx context.Context, environmentId string, name string) (types.UID, error)
 	List(ctx context.Context, environmentId string, options ListOptions) ([]testkube.TestWorkflowTemplate, error)
 	ListLabels(ctx context.Context, environmentId string) (map[string][]string, error)
 	Update(ctx context.Context, environmentId string, template testkube.TestWorkflowTemplate) error

--- a/pkg/newclients/testworkflowtemplateclient/kubernetes.go
+++ b/pkg/newclients/testworkflowtemplateclient/kubernetes.go
@@ -12,6 +12,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
 	"k8s.io/apimachinery/pkg/selection"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -81,6 +82,17 @@ func (c *k8sTestWorkflowTemplateClient) Get(ctx context.Context, environmentId s
 		return nil, err
 	}
 	return testworkflows.MapTemplateKubeToAPI(template), nil
+}
+
+func (c *k8sTestWorkflowTemplateClient) GetKubernetesObjectUID(ctx context.Context, environmentId string, name string) (types.UID, error) {
+	template, err := c.get(ctx, name)
+	if err != nil {
+		return "", err
+	}
+	if template != nil {
+		return template.UID, nil
+	}
+	return "", nil
 }
 
 func (c *k8sTestWorkflowTemplateClient) List(ctx context.Context, environmentId string, options ListOptions) ([]testkube.TestWorkflowTemplate, error) {

--- a/pkg/newclients/testworkflowtemplateclient/mock_interface.go
+++ b/pkg/newclients/testworkflowtemplateclient/mock_interface.go
@@ -10,6 +10,7 @@ import (
 
 	gomock "github.com/golang/mock/gomock"
 	testkube "github.com/kubeshop/testkube/pkg/api/v1/testkube"
+	types "k8s.io/apimachinery/pkg/types"
 )
 
 // MockTestWorkflowTemplateClient is a mock of TestWorkflowTemplateClient interface.
@@ -91,6 +92,21 @@ func (m *MockTestWorkflowTemplateClient) Get(arg0 context.Context, arg1, arg2 st
 func (mr *MockTestWorkflowTemplateClientMockRecorder) Get(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Get", reflect.TypeOf((*MockTestWorkflowTemplateClient)(nil).Get), arg0, arg1, arg2)
+}
+
+// GetKubernetesObjectUID mocks base method.
+func (m *MockTestWorkflowTemplateClient) GetKubernetesObjectUID(arg0 context.Context, arg1, arg2 string) (types.UID, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetKubernetesObjectUID", arg0, arg1, arg2)
+	ret0, _ := ret[0].(types.UID)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetKubernetesObjectUID indicates an expected call of GetKubernetesObjectUID.
+func (mr *MockTestWorkflowTemplateClientMockRecorder) GetKubernetesObjectUID(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetKubernetesObjectUID", reflect.TypeOf((*MockTestWorkflowTemplateClient)(nil).GetKubernetesObjectUID), arg0, arg1, arg2)
 }
 
 // List mocks base method.


### PR DESCRIPTION
## Pull request description 

* Add `--disable-cloud-storage` flag to `testkube devbox` command for debugging
* Fix building ownership for auto-created secrets

## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [x] tested locally
- [x] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Fixes

* https://linear.app/kubeshop/issue/TKC-3318/creating-workflow-with-repo-credentials-500-secrets-arent-created