### PR TITLE
fix: [TKC-3518] get rid of timer channel drain

### DIFF
--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -225,15 +225,10 @@ func (ag *Agent) sendResponse(ctx context.Context, stream cloud.TestKubeCloudAPI
 	t := time.NewTimer(ag.sendTimeout)
 	select {
 	case err := <-errChan:
-		if !t.Stop() {
-			<-t.C
-		}
+		t.Stop()
 		return err
 	case <-ctx.Done():
-		if !t.Stop() {
-			<-t.C
-		}
-
+		t.Stop()
 		return ctx.Err()
 	case <-t.C:
 		return errors.New("send response too slow")
@@ -251,9 +246,7 @@ func (ag *Agent) receiveCommand(ctx context.Context, stream cloud.TestKubeCloudA
 	var cmd *cloud.ExecuteRequest
 	select {
 	case resp := <-respChan:
-		if !t.Stop() {
-			<-t.C
-		}
+		t.Stop()
 
 		cmd = resp.resp
 		err := resp.err
@@ -263,10 +256,7 @@ func (ag *Agent) receiveCommand(ctx context.Context, stream cloud.TestKubeCloudA
 			return nil, err
 		}
 	case <-ctx.Done():
-		if !t.Stop() {
-			<-t.C
-		}
-
+		t.Stop()
 		return nil, ctx.Err()
 	case <-t.C:
 		return nil, errors.New("stream receive too slow")

--- a/pkg/agent/events.go
+++ b/pkg/agent/events.go
@@ -120,15 +120,10 @@ func (ag *Agent) sendEvent(ctx context.Context, stream cloud.TestKubeCloudAPI_Se
 	t := time.NewTimer(ag.sendTimeout)
 	select {
 	case err := <-errChan:
-		if !t.Stop() {
-			<-t.C
-		}
+		t.Stop()
 		return err
 	case <-ctx.Done():
-		if !t.Stop() {
-			<-t.C
-		}
-
+		t.Stop()
 		return ctx.Err()
 	case <-t.C:
 		return errors.New("too slow")

--- a/pkg/agent/logs.go
+++ b/pkg/agent/logs.go
@@ -193,14 +193,10 @@ func (ag *Agent) sendLogStreamResponse(ctx context.Context, stream cloud.TestKub
 	t := time.NewTimer(ag.sendTimeout)
 	select {
 	case err := <-errChan:
-		if !t.Stop() {
-			<-t.C
-		}
+		t.Stop()
 		return err
 	case <-ctx.Done():
-		if !t.Stop() {
-			<-t.C
-		}
+		t.Stop()
 
 		return ctx.Err()
 	case <-t.C:

--- a/pkg/controlplaneclient/runner.go
+++ b/pkg/controlplaneclient/runner.go
@@ -128,17 +128,13 @@ func (c *client) WatchRunnerRequests(ctx context.Context) RunnerRequestsWatcher 
 		t := time.NewTimer(c.opts.RecvTimeout)
 		select {
 		case err := <-errChan:
-			if !t.Stop() {
-				<-t.C
-			}
+			t.Stop()
 			if err != nil {
 				cancel(err)
 			}
 			return err
 		case <-ctx.Done():
-			if !t.Stop() {
-				<-t.C
-			}
+			t.Stop()
 			return ctx.Err()
 		case <-t.C:
 			return errors.New("send response too slow")

--- a/pkg/controlplaneclient/utils.go
+++ b/pkg/controlplaneclient/utils.go
@@ -95,16 +95,12 @@ func processNotifications[Request notificationRequest, Response any, Srv notific
 
 			select {
 			case err := <-errChan:
-				if !t.Stop() {
-					<-t.C
-				}
+				t.Stop()
 				if err != nil {
 					return err
 				}
 			case <-ctx.Done():
-				if !t.Stop() {
-					<-t.C
-				}
+				t.Stop()
 				return ctx.Err()
 			case <-t.C:
 				return fmt.Errorf("send response too slow")

--- a/pkg/testworkflows/executionworker/controller/logs.go
+++ b/pkg/testworkflows/executionworker/controller/logs.go
@@ -238,9 +238,8 @@ func WatchContainerLogs(parentCtx context.Context, clientSet kubernetes.Interfac
 				t.Reset(FlushLogTime)
 				select {
 				case <-bufferCtx.Done():
-					if !t.Stop() {
-						<-t.C
-					}
+					t.Stop()
+
 					return
 				case <-t.C:
 					flushLogBuffer()


### PR DESCRIPTION
## Pull request description 
Ref: https://pkg.go.dev/time#Timer.Stop

For a chan-based timer created with NewTimer(d), as of Go 1.23, any receive from t.C **after Stop has returned is guaranteed to block r**ather than receive a stale time value from before the Stop; if the program has not received from t.C already and the timer is running, Stop is guaranteed to return true. Before Go 1.23, the only safe way to use Stop was insert an extra <-t.C if Stop returned false to drain a potential stale value. See the [NewTimer](https://pkg.go.dev/time#NewTimer) documentation for more details.


## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [ ] tested locally
- [ ] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Breaking changes

-

## Changes

-

## Fixes

-