### PR TITLE
fix: [TKC-4092] git clone with ssh key

### DIFF
--- a/cmd/testworkflow-toolkit/commands/clone_test.go
+++ b/cmd/testworkflow-toolkit/commands/clone_test.go
@@ -210,8 +210,9 @@ func TestSetupSSHKey(t *testing.T) {
 			// Clear environment before test
 			t.Setenv("GIT_SSH_COMMAND", "")
 
-			err := setupSSHKey(tt.sshKey)
+			cleanup, err := setupSSHKey(tt.sshKey)
 			require.NoError(t, err)
+			defer cleanup()
 
 			if tt.shouldSet {
 				assert.NotEmpty(t, os.Getenv("GIT_SSH_COMMAND"))


### PR DESCRIPTION
## Pull request description 

Cloning with an SSH key failed after the refactor because the temp key file was deleted before git executed. This change ensures the key file persists for the duration of the clone/fetch/checkout and is cleaned up afterward.


## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [ ] tested locally
- [ ] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Breaking changes

-

## Changes

-

## Fixes

-