### PR TITLE
feat: TKC-3697: do not fail workflow if resource metrics cannot be saved

### DIFF
--- a/cmd/tcl/testworkflow-toolkit/commands/kill.go
+++ b/cmd/tcl/testworkflow-toolkit/commands/kill.go
@@ -137,7 +137,10 @@ func NewKillCmd() *cobra.Command {
 				}
 
 				// Fetch logs for them
-				storage := artifacts.InternalStorage()
+				storage, err := artifacts.InternalStorage()
+				if err != nil {
+					ui.Failf("could not create internal storage client: %v", err)
+				}
 				for _, id := range ids {
 					service, index := spawn.GetServiceByResourceId(id)
 					count := index + 1

--- a/cmd/tcl/testworkflow-toolkit/commands/parallel.go
+++ b/cmd/tcl/testworkflow-toolkit/commands/parallel.go
@@ -188,7 +188,10 @@ func NewParallelCmd() *cobra.Command {
 			}
 
 			// Load Kubernetes client and image inspector
-			storage := artifacts.InternalStorage()
+			storage, err := artifacts.InternalStorage()
+			if err != nil {
+				ui.Failf("could not create internal storage client: %v", err)
+			}
 
 			// Prepare runner
 			// TODO: Share resources like configMaps?

--- a/cmd/tcl/testworkflow-toolkit/execute/execute.go
+++ b/cmd/tcl/testworkflow-toolkit/execute/execute.go
@@ -61,7 +61,10 @@ func executeTestWorkflowApi(workflowName string, request testkube.TestWorkflowEx
 
 func executeTestWorkflowGrpc(workflowName string, request testkube.TestWorkflowExecutionRequest) ([]testkube.TestWorkflowExecution, error) {
 	cfg := config.Config()
-	client := env.Cloud()
+	client, err := env.Cloud()
+	if err != nil {
+		return nil, err
+	}
 	var targets []*cloud.ExecutionTarget
 	if request.Target != nil {
 		targets = commonmapper.MapAllTargetsApiToGrpc([]testkube.ExecutionTarget{*request.Target})
@@ -92,11 +95,19 @@ func listTestWorkflowsApi(labels map[string]string) ([]testkube.TestWorkflow, er
 
 func listTestWorkflowsGrpc(labels map[string]string) ([]testkube.TestWorkflow, error) {
 	cfg := config.Config()
-	client := testworkflowclient.NewCloudTestWorkflowClient(env.Cloud())
+	cloud, err := env.Cloud()
+	if err != nil {
+		return nil, err
+	}
+	client := testworkflowclient.NewCloudTestWorkflowClient(cloud)
 	return client.List(context.Background(), cfg.Execution.EnvironmentId, testworkflowclient.ListOptions{Labels: labels})
 }
 
 func GetExecution(id string) (*testkube.TestWorkflowExecution, error) {
 	cfg := config.Config()
-	return env.Cloud().GetExecution(context.Background(), cfg.Execution.EnvironmentId, id)
+	cloud, err := env.Cloud()
+	if err != nil {
+		return nil, err
+	}
+	return cloud.GetExecution(context.Background(), cfg.Execution.EnvironmentId, id)
 }

--- a/cmd/testworkflow-init/main.go
+++ b/cmd/testworkflow-init/main.go
@@ -514,7 +514,10 @@ func scrapeMetricsPostProcessor(path, step string, config testworkflowconfig.Int
 		}()
 
 		// Scrape the metrics to internal storage
-		storage := artifacts.InternalStorage()
+		storage, err := artifacts.InternalStorage()
+		if err != nil {
+			return errors.Wrapf(err, "failed to create internal storage for metrics: %v", err)
+		}
 		err = filepath.Walk(path, func(path string, info os.FileInfo, err error) error {
 			if info.IsDir() {
 				return nil

--- a/cmd/testworkflow-toolkit/commands/artifacts.go
+++ b/cmd/testworkflow-toolkit/commands/artifacts.go
@@ -76,7 +76,10 @@ func NewArtifactsCmd() *cobra.Command {
 			var handlerOpts []artifacts.HandlerOpts
 			// Archive
 			cfg := config.Config()
-			client := env.Cloud()
+			client, err := env.Cloud()
+			if err != nil {
+				ui.Failf("could not create cloud client: %v", err)
+			}
 
 			if env.HasJunitSupport() {
 				junitProcessor := artifacts.NewJUnitPostProcessor(filesystem.NewOSFileSystem(), client, cfg.Execution.EnvironmentId, cfg.Execution.Id, cfg.Workflow.Name, config.Ref(), walker.Root(), cfg.Resource.FsPrefix)

--- a/cmd/testworkflow-toolkit/commands/clone.go
+++ b/cmd/testworkflow-toolkit/commands/clone.go
@@ -81,7 +81,10 @@ func NewCloneCmd() *cobra.Command {
 					uri.User = url.User(username)
 				}
 			} else if authType == "github" {
-				client := env.Cloud()
+				client, err := env.Cloud()
+				if err != nil {
+					ui.Failf("could not create cloud client: %v", err)
+				}
 				githubToken, err := client.GetGitHubToken(cmd.Context(), uri.String())
 				if err == nil {
 					uri.User = url.UserPassword("x-access-token", githubToken)


### PR DESCRIPTION
## Pull request description 

Do not fail workflow if resource metrics cannot be saved

## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [ ] tested locally
- [ ] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Breaking changes

-

## Changes

-

## Fixes

-