### PR TITLE
feat: add `tk login [apiUrl]` command to automatically discover all required public URLs

### DIFF
--- a/cmd/kubectl-testkube/commands/pro/login.go
+++ b/cmd/kubectl-testkube/commands/pro/login.go
@@ -2,6 +2,7 @@ package pro
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -34,8 +35,6 @@ func NewLoginCmd() *cobra.Command {
 				}
 				u, err := url.Parse(args[0])
 				ui.ExitOnError("invalid instance url", err)
-				u.Path, err = url.JoinPath(u.Path, "info")
-				ui.ExitOnError("invalid instance url", err)
 
 				// Call the Control Plane
 				req, err := http.Get(u.String())
@@ -60,6 +59,9 @@ func NewLoginCmd() *cobra.Command {
 
 				if req.StatusCode != http.StatusOK {
 					ui.Fail(fmt.Errorf("unexpected error while getting control plane info: %d: %s", req.StatusCode, string(v)))
+				}
+				if result.APIURL == "" && result.RootDomain == "" {
+					ui.Fail(errors.New("unexpected error while getting control plane info missing URLs"))
 				}
 
 				// Try to fill the data

--- a/cmd/kubectl-testkube/commands/pro/login.go
+++ b/cmd/kubectl-testkube/commands/pro/login.go
@@ -43,6 +43,8 @@ func NewLoginCmd() *cobra.Command {
 				}
 				u, err := url.Parse(args[0])
 				ui.ExitOnError("invalid instance url", err)
+				u.Path, err = url.JoinPath(u.Path, "public-info")
+				ui.ExitOnError("invalid instance url", err)
 
 				// Call the Control Plane
 				req, err := http.Get(u.String())

--- a/cmd/kubectl-testkube/commands/pro/login.go
+++ b/cmd/kubectl-testkube/commands/pro/login.go
@@ -45,6 +45,7 @@ func NewLoginCmd() *cobra.Command {
 					req, err = http.Get(u.String())
 				}
 				ui.ExitOnError("requesting control plane info", err)
+
 				v, err := io.ReadAll(req.Body)
 				ui.ExitOnError("reading control plane info", err)
 				var result struct {
@@ -56,6 +57,10 @@ func NewLoginCmd() *cobra.Command {
 				}
 				err = json.Unmarshal(v, &result)
 				ui.ExitOnError("reading control plane info", err)
+
+				if req.StatusCode != http.StatusOK {
+					ui.Fail(fmt.Errorf("unexpected error while getting control plane info: %d: %s", req.StatusCode, string(v)))
+				}
 
 				// Try to fill the data
 				if result.RootDomain != "" {

--- a/cmd/tcl/kubectl-testkube/devbox/README.md
+++ b/cmd/tcl/kubectl-testkube/devbox/README.md
@@ -18,7 +18,7 @@ This utility is used to help with development of the Agent features (like Test W
 ## Usage
 
 * Login to Testkube CLI, like `testkube login`
-  * For local development Testkube Enterprise (Skaffold), consider `testkube login --api-uri-override=http://localhost:8099 --agent-uri-override=http://testkube-enterprise-api.tk-dev.svc.cluster.local:8089 --auth-uri-override=http://localhost:5556 --custom-auth`
+  * For local development Testkube Enterprise (Skaffold), consider `testkube login localhost:8099`
   * It's worth to create alias for that in own `.bashrc` or `.bash_profile`
   * It's worth to pass a devbox name, like `-n dawid`, so it's not using random name
 * For OSS version - run with `--oss` parameter


### PR DESCRIPTION
## Pull request description 

* add `tk login [apiUrl]` command to automatically discover all required public URLs

## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [x] tested locally
- [x] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test