### PR TITLE
fix(TKC-3368): use global template in new architecture when it's not inline too

### DIFF
--- a/pkg/runner/globaltemplate.go
+++ b/pkg/runner/globaltemplate.go
@@ -1,0 +1,40 @@
+package runner
+
+import (
+	"context"
+	"strings"
+
+	testworkflowsv1 "github.com/kubeshop/testkube-operator/api/testworkflows/v1"
+	"github.com/kubeshop/testkube/internal/crdcommon"
+	"github.com/kubeshop/testkube/pkg/log"
+	"github.com/kubeshop/testkube/pkg/mapper/testworkflows"
+	"github.com/kubeshop/testkube/pkg/newclients/testworkflowtemplateclient"
+)
+
+type GlobalTemplateFactory func(environmentId string) (*testworkflowsv1.TestWorkflowTemplate, error)
+
+func GlobalTemplateInline(yaml string) GlobalTemplateFactory {
+	var globalTemplateInline *testworkflowsv1.TestWorkflowTemplate
+	if yaml != "" {
+		globalTemplateInline = new(testworkflowsv1.TestWorkflowTemplate)
+		err := crdcommon.DeserializeCRD(globalTemplateInline, []byte("spec:\n  "+strings.ReplaceAll(yaml, "\n", "\n  ")))
+		globalTemplateInline.Name = inlinedGlobalTemplateName
+		if err != nil {
+			log.DefaultLogger.Errorw("failed to unmarshal inlined global template", "error", err)
+			globalTemplateInline = nil
+		}
+	}
+	return func(_ string) (*testworkflowsv1.TestWorkflowTemplate, error) {
+		return globalTemplateInline, nil
+	}
+}
+
+func GlobalTemplateSourced(client testworkflowtemplateclient.TestWorkflowTemplateClient, name string) GlobalTemplateFactory {
+	return func(environmentId string) (*testworkflowsv1.TestWorkflowTemplate, error) {
+		tpl, err := client.Get(context.Background(), environmentId, name)
+		if err != nil {
+			return nil, err
+		}
+		return testworkflows.MapTemplateAPIToKube(tpl), nil
+	}
+}

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -2,7 +2,6 @@ package runner
 
 import (
 	"context"
-	"strings"
 	"sync"
 	"time"
 
@@ -11,7 +10,6 @@ import (
 	testworkflowsv1 "github.com/kubeshop/testkube-operator/api/testworkflows/v1"
 	"github.com/kubeshop/testkube/internal/app/api/metrics"
 	"github.com/kubeshop/testkube/internal/config"
-	"github.com/kubeshop/testkube/internal/crdcommon"
 	"github.com/kubeshop/testkube/pkg/api/v1/testkube"
 	"github.com/kubeshop/testkube/pkg/controlplaneclient"
 	"github.com/kubeshop/testkube/pkg/event"
@@ -48,15 +46,15 @@ type Runner interface {
 }
 
 type runner struct {
-	worker               executionworkertypes.Worker
-	client               controlplaneclient.Client
-	configRepository     configRepo.Repository
-	emitter              event.Interface
-	metrics              metrics.Metrics
-	proContext           config.ProContext // TODO: Include Agent ID in pro context
-	dashboardURI         string
-	storageSkipVerify    bool
-	globalTemplateInline *testworkflowsv1.TestWorkflowTemplate
+	worker            executionworkertypes.Worker
+	client            controlplaneclient.Client
+	configRepository  configRepo.Repository
+	emitter           event.Interface
+	metrics           metrics.Metrics
+	proContext        config.ProContext // TODO: Include Agent ID in pro context
+	dashboardURI      string
+	storageSkipVerify bool
+	getGlobalTemplate GlobalTemplateFactory
 
 	watching sync.Map
 }
@@ -70,28 +68,18 @@ func New(
 	proContext config.ProContext,
 	dashboardURI string,
 	storageSkipVerify bool,
-	globalTemplateInlineYaml string,
+	getGlobalTemplate GlobalTemplateFactory,
 ) Runner {
-	var globalTemplateInline *testworkflowsv1.TestWorkflowTemplate
-	if globalTemplateInlineYaml != "" {
-		globalTemplateInline = new(testworkflowsv1.TestWorkflowTemplate)
-		err := crdcommon.DeserializeCRD(globalTemplateInline, []byte("spec:\n  "+strings.ReplaceAll(globalTemplateInlineYaml, "\n", "\n  ")))
-		globalTemplateInline.Name = inlinedGlobalTemplateName
-		if err != nil {
-			log.DefaultLogger.Errorw("failed to unmarshal inlined global template", "error", err)
-			globalTemplateInline = nil
-		}
-	}
 	return &runner{
-		worker:               worker,
-		configRepository:     configRepository,
-		client:               client,
-		emitter:              emitter,
-		metrics:              metrics,
-		proContext:           proContext,
-		dashboardURI:         dashboardURI,
-		storageSkipVerify:    storageSkipVerify,
-		globalTemplateInline: globalTemplateInline,
+		worker:            worker,
+		configRepository:  configRepository,
+		client:            client,
+		emitter:           emitter,
+		metrics:           metrics,
+		proContext:        proContext,
+		dashboardURI:      dashboardURI,
+		storageSkipVerify: storageSkipVerify,
+		getGlobalTemplate: getGlobalTemplate,
 	}
 }
 
@@ -253,12 +241,16 @@ func (r *runner) Notifications(ctx context.Context, id string) executionworkerty
 }
 
 func (r *runner) Execute(request executionworkertypes.ExecuteRequest) (*executionworkertypes.ExecuteResult, error) {
-	if r.globalTemplateInline != nil {
+	if r.getGlobalTemplate != nil {
+		globalTemplate, err := r.getGlobalTemplate(request.Execution.EnvironmentId)
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to get global template")
+		}
 		testworkflowresolver.AddGlobalTemplateRef(&request.Workflow, testworkflowsv1.TemplateRef{
 			Name: testworkflowresolver.GetDisplayTemplateName(inlinedGlobalTemplateName),
 		})
-		err := testworkflowresolver.ApplyTemplates(&request.Workflow, map[string]*testworkflowsv1.TestWorkflowTemplate{
-			inlinedGlobalTemplateName: r.globalTemplateInline,
+		err = testworkflowresolver.ApplyTemplates(&request.Workflow, map[string]*testworkflowsv1.TestWorkflowTemplate{
+			inlinedGlobalTemplateName: globalTemplate,
 		}, func(key, value string) (expressions.Expression, error) {
 			return nil, errors.New("not supported")
 		})

--- a/pkg/runner/service.go
+++ b/pkg/runner/service.go
@@ -24,7 +24,7 @@ type Options struct {
 
 	StorageSkipVerify bool
 
-	GlobalTemplateInline string
+	GlobalTemplate GlobalTemplateFactory
 }
 
 type service struct {
@@ -71,7 +71,7 @@ func NewService(
 			proContext,
 			opts.DashboardURI,
 			opts.StorageSkipVerify,
-			opts.GlobalTemplateInline,
+			opts.GlobalTemplate,
 		),
 	}
 }


### PR DESCRIPTION
## Pull request description 



## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [x] tested locally
- [x] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Fixes

- https://linear.app/kubeshop/issue/TKC-3368/content-from-global-template-not-replicated-in-testworkflow