### PR TITLE
fix: safely handle redundant execution start

### DIFF
--- a/pkg/runner/agent.go
+++ b/pkg/runner/agent.go
@@ -300,12 +300,6 @@ func (a *agentLoop) runTestWorkflow(environmentId string, executionId string, ex
 		return nil, a.directRunTestWorkflow(environmentId, executionId, executionToken)
 	})
 
-	// Edge case, when the execution has been already triggered before there,
-	// and now it's redundant call.
-	if err != nil && strings.Contains(err.Error(), "already exists") && strings.Contains(err.Error(), executionId) {
-		return nil
-	}
-
 	return err
 }
 
@@ -352,6 +346,11 @@ func (a *agentLoop) directRunTestWorkflow(environmentId string, executionId stri
 		if err != nil {
 			logger.Errorw("failed to run and update execution", "error", err)
 		}
+		return nil
+	}
+
+	// Inform that everything is fine, because the execution is already there.
+	if result.Redundant {
 		return nil
 	}
 

--- a/pkg/testworkflows/executionworker/executionworkertypes/interface.go
+++ b/pkg/testworkflows/executionworker/executionworkertypes/interface.go
@@ -60,6 +60,8 @@ type ExecuteResult struct {
 	ScheduledAt time.Time
 	// Namespace where it has been scheduled.
 	Namespace string
+	// Redundant says if that execution was already running.
+	Redundant bool
 }
 
 type ServiceResult struct {


### PR DESCRIPTION
## Pull request description 

* avoid marking execution as aborted due to existing job, when the execution was successfully started and working

## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [ ] tested locally
- [ ] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test