### PR TITLE
chore: Add logging to gRPC connection

### DIFF
--- a/pkg/agent/client/client.go
+++ b/pkg/agent/client/client.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"time"
 
+	grpczap "github.com/grpc-ecosystem/go-grpc-middleware/logging/zap"
 	"go.uber.org/zap"
 	"golang.org/x/sync/errgroup"
 	"google.golang.org/grpc"
@@ -92,6 +93,12 @@ func NewGRPCConnection(
 			},
 			MinConnectTimeout: connectionTimeout,
 		}),
+		grpc.WithChainStreamInterceptor(
+			grpczap.StreamClientInterceptor(logger.Desugar()),
+		),
+		grpc.WithChainUnaryInterceptor(
+			grpczap.UnaryClientInterceptor(logger.Desugar()),
+		),
 	)
 	if err != nil {
 		return client, fmt.Errorf("create new grpc client: %w", err)


### PR DESCRIPTION
By default logging will occur based on the default specified in the zap grpc package: https://pkg.go.dev/github.com/grpc-ecosystem/go-grpc-middleware/logging/zap#DefaultClientCodeToLevel Most things will log at Debug level with only really issues logging at a higher level, this is appropriate for out fault finding work without overloading a customer's log handling system.