### PR TITLE
fix: [TKC-3819] waiting for multiple running workflows

### DIFF
--- a/cmd/kubectl-testkube/commands/testworkflows/run.go
+++ b/cmd/kubectl-testkube/commands/testworkflows/run.go
@@ -191,16 +191,10 @@ func NewRunTestWorkflowCmd() *cobra.Command {
 							}
 
 							if len(args) > 0 {
-								ec := uiWatch(execution, pServiceName, serviceIndex, pParallelStepName, parallelStepIndex, client)
+								exitCode = uiWatch(execution, pServiceName, serviceIndex, pParallelStepName, parallelStepIndex, client)
 								ui.NL()
 								if downloadArtifactsEnabled {
 									tests.DownloadTestWorkflowArtifacts(execution.Id, downloadDir, format, masks, client, outputPretty)
-								}
-
-								if ec != 0 {
-									mu.Lock()
-									exitCode = ec
-									mu.Unlock()
 								}
 							} else {
 								wg.Add(1)
@@ -225,7 +219,6 @@ func NewRunTestWorkflowCmd() *cobra.Command {
 										mu.Unlock()
 									}
 								}(&execution)
-
 							}
 						} else {
 							uiShellWatchExecution(execution.Id)


### PR DESCRIPTION
## Pull request description 

Use waiting flag when run test workflows using label selector

## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [x] tested locally
- [ ] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Breaking changes

-

## Changes

-

## Fixes

-