### PR TITLE
fix: TestWorkflow/TestWorkflowTemplate Secret Owner References [TKC-3875]

### DIFF
--- a/internal/app/api/v1/secret.go
+++ b/internal/app/api/v1/secret.go
@@ -11,6 +11,7 @@ import (
 
 	testworkflowsv1 "github.com/kubeshop/testkube-operator/api/testworkflows/v1"
 	"github.com/kubeshop/testkube/internal/app/api/apiutils"
+	"github.com/kubeshop/testkube/internal/crdcommon"
 	"github.com/kubeshop/testkube/pkg/api/v1/testkube"
 	"github.com/kubeshop/testkube/pkg/secretmanager"
 )
@@ -198,13 +199,33 @@ func (s *TestkubeAPI) fetchOwnerReference(kind, name string) (metav1.OwnerRefere
 		if err != nil {
 			return metav1.OwnerReference{}, errors.Wrap(err, "fetching owner")
 		}
-		return metav1.OwnerReference{APIVersion: obj.GroupVersionKind().String(), Kind: obj.Kind, Name: obj.Name, UID: obj.UID}, nil
+
+		// Use AppendTypeMeta to set the GroupVersionKind properly
+		crdcommon.AppendTypeMeta("TestWorkflow", testworkflowsv1.GroupVersion, obj)
+
+		ownerRef := metav1.OwnerReference{
+			APIVersion: obj.APIVersion,
+			Kind:       obj.Kind,
+			Name:       obj.Name,
+			UID:        obj.UID,
+		}
+		return ownerRef, nil
 	} else if kind == testworkflowsv1.ResourceTemplate {
 		obj, err := s.TestWorkflowTemplatesK8SClient.Get(name)
 		if err != nil {
 			return metav1.OwnerReference{}, errors.Wrap(err, "fetching owner")
 		}
-		return metav1.OwnerReference{APIVersion: obj.GroupVersionKind().String(), Kind: obj.Kind, Name: obj.Name, UID: obj.UID}, nil
+
+		// Use AppendTypeMeta to set the GroupVersionKind properly
+		crdcommon.AppendTypeMeta("TestWorkflowTemplate", testworkflowsv1.GroupVersion, obj)
+
+		ownerRef := metav1.OwnerReference{
+			APIVersion: obj.APIVersion,
+			Kind:       obj.Kind,
+			Name:       obj.Name,
+			UID:        obj.UID,
+		}
+		return ownerRef, nil
 	}
 
 	return metav1.OwnerReference{}, fmt.Errorf("unsupported owner kind: %s", kind)


### PR DESCRIPTION
### Problem
Secret creation with `TestWorkflow`/`TestWorkflowTemplate` owner references failed with "kind must not be empty" error because the Kubernetes client doesn't populate type metadata fields on retrieved objects.

### Solution
Implemented proper type metadata handling using the existing [crdcommon.AppendTypeMeta](https://github.com/kubeshop/testkube/blob/26413b80e61e69fcb01a1ff8470332c19b794604/internal/crdcommon/crd.go#L26) utility function to set `GroupVersionKind` on `TestWorkflow` and `TestWorkflowTemplate` objects after retrieval.