### PR TITLE
fix: avoid getting all the records from the database when fetching list of the execution tags

### DIFF
--- a/internal/app/api/v1/labels_tags.go
+++ b/internal/app/api/v1/labels_tags.go
@@ -69,11 +69,7 @@ func (s *TestkubeAPI) ListTagsHandler() fiber.Handler {
 		if err != nil {
 			return s.ClientError(c, errPrefix, err)
 		}
-
-		results := make(map[string][]string)
-		deduplicateMap(tags, results)
-
-		return c.JSON(results)
+		return c.JSON(tags)
 	}
 }
 

--- a/pkg/repository/testworkflow/mongo.go
+++ b/pkg/repository/testworkflow/mongo.go
@@ -698,8 +698,7 @@ func (r *MongoRepository) GetExecutionTags(ctx context.Context, testWorkflowName
 
 	pipeline := []bson.M{
 		{"$match": query},
-		{"$project": bson.M{"_id": 0, "tags": 1}},
-		{"$project": bson.M{"tags": bson.M{"$objectToArray": "$tags"}}},
+		{"$project": bson.M{"_id": 0, "tags": bson.M{"$objectToArray": "$tags"}}},
 		{"$unwind": "$tags"},
 		{"$group": bson.M{"_id": "$tags.k", "values": bson.M{"$addToSet": "$tags.v"}}},
 		{"$project": bson.M{"_id": 0, "name": "$_id", "values": 1}},

--- a/pkg/repository/testworkflow/mongo.go
+++ b/pkg/repository/testworkflow/mongo.go
@@ -691,16 +691,18 @@ func (r *MongoRepository) GetNextExecutionNumber(ctx context.Context, name strin
 }
 
 func (r *MongoRepository) GetExecutionTags(ctx context.Context, testWorkflowName string) (tags map[string][]string, err error) {
-	query := bson.M{"tags": bson.M{"$exists": true}}
+	query := bson.M{"tags": bson.M{"$nin": bson.A{nil, bson.M{}}}}
 	if testWorkflowName != "" {
 		query["workflow.name"] = testWorkflowName
 	}
 
 	pipeline := []bson.M{
 		{"$match": query},
-		{"$project": bson.M{
-			"tags": 1,
-		}},
+		{"$project": bson.M{"_id": 0, "tags": 1}},
+		{"$project": bson.M{"tags": bson.M{"$objectToArray": "$tags"}}},
+		{"$unwind": "$tags"},
+		{"$group": bson.M{"_id": "$tags.k", "values": bson.M{"$addToSet": "$tags.v"}}},
+		{"$project": bson.M{"_id": 0, "name": "$_id", "values": 1}},
 	}
 
 	opts := options.Aggregate()
@@ -713,21 +715,18 @@ func (r *MongoRepository) GetExecutionTags(ctx context.Context, testWorkflowName
 		return nil, err
 	}
 
-	var executions []testkube.TestWorkflowExecutionTags
-	err = cursor.All(ctx, &executions)
+	var res []struct {
+		Name   string   `bson:"name"`
+		Values []string `bson:"values"`
+	}
+	err = cursor.All(ctx, &res)
 	if err != nil {
 		return nil, err
 	}
 
-	for i := range executions {
-		executions[i].UnscapeDots()
-	}
-
 	tags = make(map[string][]string)
-	for _, execution := range executions {
-		for key, value := range execution.Tags {
-			tags[key] = append(tags[key], value)
-		}
+	for _, tag := range res {
+		tags[tag.Name] = tag.Values
 	}
 
 	return tags, nil


### PR DESCRIPTION
## Pull request description 

* perform the grouping on MongoDB

## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [x] tested locally
- [x] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test