### PR TITLE
chore: add telemetry when api server receives user agent header, only for allowed values

### DIFF
--- a/pkg/telemetry/payload.go
+++ b/pkg/telemetry/payload.go
@@ -52,6 +52,7 @@ type Params struct {
 	License                    string     `json:"license,omitempty"`
 	Step                       string     `json:"step,omitempty"`
 	Email                      string     `json:"email,omitempty"`
+	UserAgent                  string     `json:"user_agent,omitempty"`
 }
 
 type Event struct {
@@ -320,6 +321,29 @@ func NewRunWorkflowPayload(name, clusterType string, params RunWorkflowParams) P
 					TestWorkflowImage:          params.TestWorkflowImage,
 					TestWorkflowArtifactUsed:   params.TestWorkflowArtifactUsed,
 					TestWorkflowKubeshopGitURI: params.TestWorkflowKubeshopGitURI,
+				},
+			}},
+	}
+}
+
+// NewUserAgentPayload prepares payload for Allowed User Agent connection
+func NewUserAgentPayload(userAgent, clusterType string) Payload {
+	return Payload{
+		ClientID: GetMachineID(),
+		UserID:   GetMachineID(),
+		Events: []Event{
+			{
+				Name: "allowed_user_agent",
+				Params: Params{
+					EventCount:      1,
+					EventCategory:   "api",
+					AppName:         "testkube-api-server",
+					OperatingSystem: runtime.GOOS,
+					Architecture:    runtime.GOARCH,
+					MachineID:       GetMachineID(),
+					ClusterType:     clusterType,
+					Context:         getAgentContext(),
+					UserAgent:       userAgent,
 				},
 			}},
 	}

--- a/pkg/telemetry/telemetry.go
+++ b/pkg/telemetry/telemetry.go
@@ -155,6 +155,12 @@ func SendRunWorkflowEvent(event string, params RunWorkflowParams) (string, error
 	return sendData(senders, payload)
 }
 
+// SendUserAgentEvent will send Allowed User Agent connection to API Server event
+func SendUserAgentEvent(userAgent string) (string, error) {
+	payload := NewUserAgentPayload(userAgent, GetClusterType())
+	return sendData(senders, payload)
+}
+
 // sendData sends data to all telemetry storages  in parallel and syncs sending
 func sendData(senders map[string]Sender, payload Payload) (out string, err error) {
 	var wg sync.WaitGroup


### PR DESCRIPTION
## Pull request description 

In order to enable more information from which kind of integrations users are enabling with OSS Testkube agent, this PR adds a Http Middleware to capture requests with `User-Agent` header and send an event if the value is one of the allowed integrations.

## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [x] tested locally
- [ ] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Breaking changes

-

## Changes

- Add Http Middleware at the API Rest Server to capture requests and send events

## Fixes

-