### PR TITLE
fix: custom default registry name

### DIFF
--- a/pkg/imageinspector/cranefetcher.go
+++ b/pkg/imageinspector/cranefetcher.go
@@ -29,7 +29,9 @@ func NewCraneFetcher() InfoFetcher {
 func (c *craneFetcher) Fetch(ctx context.Context, registry, image string, pullSecrets []corev1.Secret) (*Info, error) {
 	// If registry is not provided, extract it from the image name
 	if registry == "" {
-		registry = extractRegistry(image)
+		if registry = ExtractRegistry(image); registry == "" {
+			registry = utils.DefaultDockerRegistry
+		}
 	}
 
 	// If registry is provided via config and the image does not start with the registry, prepend it
@@ -109,19 +111,18 @@ type DockerImage struct {
 	} `json:"history"`
 }
 
-// extractRegistry takes a container image string and returns the registry part.
-// It defaults to "docker.io" if no registry is specified.
-func extractRegistry(image string) string {
+// ExtractRegistry takes a container image string and returns the registry part.
+func ExtractRegistry(image string) string {
 	parts := strings.Split(image, "/")
 	// If the image is just a name, return the default registry.
 	if len(parts) == 1 {
-		return utils.DefaultDockerRegistry
+		return ""
 	}
 	// If the first part contains '.' or ':', it's likely a registry.
 	if strings.Contains(parts[0], ".") || strings.Contains(parts[0], ":") {
 		return parts[0]
 	}
-	return utils.DefaultDockerRegistry
+	return ""
 }
 
 func determineUserGroupPair(userGroupStr string) (int64, int64) {

--- a/pkg/imageinspector/cranefetcher_test.go
+++ b/pkg/imageinspector/cranefetcher_test.go
@@ -15,22 +15,22 @@ func TestExtractRegistry(t *testing.T) {
 		image    string
 		expected string
 	}{
-		{"DockerHub short", "nginx:latest", "https://index.docker.io/v1/"},
-		{"DockerHub long", "library/nginx:latest", "https://index.docker.io/v1/"},
+		{"DockerHub short", "nginx:latest", ""},
+		{"DockerHub long", "library/nginx:latest", ""},
 		{"GCR", "gcr.io/google-containers/busybox:latest", "gcr.io"},
 		{"ECR", "123456789012.dkr.ecr.us-east-1.amazonaws.com/my-application:latest", "123456789012.dkr.ecr.us-east-1.amazonaws.com"},
 		{"MCR", "mcr.microsoft.com/dotnet/core/sdk:3.1", "mcr.microsoft.com"},
 		{"Quay", "quay.io/bitnami/nginx:latest", "quay.io"},
 		{"Custom port", "localhost:5000/myimage:latest", "localhost:5000"},
 		{"No tag", "myregistry.com/myimage", "myregistry.com"},
-		{"Only image", "myimage", "https://index.docker.io/v1/"},
+		{"Only image", "myimage", ""},
 		{"Custom GitLab", "registry.gitlab.com/company/base-docker-images/ubuntu-python-base-image:3.12.0-jammy", "registry.gitlab.com"},
 	}
 
 	for _, tc := range tests {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
-			got := extractRegistry(tc.image)
+			got := ExtractRegistry(tc.image)
 			assert.Equal(t, tc.expected, got)
 		})
 	}

--- a/pkg/imageinspector/inspector.go
+++ b/pkg/imageinspector/inspector.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"path/filepath"
 	"regexp"
+	"strings"
 
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
@@ -95,6 +96,11 @@ func (i *inspector) save(ctx context.Context, registry, image string, info *Info
 }
 
 func (i *inspector) ResolveName(registry, image string) string {
+	// if it already contains default registry
+	if i.defaultRegistry != "" && strings.HasPrefix(image, i.defaultRegistry) {
+		return image
+	}
+
 	if ImageWithRegistryRe.MatchString(image) {
 		return image
 	}

--- a/pkg/imageinspector/inspector.go
+++ b/pkg/imageinspector/inspector.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"fmt"
 	"path/filepath"
-	"regexp"
-	"strings"
 
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
@@ -19,10 +17,6 @@ type inspector struct {
 	secrets         SecretFetcher
 	storage         []Storage
 }
-
-var (
-	ImageWithRegistryRe = regexp.MustCompile(`^[^/]+\.[^/]+/`)
-)
 
 func NewInspector(defaultRegistry string, infoFetcher InfoFetcher, secretFetcher SecretFetcher, storage ...Storage) Inspector {
 	return &inspector{
@@ -96,12 +90,7 @@ func (i *inspector) save(ctx context.Context, registry, image string, info *Info
 }
 
 func (i *inspector) ResolveName(registry, image string) string {
-	// if it already contains default registry
-	if i.defaultRegistry != "" && strings.HasPrefix(image, i.defaultRegistry) {
-		return image
-	}
-
-	if ImageWithRegistryRe.MatchString(image) {
+	if ExtractRegistry(image) != "" {
 		return image
 	}
 	if registry == "" {

--- a/pkg/imageinspector/inspector_test.go
+++ b/pkg/imageinspector/inspector_test.go
@@ -114,3 +114,12 @@ func TestInspector_ResolveName_Default_Override(t *testing.T) {
 	assert.Equal(t, "docker.io/repo/image:1.2.3", inspector.ResolveName("default.io", "docker.io/repo/image:1.2.3"))
 	assert.Equal(t, "ghcr.io/repo/image:1.2.3", inspector.ResolveName("default.io", "ghcr.io/repo/image:1.2.3"))
 }
+
+func TestInspector_ResolveName_CustomDefault_NoOverride(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	infos := NewMockInfoFetcher(ctrl)
+	secrets := NewMockSecretFetcher(ctrl)
+	inspector := NewInspector("custom-registry:443", infos, secrets)
+
+	assert.Equal(t, "custom-registry:443/kubeshop/testkube-tw-toolkit:2.1.147", inspector.ResolveName("", "custom-registry:443/kubeshop/testkube-tw-toolkit:2.1.147"))
+}

--- a/pkg/imageinspector/inspector_test.go
+++ b/pkg/imageinspector/inspector_test.go
@@ -121,5 +121,5 @@ func TestInspector_ResolveName_CustomDefault_NoOverride(t *testing.T) {
 	secrets := NewMockSecretFetcher(ctrl)
 	inspector := NewInspector("custom-registry:443", infos, secrets)
 
-	assert.Equal(t, "custom-registry:443/kubeshop/testkube-tw-toolkit:2.1.147", inspector.ResolveName("", "custom-registry:443/kubeshop/testkube-tw-toolkit:2.1.147"))
+	assert.Equal(t, "custom-registry:443/repo/image:1.2.3", inspector.ResolveName("", "custom-registry:443/repo/image:1.2.3"))
 }


### PR DESCRIPTION
## Pull request description 

support custom default registry names without dot by switching to ExtractRegistry

## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [ ] tested locally
- [x] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [x] added a test

## Breaking changes

-

## Changes

-

## Fixes

-