### PR TITLE
fix: do stable comparison of TestWorkflow

### DIFF
--- a/pkg/api/v1/testkube/model_test_workflow_extended.go
+++ b/pkg/api/v1/testkube/model_test_workflow_extended.go
@@ -1,9 +1,10 @@
 package testkube
 
 import (
-	"bytes"
 	"encoding/json"
 	"time"
+
+	"github.com/google/go-cmp/cmp"
 
 	"github.com/kubeshop/testkube/pkg/utils"
 )
@@ -132,7 +133,6 @@ func (w *TestWorkflow) DeepCopy() *TestWorkflow {
 	return &result
 }
 
-// TODO: do it stable
 func (w *TestWorkflow) Equals(other *TestWorkflow) bool {
 	// Avoid check when there is one existing and the other one not
 	if (w == nil) != (other == nil) {
@@ -146,10 +146,7 @@ func (w *TestWorkflow) Equals(other *TestWorkflow) bool {
 	other.Created = time.Time{}
 
 	// Compare
-	w1, _ := json.Marshal(w)
-	w.Created = time.Time{}
-	w2, _ := json.Marshal(other)
-	result := bytes.Equal(w1, w2)
+	result := cmp.Equal(w, other)
 
 	// Restore values
 	w.Created = wCreated

--- a/pkg/api/v1/testkube/model_test_workflow_extended_test.go
+++ b/pkg/api/v1/testkube/model_test_workflow_extended_test.go
@@ -1,0 +1,30 @@
+package testkube
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTestWorkflowEqualsUnorderedMap(t *testing.T) {
+	o := &TestWorkflow{
+		Spec: &TestWorkflowSpec{
+			Config: map[string]TestWorkflowParameterSchema{
+				"name1":  {Description: "some name"},
+				"name2":  {Description: "another name"},
+				"name3":  {Description: "another name"},
+				"name6":  {Description: "another name"},
+				"name7":  {Description: "another name"},
+				"name4":  {Description: "another name"},
+				"name5":  {Description: "another name"},
+				"name8":  {Description: "another name"},
+				"name9":  {Description: "another name"},
+				"name10": {Description: "another name"},
+				"name11": {Description: "another name"},
+				"name12": {Description: "another name"},
+				"name13": {Description: "another name"},
+			},
+		},
+	}
+	assert.Equal(t, true, o.Equals(o.DeepCopy()))
+}

--- a/pkg/api/v1/testkube/model_test_workflow_template_extended.go
+++ b/pkg/api/v1/testkube/model_test_workflow_template_extended.go
@@ -1,10 +1,11 @@
 package testkube
 
 import (
-	"bytes"
 	"encoding/json"
 	"strings"
 	"time"
+
+	"github.com/google/go-cmp/cmp"
 
 	"github.com/kubeshop/testkube/pkg/utils"
 )
@@ -94,7 +95,6 @@ func (w *TestWorkflowTemplate) DeepCopy() *TestWorkflowTemplate {
 	return &result
 }
 
-// TODO: do it stable
 func (w *TestWorkflowTemplate) Equals(other *TestWorkflowTemplate) bool {
 	// Avoid check when there is one existing and the other one not
 	if (w == nil) != (other == nil) {
@@ -108,10 +108,7 @@ func (w *TestWorkflowTemplate) Equals(other *TestWorkflowTemplate) bool {
 	other.Created = time.Time{}
 
 	// Compare
-	w1, _ := json.Marshal(w)
-	w.Created = time.Time{}
-	w2, _ := json.Marshal(other)
-	result := bytes.Equal(w1, w2)
+	result := cmp.Equal(w, other)
 
 	// Restore values
 	w.Created = wCreated


### PR DESCRIPTION
## Pull request description 

* `json.Marshal` of maps is not guaranteed to provide the same order even for single map

## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [x] tested locally
- [x] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [x] added a test