### PR TITLE
fix: add missing workflow name to the execution's running context

### DIFF
--- a/cmd/testworkflow-init/data/client.go
+++ b/cmd/testworkflow-init/data/client.go
@@ -53,6 +53,7 @@ func CloudClient() controlplaneclient.Client {
 		}, controlplaneclient.ClientOptions{
 			StorageSkipVerify:  true,
 			ExecutionID:        cfg.Execution.Id,
+			WorkflowName:       cfg.Workflow.Name,
 			ParentExecutionIDs: strings.Split(cfg.Execution.ParentIds, "/"),
 		})
 	}

--- a/cmd/testworkflow-toolkit/env/client.go
+++ b/cmd/testworkflow-toolkit/env/client.go
@@ -242,6 +242,7 @@ func Cloud() controlplaneclient.Client {
 	return controlplaneclient.New(grpcClient, internalProContext, controlplaneclient.ClientOptions{
 		StorageSkipVerify:  true, // FIXME?
 		ExecutionID:        cfg.Execution.Id,
+		WorkflowName:       cfg.Workflow.Name,
 		ParentExecutionIDs: strings.Split(cfg.Execution.ParentIds, "/"),
 	})
 }

--- a/pkg/controlplaneclient/client.go
+++ b/pkg/controlplaneclient/client.go
@@ -23,6 +23,7 @@ type client struct {
 type ClientOptions struct {
 	StorageSkipVerify  bool
 	ExecutionID        string
+	WorkflowName       string
 	ParentExecutionIDs []string
 
 	Runtime RuntimeConfig

--- a/pkg/controlplaneclient/execution_self.go
+++ b/pkg/controlplaneclient/execution_self.go
@@ -115,7 +115,8 @@ func (c *client) ScheduleExecution(ctx context.Context, environmentId string, re
 	}
 	if c.opts.ExecutionID != "" {
 		request.RunningContext = &cloud.RunningContext{
-			Name: c.opts.ExecutionID,
+			Name: c.opts.WorkflowName,
+			Id:   c.opts.ExecutionID,
 			Type: cloud.RunningContextType_EXECUTION,
 		}
 		request.ParentExecutionIds = append(c.opts.ParentExecutionIDs, c.opts.ExecutionID)


### PR DESCRIPTION
## Pull request description 

* there was only execution ID before, that would not be enough to build link back

## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [x] tested locally
- [x] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test