### PR TITLE
feat: TKC-3709: store warning in test workflow execution if resource metrics fail

### DIFF
--- a/cmd/testworkflow-init/instructions/emit.go
+++ b/cmd/testworkflow-init/instructions/emit.go
@@ -122,3 +122,19 @@ func DetectInstruction(line []byte) (*Instruction, bool, error) {
 	}
 	return instruction, isHint, nil
 }
+
+type ExecutionWarning struct {
+	Type      string `json:"type"`
+	Component string `json:"component"`
+	Warning   string `json:"error"`
+	Reason    string `json:"reason"`
+}
+
+func NewExecutionWarning(component, warning, reason string) ExecutionWarning {
+	return ExecutionWarning{
+		Type:      "warning",
+		Component: component,
+		Warning:   warning,
+		Reason:    reason,
+	}
+}


### PR DESCRIPTION
## Pull request description 

Store warning in `outputs` field if resource metrics scraping/saving fails.

Example:
```
# Execution object
{
  ...
  "output": [
     {
      "ref": "rd6cw49",
      "name": "resource-metrics-warning",
      "value": {
        "component": "resource-metrics",
        "error": "failed to record metrics",
        "reason": "testing error"
      }
    }
  ]
}
```

## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [x] tested locally
- [x] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Breaking changes

-

## Changes

-

## Fixes

-