### PR TITLE
feat: enable agent commands without EXPERIMENTAL flag

### DIFF
--- a/cmd/kubectl-testkube/commands/agents/create.go
+++ b/cmd/kubectl-testkube/commands/agents/create.go
@@ -10,7 +10,6 @@ import (
 	"github.com/kubeshop/testkube/cmd/kubectl-testkube/config"
 	"github.com/kubeshop/testkube/internal/common"
 	cloudclient "github.com/kubeshop/testkube/pkg/cloud/client"
-	"github.com/kubeshop/testkube/pkg/log"
 	"github.com/kubeshop/testkube/pkg/ui"
 )
 
@@ -21,9 +20,8 @@ func NewCreateAgentCommand() *cobra.Command {
 		environmentIds []string
 	)
 	cmd := &cobra.Command{
-		Use:    "agent",
-		Args:   cobra.ExactArgs(1),
-		Hidden: !log.IsTrue("EXPERIMENTAL"),
+		Use:  "agent",
+		Args: cobra.ExactArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
 			agent := UiCreateAgent(cmd, agentType, args[0], labelPairs, environmentIds, false, "")
 			ui.NL()
@@ -49,9 +47,8 @@ func NewCreateRunnerCommand() *cobra.Command {
 		group          string
 	)
 	cmd := &cobra.Command{
-		Use:    "runner",
-		Args:   cobra.ExactArgs(1),
-		Hidden: !log.IsTrue("EXPERIMENTAL"),
+		Use:  "runner",
+		Args: cobra.ExactArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
 			agent := UiCreateAgent(cmd, "runner", args[0], labelPairs, environmentIds, global, group)
 			ui.NL()
@@ -76,9 +73,8 @@ func NewCreateGitOpsCommand() *cobra.Command {
 		environmentIds []string
 	)
 	cmd := &cobra.Command{
-		Use:    "gitops",
-		Args:   cobra.ExactArgs(1),
-		Hidden: !log.IsTrue("EXPERIMENTAL"),
+		Use:  "gitops",
+		Args: cobra.ExactArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
 			agent := UiCreateAgent(cmd, "gitops", args[0], labelPairs, environmentIds, false, "")
 			ui.NL()

--- a/cmd/kubectl-testkube/commands/agents/delete.go
+++ b/cmd/kubectl-testkube/commands/agents/delete.go
@@ -8,7 +8,6 @@ import (
 	"github.com/spf13/cobra"
 
 	common2 "github.com/kubeshop/testkube/cmd/kubectl-testkube/commands/common"
-	"github.com/kubeshop/testkube/pkg/log"
 	"github.com/kubeshop/testkube/pkg/ui"
 )
 
@@ -21,7 +20,6 @@ func NewDeleteAgentCommand() *cobra.Command {
 		Use:     "agent",
 		Aliases: []string{"runner", "gitops"},
 		Args:    cobra.ExactArgs(1),
-		Hidden:  !log.IsTrue("EXPERIMENTAL"),
 		Run: func(cmd *cobra.Command, args []string) {
 			if !uninstall && !noUninstall {
 				uninstall = ui.Confirm("should it uninstall agent?")
@@ -46,9 +44,8 @@ func NewDeleteCRDCommand() *cobra.Command {
 		confirm bool
 	)
 	cmd := &cobra.Command{
-		Use:    "crd",
-		Args:   cobra.MaximumNArgs(0),
-		Hidden: !log.IsTrue("EXPERIMENTAL"),
+		Use:  "crd",
+		Args: cobra.MaximumNArgs(0),
 		Run: func(cmd *cobra.Command, args []string) {
 			if !confirm && !ui.Confirm("should it uninstall CRDs?") {
 				os.Exit(1)

--- a/cmd/kubectl-testkube/commands/agents/enable.go
+++ b/cmd/kubectl-testkube/commands/agents/enable.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/kubeshop/testkube/internal/common"
 	"github.com/kubeshop/testkube/pkg/cloud/client"
-	"github.com/kubeshop/testkube/pkg/log"
 	"github.com/kubeshop/testkube/pkg/ui"
 )
 
@@ -17,7 +16,6 @@ func NewEnableAgentCommand() *cobra.Command {
 		Use:     "agent <name>",
 		Aliases: []string{"runner", "gitops"},
 		Args:    cobra.ExactArgs(1),
-		Hidden:  !log.IsTrue("EXPERIMENTAL"),
 		Run: func(cmd *cobra.Command, args []string) {
 			UiEnableAgent(cmd, strings.Join(args, ""))
 		},
@@ -31,7 +29,6 @@ func NewDisableAgentCommand() *cobra.Command {
 		Use:     "agent <name>",
 		Aliases: []string{"runner", "gitops"},
 		Args:    cobra.ExactArgs(1),
-		Hidden:  !log.IsTrue("EXPERIMENTAL"),
 		Run: func(cmd *cobra.Command, args []string) {
 			UiDisableAgent(cmd, strings.Join(args, ""))
 		},

--- a/cmd/kubectl-testkube/commands/agents/get.go
+++ b/cmd/kubectl-testkube/commands/agents/get.go
@@ -7,7 +7,6 @@ import (
 	"github.com/gookit/color"
 	"github.com/spf13/cobra"
 
-	"github.com/kubeshop/testkube/pkg/log"
 	"github.com/kubeshop/testkube/pkg/ui"
 )
 
@@ -19,7 +18,6 @@ func NewGetAgentCommand() *cobra.Command {
 		Args:    cobra.MaximumNArgs(1),
 		Use:     "agent [name]",
 		Aliases: []string{"agents", "a"},
-		Hidden:  !log.IsTrue("EXPERIMENTAL"),
 		Run: func(cmd *cobra.Command, args []string) {
 			if len(args) == 0 {
 				UiListAgents(cmd, "")
@@ -42,7 +40,6 @@ func NewGetRunnerCommand() *cobra.Command {
 		Args:    cobra.MaximumNArgs(1),
 		Use:     "runner [name]",
 		Aliases: []string{"runners"},
-		Hidden:  !log.IsTrue("EXPERIMENTAL"),
 		Run: func(cmd *cobra.Command, args []string) {
 			if len(args) == 0 {
 				UiListAgents(cmd, "runner")
@@ -65,7 +62,6 @@ func NewGetGitOpsCommand() *cobra.Command {
 		Args:    cobra.MaximumNArgs(1),
 		Use:     "gitops [name]",
 		Aliases: []string{},
-		Hidden:  !log.IsTrue("EXPERIMENTAL"),
 		Run: func(cmd *cobra.Command, args []string) {
 			if len(args) == 0 {
 				UiListAgents(cmd, "gitops")

--- a/cmd/kubectl-testkube/commands/agents/install.go
+++ b/cmd/kubectl-testkube/commands/agents/install.go
@@ -14,7 +14,6 @@ import (
 	"github.com/kubeshop/testkube/cmd/kubectl-testkube/config"
 	"github.com/kubeshop/testkube/internal/common"
 	cloudclient "github.com/kubeshop/testkube/pkg/cloud/client"
-	"github.com/kubeshop/testkube/pkg/log"
 	"github.com/kubeshop/testkube/pkg/ui"
 )
 
@@ -25,9 +24,8 @@ func NewInstallAgentCommand() *cobra.Command {
 	)
 
 	cmd := &cobra.Command{
-		Use:    "agent <name>",
-		Args:   cobra.MaximumNArgs(1),
-		Hidden: !log.IsTrue("EXPERIMENTAL"),
+		Use:  "agent <name>",
+		Args: cobra.MaximumNArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
 			UiInstallAgent(cmd, strings.Join(args, ""), "")
 		},
@@ -59,9 +57,8 @@ func NewInstallRunnerCommand() *cobra.Command {
 		environmentIds []string
 	)
 	cmd := &cobra.Command{
-		Use:    "runner <name>",
-		Args:   cobra.MaximumNArgs(1),
-		Hidden: !log.IsTrue("EXPERIMENTAL"),
+		Use:  "runner <name>",
+		Args: cobra.MaximumNArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
 			UiInstallAgent(cmd, strings.Join(args, ""), "runner")
 		},
@@ -105,9 +102,8 @@ func NewInstallGitOpsCommand() *cobra.Command {
 		environmentIds []string
 	)
 	cmd := &cobra.Command{
-		Use:    "gitops <name>",
-		Args:   cobra.MaximumNArgs(1),
-		Hidden: !log.IsTrue("EXPERIMENTAL"),
+		Use:  "gitops <name>",
+		Args: cobra.MaximumNArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
 			UiInstallAgent(cmd, strings.Join(args, ""), "gitops")
 		},
@@ -143,9 +139,8 @@ func NewInstallCRDCommand() *cobra.Command {
 	)
 
 	cmd := &cobra.Command{
-		Use:    "crd",
-		Args:   cobra.MaximumNArgs(0),
-		Hidden: !log.IsTrue("EXPERIMENTAL"),
+		Use:  "crd",
+		Args: cobra.MaximumNArgs(0),
 		Run: func(cmd *cobra.Command, args []string) {
 			UiInstallCRD(cmd, namespace, releaseName, dryRun)
 		},

--- a/cmd/kubectl-testkube/commands/agents/update.go
+++ b/cmd/kubectl-testkube/commands/agents/update.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/kubeshop/testkube/internal/common"
 	"github.com/kubeshop/testkube/pkg/cloud/client"
-	"github.com/kubeshop/testkube/pkg/log"
 	"github.com/kubeshop/testkube/pkg/ui"
 )
 
@@ -21,7 +20,6 @@ func NewUpdateAgentCommand() *cobra.Command {
 		Use:     "agent <name>",
 		Aliases: []string{"runner", "gitops"},
 		Args:    cobra.ExactArgs(1),
-		Hidden:  !log.IsTrue("EXPERIMENTAL"),
 		Run: func(cmd *cobra.Command, args []string) {
 			UiUpdateAgent(cmd, strings.Join(args, ""), setLabels, deleteLabels)
 		},

--- a/cmd/kubectl-testkube/commands/install.go
+++ b/cmd/kubectl-testkube/commands/install.go
@@ -4,14 +4,12 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/kubeshop/testkube/cmd/kubectl-testkube/commands/agents"
-	"github.com/kubeshop/testkube/pkg/log"
 	"github.com/kubeshop/testkube/pkg/ui"
 )
 
 func NewInstallCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:    "install",
-		Hidden: !log.IsTrue("EXPERIMENTAL"),
+		Use: "install",
 		Run: func(cmd *cobra.Command, args []string) {
 			err := cmd.Help()
 			ui.PrintOnError("Displaying help", err)


### PR DESCRIPTION
## Pull request description 

* enable the commands in `-h`/`--help` without `EXPERIMENTAL` flag

## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [x] tested locally
- [x] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test