### PR TITLE
feat: use testkube-runner Helm Chart for `testkube install runner`

### DIFF
--- a/cmd/kubectl-testkube/commands/agents/utils.go
+++ b/cmd/kubectl-testkube/commands/agents/utils.go
@@ -463,6 +463,49 @@ func CreateHelmOptions(
 	}
 }
 
+func CreateRunnerHelmOptions(
+	controlPlane ControlPlaneConfig,
+	installationNamespace string,
+	version string,
+	dryRun bool,
+	additionalValues map[string]interface{},
+) common2.HelmGenericOptions {
+	envId := ""
+	for _, v := range controlPlane.Agent.Environments {
+		if v.ID == controlPlane.EnvironmentID {
+			envId = v.ID
+		}
+	}
+	if envId == "" && len(controlPlane.Agent.Environments) == 1 {
+		envId = controlPlane.Agent.Environments[0].ID
+	}
+	values := map[string]interface{}{
+		// Setting the connection
+		"runner.secret":     controlPlane.Agent.SecretKey,
+		"runner.orgId":      controlPlane.OrganizationID,
+		"runner.id":         controlPlane.Agent.ID,
+		"cloud.url":         controlPlane.URL,
+		"cloud.tls.enabled": controlPlane.Secure,
+	}
+	maps.Copy(values, additionalValues)
+	if version != "" {
+		values["images.agent.tag"] = version
+		values["images.toolkit.tag"] = version
+		values["images.init.tag"] = version
+	}
+	return common2.HelmGenericOptions{
+		DryRun:         dryRun,
+		RegistryURL:    "https://kubeshop.github.io/helm-charts",
+		RepositoryName: "kubeshop",
+		ChartName:      "testkube-runner",
+		ReleaseName:    fmt.Sprintf("testkube-%s", controlPlane.Agent.Name),
+
+		Namespace: installationNamespace,
+		Args:      []string{"--wait"},
+		Values:    values,
+	}
+}
+
 func CreateCRDsHelmOptions(
 	installationNamespace string,
 	releaseName string,

--- a/cmd/kubectl-testkube/commands/agents/utils.go
+++ b/cmd/kubectl-testkube/commands/agents/utils.go
@@ -470,15 +470,6 @@ func CreateRunnerHelmOptions(
 	dryRun bool,
 	additionalValues map[string]interface{},
 ) common2.HelmGenericOptions {
-	envId := ""
-	for _, v := range controlPlane.Agent.Environments {
-		if v.ID == controlPlane.EnvironmentID {
-			envId = v.ID
-		}
-	}
-	if envId == "" && len(controlPlane.Agent.Environments) == 1 {
-		envId = controlPlane.Agent.Environments[0].ID
-	}
 	values := map[string]interface{}{
 		// Setting the connection
 		"runner.secret":     controlPlane.Agent.SecretKey,


### PR DESCRIPTION
## Pull request description 

* use Helm Chart from https://github.com/kubeshop/helm-charts/pull/1016
* allow using different namespace for execution with `-N`/`--execution-namespace`

## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [x] tested locally
- [x] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test