### PR TITLE
fix(TKC-3513): handle properly deep resolution in function arguments (built-in `passed` variable)

### DIFF
--- a/pkg/expressions/call.go
+++ b/pkg/expressions/call.go
@@ -67,6 +67,9 @@ func (s *call) SafeResolve(m ...Machine) (v Expression, changed bool, err error)
 			return nil, changed, err
 		}
 	}
+	if changed {
+		return s, true, nil
+	}
 	result, ok, err := StdLibMachine.Call(s.name, s.args)
 	if ok {
 		if err != nil {


### PR DESCRIPTION
## Pull request description 

* ensure resolved arguments to maximum before calling a function itself
   * this is to avoid having `FinalizerFail` on the function, while the arguments are still not resolved

## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [x] tested locally
- [x] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [x] added a test

## Fixes

- https://linear.app/kubeshop/issue/TKC-3513