### PR TITLE
feat: MCP server debug middleware

### DIFF
--- a/cmd/kubectl-testkube/commands/mcp.go
+++ b/cmd/kubectl-testkube/commands/mcp.go
@@ -28,6 +28,7 @@ to determine the organization and environment to connect to.`,
 
 func NewMcpServeCmd() *cobra.Command {
 	var mcpBaseURL string
+	var debug bool
 
 	cmd := &cobra.Command{
 		Use:   "serve",
@@ -105,7 +106,7 @@ over stdio. Use --verbose to see detailed output during startup.`,
 			}
 
 			// Start the MCP server
-			if err := startMCPServer(accessToken, cfg.CloudContext.OrganizationId, cfg.CloudContext.EnvironmentId, cfg.CloudContext.ApiUri, cfg.CloudContext.UiUri); err != nil {
+			if err := startMCPServer(accessToken, cfg.CloudContext.OrganizationId, cfg.CloudContext.EnvironmentId, cfg.CloudContext.ApiUri, cfg.CloudContext.UiUri, debug); err != nil {
 				if ui.IsVerbose() {
 					ui.Failf("Failed to start MCP server: %v", err)
 				}
@@ -120,11 +121,12 @@ over stdio. Use --verbose to see detailed output during startup.`,
 	}
 
 	cmd.Flags().StringVar(&mcpBaseURL, "base-url", "", "Base URL for Testkube API (uses context API URL if not specified)")
+	cmd.Flags().BoolVar(&debug, "debug", false, "Enable debug mode with detailed operation information")
 
 	return cmd
 }
 
-func startMCPServer(accessToken, orgID, envID, baseURL, dashboardURL string) error {
+func startMCPServer(accessToken, orgID, envID, baseURL, dashboardURL string, debug bool) error {
 	// Create MCP server configuration
 	mcpCfg := mcp.MCPServerConfig{
 		Version:         "1.0.0",
@@ -133,6 +135,7 @@ func startMCPServer(accessToken, orgID, envID, baseURL, dashboardURL string) err
 		AccessToken:     accessToken,
 		OrgId:           orgID,
 		EnvId:           envID,
+		Debug:           debug,
 	}
 
 	// If no base URL is provided, use the default from testkube context

--- a/pkg/mcp/config.go
+++ b/pkg/mcp/config.go
@@ -25,6 +25,9 @@ type MCPServerConfig struct {
 
 	// EnvId for Testkube environment
 	EnvId string
+
+	// Debug enables debug mode which includes detailed operation information in responses
+	Debug bool
 }
 
 // LoadConfigFromEnv loads configuration from environment variables
@@ -47,6 +50,7 @@ func LoadConfigFromEnv() MCPServerConfig {
 		AccessToken:     os.Getenv("TK_ACCESS_TOKEN"),
 		OrgId:           os.Getenv("TK_ORG_ID"),
 		EnvId:           os.Getenv("TK_ENV_ID"),
+		Debug:           os.Getenv("TK_DEBUG") == "true",
 	}
 }
 

--- a/pkg/mcp/debug.go
+++ b/pkg/mcp/debug.go
@@ -1,0 +1,33 @@
+package mcp
+
+import (
+	"context"
+)
+
+type DebugInfo struct {
+	Source string         `json:"source"` // "http", "file", "database", "cache", etc.
+	Data   map[string]any `json:"data"`   // Source-specific debug data
+}
+
+func NewDebugInfo() *DebugInfo {
+	return &DebugInfo{
+		Data: make(map[string]any),
+	}
+}
+
+type contextKey string
+
+const debugInfoKey contextKey = "debug_info"
+
+func WithDebugInfo(ctx context.Context) (context.Context, *DebugInfo) {
+	debugInfo := NewDebugInfo()
+	newCtx := context.WithValue(ctx, debugInfoKey, debugInfo)
+	return newCtx, debugInfo
+}
+
+func GetDebugInfo(ctx context.Context) *DebugInfo {
+	if debugInfo, ok := ctx.Value(debugInfoKey).(*DebugInfo); ok {
+		return debugInfo
+	}
+	return nil
+}

--- a/pkg/mcp/middleware.go
+++ b/pkg/mcp/middleware.go
@@ -1,0 +1,51 @@
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/mark3labs/mcp-go/server"
+)
+
+// DebugMiddleware creates a middleware that automatically collects debug information
+// when debug mode is enabled
+func DebugMiddleware(enabled bool) server.ToolHandlerMiddleware {
+	return func(next server.ToolHandlerFunc) server.ToolHandlerFunc {
+		return func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+			if !enabled {
+				return next(ctx, request)
+			}
+
+			debugCtx, debugInfo := WithDebugInfo(ctx)
+
+			result, err := next(debugCtx, request)
+			if err != nil {
+				return result, err
+			}
+
+			if debugInfo == nil || debugInfo.Source == "" {
+				return result, nil
+			}
+
+			return enhanceResultWithDebug(result, debugInfo), nil
+		}
+	}
+}
+
+// enhanceResultWithDebug adds debug information to the tool result
+func enhanceResultWithDebug(result *mcp.CallToolResult, debugInfo *DebugInfo) *mcp.CallToolResult {
+	if result == nil || debugInfo == nil {
+		return result
+	}
+
+	debugJSON, err := json.MarshalIndent(debugInfo, "", "  ")
+	if err != nil {
+		return result
+	}
+
+	debugContent := mcp.NewTextContent("Debug Information:\n" + string(debugJSON))
+	result.Content = append(result.Content, debugContent)
+
+	return result
+}

--- a/pkg/mcp/server.go
+++ b/pkg/mcp/server.go
@@ -22,6 +22,7 @@ func NewMCPServer(cfg MCPServerConfig, client Client) (*server.MCPServer, error)
 		"testkube-mcp",
 		cfg.Version,
 		server.WithToolCapabilities(true),
+		server.WithToolHandlerMiddleware(DebugMiddleware(cfg.Debug)),
 	)
 
 	// If no client is provided, use the default API client


### PR DESCRIPTION
This implementation introduces a context-based debug middleware that automatically collects and includes debug information in MCP tool responses when debug mode is enabled.