### PR TITLE
fix: [TKC-4119] dont use capabilities, since its not in control-plane yet

### DIFF
--- a/cmd/api-server/main.go
+++ b/cmd/api-server/main.go
@@ -222,7 +222,6 @@ func main() {
 			RunnerName:        runnerName,
 			OrganizationId:    cfg.TestkubeProOrgID,
 			Floating:          cfg.FloatingRunner,
-			Capabilities:      []cloud.AgentCapability{cloud.AgentCapability_AGENT_CAPABILITY_RUNNER},
 		})
 		if err != nil {
 			log.DefaultLogger.Fatalw("error registering runner", "error", err.Error())


### PR DESCRIPTION
## Pull request description 

This unblocks releasing of testkube, in case we have issue. As it will call grpc api with new parameter, but we dont have use new proto version it in control-plane yet.

## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [ ] tested locally
- [ ] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Breaking changes

-

## Changes

-

## Fixes

-