### PR TITLE
feat: add more detailed log for debugging executions considered aborted

### DIFF
--- a/cmd/api-server/main.go
+++ b/cmd/api-server/main.go
@@ -239,7 +239,7 @@ func main() {
 	executionWorker := services.CreateExecutionWorker(clientset, cfg, clusterId, proContext.Agent.ID, serviceAccountNames, testWorkflowProcessor, map[string]string{
 		testworkflowconfig.FeatureFlagNewArchitecture: fmt.Sprintf("%v", cfg.FeatureNewArchitecture),
 		testworkflowconfig.FeatureFlagCloudStorage:    fmt.Sprintf("%v", cfg.FeatureCloudStorage),
-	}, commonEnvVariables)
+	}, commonEnvVariables, true)
 
 	runnerOpts := runner2.Options{
 		ClusterID:           clusterId,

--- a/cmd/api-server/services/executionworker.go
+++ b/cmd/api-server/services/executionworker.go
@@ -23,6 +23,7 @@ func CreateExecutionWorker(
 	processor testworkflowprocessor.Processor,
 	featureFlags map[string]string,
 	commonEnvVariables []corev1.EnvVar,
+	logAbortedDetails bool,
 ) executionworkertypes.Worker {
 	namespacesConfig := map[string]kubernetesworker.NamespaceConfig{}
 	for n, s := range serviceAccountNames {
@@ -53,5 +54,6 @@ func CreateExecutionWorker(
 		FeatureFlags:       featureFlags,
 		RunnerId:           runnerId,
 		CommonEnvVariables: commonEnvVariables,
+		LogAbortedDetails:  logAbortedDetails,
 	})
 }

--- a/cmd/tcl/testworkflow-toolkit/spawn/utils.go
+++ b/cmd/tcl/testworkflow-toolkit/spawn/utils.go
@@ -76,6 +76,7 @@ func ExecutionWorker() executionworkertypes.Worker {
 			FeatureFlags:       cfg.Worker.FeatureFlags,
 			RunnerId:           cfg.Worker.RunnerID,
 			CommonEnvVariables: cfg.Worker.CommonEnvVariables,
+			LogAbortedDetails:  config.Debug(),
 		})
 	}
 	return executionWorker

--- a/pkg/api/v1/testkube/model_test_workflow_result_extended.go
+++ b/pkg/api/v1/testkube/model_test_workflow_result_extended.go
@@ -138,7 +138,7 @@ func (r *TestWorkflowResult) IsAnyStepAborted() bool {
 func (r *TestWorkflowResult) IsAnyStepPaused() bool {
 	// When initialization was aborted or failed - it's immediately end
 	if r.Initialization.Status.AnyError() {
-		return true
+		return false
 	}
 
 	// Analyze the rest of the steps

--- a/pkg/runner/service.go
+++ b/pkg/runner/service.go
@@ -133,7 +133,7 @@ func (s *service) recover(ctx context.Context) (err error) {
 			if err = s.client.FinishExecutionResult(ctx, environmentId, executionId, execution.Result); err != nil {
 				s.logger.Errorw("failed to recover execution: saving execution", "id", executionId, "error", err)
 			} else {
-				s.logger.Infow("recovered execution", "id", executionId, "error", err)
+				s.logger.Infow("recovered execution", "id", executionId, "status", "error", err)
 			}
 		}(exec.EnvironmentId, exec.Id)
 	}

--- a/pkg/testworkflows/executionworker/controller/controller.go
+++ b/pkg/testworkflows/executionworker/controller/controller.go
@@ -11,6 +11,7 @@ import (
 	initconstants "github.com/kubeshop/testkube/cmd/testworkflow-init/constants"
 	"github.com/kubeshop/testkube/cmd/testworkflow-init/instructions"
 	"github.com/kubeshop/testkube/pkg/api/v1/testkube"
+	"github.com/kubeshop/testkube/pkg/log"
 	"github.com/kubeshop/testkube/pkg/testworkflows/executionworker/controller/watchers"
 	"github.com/kubeshop/testkube/pkg/testworkflows/testworkflowconfig"
 	"github.com/kubeshop/testkube/pkg/testworkflows/testworkflowprocessor/stage"
@@ -88,6 +89,7 @@ func New(parentCtx context.Context, clientSet kubernetes.Interface, namespace, i
 
 		// There was a job or pod for this execution, so we may only assume it is aborted
 		if !watcher.State().JobEvents().FirstTimestamp().IsZero() || !watcher.State().PodEvents().FirstTimestamp().IsZero() {
+			log.DefaultLogger.Errorw("connecting to aborted execution", "executionId", watcher.State().ResourceId(), "debug", watcher.State().Debug())
 			return nil, ErrJobAborted
 		}
 

--- a/pkg/testworkflows/executionworker/controller/watchers/commons.go
+++ b/pkg/testworkflows/executionworker/controller/watchers/commons.go
@@ -306,6 +306,29 @@ func GetJobError(job *batchv1.Job) string {
 	return ""
 }
 
+func GetContainerStateDebug(state corev1.ContainerState) string {
+	if state.Running != nil {
+		return "running"
+	} else if state.Terminated != nil {
+		result := fmt.Sprintf("terminated, reason: '%s'", state.Terminated.Reason)
+		if state.Terminated.Message != "" {
+			result += fmt.Sprintf(", message: '%s'", state.Terminated.Message)
+		}
+		if state.Terminated.ExitCode != 0 {
+			result += fmt.Sprintf(", exit code: '%d'", state.Terminated.ExitCode)
+		}
+		if state.Terminated.Signal != 0 {
+			result += fmt.Sprintf(", signal: %d", state.Terminated.Signal)
+		}
+		return result
+	} else if state.Waiting != nil {
+		return fmt.Sprintf("waiting, reason: '%s', message: '%s'",
+			state.Waiting.Reason,
+			state.Waiting.Message)
+	}
+	return "unknown"
+}
+
 func ReadContainerResult(status *corev1.ContainerStatus, errorFallback string) ContainerResult {
 	result := ContainerResult{}
 

--- a/pkg/testworkflows/executionworker/controller/watchers/executionstate.go
+++ b/pkg/testworkflows/executionworker/controller/watchers/executionstate.go
@@ -61,6 +61,7 @@ type ExecutionState interface {
 	ExecutionError() string
 	JobExecutionError() string
 	PodExecutionError() string
+	Debug() map[string]string
 
 	PodCreationTimestamp() time.Time
 	EstimatedPodCreationTimestamp() time.Time
@@ -442,4 +443,26 @@ func (e *executionState) ExecutionError() string {
 		return jobErr
 	}
 	return podErr
+}
+
+func (e *executionState) Debug() map[string]string {
+	result := map[string]string{
+		"pod":       "unknown",
+		"job":       "unknown",
+		"podEvents": "unknown",
+		"jobEvents": "unknown",
+	}
+	if e.pod != nil {
+		result["pod"] = e.pod.Debug()
+	}
+	if e.job != nil {
+		result["job"] = e.job.Debug()
+	}
+	if e.podEvents != nil {
+		result["podEvents"] = e.podEvents.Debug()
+	}
+	if e.jobEvents != nil {
+		result["jobEvents"] = e.jobEvents.Debug()
+	}
+	return result
 }

--- a/pkg/testworkflows/executionworker/controller/watchers/job.go
+++ b/pkg/testworkflows/executionworker/controller/watchers/job.go
@@ -2,6 +2,7 @@ package watchers
 
 import (
 	"encoding/json"
+	"fmt"
 	"time"
 
 	batchv1 "k8s.io/api/batch/v1"
@@ -31,6 +32,7 @@ type Job interface {
 	InternalConfig() (testworkflowconfig.InternalConfig, error)
 	ScheduledAt() (time.Time, error)
 	ExecutionError() string
+	Debug() string
 }
 
 func NewJob(original *batchv1.Job) Job {
@@ -96,4 +98,47 @@ func (j *job) ScheduledAt() (time.Time, error) {
 
 func (j *job) ExecutionError() string {
 	return GetJobError(j.original)
+}
+
+func (j *job) Debug() string {
+	if j.original == nil {
+		return "unknown"
+	}
+	state := "found"
+	if j.original.Status.Active > 0 {
+		state += fmt.Sprintf(", active: %d", j.original.Status.Active)
+	}
+	if j.original.Status.Failed > 0 {
+		state += fmt.Sprintf(", failed: %d", j.original.Status.Failed)
+	}
+	if j.original.Status.Succeeded > 0 {
+		state += fmt.Sprintf(", succeeded: %d", j.original.Status.Succeeded)
+	}
+	if j.original.Status.Ready != nil {
+		state += fmt.Sprintf(", ready: %d", *j.original.Status.Ready)
+	}
+	if j.original.Status.Terminating != nil {
+		state += fmt.Sprintf(", terminating: %d", *j.original.Status.Terminating)
+	}
+	if j.original.Status.UncountedTerminatedPods != nil {
+		state += fmt.Sprintf(", uncounted terminated pods: (failed) %d (succeeded) %d",
+			len(j.original.Status.UncountedTerminatedPods.Failed),
+			len(j.original.Status.UncountedTerminatedPods.Succeeded))
+	}
+	if j.original.Status.StartTime != nil {
+		state += ", started"
+	}
+	if j.original.DeletionTimestamp != nil {
+		state += ", deleted"
+	}
+	if j.original.Status.CompletionTime != nil {
+		state += ", completed"
+	}
+	for i := range j.original.Status.Conditions {
+		state += fmt.Sprintf(", %s='%s'", j.original.Status.Conditions[i].Type, j.original.Status.Conditions[i].Status)
+	}
+	if j.original.Spec.TTLSecondsAfterFinished != nil {
+		state += fmt.Sprintf(", ttl after: %ds", *j.original.Spec.TTLSecondsAfterFinished)
+	}
+	return state
 }

--- a/pkg/testworkflows/executionworker/controller/watchers/job.go
+++ b/pkg/testworkflows/executionworker/controller/watchers/job.go
@@ -120,7 +120,8 @@ func (j *job) Debug() string {
 	if j.original.Status.Terminating != nil {
 		state += fmt.Sprintf(", terminating: %d", *j.original.Status.Terminating)
 	}
-	if j.original.Status.UncountedTerminatedPods != nil {
+	if j.original.Status.UncountedTerminatedPods != nil &&
+		(len(j.original.Status.UncountedTerminatedPods.Failed) > 0 || len(j.original.Status.UncountedTerminatedPods.Succeeded) > 0) {
 		state += fmt.Sprintf(", uncounted terminated pods: (failed) %d (succeeded) %d",
 			len(j.original.Status.UncountedTerminatedPods.Failed),
 			len(j.original.Status.UncountedTerminatedPods.Succeeded))

--- a/pkg/testworkflows/executionworker/controller/watchers/jobevents.go
+++ b/pkg/testworkflows/executionworker/controller/watchers/jobevents.go
@@ -1,6 +1,7 @@
 package watchers
 
 import (
+	"fmt"
 	"strings"
 	"time"
 
@@ -27,6 +28,7 @@ type JobEvents interface {
 	Error() bool
 	ErrorReason() string
 	ErrorMessage() string
+	Debug() string
 }
 
 func NewJobEvents(events []*corev1.Event) JobEvents {
@@ -166,4 +168,14 @@ func (j *jobEvents) ErrorMessage() string {
 		}
 	}
 	return ""
+}
+
+func (j *jobEvents) Debug() string {
+	firstTs := j.FirstTimestamp()
+	result := make([]string, len(j.events))
+	for i := range j.events {
+		result[i] = fmt.Sprintf("[%.1fs] %s: %s", float64(GetEventTimestamp(j.events[i]).Sub(firstTs))/float64(time.Second), j.events[i].Reason, j.events[i].Message)
+	}
+
+	return strings.Join(result, ", ")
 }

--- a/pkg/testworkflows/executionworker/controller/watchers/pod.go
+++ b/pkg/testworkflows/executionworker/controller/watchers/pod.go
@@ -2,7 +2,9 @@ package watchers
 
 import (
 	"encoding/json"
+	"fmt"
 	"strconv"
+	"strings"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
@@ -43,6 +45,7 @@ type Pod interface {
 	ContainersReady() bool
 	ContainerError() string
 	ExecutionError() string
+	Debug() string
 }
 
 func NewPod(original *corev1.Pod) Pod {
@@ -231,4 +234,54 @@ func (p *pod) ExecutionError() string {
 		return p.ContainerError()
 	}
 	return errStr
+}
+
+func (p *pod) ContainerDebug(name string) string {
+	status := GetContainerStatus(p.original, name)
+	if status == nil {
+		return "unknown"
+	}
+	state := GetContainerStateDebug(status.State)
+	if status.Started != nil {
+		state += fmt.Sprintf(", started: %v", *status.Started)
+	}
+	if last := GetContainerStateDebug(status.LastTerminationState); last != "unknown" {
+		state += fmt.Sprintf(", last: %s", last)
+	}
+	return state
+}
+
+func (p *pod) Debug() string {
+	if p.original == nil {
+		return "unknown"
+	}
+	state := "found"
+	if p.original.Status.Reason != "" {
+		state += fmt.Sprintf(", reason: '%s'", p.original.Status.Reason)
+	}
+	if p.original.Status.Message != "" {
+		state += fmt.Sprintf(", message: '%s'", p.original.Status.Message)
+	}
+	if p.original.Status.StartTime != nil {
+		state += ", started"
+	}
+	if p.original.DeletionTimestamp != nil {
+		state += ", deleted"
+	}
+	if p.ExecutionError() != "" {
+		state += fmt.Sprintf(", error: '%s'", p.ExecutionError())
+	}
+	for i := range p.original.Status.Conditions {
+		state += fmt.Sprintf(", %s='%s'", p.original.Status.Conditions[i].Type, p.original.Status.Conditions[i].Status)
+	}
+	initContainers := make([]string, 0, len(p.original.Spec.InitContainers))
+	for i := range p.original.Spec.InitContainers {
+		initContainers = append(initContainers, fmt.Sprintf("[%s]: %s", p.original.Spec.InitContainers[i].Name, p.ContainerDebug(p.original.Spec.InitContainers[i].Name)))
+	}
+	containers := make([]string, 0, len(p.original.Spec.Containers))
+	for i := range p.original.Spec.Containers {
+		containers = append(containers, fmt.Sprintf("[%s]: %s", p.original.Spec.Containers[i].Name, p.ContainerDebug(p.original.Spec.Containers[i].Name)))
+	}
+	state += fmt.Sprintf(", [INIT] %s [CONTAINERS] %s", strings.Join(initContainers, ", "), strings.Join(containers, ", "))
+	return state
 }

--- a/pkg/testworkflows/executionworker/controller/watchers/podevents.go
+++ b/pkg/testworkflows/executionworker/controller/watchers/podevents.go
@@ -1,6 +1,7 @@
 package watchers
 
 import (
+	"fmt"
 	"regexp"
 	"strings"
 	"time"
@@ -29,6 +30,7 @@ type PodEvents interface {
 	Error() bool
 	ErrorReason() string
 	ErrorMessage() string
+	Debug() string
 
 	Container(name string) ContainerEvents
 }
@@ -185,6 +187,15 @@ func (p *podEvents) ErrorMessage() string {
 		// (Failed) Back-off restarting failed container [ONLY NUMERIC CONTAINERS]
 	}
 	return ""
+}
+
+func (p *podEvents) Debug() string {
+	firstTs := p.FirstTimestamp()
+	result := make([]string, len(p.events))
+	for i := range p.events {
+		result[i] = fmt.Sprintf("[%.1fs] %s: %s", float64(GetEventTimestamp(p.events[i]).Sub(firstTs))/float64(time.Second), p.events[i].Reason, p.events[i].Message)
+	}
+	return strings.Join(result, ", ")
 }
 
 func (p *podEvents) Container(name string) ContainerEvents {

--- a/pkg/testworkflows/executionworker/controller/watchinstrumentedpod.go
+++ b/pkg/testworkflows/executionworker/controller/watchinstrumentedpod.go
@@ -21,7 +21,8 @@ const (
 )
 
 type WatchInstrumentedPodOptions struct {
-	DisableFollow bool
+	DisableFollow     bool
+	LogAbortedDetails bool
 }
 
 func WatchInstrumentedPod(parentCtx context.Context, clientSet kubernetes.Interface, signature []stage.Signature, scheduledAt time.Time, watcher watchers2.ExecutionWatcher, opts WatchInstrumentedPodOptions) (<-chan ChannelMessage[Notification], error) {
@@ -42,7 +43,7 @@ func WatchInstrumentedPod(parentCtx context.Context, clientSet kubernetes.Interf
 			ctxCancel()
 			close(notifier.ch)
 
-			if notifier.result.IsAborted() {
+			if opts.LogAbortedDetails && notifier.result.IsAborted() {
 				log.DefaultLogger.Warnw("execution (watch) detected as aborted", "executionId", watcher.State().ResourceId(), "debug", watcher.State().Debug())
 			}
 		}()

--- a/pkg/testworkflows/executionworker/controller/watchinstrumentedpod.go
+++ b/pkg/testworkflows/executionworker/controller/watchinstrumentedpod.go
@@ -11,6 +11,7 @@ import (
 	"github.com/kubeshop/testkube/cmd/testworkflow-init/constants"
 	"github.com/kubeshop/testkube/cmd/testworkflow-init/instructions"
 	"github.com/kubeshop/testkube/pkg/api/v1/testkube"
+	"github.com/kubeshop/testkube/pkg/log"
 	watchers2 "github.com/kubeshop/testkube/pkg/testworkflows/executionworker/controller/watchers"
 	"github.com/kubeshop/testkube/pkg/testworkflows/testworkflowprocessor/stage"
 )
@@ -40,6 +41,10 @@ func WatchInstrumentedPod(parentCtx context.Context, clientSet kubernetes.Interf
 			notifier.End()
 			ctxCancel()
 			close(notifier.ch)
+
+			if notifier.result.IsAborted() {
+				log.DefaultLogger.Warnw("execution (watch) detected as aborted", "executionId", watcher.State().ResourceId(), "debug", watcher.State().Debug())
+			}
 		}()
 
 		// Mark Job as started
@@ -264,6 +269,5 @@ func WatchInstrumentedPod(parentCtx context.Context, clientSet kubernetes.Interf
 		notifier.Align(watcher.State())
 	}()
 
-	//return notifierProxyCh, nil
 	return notifier.ch, nil
 }

--- a/pkg/testworkflows/executionworker/kubernetesworker/interface.go
+++ b/pkg/testworkflows/executionworker/kubernetesworker/interface.go
@@ -32,4 +32,5 @@ type Config struct {
 	FeatureFlags       map[string]string
 	RunnerId           string
 	CommonEnvVariables []corev1.EnvVar
+	LogAbortedDetails  bool
 }

--- a/pkg/testworkflows/executionworker/kubernetesworker/worker.go
+++ b/pkg/testworkflows/executionworker/kubernetesworker/worker.go
@@ -252,7 +252,7 @@ func (w *worker) Notifications(ctx context.Context, id string, opts executionwor
 
 	// Watch the resource
 	watchCtx, watchCtxCancel := context.WithCancel(ctx)
-	ch := ctrl.Watch(watchCtx, opts.NoFollow)
+	ch := ctrl.Watch(watchCtx, opts.NoFollow, w.config.LogAbortedDetails)
 	go func() {
 		defer func() {
 			watchCtxCancel()
@@ -288,7 +288,7 @@ func (w *worker) StatusNotifications(ctx context.Context, id string, opts execut
 	// Watch the resource
 	watchCtx, watchCtxCancel := context.WithCancel(ctx)
 	sig := stage.MapSignatureListToInternal(ctrl.Signature())
-	ch := ctrl.Watch(watchCtx, opts.NoFollow)
+	ch := ctrl.Watch(watchCtx, opts.NoFollow, w.config.LogAbortedDetails)
 	go func() {
 		defer func() {
 			watchCtxCancel()


### PR DESCRIPTION
## Pull request description 

* add more detailed log for debugging executions considered aborted
   * it will be available in the Agent's logs
   * it includes pod, job & events information that were used for considering the "aborted" status

## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [x] tested locally
- [x] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test