### PR TITLE
feat: support single quoted strings in the expressions

### DIFF
--- a/pkg/expressions/parse_test.go
+++ b/pkg/expressions/parse_test.go
@@ -370,3 +370,14 @@ func TestCompileEscapedTemplate(t *testing.T) {
 	assert.Equal(t, input, MustCompileTemplate(input).Template())
 	assert.Equal(t, output, must(MustCompileTemplate(input).Static().StringValue()))
 }
+
+func TestCompileSingleQuoteString(t *testing.T) {
+	assert.Equal(t, `"foobar"`, MustCompile(`'foobar'`).String())
+	assert.Equal(t, `"foo'bar"`, MustCompile(`'foo\'bar'`).String())
+	assert.Equal(t, `"foo\"bar"`, MustCompile(`'foo"bar'`).String())
+	assert.ErrorContains(t, errOnly(Compile(`'foobar\'`)), "error while decoding string")
+	assert.Equal(t, `"\nabc\ndef\n"`, MustCompile(`'
+abc
+def
+'`).String())
+}


### PR DESCRIPTION
## Pull request description 

* add support for simple single-quoted script
   * it's useful for cases where you need to pass some string with double quotes, like `map(items, '_.value + "text"')` vs `map(items, "_.value + \"text\"")`
* it's not supported inside of arrays or objects, same as variables (as they are fully parsed as JSON)

## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [x] tested locally
- [x] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [x] added a test