### PR TITLE
fix: add missing Pause/Resume methods to API Client

### DIFF
--- a/pkg/api/v1/client/interface.go
+++ b/pkg/api/v1/client/interface.go
@@ -180,6 +180,8 @@ type TestWorkflowExecutionAPI interface {
 	ListTestWorkflowExecutions(id string, limit int, options FilterTestWorkflowExecutionOptions) (executions testkube.TestWorkflowExecutionsResult, err error)
 	AbortTestWorkflowExecution(workflow string, id string) error
 	AbortTestWorkflowExecutions(workflow string) error
+	PauseTestWorkflowExecution(workflow string, id string) error
+	ResumeTestWorkflowExecution(workflow string, id string) error
 	GetTestWorkflowExecutionArtifacts(executionID string) (artifacts testkube.Artifacts, err error)
 	DownloadTestWorkflowArtifact(executionID, fileName, destination string) (artifact string, err error)
 	DownloadTestWorkflowArtifactArchive(executionID, destination string, masks []string) (archive string, err error)

--- a/pkg/api/v1/client/testworkflow.go
+++ b/pkg/api/v1/client/testworkflow.go
@@ -184,6 +184,18 @@ func (c TestWorkflowClient) ListTestWorkflowExecutions(id string, limit int, opt
 	return c.testWorkflowExecutionsResultTransport.Execute(http.MethodGet, uri, nil, params)
 }
 
+// PauseTestWorkflowExecution pauses selected execution
+func (c TestWorkflowClient) PauseTestWorkflowExecution(workflow, id string) error {
+	uri := c.testWorkflowTransport.GetURI("/test-workflows/%s/executions/%s/pause", workflow, id)
+	return c.testWorkflowTransport.ExecuteMethod(http.MethodPost, uri, "", false)
+}
+
+// ResumeTestWorkflowExecution pauses selected execution
+func (c TestWorkflowClient) ResumeTestWorkflowExecution(workflow, id string) error {
+	uri := c.testWorkflowTransport.GetURI("/test-workflows/%s/executions/%s/resume", workflow, id)
+	return c.testWorkflowTransport.ExecuteMethod(http.MethodPost, uri, "", false)
+}
+
 // AbortTestWorkflowExecution aborts selected execution
 func (c TestWorkflowClient) AbortTestWorkflowExecution(workflow, id string) error {
 	uri := c.testWorkflowTransport.GetURI("/test-workflows/%s/executions/%s/abort", workflow, id)


### PR DESCRIPTION
## Pull request description 

* The `/pause` and `/resume` endpoints were not exposed in the API Client

## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [x] tested locally
- [x] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
