### PR TITLE
feat: recover missing service/parallel step logs in case of crash

### DIFF
--- a/cmd/tcl/testworkflow-toolkit/commands/kill.go
+++ b/cmd/tcl/testworkflow-toolkit/commands/kill.go
@@ -76,6 +76,7 @@ func NewKillCmd() *cobra.Command {
 				for _, item := range items {
 					service, index := spawn.GetServiceByResourceId(item.Resource.Id)
 					if _, ok := conditions[service]; !ok {
+						instructions.PrintOutput(config.Ref(), "service", ServiceInfo{Group: groupRef, Name: service, Index: index, Done: true})
 						continue
 					}
 					serviceMachine := expressions.NewMachine().
@@ -147,7 +148,7 @@ func NewKillCmd() *cobra.Command {
 
 					logsFilePath, err := spawn.SaveLogs(context.Background(), storage, config.Namespace(), id, service+"/", index)
 					if err == nil {
-						instructions.PrintOutput(config.Ref(), "service", ServiceInfo{Group: groupRef, Name: service, Index: index, Logs: storage.FullPath(logsFilePath)})
+						instructions.PrintOutput(config.Ref(), "service", ServiceInfo{Group: groupRef, Name: service, Index: index, Logs: storage.FullPath(logsFilePath), Done: true})
 						log("saved logs")
 					} else {
 						log("warning", "problem saving the logs", err.Error())

--- a/cmd/tcl/testworkflow-toolkit/commands/parallel.go
+++ b/cmd/tcl/testworkflow-toolkit/commands/parallel.go
@@ -51,6 +51,12 @@ type ParallelStatus struct {
 	Result      *testkube.TestWorkflowResult     `json:"result,omitempty"`
 }
 
+func (s ParallelStatus) AsMap() (v map[string]interface{}) {
+	serialized, _ := json.Marshal(s)
+	_ = json.Unmarshal(serialized, &v)
+	return
+}
+
 func NewParallelCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "parallel <spec>",

--- a/cmd/tcl/testworkflow-toolkit/commands/services.go
+++ b/cmd/tcl/testworkflow-toolkit/commands/services.go
@@ -71,6 +71,13 @@ type ServiceInfo struct {
 	Description string        `json:"description,omitempty"`
 	Logs        string        `json:"logs,omitempty"`
 	Status      ServiceStatus `json:"status,omitempty"`
+	Done        bool          `json:"done,omitempty"`
+}
+
+func (s ServiceInfo) AsMap() (v map[string]interface{}) {
+	serialized, _ := json.Marshal(s)
+	_ = json.Unmarshal(serialized, &v)
+	return
 }
 
 func NewServicesCmd() *cobra.Command {

--- a/cmd/testworkflow-toolkit/artifacts/internalartifactstorage.go
+++ b/cmd/testworkflow-toolkit/artifacts/internalartifactstorage.go
@@ -11,6 +11,7 @@ import (
 	"github.com/kubeshop/testkube/cmd/testworkflow-toolkit/env"
 	"github.com/kubeshop/testkube/cmd/testworkflow-toolkit/env/config"
 	"github.com/kubeshop/testkube/pkg/bufferedstream"
+	"github.com/kubeshop/testkube/pkg/controlplaneclient"
 	"github.com/kubeshop/testkube/pkg/testworkflows/testworkflowprocessor/constants"
 )
 
@@ -41,6 +42,13 @@ func InternalStorage() InternalArtifactStorage {
 	return &internalArtifactStorage{
 		prefix:   filepath.Join(".testkube", config.Ref()),
 		uploader: newArtifactUploader(),
+	}
+}
+
+func InternalStorageForAgent(client controlplaneclient.Client, environmentId, executionId, workflowName, ref string) InternalArtifactStorage {
+	return &internalArtifactStorage{
+		prefix:   filepath.Join(".testkube", ref),
+		uploader: NewCloudUploader(client, environmentId, executionId, workflowName, ref, WithParallelismCloud(30), CloudDetectMimetype),
 	}
 }
 

--- a/pkg/api/v1/testkube/model_test_workflow_result_extended.go
+++ b/pkg/api/v1/testkube/model_test_workflow_result_extended.go
@@ -471,6 +471,9 @@ func (r *TestWorkflowResult) HealTimestamps(sigSequence []TestWorkflowSignature,
 
 func (r *TestWorkflowResult) HealAborted(sigSequence []TestWorkflowSignature, errorStr, defaultErrorStr string) {
 	errorMessage := fmt.Sprintf("The execution has been aborted. (%s)", errorStr)
+	if errorStr == "" {
+		errorMessage = fmt.Sprintf("The execution has been aborted.")
+	}
 
 	// Create marker to know if there is any step marked as aborted already
 	aborted := false

--- a/pkg/runner/service.go
+++ b/pkg/runner/service.go
@@ -79,7 +79,7 @@ func NewService(
 	}
 }
 
-func (s *service) recover(ctx context.Context) (err error) {
+func (s *service) reattach(ctx context.Context) (err error) {
 	executions, err := s.client.GetRunnerOngoingExecutions(ctx)
 	if err != nil {
 		log.DefaultLogger.Errorw("failed to get runner executions", "error", err)
@@ -97,16 +97,16 @@ func (s *service) recover(ctx context.Context) (err error) {
 				return
 			}
 
-			s.logger.Warnw("execution to monitor not found. recovering.", "id", executionId, "error", err)
+			s.logger.Warnw("execution to monitor not found. reattaching again.", "id", executionId, "error", err)
 
 			// Get the existing execution
 			execution, err := s.client.GetExecution(ctx, environmentId, executionId)
 			if err != nil {
-				s.logger.Errorw("failed to recover execution: getting execution", "id", executionId, "error", err)
+				s.logger.Errorw("failed to reattach to execution: getting execution", "id", executionId, "error", err)
 				return
 			}
 
-			// Ignore if it's still queued - orchestrator will recover it later
+			// Ignore if it's still queued - orchestrator will reattach to it later
 			if execution.Result.IsQueued() {
 				s.logger.Warnw("execution to monitor is still queued: leaving it for orchestrator", "id", executionId)
 				return
@@ -159,7 +159,7 @@ func (s *service) Start(ctx context.Context) error {
 	g, ctx := errgroup.WithContext(ctx)
 
 	g.Go(func() error {
-		return s.recover(ctx)
+		return s.reattach(ctx)
 	})
 
 	g.Go(func() error {


### PR DESCRIPTION
## Pull request description 

* If the execution crashes (or is aborted), while there are ongoing parallel steps or services, let Agent save them

## Example For Services

Just run this:

```yaml
kind: TestWorkflow
apiVersion: testworkflows.testkube.io/v1
metadata:
  name: example-services-crash
spec:
  services:
    test:
      shell: echo heeeloooooo!
  steps:
  - shell: sleep 10
  - shell: echo {{ unknown_variable }}
```

## Example For Parallel Steps

Run this, and abort while the parallel steps will be running:

```yaml
kind: TestWorkflow
apiVersion: testworkflows.testkube.io/v1
metadata:
  name: example-parallel-crash
spec:
  steps:
  - parallel:
      count: 5
      steps:
      - shell: echo hello {{ index }}
      - shell: sleep 60000
```

## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [x] tested locally
- [x] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test