### PR TITLE
fix: handle more gracefully watcher error

### DIFF
--- a/pkg/runner/service.go
+++ b/pkg/runner/service.go
@@ -88,7 +88,7 @@ func (s *service) recover(ctx context.Context) (err error) {
 
 	for _, exec := range executions {
 		go func(environmentId string, executionId string) {
-			err := s.runner.Monitor(ctx, s.proContext.OrgID, environmentId, executionId)
+			err := s.runner.Monitor(context.Background(), s.proContext.OrgID, environmentId, executionId)
 			if err == nil {
 				return
 			}


### PR DESCRIPTION
## Pull request description 

* when the watching is finished in strange way, do not try to "heal aborted"
* add more logs for edge cases

## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [x] tested locally
- [x] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test