### PR TITLE
fix: nil pointer access errors when recording metrics

### DIFF
--- a/pkg/utilization/instrument.go
+++ b/pkg/utilization/instrument.go
@@ -150,6 +150,9 @@ func aggregate(metrics []*Metrics) *Metrics {
 		Network: &net.IOCountersStat{},
 	}
 	for _, m := range metrics {
+		if m == nil {
+			continue
+		}
 		if m.Memory != nil {
 			aggregated.Memory.RSS += m.Memory.RSS
 			aggregated.Memory.VMS += m.Memory.VMS


### PR DESCRIPTION
## Pull request description 

Nil pointer access if a process cannot be scraped

## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [ ] tested locally
- [ ] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Breaking changes

-

## Changes

-

## Fixes

-