### PR TITLE
feat: allow using different default namespace for execution

### DIFF
--- a/cmd/api-server/main.go
+++ b/cmd/api-server/main.go
@@ -193,8 +193,12 @@ func main() {
 		commons.ExitOnError("Creating test workflow templates client", err)
 	}
 
+	defaultExecutionNamespace := cfg.TestkubeNamespace
+	if cfg.DefaultExecutionNamespace != "" {
+		defaultExecutionNamespace = cfg.DefaultExecutionNamespace
+	}
 	serviceAccountNames := map[string]string{
-		cfg.TestkubeNamespace: cfg.JobServiceAccountName,
+		defaultExecutionNamespace: cfg.JobServiceAccountName,
 	}
 	// Pro edition only (tcl protected code)
 	if cfg.TestkubeExecutionNamespaces != "" {
@@ -241,11 +245,11 @@ func main() {
 	executionWorker := services.CreateExecutionWorker(clientset, cfg, clusterId, proContext.Agent.ID, serviceAccountNames, testWorkflowProcessor, map[string]string{
 		testworkflowconfig.FeatureFlagNewArchitecture: fmt.Sprintf("%v", cfg.FeatureNewArchitecture),
 		testworkflowconfig.FeatureFlagCloudStorage:    fmt.Sprintf("%v", cfg.FeatureCloudStorage),
-	}, commonEnvVariables, true)
+	}, commonEnvVariables, true, defaultExecutionNamespace)
 
 	runnerOpts := runner2.Options{
 		ClusterID:           clusterId,
-		DefaultNamespace:    cfg.TestkubeNamespace,
+		DefaultNamespace:    defaultExecutionNamespace,
 		ServiceAccountNames: serviceAccountNames,
 		StorageSkipVerify:   cfg.StorageSkipVerify,
 	}
@@ -566,6 +570,7 @@ func main() {
 		"telemetryEnabled", telemetryEnabled,
 		"clusterId", clusterId,
 		"namespace", cfg.TestkubeNamespace,
+		"executionNamespace", cfg.DefaultExecutionNamespace,
 		"version", version.Version,
 	)
 

--- a/cmd/api-server/services/executionworker.go
+++ b/cmd/api-server/services/executionworker.go
@@ -24,6 +24,7 @@ func CreateExecutionWorker(
 	featureFlags map[string]string,
 	commonEnvVariables []corev1.EnvVar,
 	logAbortedDetails bool,
+	defaultNamespace string,
 ) executionworkertypes.Worker {
 	namespacesConfig := map[string]kubernetesworker.NamespaceConfig{}
 	for n, s := range serviceAccountNames {
@@ -32,7 +33,7 @@ func CreateExecutionWorker(
 	return executionworker.NewKubernetes(clientSet, processor, kubernetesworker.Config{
 		Cluster: kubernetesworker.ClusterConfig{
 			Id:               clusterId,
-			DefaultNamespace: cfg.TestkubeNamespace,
+			DefaultNamespace: defaultNamespace,
 			DefaultRegistry:  cfg.TestkubeRegistry,
 			Namespaces:       namespacesConfig,
 		},

--- a/cmd/tcl/devbox-mutating-webhook/main.go
+++ b/cmd/tcl/devbox-mutating-webhook/main.go
@@ -86,19 +86,19 @@ func main() {
 				VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}},
 			})
 
-			script := `
+			script := fmt.Sprintf(`
 				set -e
-				/.tktw-bin/wget -O /.tk-devbox/init http://devbox-binary:8080/init || exit 1
+				/.tktw-bin/wget -O /.tk-devbox/init %s/init || exit 1
 				chmod 777 /.tk-devbox/init
-				ls -lah /.tk-devbox`
+				ls -lah /.tk-devbox`, os.Getenv("STORAGE_SERVER"))
 			if usesToolkit {
-				script = `
+				script = fmt.Sprintf(`
 					set -e
-					/.tktw-bin/wget -O /.tk-devbox/init http://devbox-binary:8080/init || exit 1
-					/.tktw-bin/wget -O /.tk-devbox/toolkit http://devbox-binary:8080/toolkit || exit 1
+					/.tktw-bin/wget -O /.tk-devbox/init %s/init || exit 1
+					/.tktw-bin/wget -O /.tk-devbox/toolkit %s/toolkit || exit 1
 					chmod 777 /.tk-devbox/init
 					chmod 777 /.tk-devbox/toolkit
-					ls -lah /.tk-devbox`
+					ls -lah /.tk-devbox`, os.Getenv("STORAGE_SERVER"), os.Getenv("STORAGE_SERVER"))
 			}
 
 			pod.Spec.InitContainers = append([]corev1.Container{{

--- a/cmd/tcl/kubectl-testkube/devbox/command.go
+++ b/cmd/tcl/kubectl-testkube/devbox/command.go
@@ -60,6 +60,7 @@ func NewDevBoxCommand() *cobra.Command {
 		enableCronjobs      bool
 		forcedOs            string
 		forcedArchitecture  string
+		executionNamespace  string
 	)
 
 	cmd := &cobra.Command{
@@ -116,7 +117,7 @@ func NewDevBoxCommand() *cobra.Command {
 							fmt.Printf("Failed to delete obsolete devbox environment (%s): %s\n", env.Name, err.Error())
 							continue
 						}
-						cluster.Namespace(env.Name).Destroy()
+						cluster.Namespace(env.Name, executionNamespace).Destroy()
 						count++
 					}
 					fmt.Printf("Deleted %d/%d obsolete devbox environments\n", count, len(obsolete))
@@ -124,7 +125,7 @@ func NewDevBoxCommand() *cobra.Command {
 			}
 
 			// Initialize bare cluster resources
-			namespace := cluster.Namespace(fmt.Sprintf("devbox-%s", rawDevboxName))
+			namespace := cluster.Namespace(fmt.Sprintf("devbox-%s", rawDevboxName), executionNamespace)
 			interceptorPod := namespace.Pod("devbox-interceptor")
 			agentPod := namespace.Pod("devbox-agent")
 			binaryStoragePod := namespace.Pod("devbox-binary")
@@ -132,6 +133,7 @@ func NewDevBoxCommand() *cobra.Command {
 			minioPod := namespace.Pod("devbox-minio")
 			prometheusPod := namespace.Pod("devbox-prometheus")
 			grafanaPod := namespace.Pod("devbox-grafana")
+			executionNamespace = namespace.ExecutionName()
 
 			// Initialize binaries
 			interceptorBin := devutils.NewBinary(InterceptorMainPath, cluster.OperatingSystem(), cluster.Architecture())
@@ -148,8 +150,8 @@ func NewDevBoxCommand() *cobra.Command {
 			defer initProcessBin.Close()
 
 			// Initialize wrappers over cluster resources
-			interceptor := devutils.NewInterceptor(interceptorPod, baseInitImage, baseToolkitImage, interceptorBin)
-			agent := devutils.NewAgent(agentPod, cloud, baseAgentImage, baseInitImage, baseToolkitImage, disableCloudStorage, enableCronjobs, enableTestTriggers)
+			interceptor := devutils.NewInterceptor(interceptorPod, baseInitImage, baseToolkitImage, interceptorBin, executionNamespace)
+			agent := devutils.NewAgent(agentPod, cloud, baseAgentImage, baseInitImage, baseToolkitImage, disableCloudStorage, enableCronjobs, enableTestTriggers, executionNamespace)
 			binaryStorage := devutils.NewBinaryStorage(binaryStoragePod, binaryStorageBin)
 			mongo := devutils.NewMongo(mongoPod)
 			minio := devutils.NewMinio(minioPod)
@@ -227,7 +229,7 @@ func NewDevBoxCommand() *cobra.Command {
 			}
 			runners := make([]*devutils.RunnerAgent, len(runnersData))
 			for i := range runnersData {
-				runners[i] = devutils.NewRunnerAgent(runnerPods[i], cloud, baseAgentImage, baseInitImage, baseToolkitImage)
+				runners[i] = devutils.NewRunnerAgent(runnerPods[i], cloud, baseAgentImage, baseInitImage, baseToolkitImage, executionNamespace)
 			}
 
 			// Create GitOps agents
@@ -264,7 +266,11 @@ func NewDevBoxCommand() *cobra.Command {
 			}
 
 			// Create namespace
-			fmt.Println("Creating namespace...")
+			if namespace.ExecutionName() != namespace.Name() {
+				fmt.Println("Creating 2 namespaces for Agents and Execution...")
+			} else {
+				fmt.Println("Creating namespace...")
+			}
 			if err = namespace.Create(); err != nil {
 				fail(errors.Wrap(err, "failed to create namespace"))
 			}
@@ -877,6 +883,7 @@ func NewDevBoxCommand() *cobra.Command {
 	cmd.Flags().StringVar(&baseInitImage, "init-image", "kubeshop/testkube-tw-init:latest", "base init image")
 	cmd.Flags().StringVar(&baseToolkitImage, "toolkit-image", "kubeshop/testkube-tw-toolkit:latest", "base toolkit image")
 	cmd.Flags().StringVar(&baseAgentImage, "agent-image", "kubeshop/testkube-api-server:latest", "base agent image")
+	cmd.Flags().StringVarP(&executionNamespace, "execution-namespace", "N", "", "where runners should execute test workflows")
 	cmd.Flags().Uint16Var(&runnersCount, "runners", 0, "additional runners count")
 	cmd.Flags().BoolVar(&disableDefaultAgent, "disable-agent", false, "should disable default agent")
 	cmd.Flags().BoolVar(&disableCloudStorage, "disable-cloud-storage", false, "should disable storage in Cloud")

--- a/cmd/tcl/kubectl-testkube/devbox/devutils/agent.go
+++ b/cmd/tcl/kubectl-testkube/devbox/devutils/agent.go
@@ -28,9 +28,10 @@ type Agent struct {
 	disableCloudStorage bool
 	enableCronjobs      bool
 	enableTestTriggers  bool
+	executionNamespace  string
 }
 
-func NewAgent(pod *PodObject, cloud *CloudObject, agentImage, initProcessImage, toolkitImage string, disableCloudStorage, enableCronjobs, enableTestTriggers bool) *Agent {
+func NewAgent(pod *PodObject, cloud *CloudObject, agentImage, initProcessImage, toolkitImage string, disableCloudStorage, enableCronjobs, enableTestTriggers bool, executionNamespace string) *Agent {
 	return &Agent{
 		pod:                 pod,
 		cloud:               cloud,
@@ -40,6 +41,7 @@ func NewAgent(pod *PodObject, cloud *CloudObject, agentImage, initProcessImage, 
 		disableCloudStorage: disableCloudStorage,
 		enableCronjobs:      enableCronjobs,
 		enableTestTriggers:  enableTestTriggers,
+		executionNamespace:  executionNamespace,
 	}
 }
 
@@ -53,7 +55,8 @@ func (r *Agent) Create(ctx context.Context, env *client.Environment) error {
 		{Name: "DISABLE_DEPRECATED_TESTS", Value: "true"},
 		{Name: "TESTKUBE_ANALYTICS_ENABLED", Value: "false"},
 		{Name: "TESTKUBE_NAMESPACE", Value: r.pod.Namespace()},
-		{Name: "JOB_SERVICE_ACCOUNT_NAME", Value: "devbox-account"},
+		{Name: "DEFAULT_EXECUTION_NAMESPACE", Value: r.executionNamespace},
+		{Name: "JOB_SERVICE_ACCOUNT_NAME", Value: jobServiceAccountName},
 		{Name: "TESTKUBE_ENABLE_IMAGE_DATA_PERSISTENT_CACHE", Value: "true"},
 		{Name: "TESTKUBE_IMAGE_DATA_PERSISTENT_CACHE_KEY", Value: "testkube-image-cache"},
 		{Name: "TESTKUBE_TW_TOOLKIT_IMAGE", Value: r.toolkitImage},

--- a/cmd/tcl/kubectl-testkube/devbox/devutils/cluster.go
+++ b/cmd/tcl/kubectl-testkube/devbox/devutils/cluster.go
@@ -73,8 +73,8 @@ func (c *ClusterObject) Config() *rest.Config {
 	return c.cfg
 }
 
-func (c *ClusterObject) Namespace(name string) *NamespaceObject {
-	return NewNamespace(c.clientSet, c.cfg, name)
+func (c *ClusterObject) Namespace(name, executionName string) *NamespaceObject {
+	return NewNamespace(c.clientSet, c.cfg, name, executionName)
 }
 
 func (c *ClusterObject) Host() string {

--- a/cmd/tcl/kubectl-testkube/devbox/devutils/namespace.go
+++ b/cmd/tcl/kubectl-testkube/devbox/devutils/namespace.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
+	"golang.org/x/sync/singleflight"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
@@ -25,22 +26,36 @@ import (
 	"github.com/kubeshop/testkube/internal/common"
 )
 
+const (
+	roleName                = "devbox-role"
+	executionRoleName       = "devbox-execution-role"
+	jobServiceAccountName   = "devbox-job-account"
+	agentServiceAccountName = "devbox-account"
+)
+
 var (
 	ErrNotDevboxNamespace = errors.New("selected namespace exists and is not devbox")
 )
 
 type NamespaceObject struct {
-	name       string
-	clientSet  *kubernetes.Clientset
-	restConfig *rest.Config
-	namespace  *corev1.Namespace
+	name               string
+	executionName      string
+	clientSet          *kubernetes.Clientset
+	restConfig         *rest.Config
+	namespace          *corev1.Namespace
+	executionNamespace *corev1.Namespace
+	sf                 singleflight.Group
 }
 
-func NewNamespace(kubeClient *kubernetes.Clientset, kubeRestConfig *rest.Config, name string) *NamespaceObject {
+func NewNamespace(kubeClient *kubernetes.Clientset, kubeRestConfig *rest.Config, name, executionName string) *NamespaceObject {
+	if executionName == "" {
+		executionName = name
+	}
 	return &NamespaceObject{
-		name:       name,
-		clientSet:  kubeClient,
-		restConfig: kubeRestConfig,
+		name:          name,
+		executionName: executionName,
+		clientSet:     kubeClient,
+		restConfig:    kubeRestConfig,
 	}
 }
 
@@ -48,8 +63,16 @@ func (n *NamespaceObject) Name() string {
 	return n.name
 }
 
+func (n *NamespaceObject) ExecutionName() string {
+	return n.executionName
+}
+
 func (n *NamespaceObject) ServiceAccountName() string {
-	return "devbox-account"
+	return agentServiceAccountName
+}
+
+func (n *NamespaceObject) JobServiceAccountName() string {
+	return jobServiceAccountName
 }
 
 func (n *NamespaceObject) Pod(name string) *PodObject {
@@ -57,10 +80,26 @@ func (n *NamespaceObject) Pod(name string) *PodObject {
 }
 
 func (n *NamespaceObject) create() error {
+	ns, err := n.createNs(n.name)
+	if err != nil {
+		return err
+	}
+	n.namespace = ns
+	if n.name != n.executionName {
+		_, err = n.createNs(n.executionName)
+		if err != nil {
+			return err
+		}
+	}
+	n.executionNamespace = ns
+	return nil
+}
+
+func (n *NamespaceObject) createNs(name string) (*corev1.Namespace, error) {
 	for {
 		namespace, err := n.clientSet.CoreV1().Namespaces().Create(context.Background(), &corev1.Namespace{
 			ObjectMeta: metav1.ObjectMeta{
-				Name: n.name,
+				Name: name,
 				Labels: map[string]string{
 					"testkube.io/devbox": "namespace",
 				},
@@ -72,42 +111,84 @@ func (n *NamespaceObject) create() error {
 				continue
 			}
 			if k8serrors.IsAlreadyExists(err) {
-				namespace, err = n.clientSet.CoreV1().Namespaces().Get(context.Background(), n.name, metav1.GetOptions{})
+				namespace, err = n.clientSet.CoreV1().Namespaces().Get(context.Background(), name, metav1.GetOptions{})
 				if err != nil {
-					return err
+					return nil, err
 				}
 				if namespace.Labels["testkube.io/devbox"] != "namespace" {
-					return ErrNotDevboxNamespace
+					return nil, ErrNotDevboxNamespace
 				}
-				err = n.clientSet.CoreV1().Namespaces().Delete(context.Background(), n.name, metav1.DeleteOptions{
+				err = n.clientSet.CoreV1().Namespaces().Delete(context.Background(), name, metav1.DeleteOptions{
 					GracePeriodSeconds: common.Ptr(int64(0)),
 					PropagationPolicy:  common.Ptr(metav1.DeletePropagationForeground),
 				})
 				if err != nil {
-					return err
+					return nil, err
 				}
 				continue
 			}
-			return errors.Wrap(err, "failed to create namespace")
+			return nil, errors.Wrap(err, "failed to create namespace")
 		}
-		n.namespace = namespace
-		return nil
+		return namespace, nil
 	}
 }
 
-func (n *NamespaceObject) createServiceAccount() error {
-	// Create service account
-	serviceAccount, err := n.clientSet.CoreV1().ServiceAccounts(n.name).Create(context.Background(), &corev1.ServiceAccount{
-		ObjectMeta: metav1.ObjectMeta{Name: n.ServiceAccountName()},
+func (n *NamespaceObject) createRole() error {
+	// Create the role
+	_, err := n.clientSet.RbacV1().Roles(n.name).Create(context.Background(), &rbacv1.Role{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: roleName,
+		},
+		Rules: []rbacv1.PolicyRule{
+			{
+				Verbs:     []string{"get", "watch", "list", "create", "patch", "update", "delete"},
+				APIGroups: []string{""},
+				Resources: []string{"secrets", "configmaps"},
+			},
+			{
+				Verbs:     []string{"get", "watch", "list", "create", "patch", "update", "delete", "deletecollection"},
+				APIGroups: []string{"testworkflows.testkube.io"},
+				Resources: []string{"testworkflows", "testworkflows/status", "testworkflowtemplates"},
+			},
+			{
+				Verbs:     []string{"get", "watch", "list", "create", "patch", "update", "delete", "deletecollection"},
+				APIGroups: []string{"tests.testkube.io"},
+				Resources: []string{"testtriggers"},
+			},
+		},
 	}, metav1.CreateOptions{})
 	if err != nil && !k8serrors.IsAlreadyExists(err) {
-		return errors.Wrap(err, "failed to create service account")
+		return err
 	}
 
-	// Create service account role
-	role, err := n.clientSet.RbacV1().Roles(n.name).Create(context.Background(), &rbacv1.Role{
+	// Create the role binding for the Agent
+	_, err = n.clientSet.RbacV1().RoleBindings(n.name).Create(context.Background(), &rbacv1.RoleBinding{
+		ObjectMeta: metav1.ObjectMeta{Name: roleName + "-rb"},
+		Subjects: []rbacv1.Subject{
+			{
+				Kind:      "ServiceAccount",
+				Name:      n.ServiceAccountName(),
+				Namespace: n.name,
+			},
+		},
+		RoleRef: rbacv1.RoleRef{
+			APIGroup: "rbac.authorization.k8s.io",
+			Kind:     "Role",
+			Name:     roleName,
+		},
+	}, metav1.CreateOptions{})
+	if err != nil && !k8serrors.IsAlreadyExists(err) {
+		return err
+	}
+
+	return nil
+}
+
+func (n *NamespaceObject) createExecutionRole() error {
+	// Create the role
+	_, err := n.clientSet.RbacV1().Roles(n.executionName).Create(context.Background(), &rbacv1.Role{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: "devbox-account-role",
+			Name: executionRoleName,
 		},
 		Rules: []rbacv1.PolicyRule{
 			{
@@ -125,40 +206,78 @@ func (n *NamespaceObject) createServiceAccount() error {
 				APIGroups: []string{""},
 				Resources: []string{"pods/log", "events"},
 			},
-			{
-				Verbs:     []string{"get", "watch", "list", "create", "patch", "update", "delete", "deletecollection"},
-				APIGroups: []string{"testworkflows.testkube.io"},
-				Resources: []string{"testworkflows", "testworkflows/status", "testworkflowtemplates"},
-			},
-			{
-				Verbs:     []string{"get", "watch", "list", "create", "patch", "update", "delete", "deletecollection"},
-				APIGroups: []string{"tests.testkube.io"},
-				Resources: []string{"testtriggers"},
-			},
 		},
 	}, metav1.CreateOptions{})
 	if err != nil && !k8serrors.IsAlreadyExists(err) {
-		return errors.Wrap(err, "failed to create roles")
+		return err
 	}
 
-	// Create service account role binding
-	_, err = n.clientSet.RbacV1().RoleBindings(n.name).Create(context.Background(), &rbacv1.RoleBinding{
-		ObjectMeta: metav1.ObjectMeta{Name: "devbox-account-rb"},
+	// Create the role binding for the Agent
+	_, err = n.clientSet.RbacV1().RoleBindings(n.executionName).Create(context.Background(), &rbacv1.RoleBinding{
+		ObjectMeta: metav1.ObjectMeta{Name: executionRoleName + "-rb"},
 		Subjects: []rbacv1.Subject{
 			{
 				Kind:      "ServiceAccount",
-				Name:      serviceAccount.Name,
+				Name:      n.ServiceAccountName(),
 				Namespace: n.name,
 			},
 		},
 		RoleRef: rbacv1.RoleRef{
 			APIGroup: "rbac.authorization.k8s.io",
 			Kind:     "Role",
-			Name:     role.Name,
+			Name:     executionRoleName,
 		},
 	}, metav1.CreateOptions{})
 	if err != nil && !k8serrors.IsAlreadyExists(err) {
-		return errors.Wrap(err, "failed to create role bindings")
+		return err
+	}
+
+	// Create the role binding for the jobs (parallel and services)
+	_, err = n.clientSet.RbacV1().RoleBindings(n.executionName).Create(context.Background(), &rbacv1.RoleBinding{
+		ObjectMeta: metav1.ObjectMeta{Name: executionRoleName + "-job-rb"},
+		Subjects: []rbacv1.Subject{
+			{
+				Kind:      "ServiceAccount",
+				Name:      n.JobServiceAccountName(),
+				Namespace: n.executionName,
+			},
+		},
+		RoleRef: rbacv1.RoleRef{
+			APIGroup: "rbac.authorization.k8s.io",
+			Kind:     "Role",
+			Name:     executionRoleName,
+		},
+	}, metav1.CreateOptions{})
+	if err != nil && !k8serrors.IsAlreadyExists(err) {
+		return err
+	}
+
+	return nil
+}
+
+func (n *NamespaceObject) createServiceAccount() error {
+	// Create service account for the Agent
+	_, err := n.clientSet.CoreV1().ServiceAccounts(n.name).Create(context.Background(), &corev1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{Name: n.ServiceAccountName()},
+	}, metav1.CreateOptions{})
+	if err != nil && !k8serrors.IsAlreadyExists(err) {
+		return errors.Wrap(err, "failed to create agent service account")
+	}
+
+	// Create service account for the Jobs
+	_, err = n.clientSet.CoreV1().ServiceAccounts(n.executionName).Create(context.Background(), &corev1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{Name: n.JobServiceAccountName()},
+	}, metav1.CreateOptions{})
+	if err != nil && !k8serrors.IsAlreadyExists(err) {
+		return errors.Wrap(err, "failed to create job service account")
+	}
+
+	// Create roles & bindings
+	if err = n.createRole(); err != nil {
+		return errors.Wrap(err, "failed to create management role")
+	}
+	if err = n.createExecutionRole(); err != nil {
+		return errors.Wrap(err, "failed to create execution role")
 	}
 	return nil
 }
@@ -178,6 +297,13 @@ func (n *NamespaceObject) Create() error {
 }
 
 func (n *NamespaceObject) Destroy() error {
+	_, err, _ := n.sf.Do("destroy", func() (interface{}, error) {
+		return nil, n.destroy()
+	})
+	return err
+}
+
+func (n *NamespaceObject) destroy() error {
 	err := n.clientSet.CoreV1().Namespaces().Delete(context.Background(), n.name, metav1.DeleteOptions{
 		GracePeriodSeconds: common.Ptr(int64(0)),
 		PropagationPolicy:  common.Ptr(metav1.DeletePropagationForeground),
@@ -188,5 +314,14 @@ func (n *NamespaceObject) Destroy() error {
 	err = n.clientSet.AdmissionregistrationV1().MutatingWebhookConfigurations().DeleteCollection(context.Background(), metav1.DeleteOptions{}, metav1.ListOptions{
 		LabelSelector: fmt.Sprintf("testkube.io/devbox-name=%s", n.name),
 	})
+	if n.executionName != n.name {
+		err := n.clientSet.CoreV1().Namespaces().Delete(context.Background(), n.name, metav1.DeleteOptions{
+			GracePeriodSeconds: common.Ptr(int64(0)),
+			PropagationPolicy:  common.Ptr(metav1.DeletePropagationForeground),
+		})
+		if err != nil && !k8serrors.IsNotFound(err) {
+			return err
+		}
+	}
 	return err
 }

--- a/cmd/tcl/kubectl-testkube/devbox/devutils/runneragent.go
+++ b/cmd/tcl/kubectl-testkube/devbox/devutils/runneragent.go
@@ -20,20 +20,22 @@ import (
 )
 
 type RunnerAgent struct {
-	pod              *PodObject
-	cloud            *CloudObject
-	agentImage       string
-	initProcessImage string
-	toolkitImage     string
+	pod                *PodObject
+	cloud              *CloudObject
+	agentImage         string
+	initProcessImage   string
+	toolkitImage       string
+	executionNamespace string
 }
 
-func NewRunnerAgent(pod *PodObject, cloud *CloudObject, agentImage, initProcessImage, toolkitImage string) *RunnerAgent {
+func NewRunnerAgent(pod *PodObject, cloud *CloudObject, agentImage, initProcessImage, toolkitImage, executionNamespace string) *RunnerAgent {
 	return &RunnerAgent{
-		pod:              pod,
-		cloud:            cloud,
-		agentImage:       agentImage,
-		initProcessImage: initProcessImage,
-		toolkitImage:     toolkitImage,
+		pod:                pod,
+		cloud:              cloud,
+		agentImage:         agentImage,
+		initProcessImage:   initProcessImage,
+		toolkitImage:       toolkitImage,
+		executionNamespace: executionNamespace,
 	}
 }
 
@@ -63,7 +65,8 @@ func (r *RunnerAgent) Create(ctx context.Context, env *client.Environment, runne
 		// Runner configuration
 		{Name: "APISERVER_FULLNAME", Value: "devbox-agent"},
 		{Name: "TESTKUBE_NAMESPACE", Value: r.pod.Namespace()},
-		{Name: "JOB_SERVICE_ACCOUNT_NAME", Value: "devbox-account"},
+		{Name: "DEFAULT_EXECUTION_NAMESPACE", Value: r.executionNamespace},
+		{Name: "JOB_SERVICE_ACCOUNT_NAME", Value: jobServiceAccountName},
 		{Name: "TESTKUBE_ENABLE_IMAGE_DATA_PERSISTENT_CACHE", Value: "true"},
 		{Name: "TESTKUBE_IMAGE_DATA_PERSISTENT_CACHE_KEY", Value: "testkube-image-cache"},
 		{Name: "TESTKUBE_TW_TOOLKIT_IMAGE", Value: r.toolkitImage},

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -162,7 +162,8 @@ type ImageInspectorConfig struct {
 }
 
 type RunnerConfig struct {
-	DisableRunner bool `envconfig:"DISABLE_RUNNER" default:"false"`
+	DefaultExecutionNamespace string `envconfig:"DEFAULT_EXECUTION_NAMESPACE" default:""`
+	DisableRunner             bool   `envconfig:"DISABLE_RUNNER" default:"false"`
 }
 
 type GitOpsSyncConfig struct {


### PR DESCRIPTION
## Pull request description 

* add `DEFAULT_EXECUTION_NAMESPACE` to pass default execution namespace
* when it's passed, execution by default will be passed to this namespace (the agent's namespace won't be allowed, unless specified in the additional execution namespaces)
* support it in `tk dev` command (with `-N/--execution-namespace` parameter)

## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [x] tested locally
- [x] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test