### PR TITLE
feat: Add Execution CRD control to Agent

### DIFF
--- a/cmd/api-server/main.go
+++ b/cmd/api-server/main.go
@@ -7,11 +7,19 @@ import (
 	"os"
 	"time"
 
+	"github.com/go-logr/zapr"
 	"github.com/gofiber/fiber/v2/middleware/cors"
 	"google.golang.org/grpc"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
 
+	testexecutionv1 "github.com/kubeshop/testkube-operator/api/testexecution/v1"
+	testsuiteexecutionv1 "github.com/kubeshop/testkube-operator/api/testsuiteexecution/v1"
+	testworkflowsv1 "github.com/kubeshop/testkube-operator/api/testworkflows/v1"
 	executorsclientv1 "github.com/kubeshop/testkube-operator/pkg/client/executors/v1"
 	testkubeclientset "github.com/kubeshop/testkube-operator/pkg/clientset/versioned"
 	"github.com/kubeshop/testkube/cmd/api-server/commons"
@@ -23,6 +31,7 @@ import (
 	cloudartifacts "github.com/kubeshop/testkube/pkg/cloud/data/artifact"
 	cloudtestworkflow "github.com/kubeshop/testkube/pkg/cloud/data/testworkflow"
 	cloudwebhook "github.com/kubeshop/testkube/pkg/cloud/data/webhook"
+	"github.com/kubeshop/testkube/pkg/controller"
 	"github.com/kubeshop/testkube/pkg/controlplaneclient"
 	"github.com/kubeshop/testkube/pkg/crdstorage"
 	"github.com/kubeshop/testkube/pkg/event/kind/cdevent"
@@ -35,6 +44,7 @@ import (
 	"github.com/kubeshop/testkube/pkg/newclients/testworkflowclient"
 	"github.com/kubeshop/testkube/pkg/newclients/testworkflowtemplateclient"
 	runner2 "github.com/kubeshop/testkube/pkg/runner"
+	"github.com/kubeshop/testkube/pkg/scheduler"
 	"github.com/kubeshop/testkube/pkg/secretmanager"
 	"github.com/kubeshop/testkube/pkg/server"
 	"github.com/kubeshop/testkube/pkg/tcl/schedulertcl"
@@ -456,6 +466,51 @@ func main() {
 		eventsEmitter.Reconcile(ctx)
 		return nil
 	})
+
+	// Create Kubernetes Operators/Controllers
+	if cfg.EnableK8sControllers {
+		// Initialise the controller runtime with our logger.
+		ctrl.SetLogger(zapr.NewLogger(log.DefaultLogger.Desugar()))
+
+		// Configure a scheme to include the required resource definitions.
+		scheme := runtime.NewScheme()
+		err = testworkflowsv1.AddToScheme(scheme)
+		commons.ExitOnError("Add TestWorkflows to kubernetes runtime scheme", err)
+
+		// Legacy schemes
+		err = testexecutionv1.AddToScheme(scheme)
+		commons.ExitOnError("Add TestExecution to kubernetes runtime scheme", err)
+		err = testsuiteexecutionv1.AddToScheme(scheme)
+		commons.ExitOnError("Add TestSuiteExecution to kubernetes runtime scheme", err)
+
+		// Configure the manager to use the defined scheme and to operate in the current namespace.
+		mgr, err := manager.New(kubeConfig, manager.Options{
+			Scheme: scheme,
+			Cache: cache.Options{
+				DefaultNamespaces: map[string]cache.Config{
+					cfg.TestkubeNamespace: {},
+				},
+			},
+		})
+		commons.ExitOnError("Creating kubernetes controller manager", err)
+
+		// Initialise controllers
+		err = controller.NewTestWorkflowExecutionExecutorController(mgr, testWorkflowExecutor)
+		commons.ExitOnError("Creating TestWorkflowExecution controller", err)
+
+		// Legacy controllers
+		testExecutor := workerpool.New[testkube.Test, testkube.ExecutionRequest, testkube.Execution](scheduler.DefaultConcurrencyLevel)
+		err = controller.NewTestExecutionExecutorController(mgr, testExecutor, deprecatedSystem)
+		commons.ExitOnError("Creating TestExecution controller", err)
+		testSuiteExecutor := workerpool.New[testkube.TestSuite, testkube.TestSuiteExecutionRequest, testkube.TestSuiteExecution](scheduler.DefaultConcurrencyLevel)
+		err = controller.NewTestSuiteExecutionExecutorController(mgr, testSuiteExecutor, deprecatedSystem)
+		commons.ExitOnError("Creating TestSuiteExecution controller", err)
+
+		// Finally start the manager.
+		g.Go(func() error {
+			return mgr.Start(ctx)
+		})
+	}
 
 	// Create HTTP server
 	httpServer := server.NewServer(server.Config{Port: cfg.APIServerPort})

--- a/cmd/tcl/kubectl-testkube/devbox/command.go
+++ b/cmd/tcl/kubectl-testkube/devbox/command.go
@@ -45,22 +45,23 @@ const (
 
 func NewDevBoxCommand() *cobra.Command {
 	var (
-		oss                 bool
-		rawDevboxName       string
-		open                bool
-		baseAgentImage      string
-		baseInitImage       string
-		baseToolkitImage    string
-		syncLocalResources  []string
-		runnersCount        uint16
-		gitopsEnabled       bool
-		disableDefaultAgent bool
-		disableCloudStorage bool
-		enableTestTriggers  bool
-		enableCronjobs      bool
-		forcedOs            string
-		forcedArchitecture  string
-		executionNamespace  string
+		oss                  bool
+		rawDevboxName        string
+		open                 bool
+		baseAgentImage       string
+		baseInitImage        string
+		baseToolkitImage     string
+		syncLocalResources   []string
+		runnersCount         uint16
+		gitopsEnabled        bool
+		disableDefaultAgent  bool
+		disableCloudStorage  bool
+		enableTestTriggers   bool
+		enableCronjobs       bool
+		enableK8sControllers bool
+		forcedOs             string
+		forcedArchitecture   string
+		executionNamespace   string
 	)
 
 	cmd := &cobra.Command{
@@ -151,7 +152,7 @@ func NewDevBoxCommand() *cobra.Command {
 
 			// Initialize wrappers over cluster resources
 			interceptor := devutils.NewInterceptor(interceptorPod, baseInitImage, baseToolkitImage, interceptorBin, executionNamespace)
-			agent := devutils.NewAgent(agentPod, cloud, baseAgentImage, baseInitImage, baseToolkitImage, disableCloudStorage, enableCronjobs, enableTestTriggers, executionNamespace)
+			agent := devutils.NewAgent(agentPod, cloud, baseAgentImage, baseInitImage, baseToolkitImage, disableCloudStorage, enableCronjobs, enableTestTriggers, enableK8sControllers, executionNamespace)
 			binaryStorage := devutils.NewBinaryStorage(binaryStoragePod, binaryStorageBin)
 			mongo := devutils.NewMongo(mongoPod)
 			minio := devutils.NewMinio(minioPod)
@@ -891,6 +892,7 @@ func NewDevBoxCommand() *cobra.Command {
 	cmd.Flags().BoolVar(&enableCronjobs, "enable-cronjobs", false, "should enable cron resolution of Test Workflows")
 	cmd.Flags().StringVar(&forcedOs, "os", "", "force different OS for binary builds")
 	cmd.Flags().StringVar(&forcedArchitecture, "arch", "", "force different architecture for binary builds")
+	cmd.Flags().BoolVar(&enableK8sControllers, "enable-k8s-controllers", false, "should enable Kubernetes controllers")
 
 	return cmd
 }

--- a/cmd/tcl/kubectl-testkube/devbox/devutils/agent.go
+++ b/cmd/tcl/kubectl-testkube/devbox/devutils/agent.go
@@ -20,28 +20,30 @@ import (
 )
 
 type Agent struct {
-	pod                 *PodObject
-	cloud               *CloudObject
-	agentImage          string
-	initProcessImage    string
-	toolkitImage        string
-	disableCloudStorage bool
-	enableCronjobs      bool
-	enableTestTriggers  bool
-	executionNamespace  string
+	pod                  *PodObject
+	cloud                *CloudObject
+	agentImage           string
+	initProcessImage     string
+	toolkitImage         string
+	disableCloudStorage  bool
+	enableCronjobs       bool
+	enableTestTriggers   bool
+	enableK8sControllers bool
+	executionNamespace   string
 }
 
-func NewAgent(pod *PodObject, cloud *CloudObject, agentImage, initProcessImage, toolkitImage string, disableCloudStorage, enableCronjobs, enableTestTriggers bool, executionNamespace string) *Agent {
+func NewAgent(pod *PodObject, cloud *CloudObject, agentImage, initProcessImage, toolkitImage string, disableCloudStorage, enableCronjobs, enableTestTriggers, enableK8sControllers bool, executionNamespace string) *Agent {
 	return &Agent{
-		pod:                 pod,
-		cloud:               cloud,
-		agentImage:          agentImage,
-		initProcessImage:    initProcessImage,
-		toolkitImage:        toolkitImage,
-		disableCloudStorage: disableCloudStorage,
-		enableCronjobs:      enableCronjobs,
-		enableTestTriggers:  enableTestTriggers,
-		executionNamespace:  executionNamespace,
+		pod:                  pod,
+		cloud:                cloud,
+		agentImage:           agentImage,
+		initProcessImage:     initProcessImage,
+		toolkitImage:         toolkitImage,
+		disableCloudStorage:  disableCloudStorage,
+		enableCronjobs:       enableCronjobs,
+		enableTestTriggers:   enableTestTriggers,
+		enableK8sControllers: enableK8sControllers,
+		executionNamespace:   executionNamespace,
 	}
 }
 
@@ -69,6 +71,9 @@ func (r *Agent) Create(ctx context.Context, env *client.Environment) error {
 	}
 	if r.enableCronjobs {
 		envVariables = append(envVariables, corev1.EnvVar{Name: "ENABLE_CRON_JOBS", Value: "true"})
+	}
+	if r.enableK8sControllers {
+		envVariables = append(envVariables, corev1.EnvVar{Name: "ENABLE_K8S_CONTROLLERS", Value: "true"})
 	}
 	if env != nil {
 		tlsInsecure := "false"

--- a/cmd/tcl/kubectl-testkube/devbox/devutils/namespace.go
+++ b/cmd/tcl/kubectl-testkube/devbox/devutils/namespace.go
@@ -148,12 +148,12 @@ func (n *NamespaceObject) createRole() error {
 			{
 				Verbs:     []string{"get", "watch", "list", "create", "patch", "update", "delete", "deletecollection"},
 				APIGroups: []string{"testworkflows.testkube.io"},
-				Resources: []string{"testworkflows", "testworkflows/status", "testworkflowtemplates"},
+				Resources: []string{"testworkflows", "testworkflows/status", "testworkflowtemplates", "testworkflowexecutions"},
 			},
 			{
 				Verbs:     []string{"get", "watch", "list", "create", "patch", "update", "delete", "deletecollection"},
 				APIGroups: []string{"tests.testkube.io"},
-				Resources: []string{"testtriggers"},
+				Resources: []string{"testtriggers", "testexecutions", "testsuiteexecutions"},
 			},
 		},
 	}, metav1.CreateOptions{})

--- a/go.mod
+++ b/go.mod
@@ -23,6 +23,7 @@ require (
 	github.com/fsnotify/fsnotify v1.8.0
 	github.com/gabriel-vasile/mimetype v1.4.6
 	github.com/go-errors/errors v1.5.1
+	github.com/go-logr/zapr v1.3.0
 	github.com/gofiber/adaptor/v2 v2.1.29
 	github.com/gofiber/fiber/v2 v2.52.5
 	github.com/gofiber/websocket/v2 v2.1.1

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -250,6 +250,7 @@ func Get() (*Config, error) {
 		c.DisableDefaultAgent = true
 		c.NatsEmbedded = true // we don't use it there
 		c.EnableCronJobs = "false"
+		c.EnableK8sControllers = false
 	} else if strings.HasPrefix(c.TestkubeProAgentID, "tkcsync_") {
 		c.DisableTestTriggers = true
 		c.DisableWebhooks = true
@@ -258,6 +259,7 @@ func Get() (*Config, error) {
 		c.DisableDefaultAgent = true
 		c.NatsEmbedded = true // we don't use it there
 		c.EnableCronJobs = "false"
+		c.EnableK8sControllers = false
 	}
 
 	if c.TestkubeProAPIKey == "" && deprecated.TestkubeCloudAPIKey != "" {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -217,6 +217,7 @@ type Config struct {
 	DisableDeprecatedTests          bool     `envconfig:"DISABLE_DEPRECATED_TESTS" default:"false"`
 	DisableWebhooks                 bool     `envconfig:"DISABLE_WEBHOOKS" default:"false"`
 	AllowLowSecurityFields          bool     `envconfig:"ALLOW_LOW_SECURITY_FIELDS" default:"false"`
+	EnableK8sControllers            bool     `envconfig:"ENABLE_K8S_CONTROLLERS" default:"false"`
 
 	FeatureNewArchitecture bool `envconfig:"FEATURE_NEW_ARCHITECTURE" default:"false"`
 	FeatureCloudStorage    bool `envconfig:"FEATURE_CLOUD_STORAGE" default:"false"`

--- a/pkg/controller/testexecutionexecutor.go
+++ b/pkg/controller/testexecutionexecutor.go
@@ -1,0 +1,78 @@
+package controller
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/api/errors"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	testexecutionv1 "github.com/kubeshop/testkube-operator/api/testexecution/v1"
+	testsv3 "github.com/kubeshop/testkube-operator/api/tests/v3"
+	"github.com/kubeshop/testkube/cmd/api-server/services"
+	testkubev1 "github.com/kubeshop/testkube/pkg/api/v1/testkube"
+	"github.com/kubeshop/testkube/pkg/workerpool"
+)
+
+type TestExecutor = workerpool.Service[testkubev1.Test, testkubev1.ExecutionRequest, testkubev1.Execution]
+
+func NewTestExecutionExecutorController(mgr ctrl.Manager, exec TestExecutor, system *services.DeprecatedSystem) error {
+	if err := ctrl.NewControllerManagedBy(mgr).
+		For(&testexecutionv1.TestExecution{}).
+		WithEventFilter(predicate.GenerationChangedPredicate{}).
+		Complete(testExecutionExecutor(mgr.GetClient(), exec, system)); err != nil {
+		return fmt.Errorf("create new controller for TestExecution: %w", err)
+	}
+	return nil
+}
+
+func testExecutionExecutor(client client.Reader, exec TestExecutor, system *services.DeprecatedSystem) reconcile.Reconciler {
+	return reconcile.Func(func(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+		// Get and validate the TestExecution.
+		var te testexecutionv1.TestExecution
+		err := client.Get(ctx, req.NamespacedName, &te)
+		switch {
+		case errors.IsNotFound(err):
+			return ctrl.Result{}, nil
+		case err != nil:
+			return ctrl.Result{}, err
+		case te.Spec.Test == nil:
+			return ctrl.Result{}, nil
+		case te.Generation == te.Status.Generation:
+			return ctrl.Result{}, nil
+		case te.Spec.ExecutionRequest == nil:
+			te.Spec.ExecutionRequest = &testexecutionv1.ExecutionRequest{}
+		}
+
+		test, err := system.Clients.Tests().Get(te.Spec.Test.Name)
+		switch {
+		case errors.IsNotFound(err):
+			return ctrl.Result{}, fmt.Errorf("test does not exist: %w", err)
+		case err != nil:
+			return ctrl.Result{}, fmt.Errorf("can't get test: %w", err)
+		}
+
+		// This is a gross hack but as this controller is legacy it is not worth the effort
+		// to map between the types correctly.
+		jsonData, err := json.Marshal(te.Spec.ExecutionRequest)
+		if err != nil {
+			return ctrl.Result{}, err
+		}
+		var request testkubev1.ExecutionRequest
+		if err := json.Unmarshal(jsonData, &request); err != nil {
+			return ctrl.Result{}, err
+		}
+
+		go exec.SendRequests(system.Scheduler.PrepareTestRequests([]testsv3.Test{*test}, request))
+		go exec.Run(ctx)
+
+		log := ctrl.LoggerFrom(ctx)
+		log.Info("executed test suite", "name", te.Spec.Test.Name)
+
+		return ctrl.Result{}, nil
+	})
+}

--- a/pkg/controller/testsuiteexecutionexecutor.go
+++ b/pkg/controller/testsuiteexecutionexecutor.go
@@ -1,0 +1,83 @@
+package controller
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/api/errors"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	testsuitesv3 "github.com/kubeshop/testkube-operator/api/testsuite/v3"
+	testsuiteexecutionv1 "github.com/kubeshop/testkube-operator/api/testsuiteexecution/v1"
+	"github.com/kubeshop/testkube/cmd/api-server/services"
+	testkubev1 "github.com/kubeshop/testkube/pkg/api/v1/testkube"
+	"github.com/kubeshop/testkube/pkg/workerpool"
+)
+
+type TestSuiteExecutor = workerpool.Service[testkubev1.TestSuite, testkubev1.TestSuiteExecutionRequest, testkubev1.TestSuiteExecution]
+
+func NewTestSuiteExecutionExecutorController(mgr ctrl.Manager, exec TestSuiteExecutor, system *services.DeprecatedSystem) error {
+	if err := ctrl.NewControllerManagedBy(mgr).
+		For(&testsuiteexecutionv1.TestSuiteExecution{}).
+		WithEventFilter(predicate.GenerationChangedPredicate{}).
+		Complete(testSuiteExecutionExecutor(mgr.GetClient(), exec, system)); err != nil {
+		return fmt.Errorf("create new controller for TestExecution: %w", err)
+	}
+	return nil
+}
+
+func testSuiteExecutionExecutor(client client.Reader, exec TestSuiteExecutor, system *services.DeprecatedSystem) reconcile.Reconciler {
+	return reconcile.Func(func(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+		// Get and validate the TestSuiteExecution.
+		var tse testsuiteexecutionv1.TestSuiteExecution
+		err := client.Get(ctx, req.NamespacedName, &tse)
+		switch {
+		case errors.IsNotFound(err):
+			return ctrl.Result{}, nil
+		case err != nil:
+			return ctrl.Result{}, err
+		case tse.Spec.TestSuite == nil:
+			return ctrl.Result{}, nil
+		case tse.Generation == tse.Status.Generation:
+			return ctrl.Result{}, nil
+		case tse.Spec.ExecutionRequest == nil:
+			tse.Spec.ExecutionRequest = &testsuiteexecutionv1.TestSuiteExecutionRequest{}
+		}
+
+		testSuite, err := system.Clients.TestSuites().Get(tse.Spec.TestSuite.Name)
+		switch {
+		case errors.IsNotFound(err):
+			return ctrl.Result{}, fmt.Errorf("test suite does not exist: %w", err)
+		case err != nil:
+			return ctrl.Result{}, fmt.Errorf("can't get test suite: %w", err)
+		}
+
+		tse.Spec.ExecutionRequest.RunningContext = &testsuiteexecutionv1.RunningContext{
+			Type_:   testsuiteexecutionv1.RunningContextTypeTestSuiteExecution,
+			Context: tse.Name,
+		}
+
+		// This is a gross hack but as this controller is legacy it is not worth the effort
+		// to map between the types correctly.
+		jsonData, err := json.Marshal(tse.Spec.ExecutionRequest)
+		if err != nil {
+			return ctrl.Result{}, err
+		}
+		var request testkubev1.TestSuiteExecutionRequest
+		if err := json.Unmarshal(jsonData, &request); err != nil {
+			return ctrl.Result{}, err
+		}
+
+		go exec.SendRequests(system.Scheduler.PrepareTestSuiteRequests([]testsuitesv3.TestSuite{*testSuite}, request))
+		go exec.Run(ctx)
+
+		log := ctrl.LoggerFrom(ctx)
+		log.Info("executed test suite", "name", tse.Spec.TestSuite.Name)
+
+		return ctrl.Result{}, nil
+	})
+}

--- a/pkg/controller/testworkflowexecutionexecutor.go
+++ b/pkg/controller/testworkflowexecutionexecutor.go
@@ -1,0 +1,104 @@
+package controller
+
+import (
+	"context"
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/api/errors"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	testworkflowsv1 "github.com/kubeshop/testkube-operator/api/testworkflows/v1"
+	testkubev1 "github.com/kubeshop/testkube/pkg/api/v1/testkube"
+	"github.com/kubeshop/testkube/pkg/cloud"
+	"github.com/kubeshop/testkube/pkg/mapper/testworkflows"
+	"github.com/kubeshop/testkube/pkg/testworkflows/testworkflowexecutor"
+)
+
+type TestWorkflowExecutor interface {
+	Execute(ctx context.Context, namespace string, request *cloud.ScheduleRequest) testworkflowexecutor.TestWorkflowExecutionStream
+}
+
+func NewTestWorkflowExecutionExecutorController(mgr ctrl.Manager, exec TestWorkflowExecutor) error {
+	if err := ctrl.NewControllerManagedBy(mgr).
+		For(&testworkflowsv1.TestWorkflowExecution{}).
+		WithEventFilter(predicate.GenerationChangedPredicate{}).
+		Complete(testWorkflowExecutionExecutor(mgr.GetClient(), exec)); err != nil {
+		return fmt.Errorf("create new controller for TestWorkflowExecution: %w", err)
+	}
+	return nil
+}
+
+func testWorkflowExecutionExecutor(client client.Reader, exec TestWorkflowExecutor) reconcile.Reconciler {
+	return reconcile.Func(func(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+		// Get and validate the TestWorkflowExecution.
+		var twe testworkflowsv1.TestWorkflowExecution
+		err := client.Get(ctx, req.NamespacedName, &twe)
+		switch {
+		case errors.IsNotFound(err):
+			return ctrl.Result{}, nil
+		case err != nil:
+			return ctrl.Result{}, err
+		case twe.Spec.TestWorkflow == nil:
+			return ctrl.Result{}, nil
+		case twe.Generation == twe.Status.Generation:
+			return ctrl.Result{}, nil
+		case twe.Spec.ExecutionRequest == nil:
+			twe.Spec.ExecutionRequest = &testworkflowsv1.TestWorkflowExecutionRequest{}
+		}
+
+		// Wrangle the Kubernetes type into the internal representation used by the executor.
+		interface_ := testkubev1.API_TestWorkflowRunningContextInterfaceType
+		actor := testkubev1.TESTWORKFLOWEXECUTION_TestWorkflowRunningContextActorType
+		runningContext := &testkubev1.TestWorkflowRunningContext{
+			Interface_: &testkubev1.TestWorkflowRunningContextInterface{
+				Type_: &interface_,
+			},
+			Actor: &testkubev1.TestWorkflowRunningContextActor{
+				Name:  twe.Name,
+				Type_: &actor,
+			},
+		}
+		rc, user := testworkflowexecutor.GetNewRunningContext(runningContext, nil)
+
+		var scheduleExecution cloud.ScheduleExecution
+		if twe.Spec.ExecutionRequest.Target != nil {
+			target := &cloud.ExecutionTarget{Replicate: twe.Spec.ExecutionRequest.Target.Replicate}
+			if twe.Spec.ExecutionRequest.Target.Match != nil {
+				target.Match = make(map[string]*cloud.ExecutionTargetLabels)
+				for k, v := range twe.Spec.ExecutionRequest.Target.Match {
+					target.Match[k] = &cloud.ExecutionTargetLabels{Labels: v}
+				}
+			}
+			if twe.Spec.ExecutionRequest.Target.Not != nil {
+				target.Not = make(map[string]*cloud.ExecutionTargetLabels)
+				for k, v := range twe.Spec.ExecutionRequest.Target.Not {
+					target.Not[k] = &cloud.ExecutionTargetLabels{Labels: v}
+				}
+			}
+			scheduleExecution.Targets = []*cloud.ExecutionTarget{target}
+		}
+		scheduleExecution.Selector = &cloud.ScheduleResourceSelector{Name: twe.Spec.TestWorkflow.Name}
+		scheduleExecution.Config = testworkflows.MapConfigValueKubeToAPI(twe.Spec.ExecutionRequest.Config)
+
+		executions := exec.Execute(ctx, "", &cloud.ScheduleRequest{
+			Executions:           []*cloud.ScheduleExecution{&scheduleExecution},
+			DisableWebhooks:      twe.Spec.ExecutionRequest.DisableWebhooks,
+			Tags:                 twe.Spec.ExecutionRequest.Tags,
+			RunningContext:       rc,
+			KubernetesObjectName: twe.Spec.ExecutionRequest.TestWorkflowExecutionName,
+			User:                 user,
+		})
+
+		if executions.Error() != nil {
+			return ctrl.Result{}, fmt.Errorf("executing test workflow from execution %q: %w", twe.Name, executions.Error())
+		}
+
+		log := ctrl.LoggerFrom(ctx)
+		log.Info("executed test workflow", "name", twe.Spec.TestWorkflow.Name)
+
+		return ctrl.Result{}, nil
+	})
+}

--- a/pkg/controller/testworkflowexecutionexecutor_test.go
+++ b/pkg/controller/testworkflowexecutionexecutor_test.go
@@ -1,0 +1,204 @@
+package controller
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	commonv1 "github.com/kubeshop/testkube-operator/api/common/v1"
+	testworkflowsv1 "github.com/kubeshop/testkube-operator/api/testworkflows/v1"
+	testkubev1 "github.com/kubeshop/testkube/pkg/api/v1/testkube"
+	"github.com/kubeshop/testkube/pkg/cloud"
+	"github.com/kubeshop/testkube/pkg/testworkflows/testworkflowexecutor"
+)
+
+var scheduleCmpOpts = []cmp.Option{
+	cmpopts.IgnoreUnexported(
+		cloud.ScheduleRequest{},
+		cloud.RunningContext{},
+		cloud.ScheduleExecution{},
+		cloud.ScheduleResourceSelector{},
+		cloud.ExecutionTarget{},
+		cloud.ExecutionTargetLabels{},
+	),
+}
+
+type fakeTestWorkflowExecutor struct {
+	req *cloud.ScheduleRequest
+}
+
+func (f *fakeTestWorkflowExecutor) Execute(_ context.Context, _ string, request *cloud.ScheduleRequest) testworkflowexecutor.TestWorkflowExecutionStream {
+	f.req = request
+	return testworkflowexecutor.NewStream[*testkubev1.TestWorkflowExecution](make(chan *testkubev1.TestWorkflowExecution))
+}
+
+func TestWorkflowExecutionExecutorController(t *testing.T) {
+	tests := map[string]struct {
+		objs    []client.Object
+		request reconcile.Request
+		expect  *cloud.ScheduleRequest
+	}{
+		// Should pass through a basic test workflow execution.
+		"execute": {
+			objs: []client.Object{
+				&testworkflowsv1.TestWorkflowExecution{
+					TypeMeta: metav1.TypeMeta{
+						Kind:       "TestWorkflowExecution",
+						APIVersion: "testworkflows.testkube.io/v1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name:       "test-workflow-execution",
+						Namespace:  "test-namespace",
+						Generation: 1,
+					},
+					Spec: testworkflowsv1.TestWorkflowExecutionSpec{
+						TestWorkflow: &v1.LocalObjectReference{Name: "test-workflow"},
+					},
+					Status: testworkflowsv1.TestWorkflowExecutionStatus{},
+				},
+			},
+			request: reconcile.Request{
+				NamespacedName: client.ObjectKey{
+					Name:      "test-workflow-execution",
+					Namespace: "test-namespace",
+				},
+			},
+			expect: &cloud.ScheduleRequest{
+				Executions: []*cloud.ScheduleExecution{{
+					Selector: &cloud.ScheduleResourceSelector{Name: "test-workflow"},
+				}},
+				RunningContext: &cloud.RunningContext{
+					Name: "test-workflow-execution",
+					Type: cloud.RunningContextType_KUBERNETESOBJECT,
+				},
+			},
+		},
+		// Should pass through a basic test workflow execution with target selectors.
+		"target": {
+			objs: []client.Object{
+				&testworkflowsv1.TestWorkflowExecution{
+					TypeMeta: metav1.TypeMeta{
+						Kind:       "TestWorkflowExecution",
+						APIVersion: "testworkflows.testkube.io/v1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name:       "test-workflow-execution",
+						Namespace:  "test-namespace",
+						Generation: 1,
+					},
+					Spec: testworkflowsv1.TestWorkflowExecutionSpec{
+						TestWorkflow: &v1.LocalObjectReference{Name: "test-workflow"},
+						ExecutionRequest: &testworkflowsv1.TestWorkflowExecutionRequest{
+							Target: &commonv1.Target{
+								Match: map[string][]string{
+									"foo": {"bar"},
+									"baz": {"qux", "quux"},
+								},
+								Not: map[string][]string{
+									"one":   {"two"},
+									"three": {"four", "five"},
+								},
+							},
+						},
+					},
+					Status: testworkflowsv1.TestWorkflowExecutionStatus{},
+				},
+			},
+			request: reconcile.Request{
+				NamespacedName: client.ObjectKey{
+					Name:      "test-workflow-execution",
+					Namespace: "test-namespace",
+				},
+			},
+			expect: &cloud.ScheduleRequest{
+				Executions: []*cloud.ScheduleExecution{{
+					Selector: &cloud.ScheduleResourceSelector{Name: "test-workflow"},
+					Targets: []*cloud.ExecutionTarget{{
+						Match: map[string]*cloud.ExecutionTargetLabels{
+							"foo": {Labels: []string{"bar"}},
+							"baz": {Labels: []string{"qux", "quux"}},
+						},
+						Not: map[string]*cloud.ExecutionTargetLabels{
+							"one":   {Labels: []string{"two"}},
+							"three": {Labels: []string{"four", "five"}},
+						},
+					}},
+				}},
+				RunningContext: &cloud.RunningContext{
+					Name: "test-workflow-execution",
+					Type: cloud.RunningContextType_KUBERNETESOBJECT,
+				},
+			},
+		},
+		// Should not execute if the generation has not changed.
+		"ignore generation": {
+			objs: []client.Object{
+				&testworkflowsv1.TestWorkflowExecution{
+					TypeMeta: metav1.TypeMeta{
+						Kind:       "TestWorkflowExecution",
+						APIVersion: "testworkflows.testkube.io/v1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name:       "test-workflow-execution",
+						Namespace:  "test-namespace",
+						Generation: 1,
+					},
+					Spec: testworkflowsv1.TestWorkflowExecutionSpec{
+						TestWorkflow: &v1.LocalObjectReference{Name: "test-workflow"},
+						ExecutionRequest: &testworkflowsv1.TestWorkflowExecutionRequest{
+							Target: &commonv1.Target{
+								Match: map[string][]string{
+									"foo": {"bar"},
+									"baz": {"qux", "quux"},
+								},
+								Not: map[string][]string{
+									"one":   {"two"},
+									"three": {"four", "five"},
+								},
+							},
+						},
+					},
+					Status: testworkflowsv1.TestWorkflowExecutionStatus{
+						Generation: 1,
+					},
+				},
+			},
+			request: reconcile.Request{
+				NamespacedName: client.ObjectKey{
+					Name:      "test-workflow-execution",
+					Namespace: "test-namespace",
+				},
+			},
+			expect: nil,
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			exec := &fakeTestWorkflowExecutor{}
+			scheme := runtime.NewScheme()
+			if err := testworkflowsv1.AddToScheme(scheme); err != nil {
+				t.Fatalf("failed to add testworkflowsv1 to scheme: %v", err)
+			}
+			k8sClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(test.objs...).Build()
+			reconciler := testWorkflowExecutionExecutor(k8sClient, exec)
+
+			_, err := reconciler.Reconcile(context.Background(), test.request)
+			if err != nil {
+				t.Errorf("reconcile: %v", err)
+			}
+			if !cmp.Equal(test.expect, exec.req, scheduleCmpOpts...) {
+				t.Errorf("Incorrect execution request, diff: %s", cmp.Diff(test.expect, exec.req, scheduleCmpOpts...))
+			}
+		})
+	}
+
+}


### PR DESCRIPTION
## Pull request description 

These changes add Kubernetes controllers for the `TestWorkflowExecution` CRD as well as the `TestSuiteExecution` and `TestExecution` legacy CRDs.
The controllers mimic the effect of the `testkube-operator` on the CRDs, however as they are integrated into the agent they are able to call the execution functions directly rather than having to go via the API.

Initialisation of the controllers is behind a new `ENABLE_K8S_CONTROLLERS` environment variable as it would not be desirable to have these controllers running at the same time as the `testkube-operator`.

Additionally the Agent will now also attempt to clean up legacy `CronJob` resources when using the newer cronjob scheduler. This is a duplication of the existing logic in the operator, however the two should not conflict and enables fully operator-less deployment.

The TestKube CLI `devbox` command has also been updated to create the correct permissions for the `Role` as well as to include a new `--enable-k8s-controllers` flag.

## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [x] tested locally
- [ ] tested on cluster
- [x] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Changes

- Added Execution CRD controllers to Agent behind `ENABLE_K8S_CONTROLLERS` environment variable.
