### PR TITLE
fix: improve demo profile usage

### DIFF
--- a/cmd/kubectl-testkube/commands/pro/login.go
+++ b/cmd/kubectl-testkube/commands/pro/login.go
@@ -100,6 +100,26 @@ func NewLoginCmd() *cobra.Command {
 						}
 						cmd.Flags().Set("agent-uri-override", result.AgentURL)
 					}
+
+					if !cmd.Flags().Changed("callback-port") {
+						callbackPort, _ := cmd.Flags().GetInt("callback-port")
+						reservedURLs := []string{
+							fmt.Sprintf("http://localhost:%d", callbackPort),
+							fmt.Sprintf("http://127.0.0.1:%d", callbackPort),
+							fmt.Sprintf("https://localhost:%d", callbackPort),
+							fmt.Sprintf("https://127.0.0.1:%d", callbackPort),
+						}
+						conflicting := false
+						for _, url := range reservedURLs {
+							if result.APIURL == url || strings.HasPrefix(result.APIURL, url+"/") {
+								conflicting = true
+								break
+							}
+						}
+						if conflicting {
+							cmd.Flags().Set("callback-port", fmt.Sprintf("%d", config.AlternativeCallbackPort))
+						}
+					}
 					cmd.Flags().Set("custom-auth", "true")
 				}
 			}

--- a/cmd/kubectl-testkube/config/data.go
+++ b/cmd/kubectl-testkube/config/data.go
@@ -9,7 +9,8 @@ const (
 	TokenTypeOIDC = "oidc"
 	TokenTypeAPI  = "api"
 
-	CallbackPort = 8090
+	CallbackPort            = 8090
+	AlternativeCallbackPort = 38090
 )
 
 type CloudContext struct {


### PR DESCRIPTION
## Pull request description 

* attach by default service URLs (so runners could be installed in different namespaces)
* correctly show errors on callback server (when address is already in use)
* automatically detect address conflict because of demo profile (to automatically replace the callback port)

## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [x] tested locally
- [x] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test