### PR TITLE
feat: add global/independent/grouped runners

### DIFF
--- a/cmd/kubectl-testkube/commands/agents/install.go
+++ b/cmd/kubectl-testkube/commands/agents/install.go
@@ -51,6 +51,8 @@ func NewInstallRunnerCommand() *cobra.Command {
 		dryRun    bool
 
 		globalTemplatePath string
+		global             bool
+		group              string
 
 		autoCreate     bool
 		labelPairs     []string
@@ -72,6 +74,8 @@ func NewInstallRunnerCommand() *cobra.Command {
 
 	// Installation > Runner
 	cmd.Flags().StringVarP(&globalTemplatePath, "global-template-path", "g", "", "include global template")
+	cmd.Flags().BoolVar(&global, "global", false, "make it global runner")
+	cmd.Flags().StringVar(&group, "group", "", "make it grouped runner")
 
 	// Install existing
 	cmd.Flags().StringVarP(&secretKey, "secret", "s", "", "secret key for the selected agent")
@@ -192,6 +196,8 @@ func UiInstallAgent(cmd *cobra.Command, name string, agentType string) {
 	dryRun, _ := cmd.Flags().GetBool("dry-run")
 	agentType, _ = GetInternalAgentType(agentType)
 	globalTemplatePath, _ := cmd.Flags().GetString("global-template-path")
+	isGlobalRunner, _ := cmd.Flags().GetBool("global")
+	runnerGroup, _ := cmd.Flags().GetString("group")
 	var globalTemplate []byte
 	if globalTemplatePath != "" {
 		var err error
@@ -238,7 +244,7 @@ func UiInstallAgent(cmd *cobra.Command, name string, agentType string) {
 	if agent == nil && autoCreate {
 		labels, _ := cmd.Flags().GetStringSlice("label")
 		environmentIds, _ := cmd.Flags().GetStringSlice("env")
-		agent = UiCreateAgent(cmd, agentType, name, labels, environmentIds)
+		agent = UiCreateAgent(cmd, agentType, name, labels, environmentIds, isGlobalRunner, runnerGroup)
 	}
 
 	// Load agents from the Control Plane and select one

--- a/cmd/kubectl-testkube/commands/agents/utils.go
+++ b/cmd/kubectl-testkube/commands/agents/utils.go
@@ -523,6 +523,11 @@ func PrintControlPlaneAgent(agent cloudclient.Agent) {
 	if len(agent.Labels) == 0 {
 		fmt.Println("   none")
 	}
+
+	if agent.RunnerPolicy != nil && len(agent.RunnerPolicy.RequiredMatch) > 0 {
+		ui.Warn("Policy:")
+		ui.Warn("   Required Matching Labels:", strings.Join(agent.RunnerPolicy.RequiredMatch, ", "))
+	}
 }
 
 func PrintKubernetesAgent(agent internalAgent) {

--- a/pkg/cloud/client/agents.go
+++ b/pkg/cloud/client/agents.go
@@ -33,6 +33,11 @@ type AgentInput struct {
 	Type         string             `json:"type,omitempty"`
 	Labels       *map[string]string `json:"labels,omitempty"`
 	Environments []string           `json:"environments,omitempty"`
+	RunnerPolicy *RunnerPolicy      `json:"runnerPolicy,omitempty"`
+}
+
+type RunnerPolicy struct {
+	RequiredMatch []string `json:"requiredMatch,omitempty"`
 }
 
 type Agent struct {
@@ -50,6 +55,7 @@ type Agent struct {
 	AccessedAt   *time.Time         `json:"accessedAt,omitempty"`
 	CreatedAt    time.Time          `json:"createdAt"`
 	SecretKey    string             `json:"secretKey"`
+	RunnerPolicy *RunnerPolicy      `json:"runnerPolicy,omitempty"`
 }
 
 type AgentEnvironment struct {


### PR DESCRIPTION
## Pull request description 

* Runner created without additional options has to be directly called by `id` or `name` (`--target name=my-runner`)
* Runner created with `--group <name>` option will be taken in account only when execution's `--target group=<name>`
* Runner created with `--global` flag will be taken in account for all executions

## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [x] tested locally
- [x] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test