### PR TITLE
fix: [TKC-4102] fix up get qouted trigger

### DIFF
--- a/pkg/api/v1/testkube/model_test_trigger_extended.go
+++ b/pkg/api/v1/testkube/model_test_trigger_extended.go
@@ -70,6 +70,12 @@ func (t *TestTrigger) QuoteTextFields() {
 			if t.ConditionSpec.Conditions[i].Type_ != "" {
 				t.ConditionSpec.Conditions[i].Type_ = fmt.Sprintf("%q", t.ConditionSpec.Conditions[i].Type_)
 			}
+			if t.ConditionSpec.Conditions[i].Status != nil {
+				status := t.ConditionSpec.Conditions[i].Status
+				if string(*status) != "" {
+					*status = TestTriggerConditionStatuses(fmt.Sprintf("%q", string(*status)))
+				}
+			}
 			if t.ConditionSpec.Conditions[i].Reason != "" {
 				t.ConditionSpec.Conditions[i].Reason = fmt.Sprintf("%q", t.ConditionSpec.Conditions[i].Reason)
 			}


### PR DESCRIPTION
## Pull request description 


condition status renders True, instead of "True", which is invalid since True is bool in yaml, not string.
```
  conditionSpec:
    - type: Progressing
      status: True
      reason: NewReplicaSetAvailable
      ttl: 60
```

## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [ ] tested locally
- [ ] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Breaking changes

-

## Changes

-

## Fixes

-