### PR TITLE
feat: support AWS ECR generating token when registry has the URL format

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -91,6 +91,8 @@ require (
 	k8s.io/utils v0.0.0-20241210054802-24370beab758
 	sigs.k8s.io/controller-runtime v0.20.1
 	sigs.k8s.io/kustomize/kyaml v0.19.0
+	github.com/aws/aws-sdk-go-v2/config v1.29.17
+	github.com/aws/aws-sdk-go-v2/service/ecr v1.45.1
 )
 
 require (


### PR DESCRIPTION
## Pull request description 

Generate AWS ECR auth token from env variables, configuration file, or IAM role, to inspect images that will be used into a TW execution and have as origin an AWS ECR private registry.

## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [ ] tested locally
- [ ] tested on cluster
- [X] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Breaking changes

-

## Changes

- Add action to generate AWS ECR auth token if registry URI matches with a ECR private registry.

## Fixes

-