### PR TITLE
fix: assignment lock logic

### DIFF
--- a/pkg/repository/testworkflow/mongo.go
+++ b/pkg/repository/testworkflow/mongo.go
@@ -780,11 +780,35 @@ func (r *MongoRepository) Init(ctx context.Context, id string, data InitData) er
 }
 
 func (r *MongoRepository) Assign(ctx context.Context, id string, prevRunnerId string, newRunnerId string, assignedAt *time.Time) (bool, error) {
+	oneMinuteAgo := time.Now().Add(-1 * time.Minute)
 	res, err := r.Coll.UpdateOne(ctx, bson.M{
 		"$and": []bson.M{
 			{"id": id},
 			{"result.status": testkube.QUEUED_TestWorkflowStatus},
-			{"$or": []bson.M{{"runnerid": prevRunnerId}, {"runnerid": newRunnerId}, {"runnerid": nil}}},
+			{"$or": []bson.M{
+				// New assignment - workflow has no runner assigned
+				{
+					"$or": []bson.M{
+						{"runnerid": nil},
+						{"runnerid": ""},
+					},
+				},
+				// Extension of existing assignment - extension to assignment timeout
+				{
+					"$and": []bson.M{
+						{"runnerid": newRunnerId},
+						{"assignedat": bson.M{"$lt": assignedAt}},
+					},
+				},
+				// Reassignment to new runner - must wait one minute between assignments
+				{
+					"$and": []bson.M{
+						{"runnerid": prevRunnerId},
+						{"assignedat": bson.M{"$lt": oneMinuteAgo}},
+						{"assignedat": bson.M{"$lt": assignedAt}},
+					},
+				},
+			}},
 		},
 	}, bson.M{"$set": map[string]interface{}{
 		"runnerid":   newRunnerId,


### PR DESCRIPTION
## Pull request description 

The locking via assignment logic was not quite tight.

The runnerid can be a non-nil blank string, because when there is an error sending start request to the runner the orchestrator immediately tries to unassign the execution by setting it to blank string. If this happens, then it seems the execution will then be unassignable through the current logic. The `GetUnassigned` logic takes this case into account returning the values with blank strings as well, but it does not seem `Assign` is able to handle such a precondition.

Another possible problem is with reassignment, before reassigning an execution to a different runner, the lock should enforce an assignment timeout this should help avoid multiple orchestrator instances from reassigning an execution in short order. Particularly, this could be happening in the recovery loop after an execution has been assigned for one minute or longer. The one minute timeout in these conditions comes from the recovery loop period and other preexisting logic that seems to attempt to do the same thing without accounting for concurrency of orchestrator instances.

The immediate unassigning on start request failure will need to be removed also because of the above, and in this cases it should just fall back to the one minute recovery loop for the sake of simplicity.

Other guard rails put in place to make sure the assigned at time monotonicly increases.

## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [ ] tested locally
- [x] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Breaking changes

-

## Changes

-

## Fixes

-