### PR TITLE
fix: TKC-3957: fix issue where envvars aren't correctly resolved in parallel workers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -591,3 +591,4 @@ video: ## Generate project activity video using gource
 		--output-framerate 30
 	@ffmpeg -y -r 30 -f image2pipe -vcodec ppm -i stream.out -b 65536K movie.mp4
 	@rm stream.out
+

--- a/cmd/tcl/testworkflow-toolkit/commands/parallel.go
+++ b/cmd/tcl/testworkflow-toolkit/commands/parallel.go
@@ -65,7 +65,10 @@ func NewParallelCmd() *cobra.Command {
 
 		Run: func(cmd *cobra.Command, args []string) {
 			// Initialize internal machine
-			baseMachine := spawn.CreateBaseMachine()
+			// Use machine without env resolution to preserve env.* expressions for parallel workers
+			baseMachine := spawn.CreateBaseMachineWithoutEnv()
+			// Keep full machine for non-parallel operations
+			fullBaseMachine := spawn.CreateBaseMachine()
 
 			// Read the template
 			var parallel *testworkflowsv1.StepParallel
@@ -213,7 +216,7 @@ func NewParallelCmd() *cobra.Command {
 				machine := expressions.CombinedMachines(
 					testworkflowconfig.CreateResourceMachine(&cfg.Resource),
 					testworkflowconfig.CreateWorkerMachine(&cfg.Worker),
-					baseMachine,
+					fullBaseMachine, // Use full machine with env resolution in the worker
 					testworkflowconfig.CreatePvcMachine(cfg.Execution.PvcNames),
 					params.MachineAt(index),
 				)
@@ -247,7 +250,7 @@ func NewParallelCmd() *cobra.Command {
 				defer func() {
 					shouldSaveLogs := logConditions[index] == nil
 					if !shouldSaveLogs {
-						shouldSaveLogs, _ = spawn.EvalLogCondition(*logConditions[index], lastResult, machine, baseMachine, params.MachineAt(index))
+						shouldSaveLogs, _ = spawn.EvalLogCondition(*logConditions[index], lastResult, machine, fullBaseMachine, params.MachineAt(index))
 						if err != nil {
 							log("warning", "log condition", err.Error())
 						}

--- a/cmd/tcl/testworkflow-toolkit/spawn/utils.go
+++ b/cmd/tcl/testworkflow-toolkit/spawn/utils.go
@@ -12,6 +12,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"os"
 	"regexp"
 	"strconv"
 	"strings"
@@ -33,6 +34,7 @@ import (
 	"github.com/kubeshop/testkube/pkg/api/v1/testkube"
 	"github.com/kubeshop/testkube/pkg/credentials"
 	"github.com/kubeshop/testkube/pkg/expressions"
+	"github.com/kubeshop/testkube/pkg/expressions/libs"
 	"github.com/kubeshop/testkube/pkg/testworkflows/executionworker"
 	"github.com/kubeshop/testkube/pkg/testworkflows/executionworker/executionworkertypes"
 	"github.com/kubeshop/testkube/pkg/testworkflows/executionworker/kubernetesworker"
@@ -336,6 +338,52 @@ func CreateBaseMachine() expressions.Machine {
 		testworkflowconfig.CreateWorkflowMachine(&cfg.Workflow),
 		credentials.NewCredentialMachine(data.Credentials()),
 	)
+}
+
+// CreateBaseMachineWithoutEnv creates a base machine without environment resolution
+// This is used for parallel steps to preserve env.* expressions for later evaluation
+func CreateBaseMachineWithoutEnv() expressions.Machine {
+	cfg := config.Config()
+	return createBaseMachineWithoutEnv(cfg)
+}
+
+// createBaseMachineWithoutEnv creates a base machine without environment resolution using the provided config
+// This allows for easier unit testing without requiring environment variables
+func createBaseMachineWithoutEnv(cfg *testworkflowconfig.InternalConfig) expressions.Machine {
+	orgSlug := cfg.Execution.OrganizationSlug
+	if orgSlug == "" {
+		orgSlug = cfg.Execution.OrganizationId
+	}
+	envSlug := cfg.Execution.EnvironmentSlug
+	if envSlug == "" {
+		envSlug = cfg.Execution.EnvironmentId
+	}
+
+	// Get the base machine components without EnvMachine
+	var wd, err = os.Getwd()
+	if err != nil {
+		wd = "/"
+	}
+	fileMachine := libs.NewFsMachine(os.DirFS("/"), wd)
+
+	// Create machines list
+	machines := []expressions.Machine{
+		fileMachine, // File system access
+		testworkflowconfig.CreateCloudMachine(&cfg.ControlPlane, orgSlug, envSlug),
+		testworkflowconfig.CreateExecutionMachine(&cfg.Execution),
+		testworkflowconfig.CreateWorkflowMachine(&cfg.Workflow),
+	}
+
+	// Only add state and credential machines if they are available (not in unit tests)
+	if os.Getenv("TK_CFG") != "" {
+		data.GetState() // load state
+		machines = append(machines,
+			data.StateMachine, // State machine for status, output, etc
+			credentials.NewCredentialMachine(data.Credentials()),
+		)
+	}
+
+	return expressions.CombinedMachines(machines...)
 }
 
 func CreateResultMachine(result testkube.TestWorkflowResult) expressions.Machine {

--- a/cmd/tcl/testworkflow-toolkit/spawn/utils_test.go
+++ b/cmd/tcl/testworkflow-toolkit/spawn/utils_test.go
@@ -1,0 +1,95 @@
+// Copyright 2024 Testkube.
+//
+// Licensed as a Testkube Pro file under the Testkube Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+//	https://github.com/kubeshop/testkube/blob/main/licenses/TCL.txt
+
+package spawn
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/kubeshop/testkube/pkg/expressions"
+	"github.com/kubeshop/testkube/pkg/testworkflows/testworkflowconfig"
+)
+
+func TestCreateBaseMachineWithoutEnv(t *testing.T) {
+	t.Run("env expressions remain unresolved", func(t *testing.T) {
+		cfg := &testworkflowconfig.InternalConfig{
+			Execution: testworkflowconfig.ExecutionConfig{
+				OrganizationSlug: "test-org",
+				EnvironmentSlug:  "test-env",
+			},
+		}
+		
+		machine := createBaseMachineWithoutEnv(cfg)
+		
+		// Verify env.* expressions are NOT resolved
+		expr, err := expressions.Compile("env.TEST_VAR")
+		require.NoError(t, err)
+		result, err := expr.Resolve(machine)
+		require.NoError(t, err)
+		assert.Equal(t, "{{env.TEST_VAR}}", result.Template())
+	})
+
+	t.Run("uses ID when slug is empty", func(t *testing.T) {
+		cfg := &testworkflowconfig.InternalConfig{
+			Execution: testworkflowconfig.ExecutionConfig{
+				OrganizationId:   "org-123",
+				OrganizationSlug: "", // empty
+				EnvironmentId:    "env-456",
+				EnvironmentSlug:  "", // empty
+			},
+		}
+		
+		machine := createBaseMachineWithoutEnv(cfg)
+		
+		// Should still create a valid machine using IDs
+		assert.NotNil(t, machine)
+		
+		// Verify organization.id is accessible (testing the fallback logic)
+		expr, err := expressions.Compile("organization.id")
+		require.NoError(t, err)
+		result, err := expr.Resolve(machine)
+		require.NoError(t, err)
+		value, err := result.Static().StringValue()
+		require.NoError(t, err)
+		assert.Equal(t, "org-123", value)
+	})
+
+	t.Run("non-env expressions work normally", func(t *testing.T) {
+		cfg := &testworkflowconfig.InternalConfig{
+			Execution: testworkflowconfig.ExecutionConfig{
+				Id: "exec-123",
+			},
+			Workflow: testworkflowconfig.WorkflowConfig{
+				Name: "test-workflow",
+			},
+		}
+		
+		machine := createBaseMachineWithoutEnv(cfg)
+		
+		// execution.id should resolve
+		execExpr, err := expressions.Compile("execution.id")
+		require.NoError(t, err)
+		execResult, err := execExpr.Resolve(machine)
+		require.NoError(t, err)
+		execValue, err := execResult.Static().StringValue()
+		require.NoError(t, err)
+		assert.Equal(t, "exec-123", execValue)
+		
+		// workflow.name should resolve
+		wfExpr, err := expressions.Compile("workflow.name")
+		require.NoError(t, err)
+		wfResult, err := wfExpr.Resolve(machine)
+		require.NoError(t, err)
+		wfValue, err := wfResult.Static().StringValue()
+		require.NoError(t, err)
+		assert.Equal(t, "test-workflow", wfValue)
+	})
+}

--- a/pkg/tcl/testworkflowstcl/testworkflowprocessor/operations.go
+++ b/pkg/tcl/testworkflowstcl/testworkflowprocessor/operations.go
@@ -19,7 +19,6 @@ import (
 
 	testworkflowsv1 "github.com/kubeshop/testkube-operator/api/testworkflows/v1"
 	"github.com/kubeshop/testkube/internal/common"
-	"github.com/kubeshop/testkube/pkg/expressions"
 	"github.com/kubeshop/testkube/pkg/testworkflows/testworkflowprocessor"
 	"github.com/kubeshop/testkube/pkg/testworkflows/testworkflowprocessor/constants"
 	"github.com/kubeshop/testkube/pkg/testworkflows/testworkflowprocessor/stage"
@@ -56,14 +55,14 @@ func ProcessExecute(_ testworkflowprocessor.InternalProcessor, layer testworkflo
 		if err != nil {
 			return nil, errors.Wrap(err, "execute: serializing Test")
 		}
-		args = append(args, "-t", expressions.NewStringValue(string(b)).Template())
+		args = append(args, "-t", string(b))
 	}
 	for _, w := range step.Execute.Workflows {
 		b, err := json.Marshal(w)
 		if err != nil {
 			return nil, errors.Wrap(err, "execute: serializing TestWorkflow")
 		}
-		args = append(args, "-w", expressions.NewStringValue(string(b)).Template())
+		args = append(args, "-w", string(b))
 	}
 	if step.Execute.Async {
 		args = append(args, "--async")
@@ -126,7 +125,7 @@ func ProcessParallel(_ testworkflowprocessor.InternalProcessor, layer testworkfl
 	if err != nil {
 		return nil, errors.Wrap(err, "parallel: marshalling error")
 	}
-	stage.Container().SetArgs(expressions.NewStringValue(string(v)).Template())
+	stage.Container().SetArgs(string(v))
 
 	return stage, nil
 }
@@ -176,7 +175,7 @@ func ProcessServicesStart(_ testworkflowprocessor.InternalProcessor, layer testw
 		if err != nil {
 			return nil, errors.Wrapf(err, "services[%s]: marshalling error", name)
 		}
-		args = append(args, fmt.Sprintf("%s=%s", name, expressions.NewStringValue(string(v)).Template()))
+		args = append(args, fmt.Sprintf("%s=%s", name, string(v)))
 	}
 	stage.Container().SetArgs(args...)
 


### PR DESCRIPTION
## Pull request description 

Fixed environment variable expressions in parallel TestWorkflows. The issue was that {{env.VAR}} expressions were being evaluated with the parent
process's environment instead of the parallel worker's environment.

**Changes**:
- Removed .Template() calls from operations.go that were corrupting JSON passed to parallel workers
- Added CreateBaseMachineWithoutEnv() to preserve env expressions during initial processing
- Modified parallel command to use two machines: one without env resolution for initial setup, one with env resolution for worker execution

**Result**: Parallel workers now correctly see their own environment variables instead of inheriting values from the parent process.


## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [x] tested locally
- [x] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Breaking changes

-

## Changes

-

## Fixes

-