### PR TITLE
feat: [TKC-3485]  add send and receive timeout

### DIFF
--- a/cmd/api-server/main.go
+++ b/cmd/api-server/main.go
@@ -179,6 +179,8 @@ func main() {
 		Runtime: controlplaneclient.RuntimeConfig{
 			Namespace: cfg.TestkubeNamespace,
 		},
+		SendTimeout: cfg.TestkubeProSendTimeout,
+		RecvTimeout: cfg.TestkubeProRecvTimeout,
 	})
 
 	if proContext.CloudStorage {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -99,17 +99,19 @@ type LogServerConfig struct {
 }
 
 type ControlPlaneConfig struct {
-	TestkubeProEnvID             string `envconfig:"TESTKUBE_PRO_ENV_ID" default:""`
-	TestkubeProOrgID             string `envconfig:"TESTKUBE_PRO_ORG_ID" default:""`
-	TestkubeProAgentID           string `envconfig:"TESTKUBE_PRO_AGENT_ID" default:""`
-	TestkubeProAPIKey            string `envconfig:"TESTKUBE_PRO_API_KEY" default:""`
-	TestkubeProURL               string `envconfig:"TESTKUBE_PRO_URL" default:""`
-	TestkubeProTLSInsecure       bool   `envconfig:"TESTKUBE_PRO_TLS_INSECURE" default:"false"`
-	TestkubeProSkipVerify        bool   `envconfig:"TESTKUBE_PRO_SKIP_VERIFY" default:"false"`
-	TestkubeProConnectionTimeout int    `envconfig:"TESTKUBE_PRO_CONNECTION_TIMEOUT" default:"10"`
-	TestkubeProCertFile          string `envconfig:"TESTKUBE_PRO_CERT_FILE" default:""`
-	TestkubeProKeyFile           string `envconfig:"TESTKUBE_PRO_KEY_FILE" default:""`
-	TestkubeProTLSSecret         string `envconfig:"TESTKUBE_PRO_TLS_SECRET" default:""`
+	TestkubeProEnvID             string        `envconfig:"TESTKUBE_PRO_ENV_ID" default:""`
+	TestkubeProOrgID             string        `envconfig:"TESTKUBE_PRO_ORG_ID" default:""`
+	TestkubeProAgentID           string        `envconfig:"TESTKUBE_PRO_AGENT_ID" default:""`
+	TestkubeProAPIKey            string        `envconfig:"TESTKUBE_PRO_API_KEY" default:""`
+	TestkubeProURL               string        `envconfig:"TESTKUBE_PRO_URL" default:""`
+	TestkubeProTLSInsecure       bool          `envconfig:"TESTKUBE_PRO_TLS_INSECURE" default:"false"`
+	TestkubeProSkipVerify        bool          `envconfig:"TESTKUBE_PRO_SKIP_VERIFY" default:"false"`
+	TestkubeProConnectionTimeout int           `envconfig:"TESTKUBE_PRO_CONNECTION_TIMEOUT" default:"10"`
+	TestkubeProCertFile          string        `envconfig:"TESTKUBE_PRO_CERT_FILE" default:""`
+	TestkubeProKeyFile           string        `envconfig:"TESTKUBE_PRO_KEY_FILE" default:""`
+	TestkubeProTLSSecret         string        `envconfig:"TESTKUBE_PRO_TLS_SECRET" default:""`
+	TestkubeProSendTimeout       time.Duration `envconfig:"TESTKUBE_PRO_SEND_TIMEOUT" default:"30s"`
+	TestkubeProRecvTimeout       time.Duration `envconfig:"TESTKUBE_PRO_RECV_TIMEOUT" default:"5m"`
 
 	// TestkubeProCAFile is meant to provide a custom CA when making a TLS connection to
 	// the agent API.

--- a/pkg/controlplaneclient/client.go
+++ b/pkg/controlplaneclient/client.go
@@ -2,6 +2,7 @@ package controlplaneclient
 
 import (
 	"strings"
+	"time"
 
 	"github.com/kubeshop/testkube/internal/config"
 	"github.com/kubeshop/testkube/pkg/cloud"
@@ -26,7 +27,9 @@ type ClientOptions struct {
 	WorkflowName       string
 	ParentExecutionIDs []string
 
-	Runtime RuntimeConfig
+	Runtime     RuntimeConfig
+	SendTimeout time.Duration
+	RecvTimeout time.Duration
 }
 
 type RuntimeConfig struct {

--- a/pkg/runner/agent.go
+++ b/pkg/runner/agent.go
@@ -149,22 +149,18 @@ func (a *agentLoop) run(ctx context.Context) error {
 	// Handle the new mechanism for runners
 	if a.proContext.NewArchitecture {
 		g.Go(func() error {
-			fmt.Println("loopRunnerRequests")
 			return errors2.Wrap(a.loopRunnerRequests(ctx), "runners loop")
 		})
 	}
 
 	// Handle Test Workflow notifications of all kinds
 	g.Go(func() error {
-		fmt.Println("loopNotifications")
 		return errors2.Wrap(a.loopNotifications(ctx), "notifications loop")
 	})
 	g.Go(func() error {
-		fmt.Println("loopServiceNotifications")
 		return errors2.Wrap(a.loopServiceNotifications(ctx), "service notifications loop")
 	})
 	g.Go(func() error {
-		fmt.Println("loopParallelStepNotifications")
 		return errors2.Wrap(a.loopParallelStepNotifications(ctx), "parallel steps notifications loop")
 	})
 
@@ -222,7 +218,6 @@ func (a *agentLoop) loopParallelStepNotifications(ctx context.Context) error {
 func (a *agentLoop) loopRunnerRequests(ctx context.Context) error {
 	watcher := a.client.WatchRunnerRequests(ctx)
 	var wg sync.WaitGroup
-	wg.Add(1)
 	for req := range watcher.Channel() {
 		wg.Add(1)
 		go func(req controlplaneclient.RunnerRequest) {
@@ -294,7 +289,6 @@ func (a *agentLoop) loopRunnerRequests(ctx context.Context) error {
 			}
 		}(req)
 	}
-	wg.Done()
 	wg.Wait()
 	return watcher.Err()
 }


### PR DESCRIPTION
## Pull request description 

Add send and receiver grpc timeouts, in case of network failures we should kill connection and try again.

Receive timeout is 5 minutes, and we send heartbeats every 10s, so should be big enough.

Send time-out is 30s, same as we have in other grpc stream methods


## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [ ] tested locally
- [ ] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Breaking changes

-

## Changes

-

## Fixes

-