### PR TITLE
feat: [TKC-4120] allow fetching triggers from cp

### DIFF
--- a/cmd/api-server/main.go
+++ b/cmd/api-server/main.go
@@ -717,6 +717,7 @@ func main() {
 			triggers.WithWatcherNamespaces(cfg.TestkubeWatcherNamespaces),
 			triggers.WithDisableSecretCreation(!secretConfig.AutoCreate),
 			triggers.WithProContext(&proContext),
+			triggers.WithTestTriggerControlPlane(cfg.TestTriggerControlPlane),
 		)
 		log.DefaultLogger.Info("starting trigger service")
 		g.Go(func() error {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -227,8 +227,9 @@ type Config struct {
 	AllowLowSecurityFields          bool     `envconfig:"ALLOW_LOW_SECURITY_FIELDS" default:"false"`
 	EnableK8sControllers            bool     `envconfig:"ENABLE_K8S_CONTROLLERS" default:"false"`
 
-	FeatureNewArchitecture bool `envconfig:"FEATURE_NEW_ARCHITECTURE" default:"false"`
-	FeatureCloudStorage    bool `envconfig:"FEATURE_CLOUD_STORAGE" default:"false"`
+	FeatureNewArchitecture  bool `envconfig:"FEATURE_NEW_ARCHITECTURE" default:"false"`
+	FeatureCloudStorage     bool `envconfig:"FEATURE_CLOUD_STORAGE" default:"false"`
+	TestTriggerControlPlane bool `envconfig:"TEST_TRIGGER_CONTROL_PLANE" default:"false"`
 }
 
 type DeprecatedConfig struct {

--- a/pkg/triggers/service.go
+++ b/pkg/triggers/service.go
@@ -76,6 +76,7 @@ type Service struct {
 	disableSecretCreation         bool
 	deprecatedSystem              *services.DeprecatedSystem
 	proContext                    *intconfig.ProContext
+	testTriggerControlPlane       bool
 }
 
 type Option func(*Service)
@@ -209,6 +210,13 @@ func WithDisableSecretCreation(disableSecretCreation bool) Option {
 func WithProContext(proContext *intconfig.ProContext) Option {
 	return func(s *Service) {
 		s.proContext = proContext
+	}
+}
+
+// WithTestTriggerControlPlane enables Control Plane-backed trigger watching
+func WithTestTriggerControlPlane(enabled bool) Option {
+	return func(s *Service) {
+		s.testTriggerControlPlane = enabled
 	}
 }
 

--- a/pkg/triggers/watcher.go
+++ b/pkg/triggers/watcher.go
@@ -171,7 +171,7 @@ func (s *Service) runInformers(ctx context.Context, stop <-chan struct{}) {
 		s.informers.configMapInformers[i].Informer().AddEventHandler(s.configMapEventHandler(ctx))
 	}
 
-	if s.proContext.CloudStorage {
+	if s.testTriggerControlPlane {
 		s.startCloudTestTriggerWatch(ctx, stop)
 	} else {
 		s.informers.testTriggerInformer.Informer().AddEventHandler(s.testTriggerEventHandler())
@@ -219,7 +219,7 @@ func (s *Service) runInformers(ctx context.Context, stop <-chan struct{}) {
 		go s.informers.configMapInformers[i].Informer().Run(stop)
 	}
 
-	if !s.proContext.CloudStorage {
+	if !s.testTriggerControlPlane {
 		s.logger.Debugf("trigger service: starting test trigger informer")
 		go s.informers.testTriggerInformer.Informer().Run(stop)
 	}


### PR DESCRIPTION
## Pull request description 

This adds a feature flag to whether use control-plane to fetch test triggers or to keep default beahviour use kubernetes informers. Which allows to either fetch triggers from mongo or from superagent.

Default is kubernetes informers for backwards compatability.

## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [ ] tested locally
- [ ] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Breaking changes

-

## Changes

-

## Fixes

-