### PR TITLE
fix: getting execution logs with `get <name>`

### DIFF
--- a/cmd/kubectl-testkube/commands/testworkflows/executions.go
+++ b/cmd/kubectl-testkube/commands/testworkflows/executions.go
@@ -72,9 +72,9 @@ func NewGetTestWorkflowExecutionsCmd() *cobra.Command {
 			}
 
 			if outputPretty {
-				ui.Info("Getting logs for test workflow execution", executionID)
+				ui.Info("Getting logs for test workflow execution", execution.Id)
 
-				logs, err := client.GetTestWorkflowExecutionLogs(executionID)
+				logs, err := client.GetTestWorkflowExecutionLogs(execution.Id)
 				ui.ExitOnError("getting logs from test workflow", err)
 
 				sigs := flattenSignatures(execution.Signature)


### PR DESCRIPTION
## Pull request description 

* It was trying to use execution name for logs endpoint, which doesn't support it.

## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [x] tested locally
- [x] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test