### PR TITLE
fix(TKC-4063): include organization-id and agent-id in ScheduleExecution gRPC metadata to fix trigger execution error

### DIFF
--- a/pkg/testworkflows/testworkflowexecutor/executor.go
+++ b/pkg/testworkflows/testworkflowexecutor/executor.go
@@ -129,6 +129,8 @@ func (e *executor) execute(ctx context.Context, environmentId string, req *cloud
 	opts := []grpc.CallOption{grpc.UseCompressor(gzip.Name), grpc.MaxCallRecvMsgSize(math.MaxInt32)}
 	ctx = agentclient.AddAPIKeyMeta(ctx, e.apiKey)
 	ctx = metadata.AppendToOutgoingContext(ctx, "environment-id", environmentId)
+	ctx = metadata.AppendToOutgoingContext(ctx, "organization-id", e.organizationId)
+	ctx = metadata.AppendToOutgoingContext(ctx, "agent-id", e.agentId)
 	resp, err := e.grpcClient.ScheduleExecution(ctx, req, opts...)
 	resultStream := NewStream(ch)
 	if err != nil {


### PR DESCRIPTION
## Pull request description 

If you use runner agent token, then our cloud api validates that grpc calls have  org-id and agent-id headers; while we skip this validation for superagents:

```
func (cs *CloudServer) getSource(ctx context.Context) (SourceContext, error) {
     ...
	// SuperAgent
	if strings.HasPrefix(apiKey, "tkcagnt_") {
		return cs.getSuperAgentSource(ctx)
	}

	// Regular agent
	if strings.HasPrefix(apiKey, "tkckey_run_") || strings.HasPrefix(apiKey, "tkckey_sync_") {
		return cs.getAgentSource(ctx)
	}
}
```

So my change adds the required headers to grpc calls. This is needed to fix the error for scheduling triggers when running in non superagent mode:
```
{"level":"error","ts":"2025-08-13T10:58:52Z","caller":"triggers/executor.go:245","msg":"trigger service: error executing testworkflow for trigger tk-dev/k6","error":"rpc error: code = InvalidArgument desc = organization ID not provided","stacktrace":"github.com/kubeshop/testkube/pkg/triggers.(*Service).execute\n\t/app/pkg/triggers/executor.go:245\ngithub.com/kubeshop/testkube/pkg/triggers.(*Service).match\n\t/app/pkg/triggers/matcher.go:104\ngithub.com/kubeshop/testkube/pkg/triggers.(*Service).runInformers.(*Service).podEventHandler.func3\n\t/app/pkg/triggers/watcher.go:267\nk8s.io/client-go/tools/cache.ResourceEventHandlerFuncs.OnAdd\n\t/root/.cache/go-build/k8s.io/client-go@v0.32.0/tools/cache/controller.go:246\nk8s.io/client-go/tools/cache.(*processorListener).run.func1\n\t/root/.cache/go-C
```



## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [ ] tested locally
- [ ] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Breaking changes

-

## Changes

-

## Fixes

-