### PR TITLE
fix: mark as not watched if failed to get execution

### DIFF
--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -230,6 +230,7 @@ func (r *runner) Monitor(ctx context.Context, organizationId string, environment
 	// Load the execution TODO: retry?
 	execution, err := r.client.GetExecution(ctx, environmentId, id)
 	if err != nil {
+		r.watching.Delete(id)
 		log.DefaultLogger.Errorw("failed to get execution", "id", id, "error", err)
 		return err
 	}


### PR DESCRIPTION
## Pull request description 

* it was not clearing the lock on execution if failed to get it from the database

## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [x] tested locally
- [x] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test