### PR TITLE
fix: pass execution copy

### DIFF
--- a/cmd/api-server/services/controlplane.go
+++ b/cmd/api-server/services/controlplane.go
@@ -293,10 +293,10 @@ func CreateControlPlane(ctx context.Context, cfg *config.Config, features featur
 			return
 		}),
 		cloudtestworkflow.CmdTestWorkflowExecutionInsert: controlplane.Handler(func(ctx context.Context, data cloudtestworkflow.ExecutionInsertRequest) (r cloudtestworkflow.ExecutionInsertResponse, err error) {
-			return r, testWorkflowResultsRepository.Insert(ctx, data.WorkflowExecution)
+			return r, testWorkflowResultsRepository.Insert(ctx, *data.WorkflowExecution.Clone())
 		}),
 		cloudtestworkflow.CmdTestWorkflowExecutionUpdate: controlplane.Handler(func(ctx context.Context, data cloudtestworkflow.ExecutionUpdateRequest) (r cloudtestworkflow.ExecutionUpdateResponse, err error) {
-			return r, testWorkflowResultsRepository.Update(ctx, data.WorkflowExecution)
+			return r, testWorkflowResultsRepository.Update(ctx, *data.WorkflowExecution.Clone())
 		}),
 		cloudtestworkflow.CmdTestWorkflowExecutionUpdateResult: controlplane.Handler(func(ctx context.Context, data cloudtestworkflow.ExecutionUpdateResultRequest) (r cloudtestworkflow.ExecutionUpdateResultResponse, err error) {
 			return r, testWorkflowResultsRepository.UpdateResult(ctx, data.ID, data.Result)

--- a/pkg/testworkflows/testworkflowexecutor/scheduler.go
+++ b/pkg/testworkflows/testworkflowexecutor/scheduler.go
@@ -117,7 +117,7 @@ func NewScheduler(
 
 func (s *scheduler) insert(ctx context.Context, execution *testkube.TestWorkflowExecution) error {
 	err := retry(SaveResultRetryMaxAttempts, SaveResultRetryBaseDelay, func() error {
-		err := s.resultsRepository.Insert(ctx, *execution)
+		err := s.resultsRepository.Insert(ctx, *execution.Clone())
 		if err != nil {
 			s.logger.Warnw("failed to update the TestWorkflow execution in database", "recoverable", true, "executionId", execution.Id, "error", err)
 		}
@@ -131,7 +131,7 @@ func (s *scheduler) insert(ctx context.Context, execution *testkube.TestWorkflow
 
 func (s *scheduler) update(ctx context.Context, execution *testkube.TestWorkflowExecution) error {
 	err := retry(SaveResultRetryMaxAttempts, SaveResultRetryBaseDelay, func() error {
-		err := s.resultsRepository.Update(ctx, *execution)
+		err := s.resultsRepository.Update(ctx, *execution.Clone())
 		if err != nil {
 			s.logger.Warnw("failed to update the TestWorkflow execution in database", "recoverable", true, "executionId", execution.Id, "error", err)
 		}


### PR DESCRIPTION
## Pull request description 

Becuase Wokflow spec is passed using pointers in execution, we need to clone them before insert/update

## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [ ] tested locally
- [ ] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Breaking changes

-

## Changes

-

## Fixes

-