### PR TITLE
fix: allow assigning only queued executions

### DIFF
--- a/pkg/repository/testworkflow/mongo.go
+++ b/pkg/repository/testworkflow/mongo.go
@@ -746,7 +746,7 @@ func (r *MongoRepository) Assign(ctx context.Context, id string, prevRunnerId st
 	res, err := r.Coll.UpdateOne(ctx, bson.M{
 		"$and": []bson.M{
 			{"id": id},
-			{"result.status": bson.M{"$in": bson.A{testkube.QUEUED_TestWorkflowStatus, testkube.RUNNING_TestWorkflowStatus, testkube.PAUSED_TestWorkflowStatus}}},
+			{"result.status": testkube.QUEUED_TestWorkflowStatus},
 			{"$or": []bson.M{{"runnerid": prevRunnerId}, {"runnerid": newRunnerId}, {"runnerid": nil}}},
 		},
 	}, bson.M{"$set": map[string]interface{}{


### PR DESCRIPTION
## Pull request description 

* block reassigning running/paused executions

## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [x] tested locally
- [x] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test