### PR TITLE
feat: [TKC-4084] Allows runners to fetch triggers from cloud

### DIFF
--- a/cmd/api-server/main.go
+++ b/cmd/api-server/main.go
@@ -257,12 +257,12 @@ func main() {
 		testWorkflowTemplatesClient testworkflowtemplateclient.TestWorkflowTemplateClient
 		testTriggersClient          testtriggerclient.TestTriggerClient
 	)
+	proContext := commons.ReadProContext(ctx, cfg, grpcClient)
 
-	testWorkflowResultsRepository := cloudtestworkflow.NewCloudRepository(grpcClient, cfg.TestkubeProAPIKey)
-	testWorkflowOutputRepository := cloudtestworkflow.NewCloudOutputRepository(grpcClient, cfg.TestkubeProAPIKey, cfg.StorageSkipVerify)
-	webhookRepository := cloudwebhook.NewCloudRepository(grpcClient, cfg.TestkubeProAPIKey)
-
-	artifactStorage := cloudartifacts.NewCloudArtifactsStorage(grpcClient, cfg.TestkubeProAPIKey)
+	testWorkflowResultsRepository := cloudtestworkflow.NewCloudRepository(grpcClient, &proContext)
+	testWorkflowOutputRepository := cloudtestworkflow.NewCloudOutputRepository(grpcClient, cfg.StorageSkipVerify, &proContext)
+	webhookRepository := cloudwebhook.NewCloudRepository(grpcClient, &proContext)
+	artifactStorage := cloudartifacts.NewCloudArtifactsStorage(grpcClient, &proContext)
 
 	log.DefaultLogger.Info("connecting to NATS...")
 	nc := commons.MustCreateNATSConnection(cfg)
@@ -273,8 +273,6 @@ func main() {
 		eventBus.TraceEvents()
 	}
 	eventsEmitter = event.NewEmitter(eventBus, cfg.TestkubeClusterName)
-
-	proContext := commons.ReadProContext(ctx, cfg, grpcClient)
 
 	// Build new client
 	client := controlplaneclient.New(grpcClient, proContext, controlplaneclient.ClientOptions{
@@ -704,6 +702,7 @@ func main() {
 			clientset,
 			testkubeClientset,
 			testWorkflowsClient,
+			testTriggersClient,
 			lb,
 			log.DefaultLogger,
 			configMapConfig,

--- a/cmd/api-server/services/deprecatedsystem.go
+++ b/cmd/api-server/services/deprecatedsystem.go
@@ -192,7 +192,7 @@ func CreateDeprecatedSystem(
 	// Use direct MinIO artifact storage for deprecated API for backwards compatibility
 	var deprecatedArtifactStorage storage.ArtifactsStorage
 	if mode == common.ModeAgent {
-		deprecatedArtifactStorage = cloudartifacts.NewCloudArtifactsStorage(grpcClient, cfg.TestkubeProAPIKey)
+		deprecatedArtifactStorage = cloudartifacts.NewCloudArtifactsStorageWithParams(grpcClient, cfg.TestkubeProAPIKey, "", "")
 	} else {
 		deprecatedArtifactStorage = minio.NewMinIOArtifactClient(commons.MustGetMinioClient(cfg))
 	}

--- a/pkg/agent/client/client.go
+++ b/pkg/agent/client/client.go
@@ -23,9 +23,11 @@ import (
 )
 
 const (
-	connectionTimeout = 10 * time.Second
-	apiKeyMeta        = "api-key"
-
+	connectionTimeout          = 10 * time.Second
+	apiKeyMeta                 = "api-key"
+	organizationIdMetadataName = "organization-id"
+	environmentIdMetadataName  = "environment-id"
+	agentIdMetadataName        = "agent-id"
 	// The backoff values chosen here are copied from an example in the
 	// gRPC documentation and represent a starting point that may be
 	// iterated on as we learn more about the connection issues faced
@@ -148,5 +150,15 @@ func clientCert(tlsConfig *tls.Config, certFile, keyFile string) error {
 
 func AddAPIKeyMeta(ctx context.Context, apiKey string) context.Context {
 	md := metadata.Pairs(apiKeyMeta, apiKey)
+	return metadata.NewOutgoingContext(ctx, md)
+}
+
+func AddMetadata(ctx context.Context, apiKey, orgID, envID, agentID string) context.Context {
+	md := metadata.Pairs(
+		apiKeyMeta, apiKey,
+		organizationIdMetadataName, orgID,
+		environmentIdMetadataName, envID,
+		agentIdMetadataName, agentID,
+	)
 	return metadata.NewOutgoingContext(ctx, md)
 }

--- a/pkg/cloud/data/artifact/artifacts_storage.go
+++ b/pkg/cloud/data/artifact/artifacts_storage.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/pkg/errors"
 
+	intconfig "github.com/kubeshop/testkube/internal/config"
 	"github.com/kubeshop/testkube/pkg/api/v1/testkube"
 	"github.com/kubeshop/testkube/pkg/archive"
 	"github.com/kubeshop/testkube/pkg/cloud"
@@ -26,8 +27,19 @@ type CloudArtifactsStorage struct {
 
 var ErrOperationNotSupported = errors.New("operation not supported")
 
-func NewCloudArtifactsStorage(cloudClient cloud.TestKubeCloudAPIClient, apiKey string) *CloudArtifactsStorage {
-	return &CloudArtifactsStorage{executor: executor.NewCloudGRPCExecutor(cloudClient, apiKey)}
+func NewCloudArtifactsStorage(cloudClient cloud.TestKubeCloudAPIClient, proContext *intconfig.ProContext) *CloudArtifactsStorage {
+	return &CloudArtifactsStorage{executor: executor.NewCloudGRPCExecutor(cloudClient, proContext)}
+}
+
+// NewCloudArtifactsStorageWithParams creates a new cloud artifacts storage with individual parameters (for deprecated system)
+func NewCloudArtifactsStorageWithParams(cloudClient cloud.TestKubeCloudAPIClient, apiKey string, orgID string, envID string) *CloudArtifactsStorage {
+	// Create a minimal proContext for the deprecated system
+	proContext := &intconfig.ProContext{
+		APIKey: apiKey,
+		OrgID:  orgID,
+		EnvID:  envID,
+	}
+	return &CloudArtifactsStorage{executor: executor.NewCloudGRPCExecutor(cloudClient, proContext)}
 }
 
 func (c *CloudArtifactsStorage) ListFiles(ctx context.Context, executionID, testName, testSuiteName, testWorkflowName string) ([]testkube.Artifact, error) {

--- a/pkg/cloud/data/executor/executor.go
+++ b/pkg/cloud/data/executor/executor.go
@@ -9,6 +9,7 @@ import (
 	"google.golang.org/grpc/encoding/gzip"
 	"google.golang.org/protobuf/types/known/structpb"
 
+	intconfig "github.com/kubeshop/testkube/internal/config"
 	agentclient "github.com/kubeshop/testkube/pkg/agent/client"
 	"github.com/kubeshop/testkube/pkg/cloud"
 )
@@ -21,12 +22,15 @@ type Executor interface {
 }
 
 type CloudGRPCExecutor struct {
-	client cloud.TestKubeCloudAPIClient
-	apiKey string
+	client  cloud.TestKubeCloudAPIClient
+	apiKey  string
+	orgID   string
+	envID   string
+	agentID string
 }
 
-func NewCloudGRPCExecutor(client cloud.TestKubeCloudAPIClient, apiKey string) *CloudGRPCExecutor {
-	return &CloudGRPCExecutor{client: client, apiKey: apiKey}
+func NewCloudGRPCExecutor(client cloud.TestKubeCloudAPIClient, proContext *intconfig.ProContext) *CloudGRPCExecutor {
+	return &CloudGRPCExecutor{client: client, apiKey: proContext.APIKey, orgID: proContext.OrgID, envID: proContext.EnvID, agentID: proContext.Agent.ID}
 }
 
 func (e *CloudGRPCExecutor) Execute(ctx context.Context, command Command, payload any) (response []byte, err error) {
@@ -42,7 +46,7 @@ func (e *CloudGRPCExecutor) Execute(ctx context.Context, command Command, payloa
 		Command: string(command),
 		Payload: &s,
 	}
-	ctx = agentclient.AddAPIKeyMeta(ctx, e.apiKey)
+	ctx = agentclient.AddMetadata(ctx, e.apiKey, e.orgID, e.envID, e.agentID)
 	opts := []grpc.CallOption{grpc.UseCompressor(gzip.Name), grpc.MaxCallRecvMsgSize(math.MaxInt32)}
 	cmdResponse, err := e.client.Call(ctx, &req, opts...)
 	if err != nil {

--- a/pkg/cloud/data/result/result.go
+++ b/pkg/cloud/data/result/result.go
@@ -7,6 +7,7 @@ import (
 
 	"go.mongodb.org/mongo-driver/mongo"
 
+	intconfig "github.com/kubeshop/testkube/internal/config"
 	"github.com/kubeshop/testkube/pkg/cloud/data/executor"
 
 	"github.com/pkg/errors"
@@ -25,7 +26,13 @@ type CloudRepository struct {
 }
 
 func NewCloudResultRepository(cloudClient cloud.TestKubeCloudAPIClient, apiKey string) *CloudRepository {
-	return &CloudRepository{executor: executor.NewCloudGRPCExecutor(cloudClient, apiKey)}
+	// Create a minimal proContext for this repository
+	proContext := &intconfig.ProContext{
+		APIKey: apiKey,
+		OrgID:  "",
+		EnvID:  "",
+	}
+	return &CloudRepository{executor: executor.NewCloudGRPCExecutor(cloudClient, proContext)}
 }
 
 func (r *CloudRepository) GetNextExecutionNumber(ctx context.Context, testName string) (int32, error) {

--- a/pkg/cloud/data/testresult/testresult.go
+++ b/pkg/cloud/data/testresult/testresult.go
@@ -8,6 +8,7 @@ import (
 
 	"go.mongodb.org/mongo-driver/mongo"
 
+	intconfig "github.com/kubeshop/testkube/internal/config"
 	"github.com/kubeshop/testkube/pkg/api/v1/testkube"
 	"github.com/kubeshop/testkube/pkg/cloud"
 	"github.com/kubeshop/testkube/pkg/cloud/data/executor"
@@ -21,7 +22,13 @@ type CloudRepository struct {
 }
 
 func NewCloudRepository(client cloud.TestKubeCloudAPIClient, apiKey string) *CloudRepository {
-	return &CloudRepository{executor: executor.NewCloudGRPCExecutor(client, apiKey)}
+	// Create a minimal proContext for this repository
+	proContext := &intconfig.ProContext{
+		APIKey: apiKey,
+		OrgID:  "",
+		EnvID:  "",
+	}
+	return &CloudRepository{executor: executor.NewCloudGRPCExecutor(client, proContext)}
 }
 
 func (r *CloudRepository) Get(ctx context.Context, id string) (testkube.TestSuiteExecution, error) {

--- a/pkg/cloud/data/testworkflow/execution.go
+++ b/pkg/cloud/data/testworkflow/execution.go
@@ -8,6 +8,7 @@ import (
 
 	testworkflow2 "github.com/kubeshop/testkube/pkg/repository/testworkflow"
 
+	intconfig "github.com/kubeshop/testkube/internal/config"
 	"github.com/kubeshop/testkube/pkg/api/v1/testkube"
 	"github.com/kubeshop/testkube/pkg/cloud"
 	"github.com/kubeshop/testkube/pkg/cloud/data/executor"
@@ -19,8 +20,8 @@ type CloudRepository struct {
 	executor executor.Executor
 }
 
-func NewCloudRepository(client cloud.TestKubeCloudAPIClient, apiKey string) *CloudRepository {
-	return &CloudRepository{executor: executor.NewCloudGRPCExecutor(client, apiKey)}
+func NewCloudRepository(client cloud.TestKubeCloudAPIClient, proContext *intconfig.ProContext) *CloudRepository {
+	return &CloudRepository{executor: executor.NewCloudGRPCExecutor(client, proContext)}
 }
 
 func (r *CloudRepository) Get(ctx context.Context, id string) (testkube.TestWorkflowExecution, error) {

--- a/pkg/cloud/data/testworkflow/output.go
+++ b/pkg/cloud/data/testworkflow/output.go
@@ -11,6 +11,7 @@ import (
 	"github.com/kubeshop/testkube/pkg/bufferedstream"
 	"github.com/kubeshop/testkube/pkg/repository/testworkflow"
 
+	intconfig "github.com/kubeshop/testkube/internal/config"
 	"github.com/kubeshop/testkube/pkg/cloud"
 	"github.com/kubeshop/testkube/pkg/cloud/data/executor"
 )
@@ -22,8 +23,8 @@ type CloudOutputRepository struct {
 	httpClient *http.Client
 }
 
-func NewCloudOutputRepository(client cloud.TestKubeCloudAPIClient, apiKey string, skipVerify bool) *CloudOutputRepository {
-	r := &CloudOutputRepository{executor: executor.NewCloudGRPCExecutor(client, apiKey), httpClient: http.DefaultClient}
+func NewCloudOutputRepository(client cloud.TestKubeCloudAPIClient, skipVerify bool, proContext *intconfig.ProContext) *CloudOutputRepository {
+	r := &CloudOutputRepository{executor: executor.NewCloudGRPCExecutor(client, proContext), httpClient: http.DefaultClient}
 	if skipVerify {
 		transport := &http.Transport{TLSClientConfig: &tls.Config{InsecureSkipVerify: true}}
 		r.httpClient.Transport = transport

--- a/pkg/cloud/data/webhook/webhook.go
+++ b/pkg/cloud/data/webhook/webhook.go
@@ -3,6 +3,7 @@ package webhook
 import (
 	"context"
 
+	intconfig "github.com/kubeshop/testkube/internal/config"
 	"github.com/kubeshop/testkube/pkg/api/v1/testkube"
 	"github.com/kubeshop/testkube/pkg/cloud"
 	"github.com/kubeshop/testkube/pkg/cloud/data/executor"
@@ -17,8 +18,8 @@ type WebhookRepository interface {
 	CollectExecutionResult(ctx context.Context, event testkube.Event, webhookName, errorMessage string, statusCode int) error
 }
 
-func NewCloudRepository(cloudClient cloud.TestKubeCloudAPIClient, apiKey string) *CloudRepository {
-	return &CloudRepository{executor: executor.NewCloudGRPCExecutor(cloudClient, apiKey)}
+func NewCloudRepository(cloudClient cloud.TestKubeCloudAPIClient, proContext *intconfig.ProContext) *CloudRepository {
+	return &CloudRepository{executor: executor.NewCloudGRPCExecutor(cloudClient, proContext)}
 }
 
 func (c *CloudRepository) CollectExecutionResult(ctx context.Context, event testkube.Event, webhookName, errorMessage string, statusCode int) error {

--- a/pkg/executor/scraper/factory/factory.go
+++ b/pkg/executor/scraper/factory/factory.go
@@ -8,6 +8,7 @@ import (
 	cloudevents "github.com/cloudevents/sdk-go/v2"
 	"github.com/pkg/errors"
 
+	intconfig "github.com/kubeshop/testkube/internal/config"
 	agentclient "github.com/kubeshop/testkube/pkg/agent/client"
 	"github.com/kubeshop/testkube/pkg/cloud"
 	cloudscraper "github.com/kubeshop/testkube/pkg/cloud/data/artifact"
@@ -119,7 +120,12 @@ func getRemoteStorageUploader(ctx context.Context, params envs.Params) (uploader
 	output.PrintLogf("%s Connected to Agent API", ui.IconCheckMark)
 
 	grpcClient := cloud.NewTestKubeCloudAPIClient(grpcConn)
-	cloudExecutor := cloudexecutor.NewCloudGRPCExecutor(grpcClient, params.ProAPIKey)
+
+	proContext := &intconfig.ProContext{
+		APIKey: params.ProAPIKey,
+	}
+
+	cloudExecutor := cloudexecutor.NewCloudGRPCExecutor(grpcClient, proContext)
 	return cloudscraper.NewCloudUploader(cloudExecutor, params.SkipVerify), nil
 }
 

--- a/pkg/newclients/testtriggerclient/cloud.go
+++ b/pkg/newclients/testtriggerclient/cloud.go
@@ -7,9 +7,7 @@ import (
 
 	"github.com/kubeshop/testkube/internal/common"
 	"github.com/kubeshop/testkube/pkg/api/v1/testkube"
-	"github.com/kubeshop/testkube/pkg/cloud"
 	"github.com/kubeshop/testkube/pkg/controlplaneclient"
-	"github.com/kubeshop/testkube/pkg/repository/channels"
 )
 
 var _ TestTriggerClient = &cloudTestTriggerClient{}
@@ -68,19 +66,4 @@ func (c *cloudTestTriggerClient) DeleteAll(ctx context.Context, environmentId st
 
 func (c *cloudTestTriggerClient) DeleteByLabels(ctx context.Context, environmentId string, selector string, namespace string) (uint32, error) {
 	return c.client.DeleteTestTriggersByLabels(ctx, environmentId, selector, namespace)
-}
-
-func (c *cloudTestTriggerClient) WatchUpdates(ctx context.Context, environmentId string, namespace string, includeInitialData bool) Watcher {
-	return channels.Transform(c.client.WatchTestTriggerUpdates(ctx, environmentId, namespace, includeInitialData), func(t *controlplaneclient.TestTriggerUpdate) (Update, bool) {
-		switch t.Type {
-		case cloud.UpdateType_UPDATE:
-			return Update{Type: EventTypeUpdate, Timestamp: t.Timestamp, Resource: t.Resource}, true
-		case cloud.UpdateType_DELETE:
-			return Update{Type: EventTypeDelete, Timestamp: t.Timestamp, Resource: t.Resource}, true
-		case cloud.UpdateType_CREATE:
-			return Update{Type: EventTypeCreate, Timestamp: t.Timestamp, Resource: t.Resource}, true
-		default:
-			return Update{}, false
-		}
-	})
 }

--- a/pkg/newclients/testtriggerclient/interface.go
+++ b/pkg/newclients/testtriggerclient/interface.go
@@ -2,12 +2,10 @@ package testtriggerclient
 
 import (
 	"context"
-	"time"
 
 	"k8s.io/apimachinery/pkg/types"
 
 	"github.com/kubeshop/testkube/pkg/api/v1/testkube"
-	"github.com/kubeshop/testkube/pkg/repository/channels"
 )
 
 type ListOptions struct {
@@ -17,22 +15,6 @@ type ListOptions struct {
 	Offset     uint32
 	Limit      uint32
 }
-
-type EventType string
-
-const (
-	EventTypeCreate EventType = "create"
-	EventTypeUpdate EventType = "update"
-	EventTypeDelete EventType = "delete"
-)
-
-type Update struct {
-	Type      EventType
-	Timestamp time.Time
-	Resource  *testkube.TestTrigger
-}
-
-type Watcher channels.Watcher[Update]
 
 //go:generate mockgen -destination=./mock_interface.go -package=testtriggerclient "github.com/kubeshop/testkube/pkg/newclients/testtriggerclient" TestTriggerClient
 type TestTriggerClient interface {
@@ -45,5 +27,4 @@ type TestTriggerClient interface {
 	Delete(ctx context.Context, environmentId string, name string, namespace string) error
 	DeleteAll(ctx context.Context, environmentId string, namespace string) (uint32, error)
 	DeleteByLabels(ctx context.Context, environmentId string, selector string, namespace string) (uint32, error)
-	WatchUpdates(ctx context.Context, environmentId string, namespace string, includeInitialData bool) Watcher
 }

--- a/pkg/newclients/testtriggerclient/kubernetes.go
+++ b/pkg/newclients/testtriggerclient/kubernetes.go
@@ -8,7 +8,6 @@ import (
 	testtriggersclientv1 "github.com/kubeshop/testkube-operator/pkg/client/testtriggers/v1"
 	"github.com/kubeshop/testkube/pkg/api/v1/testkube"
 	"github.com/kubeshop/testkube/pkg/mapper/testtriggers"
-	"github.com/kubeshop/testkube/pkg/repository/channels"
 )
 
 var _ TestTriggerClient = &k8sTestTriggerClient{}
@@ -135,12 +134,4 @@ func (c *k8sTestTriggerClient) DeleteByLabels(ctx context.Context, environmentId
 	// The old client doesn't return count, so we return 0
 	// This could be improved by first listing and counting
 	return 0, nil
-}
-
-func (c *k8sTestTriggerClient) WatchUpdates(ctx context.Context, environmentId string, namespace string, includeInitialData bool) Watcher {
-	// The old client doesn't support watching, so return an empty watcher
-	// This could be implemented using Kubernetes watch APIs
-	watcher := channels.NewWatcher[Update]()
-	watcher.Close(nil)
-	return watcher
 }

--- a/pkg/newclients/testtriggerclient/mock_interface.go
+++ b/pkg/newclients/testtriggerclient/mock_interface.go
@@ -167,17 +167,3 @@ func (mr *MockTestTriggerClientMockRecorder) Update(arg0, arg1, arg2 interface{}
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Update", reflect.TypeOf((*MockTestTriggerClient)(nil).Update), arg0, arg1, arg2)
 }
-
-// WatchUpdates mocks base method.
-func (m *MockTestTriggerClient) WatchUpdates(arg0 context.Context, arg1, arg2 string, arg3 bool) Watcher {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "WatchUpdates", arg0, arg1, arg2, arg3)
-	ret0, _ := ret[0].(Watcher)
-	return ret0
-}
-
-// WatchUpdates indicates an expected call of WatchUpdates.
-func (mr *MockTestTriggerClientMockRecorder) WatchUpdates(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WatchUpdates", reflect.TypeOf((*MockTestTriggerClient)(nil).WatchUpdates), arg0, arg1, arg2, arg3)
-}

--- a/pkg/triggers/executor.go
+++ b/pkg/triggers/executor.go
@@ -390,6 +390,7 @@ func (s *Service) getTestWorkflows(t *testtriggersv1.TestTrigger) ([]testworkflo
 	var testWorkflows []testworkflowsv1.TestWorkflow
 	if t.Spec.TestSelector.Name != "" {
 		s.logger.Debugf("trigger service: executor component: fetching testworkflowsv3.TestWorkflow with name %s", t.Spec.TestSelector.Name)
+
 		testWorkflow, err := s.testWorkflowsClient.Get(context.Background(), s.getEnvironmentId(), t.Spec.TestSelector.Name)
 		if err != nil {
 			return nil, err

--- a/pkg/triggers/service.go
+++ b/pkg/triggers/service.go
@@ -21,6 +21,7 @@ import (
 	"github.com/kubeshop/testkube/pkg/api/v1/testkube"
 	"github.com/kubeshop/testkube/pkg/event/bus"
 	"github.com/kubeshop/testkube/pkg/http"
+	"github.com/kubeshop/testkube/pkg/newclients/testtriggerclient"
 	"github.com/kubeshop/testkube/pkg/newclients/testworkflowclient"
 	"github.com/kubeshop/testkube/pkg/repository/config"
 	"github.com/kubeshop/testkube/pkg/repository/leasebackend"
@@ -61,6 +62,7 @@ type Service struct {
 	clientset                     kubernetes.Interface
 	testKubeClientset             testkubeclientsetv1.Interface
 	testWorkflowsClient           testworkflowclient.TestWorkflowClient
+	testTriggersClient            testtriggerclient.TestTriggerClient
 	logger                        *zap.SugaredLogger
 	configMap                     config.Repository
 	httpClient                    http.HttpClient
@@ -83,6 +85,7 @@ func NewService(
 	clientset kubernetes.Interface,
 	testKubeClientset testkubeclientsetv1.Interface,
 	testWorkflowsClient testworkflowclient.TestWorkflowClient,
+	testTriggersClient testtriggerclient.TestTriggerClient,
 	leaseBackend leasebackend.Repository,
 	logger *zap.SugaredLogger,
 	configMap config.Repository,
@@ -107,6 +110,7 @@ func NewService(
 		clientset:                     clientset,
 		testKubeClientset:             testKubeClientset,
 		testWorkflowsClient:           testWorkflowsClient,
+		testTriggersClient:            testTriggersClient,
 		leaseBackend:                  leaseBackend,
 		logger:                        logger,
 		configMap:                     configMap,
@@ -119,6 +123,7 @@ func NewService(
 		watchFromDate:                 time.Now(),
 		triggerStatus:                 make(map[statusKey]*triggerStatus),
 		deprecatedSystem:              deprecatedSystem,
+		proContext:                    &intconfig.ProContext{},
 	}
 	if s.triggerExecutor == nil {
 		s.triggerExecutor = s.execute

--- a/pkg/triggers/service_test.go
+++ b/pkg/triggers/service_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/kubeshop/testkube/pkg/featureflags"
 	"github.com/kubeshop/testkube/pkg/log"
 	logsclient "github.com/kubeshop/testkube/pkg/logs/client"
+	"github.com/kubeshop/testkube/pkg/newclients/testtriggerclient"
 	"github.com/kubeshop/testkube/pkg/newclients/testworkflowclient"
 	"github.com/kubeshop/testkube/pkg/repository/config"
 	"github.com/kubeshop/testkube/pkg/repository/leasebackend"
@@ -69,6 +70,7 @@ func TestService_Run(t *testing.T) {
 	mockTestWorkflowExecutor := testworkflowexecutor.NewMockTestWorkflowExecutor(mockCtrl)
 	mockTestWorkflowRepository := testworkflow.NewMockRepository(mockCtrl)
 	mockExecutionWorkerClient := executionworkertypes.NewMockWorker(mockCtrl)
+	mockTestTriggersClient := testtriggerclient.NewMockTestTriggerClient(mockCtrl)
 
 	mockDeprecatedClients := commons.NewMockDeprecatedClients(mockCtrl)
 	mockDeprecatedClients.EXPECT().Executors().Return(mockExecutorsClient).AnyTimes()
@@ -183,6 +185,7 @@ func TestService_Run(t *testing.T) {
 		fakeClientset,
 		fakeTestkubeClientset,
 		mockTestWorkflowsClient,
+		mockTestTriggersClient,
 		mockLeaseBackend,
 		testLogger,
 		configMapConfig,

--- a/pkg/triggers/watcher_test.go
+++ b/pkg/triggers/watcher_test.go
@@ -14,6 +14,7 @@ import (
 	faketestkube "github.com/kubeshop/testkube-operator/pkg/clientset/versioned/fake"
 	"github.com/kubeshop/testkube/cmd/api-server/services"
 	"github.com/kubeshop/testkube/internal/app/api/metrics"
+	intconfig "github.com/kubeshop/testkube/internal/config"
 	"github.com/kubeshop/testkube/pkg/event/bus"
 	"github.com/kubeshop/testkube/pkg/log"
 )
@@ -39,6 +40,7 @@ func TestService_runWatcher_lease(t *testing.T) {
 			informers:         newK8sInformers(clientset, testKubeClientset, "", []string{}),
 			eventsBus:         &bus.EventBusMock{},
 			metrics:           metrics.NewMetrics(),
+			proContext:        &intconfig.ProContext{},
 		}
 
 		leaseChan := make(chan bool)
@@ -100,6 +102,7 @@ func TestService_runWatcher_lease(t *testing.T) {
 			informers:         newK8sInformers(clientset, testKubeClientset, "", []string{}),
 			eventsBus:         &bus.EventBusMock{},
 			metrics:           metrics.NewMetrics(),
+			proContext:        &intconfig.ProContext{},
 		}
 
 		leaseChan := make(chan bool)
@@ -165,6 +168,7 @@ func TestService_runWatcher_noLease(t *testing.T) {
 			informers:         newK8sInformers(clientset, testKubeClientset, "", []string{}),
 			eventsBus:         &bus.EventBusMock{},
 			metrics:           metrics.NewMetrics(),
+			proContext:        &intconfig.ProContext{},
 		}
 
 		leaseChan := make(chan bool)
@@ -208,6 +212,7 @@ func TestService_runWatcher_noLease(t *testing.T) {
 			informers:         newK8sInformers(clientset, testKubeClientset, "", []string{}),
 			eventsBus:         &bus.EventBusMock{},
 			metrics:           metrics.NewMetrics(),
+			proContext:        &intconfig.ProContext{},
 		}
 
 		leaseChan := make(chan bool)
@@ -253,6 +258,7 @@ func TestService_runWatcher_noLease(t *testing.T) {
 			informers:         newK8sInformers(clientset, testKubeClientset, "", []string{}),
 			eventsBus:         &bus.EventBusMock{},
 			metrics:           metrics.NewMetrics(),
+			proContext:        &intconfig.ProContext{},
 		}
 
 		leaseChan := make(chan bool)


### PR DESCRIPTION
## Pull request description 

- adding grpc metadata to grpc calls to Cloud API to fetch executions and other data
- when cloud storage is enabled (fetched via pro context grpc call), it watches for test triggers via cloud api.

Tested using tk-dev



## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [ ] tested locally
- [ ] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Breaking changes

-

## Changes

-

## Fixes

-