### PR TITLE
fix: further improve race conditions on starting execution

### DIFF
--- a/pkg/controlplaneclient/execution_self.go
+++ b/pkg/controlplaneclient/execution_self.go
@@ -127,7 +127,9 @@ func (c *client) ScheduleExecution(ctx context.Context, environmentId string, re
 	}
 	watcher := channels.NewWatcher[testkube.TestWorkflowExecution]()
 	go func() {
-		defer watcher.Close(err)
+		defer func() {
+			watcher.Close(err)
+		}()
 		for {
 			item, itemErr := res.Recv()
 			if itemErr != nil {

--- a/pkg/runner/agent.go
+++ b/pkg/runner/agent.go
@@ -312,6 +312,14 @@ func (a *agentLoop) directRunTestWorkflow(environmentId string, executionId stri
 	if err != nil {
 		return errors2.Wrapf(err, "failed to get execution details '%s/%s' from Control Plane", environmentId, executionId)
 	}
+	if execution.RunnerId != a.proContext.Agent.ID && execution.RunnerId != "" {
+		return errors.New("execution is assigned to a different runner")
+	}
+
+	// Inform that everything is fine, because the execution is already there.
+	if execution.Result != nil && !execution.Result.IsQueued() {
+		return nil
+	}
 
 	parentIds := ""
 	if execution.RunningContext != nil && execution.RunningContext.Actor != nil {

--- a/pkg/testworkflows/testworkflowexecutor/scheduler.go
+++ b/pkg/testworkflows/testworkflowexecutor/scheduler.go
@@ -238,7 +238,11 @@ func (s *scheduler) Schedule(ctx context.Context, sensitiveDataHandler Sensitive
 	// Flatten selectors
 	intermediateSelectors := make([]*cloud.ScheduleExecution, 0, len(req.Executions))
 	for _, execution := range req.Executions {
-		list, _ := testWorkflows.Get(execution.Selector)
+		list, err := testWorkflows.Get(execution.Selector)
+		if err != nil {
+			close(ch)
+			return ch, err
+		}
 		for _, w := range list {
 			intermediateSelectors = append(intermediateSelectors, &cloud.ScheduleExecution{
 				Selector:      &cloud.ScheduleResourceSelector{Name: w.Name},


### PR DESCRIPTION
## Pull request description 

* improve checks on "start execution" request
* handle errors while searching for a workflow for scheduling (earlier - if Test Workflow was not found, it was still success, just without any execution)
* handle errors in `execute` (earlier - if BE returned scheduling error, it would mark as passed)

## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [x] tested locally
- [x] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test