### PR TITLE
fix: [TKC-3433] fix fatal error: concurrent map writes

### DIFF
--- a/pkg/testworkflows/testworkflowexecutor/testworkflowtemplatefetcher_test.go
+++ b/pkg/testworkflows/testworkflowexecutor/testworkflowtemplatefetcher_test.go
@@ -1,0 +1,122 @@
+package testworkflowexecutor
+
+import (
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/kubeshop/testkube/pkg/api/v1/testkube"
+	"github.com/kubeshop/testkube/pkg/newclients/testworkflowtemplateclient"
+)
+
+func TestTestWorkflowTemplateFetcher_ConcurrentAccess(t *testing.T) {
+	// Create mock controller
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	// Create mock client
+	mockClient := testworkflowtemplateclient.NewMockTestWorkflowTemplateClient(ctrl)
+
+	// Create test templates
+	templates := make([]*testkube.TestWorkflowTemplate, 10)
+	for i := 0; i < 10; i++ {
+		templates[i] = &testkube.TestWorkflowTemplate{
+			Name:        "template-" + string(rune('A'+i)),
+			Description: "description-" + string(rune('A'+i)),
+			Labels:      map[string]string{"key": "value"},
+			Spec:        &testkube.TestWorkflowTemplateSpec{},
+		}
+	}
+
+	// Setup mock expectations
+	for _, tmpl := range templates {
+		mockClient.EXPECT().
+			Get(gomock.Any(), "test-env", tmpl.Name).
+			Return(tmpl, nil).
+			AnyTimes()
+	}
+
+	// Create fetcher
+	fetcher := NewTestWorkflowTemplateFetcher(mockClient, "test-env")
+
+	// Test concurrent prefetch
+	t.Run("concurrent prefetch", func(t *testing.T) {
+		names := make(map[string]struct{})
+		for _, tmpl := range templates {
+			names[tmpl.Name] = struct{}{}
+		}
+
+		// Launch multiple goroutines to prefetch templates
+		err := fetcher.PrefetchMany(names)
+		assert.NoError(t, err)
+
+		// Verify all templates were fetched
+		for _, tmpl := range templates {
+			fetched, err := fetcher.Get(tmpl.Name)
+			assert.NoError(t, err)
+			assert.Equal(t, tmpl.Name, fetched.Name)
+			assert.Equal(t, tmpl.Description, fetched.Description)
+			assert.Equal(t, tmpl.Labels, fetched.Labels)
+		}
+	})
+
+	// Test concurrent get
+	t.Run("concurrent get", func(t *testing.T) {
+		names := make(map[string]struct{})
+		for _, tmpl := range templates {
+			names[tmpl.Name] = struct{}{}
+		}
+
+		// Launch multiple goroutines to get templates
+		results, err := fetcher.GetMany(names)
+		assert.NoError(t, err)
+		assert.Len(t, results, len(templates))
+
+		// Verify all templates were retrieved correctly
+		for _, tmpl := range templates {
+			fetched, ok := results[tmpl.Name]
+			assert.True(t, ok)
+			assert.Equal(t, tmpl.Name, fetched.Name)
+			assert.Equal(t, tmpl.Description, fetched.Description)
+			assert.Equal(t, tmpl.Labels, fetched.Labels)
+		}
+	})
+
+	// Test concurrent set and get
+	t.Run("concurrent set and get", func(t *testing.T) {
+		// Create a new template
+		newTmpl := &testkube.TestWorkflowTemplate{
+			Name:        "new-template",
+			Description: "new-description",
+			Labels:      map[string]string{"key": "value"},
+			Spec:        &testkube.TestWorkflowTemplateSpec{},
+		}
+
+		// Setup mock expectations for the new template
+		mockClient.EXPECT().
+			Get(gomock.Any(), "test-env", newTmpl.Name).
+			Return(newTmpl, nil).
+			AnyTimes()
+
+		// Launch goroutines to set and get the template concurrently
+		done := make(chan struct{})
+		go func() {
+			for i := 0; i < 100; i++ {
+				fetcher.SetCache(newTmpl.Name, newTmpl)
+			}
+			close(done)
+		}()
+
+		// Try to get the template while it's being set
+		for i := 0; i < 100; i++ {
+			fetched, err := fetcher.Get(newTmpl.Name)
+			assert.NoError(t, err)
+			assert.Equal(t, newTmpl.Name, fetched.Name)
+			assert.Equal(t, newTmpl.Description, fetched.Description)
+			assert.Equal(t, newTmpl.Labels, fetched.Labels)
+		}
+
+		<-done // Wait for set operations to complete
+	})
+}


### PR DESCRIPTION
## Pull request description 

Adds read write mutex to protect the cache, our cloud-api is currently failing with:
```
{"level":"warn","ts":"2025-03-20T11:34:51Z","caller":"agentserver/agent_stream.go:40","msg":"error getting environment by api key","version":"1.11.18","build":"cloud","service":"AgentServer","error":"record does not exists","errorVerbose":"record does not exists:\n    github.com/kubeshop/testkube-cloud-api/pkg/repository/common.init\n        /app/pkg/repository/common/errors.go:5","obfuscatedKey":"tkcagnt_02**************************bf"}
fatal error: concurrent map writes

goroutine 3400656 [running]:
github.com/kubeshop/testkube/pkg/testworkflows/testworkflowexecutor.(*testWorkflowTemplateFetcher).Prefetch(0xc001cfb830, {0xc004ebd904?, 0x0?})
	/root/.cache/go-build/github.com/kubeshop/testkube@v1.17.66-0.20250318131550-7b6a37946575/pkg/testworkflows/testworkflowexecutor/testworkflowtemplatefetcher.go:53 +0xec
github.com/kubeshop/testkube/pkg/testworkflows/testworkflowexecutor.(*testWorkflowTemplateFetcher).PrefetchMany.(*testWorkflowTemplateFetcher).PrefetchMany.func1.func2()
	/root/.cache/go-build/github.com/kubeshop/testkube@v1.17.66-0.20250318131550-7b6a37946575/pkg/testworkflows/testworkflowexecutor/testworkflowtemplatefetcher.go:70 +0x1f
golang.org/x/sync/errgroup.(*Group).Go.func1()
	/root/.cache/go-build/golang.org/x/sync@v0.11.0/errgroup/errgroup.go:78 +0x50
created by golang.org/x/sync/errgroup.(*Group).Go in goroutine 3400649
	/root/.cache/go-build/golang.org/x/sync@v0.11.0/errgroup/errgroup.go:75 +0x96
```


## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [ ] tested locally
- [ ] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Breaking changes

-

## Changes

-

## Fixes

-