### PR TITLE
feat: automatically close login window after successful auth

### DIFF
--- a/pkg/cloudlogin/login.go
+++ b/pkg/cloudlogin/login.go
@@ -39,6 +39,7 @@ func CloudLogin(ctx context.Context, providerURL, connectorID string, port int) 
 		code := r.URL.Query().Get("code")
 		if code != "" {
 			ch <- code
+			fmt.Fprintln(w, "<script>window.close()</script>")
 			fmt.Fprintln(w, "Your testkube CLI is now succesfully authenticated. Go back to the terminal to continue.")
 		} else {
 			fmt.Fprintln(w, "Authorization failed.")


### PR DESCRIPTION
## Pull request description 

* When using `testkube login`, automatically close browser window after logged in

## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [x] tested locally
- [x] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test