### PR TITLE
feat: improve debugging of MCP server

### DIFF
--- a/cmd/kubectl-testkube/commands/mcp.go
+++ b/cmd/kubectl-testkube/commands/mcp.go
@@ -28,6 +28,7 @@ to determine the organization and environment to connect to.`,
 
 func NewMcpServeCmd() *cobra.Command {
 	var mcpBaseURL string
+	var debugMode bool
 
 	cmd := &cobra.Command{
 		Use:   "serve",
@@ -105,7 +106,7 @@ over stdio. Use --verbose to see detailed output during startup.`,
 			}
 
 			// Start the MCP server
-			if err := startMCPServer(accessToken, cfg.CloudContext.OrganizationId, cfg.CloudContext.EnvironmentId, cfg.CloudContext.ApiUri, cfg.CloudContext.UiUri); err != nil {
+			if err := startMCPServer(accessToken, cfg.CloudContext.OrganizationId, cfg.CloudContext.EnvironmentId, cfg.CloudContext.ApiUri, cfg.CloudContext.UiUri, debugMode); err != nil {
 				if ui.IsVerbose() {
 					ui.Failf("Failed to start MCP server: %v", err)
 				}
@@ -120,11 +121,12 @@ over stdio. Use --verbose to see detailed output during startup.`,
 	}
 
 	cmd.Flags().StringVar(&mcpBaseURL, "base-url", "", "Base URL for Testkube API (uses context API URL if not specified)")
+	cmd.Flags().BoolVar(&debugMode, "debug", false, "Enable debug mode to return HTTP request/response details in MCP tool responses")
 
 	return cmd
 }
 
-func startMCPServer(accessToken, orgID, envID, baseURL, dashboardURL string) error {
+func startMCPServer(accessToken, orgID, envID, baseURL, dashboardURL string, debug bool) error {
 	// Create MCP server configuration
 	mcpCfg := mcp.MCPServerConfig{
 		Version:         "1.0.0",
@@ -133,6 +135,7 @@ func startMCPServer(accessToken, orgID, envID, baseURL, dashboardURL string) err
 		AccessToken:     accessToken,
 		OrgId:           orgID,
 		EnvId:           envID,
+		Debug:           debug,
 	}
 
 	// If no base URL is provided, use the default from testkube context

--- a/pkg/mcp/config.go
+++ b/pkg/mcp/config.go
@@ -25,6 +25,9 @@ type MCPServerConfig struct {
 
 	// EnvId for Testkube environment
 	EnvId string
+
+	// Debug enables debug mode to return HTTP request/response details
+	Debug bool
 }
 
 // LoadConfigFromEnv loads configuration from environment variables

--- a/pkg/mcp/server.go
+++ b/pkg/mcp/server.go
@@ -27,7 +27,11 @@ func NewMCPServer(cfg MCPServerConfig, client Client) (*server.MCPServer, error)
 	// If no client is provided, use the default API client
 	if client == nil {
 		httpClient := &http.Client{}
-		client = NewAPIClient(&cfg, httpClient)
+		if cfg.Debug {
+			client = NewDebugAPIClient(&cfg, httpClient)
+		} else {
+			client = NewAPIClient(&cfg, httpClient)
+		}
 	}
 
 	// Dashboard tools

--- a/pkg/mcp/tools/artifacts.go
+++ b/pkg/mcp/tools/artifacts.go
@@ -29,7 +29,7 @@ func ListArtifacts(client ArtifactLister) (tool mcp.Tool, handler server.ToolHan
 			return mcp.NewToolResultError(fmt.Sprintf("Failed to list artifacts: %v", err)), nil
 		}
 
-		return mcp.NewToolResultText(result), nil
+		return CreateToolResultWithDebug(result, client), nil
 	}
 
 	return tool, handler
@@ -70,7 +70,7 @@ func ReadArtifact(client ArtifactReader) (tool mcp.Tool, handler server.ToolHand
 
 		// Limit content to max lines
 		limitedContent := LimitContentToLines(content, MaxLines)
-		return mcp.NewToolResultText(limitedContent), nil
+		return CreateToolResultWithDebug(limitedContent, client), nil
 	}
 
 	return tool, handler

--- a/pkg/mcp/tools/executions.go
+++ b/pkg/mcp/tools/executions.go
@@ -119,7 +119,7 @@ func GetExecutionInfo(client ExecutionInfoGetter) (tool mcp.Tool, handler server
 			return mcp.NewToolResultError(fmt.Sprintf("Failed to get execution info: %v", err)), nil
 		}
 
-		return mcp.NewToolResultText(result), nil
+		return CreateToolResultWithDebug(result, client), nil
 	}
 
 	return tool, handler
@@ -155,7 +155,7 @@ func LookupExecutionId(client ExecutionLookup) (tool mcp.Tool, handler server.To
 			return mcp.NewToolResultError(err.Error()), nil
 		}
 
-		return mcp.NewToolResultText(executionID), nil
+		return CreateToolResultWithDebug(executionID, client), nil
 	}
 
 	return tool, handler

--- a/pkg/mcp/tools/workflows.go
+++ b/pkg/mcp/tools/workflows.go
@@ -59,8 +59,7 @@ func ListWorkflows(client WorkflowLister) (tool mcp.Tool, handler server.ToolHan
 		if err != nil {
 			return mcp.NewToolResultError(fmt.Sprintf("Failed to list workflows: %v", err)), nil
 		}
-
-		return mcp.NewToolResultText(result), nil
+		return CreateToolResultWithDebug(result, client), nil
 	}
 
 	return tool, handler
@@ -87,7 +86,7 @@ func CreateWorkflow(client WorkflowCreator) (tool mcp.Tool, handler server.ToolH
 			return mcp.NewToolResultError(fmt.Sprintf("Failed to create workflow: %v", err)), nil
 		}
 
-		return mcp.NewToolResultText(result), nil
+		return CreateToolResultWithDebug(result, client), nil
 	}
 
 	return tool, handler
@@ -113,8 +112,7 @@ func GetWorkflowDefinition(client WorkflowDefinitionGetter) (tool mcp.Tool, hand
 		if err != nil {
 			return mcp.NewToolResultError(fmt.Sprintf("Failed to get workflow definition: %v", err)), nil
 		}
-
-		return mcp.NewToolResultText(result), nil
+		return CreateToolResultWithDebug(result, client), nil
 	}
 
 	return tool, handler
@@ -140,8 +138,7 @@ func GetWorkflow(client WorkflowGetter) (tool mcp.Tool, handler server.ToolHandl
 		if err != nil {
 			return mcp.NewToolResultError(fmt.Sprintf("Failed to get workflow: %v", err)), nil
 		}
-
-		return mcp.NewToolResultText(result), nil
+		return CreateToolResultWithDebug(result, client), nil
 	}
 
 	return tool, handler
@@ -198,7 +195,7 @@ func RunWorkflow(client WorkflowRunner) (tool mcp.Tool, handler server.ToolHandl
 			return mcp.NewToolResultError(fmt.Sprintf("Failed to run workflow: %v", err)), nil
 		}
 
-		return mcp.NewToolResultText(result), nil
+		return CreateToolResultWithDebug(result, client), nil
 	}
 
 	return tool, handler


### PR DESCRIPTION
Added flexible debug mode support to Testkube MCP server. 

This implementation introduces a `DebugInfo` type alias (map[string]any) that allows any client type (HTTP, file, database, mock, gRPC, etc.) to provide their own debug information structure. 

The core pattern uses a `DebugInfoProvider` interface with a `GetLastDebugInfo()` method, and `CreateToolResultWithDebug` helper function that automatically includes debug information as additional MCP tool content when available. 

For HTTP clients, we've implemented a `DebugAPIClient` wrapper with `DebugRoundTripper` that captures request/response details including URL, method, headers (with sensitive data redacted), timing, and response previews. 