### PR TITLE
fix: [TKC-3219] show temp logs to support abnormally terminated execution pods

### DIFF
--- a/cmd/kubectl-testkube/commands/testworkflows/run.go
+++ b/cmd/kubectl-testkube/commands/testworkflows/run.go
@@ -620,7 +620,7 @@ func printStructuredLogLines(logs string, isLineBeginning, isFirstLine bool) (bo
 			fmt.Print("\n")
 		}
 		text := trimTimestamp(scanner.Text())
-		if text == registry.ErrResourceNotFound.Error() && isFirstLine {
+		if isFirstLine && text == registry.ErrResourceNotFound.Error() {
 			return isLineBeginning, registry.ErrResourceNotFound
 		}
 		fmt.Print(text)

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -122,10 +122,6 @@ func (r *runner) monitor(ctx context.Context, organizationId string, environment
 	currentRef := ""
 	var lastResult *testkube.TestWorkflowResult
 	for n := range notifications.Channel() {
-		if n.Temporary {
-			continue
-		}
-
 		if n.Output != nil {
 			saver.AppendOutput(*n.Output)
 		} else if n.Result != nil {

--- a/pkg/testworkflows/executionworker/controller/controller.go
+++ b/pkg/testworkflows/executionworker/controller/controller.go
@@ -295,7 +295,7 @@ func (c *controller) Logs(parentCtx context.Context, follow bool) io.Reader {
 			return
 		}
 		for v := range ch {
-			if v.Error == nil && v.Value.Log != "" && !v.Value.Temporary {
+			if v.Error == nil && v.Value.Log != "" {
 				if ref != v.Value.Ref && v.Value.Ref != "" {
 					ref = v.Value.Ref
 					_, _ = writer.Write([]byte(instructions.SprintHint(ref, initconstants.InstructionStart)))

--- a/pkg/testworkflows/executionworker/kubernetesworker/worker.go
+++ b/pkg/testworkflows/executionworker/kubernetesworker/worker.go
@@ -378,7 +378,7 @@ func (w *worker) Logs(ctx context.Context, id string, options executionworkertyp
 		defer reader.Close()
 		ref := ""
 		for v := range notifications.Channel() {
-			if v.Log != "" && !v.Temporary {
+			if v.Log != "" {
 				if ref != v.Ref && v.Ref != "" {
 					ref = v.Ref
 					_, _ = reader.Write([]byte(instructions.SprintHint(ref, initconstants.InstructionStart)))


### PR DESCRIPTION
## Pull request description 

- store and show temp logs to support abnormally terminated execution pods
- tune log watching for delayed test jobs

## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [x] tested locally
- [x] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Breaking changes

-

## Changes

-

## Fixes

-