### PR TITLE
fix: fix artifact double authentication

### DIFF
--- a/pkg/api/v1/client/cloud_client.go
+++ b/pkg/api/v1/client/cloud_client.go
@@ -80,7 +80,10 @@ func (t CloudClient[A]) GetFile(uri, fileName, destination string, params map[st
 	if err != nil {
 		return "", err
 	}
-	resp, err = t.client.Do(req)
+	// Signed URLs should use default client as these URLs are self-sufficient
+	// and do not need Authorization headers added. Some Object Storage Providers
+	// even fail when both Auth header and signed query parameter are present.
+	resp, err = http.DefaultClient.Do(req)
 	if err != nil {
 		return name, err
 	}


### PR DESCRIPTION
This PR fixes TKC-3871. It prevents making requests which have two authentication mechanisms. Some object storage providers handle this gracefully, but others will fail on this.