### PR TITLE
fix: [TKC-3950] add receive timeout for notifications and tests

### DIFF
--- a/cmd/api-server/main.go
+++ b/cmd/api-server/main.go
@@ -241,7 +241,7 @@ func main() {
 		},
 		SendTimeout: cfg.TestkubeProSendTimeout,
 		RecvTimeout: cfg.TestkubeProRecvTimeout,
-	})
+	}, log.DefaultLogger)
 
 	if proContext.CloudStorage {
 		testWorkflowsClient = testworkflowclient.NewCloudTestWorkflowClient(client)

--- a/cmd/testworkflow-init/data/client.go
+++ b/cmd/testworkflow-init/data/client.go
@@ -55,7 +55,7 @@ func CloudClient() controlplaneclient.Client {
 			ExecutionID:        cfg.Execution.Id,
 			WorkflowName:       cfg.Workflow.Name,
 			ParentExecutionIDs: strings.Split(cfg.Execution.ParentIds, "/"),
-		})
+		}, log.DefaultLogger)
 	}
 	return cloudClient
 }

--- a/cmd/testworkflow-toolkit/env/client.go
+++ b/cmd/testworkflow-toolkit/env/client.go
@@ -253,5 +253,5 @@ func Cloud() (controlplaneclient.Client, error) {
 		ExecutionID:        cfg.Execution.Id,
 		WorkflowName:       cfg.Workflow.Name,
 		ParentExecutionIDs: strings.Split(cfg.Execution.ParentIds, "/"),
-	}), nil
+	}, log.DefaultLogger), nil
 }

--- a/pkg/controlplaneclient/client.go
+++ b/pkg/controlplaneclient/client.go
@@ -4,6 +4,8 @@ import (
 	"strings"
 	"time"
 
+	"go.uber.org/zap"
+
 	"github.com/kubeshop/testkube/internal/config"
 	"github.com/kubeshop/testkube/pkg/cloud"
 )
@@ -19,6 +21,7 @@ type client struct {
 	client     cloud.TestKubeCloudAPIClient
 	proContext config.ProContext
 	opts       ClientOptions
+	logger     *zap.SugaredLogger
 }
 
 type ClientOptions struct {
@@ -49,11 +52,12 @@ type Client interface {
 	TestWorkflowTemplatesClient
 }
 
-func New(grpcClient cloud.TestKubeCloudAPIClient, proContext config.ProContext, opts ClientOptions) Client {
+func New(grpcClient cloud.TestKubeCloudAPIClient, proContext config.ProContext, opts ClientOptions, logger *zap.SugaredLogger) Client {
 	return &client{
 		client:     grpcClient,
 		proContext: proContext,
 		opts:       opts,
+		logger:     logger,
 	}
 }
 

--- a/pkg/runner/agent.go
+++ b/pkg/runner/agent.go
@@ -74,6 +74,8 @@ func newAgentLoop(
 
 func (a *agentLoop) Start(ctx context.Context) error {
 	for {
+		a.logger.Infow("starting runner agent connection with control plane")
+
 		if ctx.Err() != nil {
 			return ctx.Err()
 		}
@@ -151,7 +153,6 @@ func (a *agentLoop) init(ctx context.Context, environmentId string, execution *t
 
 func (a *agentLoop) run(ctx context.Context) error {
 	g, ctx := errgroup.WithContext(ctx)
-
 	// Handle the new mechanism for runners
 	if a.proContext.NewArchitecture {
 		g.Go(func() error {

--- a/pkg/runner/agent_conn_test.go
+++ b/pkg/runner/agent_conn_test.go
@@ -1,0 +1,235 @@
+package runner
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/zap"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"github.com/kubeshop/testkube/internal/config"
+	"github.com/kubeshop/testkube/pkg/api/v1/testkube"
+	"github.com/kubeshop/testkube/pkg/cloud"
+	"github.com/kubeshop/testkube/pkg/controlplaneclient"
+	"github.com/kubeshop/testkube/pkg/testworkflows/executionworker/executionworkertypes"
+	"github.com/kubeshop/testkube/pkg/testworkflows/testworkflowconfig"
+)
+
+// Simple mock event emitter
+type simpleMockEventEmitter struct{}
+
+func (m *simpleMockEventEmitter) Notify(event testkube.Event) {}
+
+func TestAgentLoop_Start_SimpleReconnectionDelay(t *testing.T) {
+	// Create test gRPC server and client
+	testServer := &testGRPCServer{
+		getRunnerRequestsErrorToReturn:                   status.Error(codes.Unavailable, "server unavailable"),
+		getRunnerRequestSendPing:                         true,
+		getTestWorkflowNotificationsSendPing:             true,
+		getTestWorkflowServiceNotificationsSendPing:      true,
+		getTestWorkflowParallelStepNotificationsSendPing: true,
+	}
+	grpcServer, conn, testServer := createTestGRPCServer(testServer)
+	defer grpcServer.Stop()
+	defer conn.Close()
+
+	// Create real gRPC client
+	grpcClient := cloud.NewTestKubeCloudAPIClient(conn)
+
+	// Create control plane client
+	mockClient := controlplaneclient.New(grpcClient, config.ProContext{
+		NewArchitecture: true,
+		Agent: config.ProContextAgent{
+			ID: "test-agent",
+		},
+	}, controlplaneclient.ClientOptions{
+		StorageSkipVerify: true,
+		Runtime: controlplaneclient.RuntimeConfig{
+			Namespace: "test-namespace",
+		},
+		SendTimeout: 5 * time.Second,
+		RecvTimeout: 5 * time.Second,
+	}, zap.NewNop().Sugar())
+
+	// Create mocks for other dependencies
+	mockRunner := &MockRunner{}
+	mockWorker := executionworkertypes.NewMockWorker(nil)
+	mockEmitter := &simpleMockEventEmitter{}
+
+	logger := zap.NewNop().Sugar()
+
+	// Create agent loop
+	agent := newAgentLoop(
+		mockRunner,
+		mockWorker,
+		logger,
+		mockEmitter,
+		mockClient,
+		testworkflowconfig.ControlPlaneConfig{},
+		config.ProContext{
+			NewArchitecture: true,
+			Agent: config.ProContextAgent{
+				ID: "test-agent",
+			},
+		},
+		"test-org",
+		"test-env",
+	)
+
+	// Create context with timeout
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	// Start the agent loop
+	err := agent.Start(ctx)
+
+	// Should return context deadline exceeded error (expected) and should have made multiple calls
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "context deadline exceeded")
+	assert.GreaterOrEqual(t, testServer.GetCallCount(), 2)
+}
+
+func TestAgentLoop_GetRunnerRequests_ReconnectionOnReceiveTimeout(t *testing.T) {
+	testServer := &testGRPCServer{
+		getRunnerRequestSendPing:                         false,
+		getTestWorkflowNotificationsSendPing:             true,
+		getTestWorkflowServiceNotificationsSendPing:      true,
+		getTestWorkflowParallelStepNotificationsSendPing: true,
+	}
+	grpcServer, conn, testServer := createTestGRPCServer(testServer)
+	defer grpcServer.Stop()
+	defer conn.Close()
+
+	grpcClient := cloud.NewTestKubeCloudAPIClient(conn)
+
+	mockClient := controlplaneclient.New(grpcClient, config.ProContext{
+		NewArchitecture: true,
+		Agent: config.ProContextAgent{
+			ID: "test-agent",
+		},
+	}, controlplaneclient.ClientOptions{
+		StorageSkipVerify: true,
+		Runtime: controlplaneclient.RuntimeConfig{
+			Namespace: "test-namespace",
+		},
+		SendTimeout: 100 * time.Second,
+		RecvTimeout: 2 * time.Second, // Set receive timeout to 2 seconds
+	}, zap.NewExample().Sugar())
+
+	// Create mocks for other dependencies
+	mockRunner := &MockRunner{}
+	mockWorker := executionworkertypes.NewMockWorker(nil)
+	mockEmitter := &simpleMockEventEmitter{}
+
+	// Enable debug logging to see what's happening
+	logger := zap.NewExample().Sugar()
+
+	// Create agent loop
+	agent := newAgentLoop(
+		mockRunner,
+		mockWorker,
+		logger,
+		mockEmitter,
+		mockClient,
+		testworkflowconfig.ControlPlaneConfig{},
+		config.ProContext{
+			NewArchitecture: true,
+			Agent: config.ProContextAgent{
+				ID: "test-agent",
+			},
+		},
+		"test-org",
+		"test-env",
+	)
+
+	// Create context with timeout longer than the receive timeout
+	ctx, cancel := context.WithTimeout(context.Background(), 7*time.Second)
+	defer cancel()
+
+	// Start the agent loop
+	err := agent.Start(ctx)
+
+	// Should return context deadline exceeded error (expected) and should have made multiple calls
+	// due to receive timeout causing reconnections
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "context deadline exceeded")
+
+	// Should have made multiple calls due to receive timeout reconnections
+	// Each call should timeout after 2 seconds, so we expect at least 2 calls in 7 seconds
+	assert.GreaterOrEqual(t, testServer.GetCallCount(), 2,
+		"Expected at least 2 calls due to receive timeout reconnections, got %d", testServer.GetCallCount())
+}
+
+func TestAgentLoop_GetNotifications_ReconnectionOnReceiveTimeout(t *testing.T) {
+	testServer := &testGRPCServer{
+		getRunnerRequestSendPing:                         true,
+		getTestWorkflowNotificationsSendPing:             false,
+		getTestWorkflowServiceNotificationsSendPing:      true,
+		getTestWorkflowParallelStepNotificationsSendPing: true,
+	}
+	grpcServer, conn, testServer := createTestGRPCServer(testServer)
+	defer grpcServer.Stop()
+	defer conn.Close()
+
+	grpcClient := cloud.NewTestKubeCloudAPIClient(conn)
+
+	mockClient := controlplaneclient.New(grpcClient, config.ProContext{
+		NewArchitecture: true,
+		Agent: config.ProContextAgent{
+			ID: "test-agent",
+		},
+	}, controlplaneclient.ClientOptions{
+		StorageSkipVerify: true,
+		Runtime: controlplaneclient.RuntimeConfig{
+			Namespace: "test-namespace",
+		},
+		SendTimeout: 100 * time.Second,
+		RecvTimeout: 2 * time.Second, // Set receive timeout to 2 seconds
+	}, zap.NewExample().Sugar())
+
+	// Create mocks for other dependencies
+	mockRunner := &MockRunner{}
+	mockWorker := executionworkertypes.NewMockWorker(nil)
+	mockEmitter := &simpleMockEventEmitter{}
+
+	// Enable debug logging to see what's happening
+	logger := zap.NewExample().Sugar()
+
+	// Create agent loop
+	agent := newAgentLoop(
+		mockRunner,
+		mockWorker,
+		logger,
+		mockEmitter,
+		mockClient,
+		testworkflowconfig.ControlPlaneConfig{},
+		config.ProContext{
+			NewArchitecture: true,
+			Agent: config.ProContextAgent{
+				ID: "test-agent",
+			},
+		},
+		"test-org",
+		"test-env",
+	)
+
+	// Create context with timeout longer than the receive timeout
+	ctx, cancel := context.WithTimeout(context.Background(), 7*time.Second)
+	defer cancel()
+
+	// Start the agent loop
+	err := agent.Start(ctx)
+
+	// Should return context deadline exceeded error (expected) and should have made multiple calls
+	// due to receive timeout causing reconnections
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "context deadline exceeded")
+
+	// Should have made multiple calls due to receive timeout reconnections
+	// Each call should timeout after 2 seconds, so we expect at least 2 calls in 7 seconds
+	assert.GreaterOrEqual(t, testServer.GetCallCount(), 2,
+		"Expected at least 2 calls due to receive timeout reconnections, got %d", testServer.GetCallCount())
+}

--- a/pkg/runner/mock_grpc_server.go
+++ b/pkg/runner/mock_grpc_server.go
@@ -1,0 +1,174 @@
+package runner
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"sync"
+	"time"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/test/bufconn"
+
+	"github.com/kubeshop/testkube/pkg/cloud"
+)
+
+// Test gRPC server implementation
+type testGRPCServer struct {
+	cloud.UnimplementedTestKubeCloudAPIServer
+	getRunnerRequestsErrorToReturn                        error
+	getRunnerRequestsSendData                             *cloud.RunnerRequest
+	getTestWorkflowNotificationsErrorToReturn             error
+	getTestWorkflowServiceNotificationsErrorToReturn      error
+	getTestWorkflowParallelStepNotificationsErrorToReturn error
+	getRunnerRequestSendPing                              bool
+	getTestWorkflowNotificationsSendPing                  bool
+	getTestWorkflowServiceNotificationsSendPing           bool
+	getTestWorkflowParallelStepNotificationsSendPing      bool
+	callCount                                             int
+	mu                                                    sync.Mutex
+}
+
+func (s *testGRPCServer) GetRunnerRequests(stream cloud.TestKubeCloudAPI_GetRunnerRequestsServer) error {
+	s.mu.Lock()
+	s.callCount++
+	currentCall := s.callCount
+	s.mu.Unlock()
+
+	fmt.Printf("DEBUG: GetRunnerRequests called (call #%d)\n", currentCall)
+	if s.getRunnerRequestsErrorToReturn != nil {
+		fmt.Printf("DEBUG: GetRunnerRequests returning error: %v\n", s.getRunnerRequestsErrorToReturn)
+		return s.getRunnerRequestsErrorToReturn
+	}
+
+	for {
+		select {
+		case <-stream.Context().Done():
+			fmt.Printf("DEBUG: GetRunnerRequests context cancelled\n")
+			return stream.Context().Err()
+		case <-time.After(1 * time.Second):
+			if s.getRunnerRequestSendPing {
+				stream.Send(&cloud.RunnerRequest{
+					Type: cloud.RunnerRequestType_PING,
+				})
+				var req cloud.RunnerRequest
+				stream.RecvMsg(&req)
+			}
+
+			if s.getRunnerRequestsSendData != nil {
+				stream.Send(s.getRunnerRequestsSendData)
+			}
+		}
+
+	}
+
+}
+
+func (s *testGRPCServer) GetTestWorkflowNotificationsStream(stream cloud.TestKubeCloudAPI_GetTestWorkflowNotificationsStreamServer) error {
+	if s.getTestWorkflowNotificationsErrorToReturn != nil {
+		return s.getTestWorkflowNotificationsErrorToReturn
+	}
+
+	// Send an empty request and wait for context cancellation
+	for {
+		select {
+		case <-stream.Context().Done():
+			fmt.Printf("DEBUG: GetTestWorkflowNotificationsStream context cancelled\n")
+			return stream.Context().Err()
+		case <-time.After(1 * time.Second):
+			if s.getTestWorkflowNotificationsSendPing {
+				stream.Send(&cloud.TestWorkflowNotificationsRequest{
+					StreamId:    "test-stream-id",
+					RequestType: cloud.TestWorkflowNotificationsRequestType_WORKFLOW_STREAM_HEALTH_CHECK,
+				})
+				var req cloud.TestWorkflowNotificationsRequest
+				stream.RecvMsg(&req)
+			}
+		}
+	}
+}
+
+func (s *testGRPCServer) GetTestWorkflowServiceNotificationsStream(stream cloud.TestKubeCloudAPI_GetTestWorkflowServiceNotificationsStreamServer) error {
+	if s.getTestWorkflowServiceNotificationsErrorToReturn != nil {
+		return s.getTestWorkflowServiceNotificationsErrorToReturn
+	}
+
+	// Send an empty request and wait for context cancellation
+	for {
+		select {
+		case <-stream.Context().Done():
+			return stream.Context().Err()
+		case <-time.After(1 * time.Second):
+			if s.getTestWorkflowServiceNotificationsSendPing {
+				stream.Send(&cloud.TestWorkflowServiceNotificationsRequest{
+					StreamId:    "test-stream-id",
+					RequestType: cloud.TestWorkflowNotificationsRequestType_WORKFLOW_STREAM_HEALTH_CHECK,
+				})
+				var req cloud.TestWorkflowServiceNotificationsRequest
+				stream.RecvMsg(&req)
+			}
+		}
+	}
+}
+
+func (s *testGRPCServer) GetTestWorkflowParallelStepNotificationsStream(stream cloud.TestKubeCloudAPI_GetTestWorkflowParallelStepNotificationsStreamServer) error {
+	if s.getTestWorkflowParallelStepNotificationsErrorToReturn != nil {
+		return s.getTestWorkflowParallelStepNotificationsErrorToReturn
+	}
+
+	// Send an empty request and wait for context cancellation
+	for {
+		select {
+		case <-stream.Context().Done():
+			return stream.Context().Err()
+		case <-time.After(1 * time.Second):
+			if s.getTestWorkflowParallelStepNotificationsSendPing {
+				stream.Send(&cloud.TestWorkflowParallelStepNotificationsRequest{
+					StreamId:    "test-stream-id",
+					RequestType: cloud.TestWorkflowNotificationsRequestType_WORKFLOW_STREAM_HEALTH_CHECK,
+				})
+				var req cloud.TestWorkflowParallelStepNotificationsRequest
+				stream.RecvMsg(&req)
+			}
+		}
+	}
+}
+
+func (s *testGRPCServer) GetCallCount() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.callCount
+}
+
+// Helper function to create a test gRPC server and client
+func createTestGRPCServer(testServer *testGRPCServer) (*grpc.Server, *grpc.ClientConn, *testGRPCServer) {
+	// Create a buffer-based listener for testing
+	listener := bufconn.Listen(1024 * 1024)
+
+	// Create gRPC server
+	grpcServer := grpc.NewServer()
+	cloud.RegisterTestKubeCloudAPIServer(grpcServer, testServer)
+
+	// Start server in background
+	go func() {
+		if err := grpcServer.Serve(listener); err != nil {
+			// Ignore server closed errors
+			fmt.Printf("DEBUG: grpcServer.Serve error: %v\n", err)
+		}
+	}()
+
+	// Create client connection
+	ctx := context.Background()
+	conn, err := grpc.DialContext(ctx, "bufnet", //nolint
+		grpc.WithContextDialer(func(context.Context, string) (net.Conn, error) {
+			return listener.Dial()
+		}),
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+	)
+	if err != nil {
+		panic(err)
+	}
+
+	return grpcServer, conn, testServer
+}


### PR DESCRIPTION
## Pull request description 

- Adding more logs on runner connections
- Adding receive timeout to all Notification streams (we by default send pings every 30seconds), default receive timeout is 5minutes.
- Adding tests, they are a bit slow, but they check that reconnection works properly on errors and stuck connections

Example:
```
--- PASS: TestAgentLoop_GetRunnerRequests_ReconnectionOnReceiveTimeout (10.00s)
=== RUN   TestAgentLoop_GetNotifications_ReconnectionOnReceiveTimeout
{"level":"info","msg":"starting runner agent connection with control plane"}
DEBUG: GetRunnerRequests called (call #1)
{"level":"error","msg":"process notifications error","error":"receive request too slow"}
DEBUG: GetTestWorkflowNotificationsStream context cancelled
DEBUG: GetRunnerRequests context cancelled
{"level":"error","msg":"shutting down watch runner requests","error":"context canceled"}
{"level":"error","msg":"runner agent connection failed, reconnecting","error":"notifications loop: receive request too slow","errorVerbose":"receive request too slow\nnotifications loop\ngithub.com/kubeshop/testkube/pkg/runner.(*agentLoop).run.func2\n\t/home/povilasv/gocode/src/github.com/kubeshop/testkube/pkg/runner/agent.go:165\ngolang.org/x/sync/errgroup.(*Group).add.func1\n\t/home/povilasv/gocode/pkg/mod/golang.org/x/sync@v0.14.0/errgroup/errgroup.go:130\nruntime.goexit\n\t/usr/lib/go/src/runtime/asm_amd64.s:1700"}
{"level":"info","msg":"starting runner agent connection with control plane"}
DEBUG: GetRunnerRequests called (call #2)
DEBUG: GetTestWorkflowNotificationsStream context cancelled
DEBUG: GetRunnerRequests context cancelled
{"level":"error","msg":"shutting down watch runner requests","error":"context deadline exceeded"}
{"level":"error","msg":"runner agent connection failed, reconnecting","error":"service notifications loop: context deadline exceeded","errorVerbose":"context deadline exceeded\nservice notifications loop\ngithub.com/kubeshop/testkube/pkg/runner.(*agentLoop).run.func3\n\t/home/povilasv/gocode/src/github.com/kubeshop/testkube/pkg/runner/agent.go:168\ngolang.org/x/sync/errgroup.(*Group).add.func1\n\t/home/povilasv/gocode/pkg/mod/golang.org/x/sync@v0.14.0/errgroup/errgroup.go:130\nruntime.goexit\n\t/usr/lib/go/src/runtime/asm_amd64.s:1700"}
{"level":"info","msg":"starting runner agent connection with control plane"}
--- PASS: TestAgentLoop_GetNotifications_ReconnectionOnReceiveTimeout (10.00s)
```
## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [ ] tested locally
- [ ] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Breaking changes

-

## Changes

-

## Fixes

-