### PR TITLE
fix: don't expect ManagedFields[n].Time to be existing

### DIFF
--- a/pkg/mapper/secrets/mapper.go
+++ b/pkg/mapper/secrets/mapper.go
@@ -42,7 +42,7 @@ func MapSecretKubeToAPI(secret *corev1.Secret) testkube.Secret {
 
 	updateTime := secret.CreationTimestamp.Time
 	for _, field := range secret.ManagedFields {
-		if field.Time.After(updateTime) {
+		if field.Time != nil && field.Time.After(updateTime) {
 			updateTime = field.Time.Time
 		}
 	}

--- a/pkg/mapper/testworkflows/kube_openapi.go
+++ b/pkg/mapper/testworkflows/kube_openapi.go
@@ -1283,7 +1283,7 @@ func MapTestWorkflowKubeToAPI(w testworkflowsv1.TestWorkflow) testkube.TestWorkf
 		updateTime = w.DeletionTimestamp.Time
 	} else {
 		for _, field := range w.ManagedFields {
-			if field.Time.After(updateTime) {
+			if field.Time != nil && field.Time.After(updateTime) {
 				updateTime = field.Time.Time
 			}
 		}
@@ -1307,7 +1307,7 @@ func MapTestWorkflowTemplateKubeToAPI(w testworkflowsv1.TestWorkflowTemplate) te
 		updateTime = w.DeletionTimestamp.Time
 	} else {
 		for _, field := range w.ManagedFields {
-			if field.Time.After(updateTime) {
+			if field.Time != nil && field.Time.After(updateTime) {
 				updateTime = field.Time.Time
 			}
 		}


### PR DESCRIPTION
## Pull request description 

* It's a pointer. It shouldn't be empty, but apparently, it happens.

## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [ ] tested locally
- [ ] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test