### PR TITLE
feat: [TKC-4131] allow target matching based with gotemplates and agent data

### DIFF
--- a/cmd/api-server/main.go
+++ b/cmd/api-server/main.go
@@ -711,11 +711,11 @@ func main() {
 			executionWorker,
 			testWorkflowExecutor,
 			testWorkflowResultsRepository,
+			&proContext,
 			triggers.WithHostnameIdentifier(),
 			triggers.WithTestkubeNamespace(cfg.TestkubeNamespace),
 			triggers.WithWatcherNamespaces(cfg.TestkubeWatcherNamespaces),
 			triggers.WithDisableSecretCreation(!secretConfig.AutoCreate),
-			triggers.WithProContext(&proContext),
 			triggers.WithTestTriggerControlPlane(cfg.TestTriggerControlPlane),
 		)
 		log.DefaultLogger.Info("starting trigger service")

--- a/pkg/triggers/event.go
+++ b/pkg/triggers/event.go
@@ -29,14 +29,21 @@ type addressGetterFn func(ctx context.Context, delay time.Duration) (string, err
 type watcherEvent struct {
 	resource         testtrigger.ResourceType
 	name             string
-	namespace        string
+	Namespace        string `json:"namespace"`
 	labels           map[string]string
 	objectMeta       metav1.Object
-	object           any
+	Object           any `json:"object"`
 	eventType        testtrigger.EventType
 	causes           []testtrigger.Cause
 	conditionsGetter conditionsGetterFn
 	addressGetter    addressGetterFn
+	Agent            watcherAgent `json:"agent"`
+}
+
+// watcherAgent represents agent context exposed to templates and JSONPath
+type watcherAgent struct {
+	Name   string            `json:"name"`
+	Labels map[string]string `json:"labels"`
 }
 
 type watcherOpts func(*watcherEvent)
@@ -72,16 +79,18 @@ func newWatcherEvent(
 	objectMeta metav1.Object,
 	object any,
 	resource testtrigger.ResourceType,
+	agent watcherAgent,
 	opts ...watcherOpts,
 ) *watcherEvent {
 	w := &watcherEvent{
 		resource:   resource,
 		name:       objectMeta.GetName(),
-		namespace:  objectMeta.GetNamespace(),
+		Namespace:  objectMeta.GetNamespace(),
 		labels:     objectMeta.GetLabels(),
 		objectMeta: objectMeta,
-		object:     object,
+		Object:     object,
 		eventType:  eventType,
+		Agent:      agent,
 	}
 
 	for _, opt := range opts {

--- a/pkg/triggers/matcher.go
+++ b/pkg/triggers/matcher.go
@@ -131,7 +131,7 @@ func matchSelector(selector *testtriggersv1.TestTriggerSelector, namespace strin
 		resourceLabelSet := labels.Set(event.labels)
 		_, err = resourceLabelSet.AsValidatedSelector()
 		if err != nil {
-			logger.Errorf("%s %s/%s labels are invalid: %v", event.resource, event.namespace, event.name, err)
+			logger.Errorf("%s %s/%s labels are invalid: %v", event.resource, event.Namespace, event.name, err)
 			return false
 		}
 
@@ -154,7 +154,7 @@ func matchSelector(selector *testtriggersv1.TestTriggerSelector, namespace strin
 	}
 
 	if selector.Namespace != "" {
-		isSameNamespace = selector.Namespace == event.namespace
+		isSameNamespace = selector.Namespace == event.Namespace
 	}
 
 	if selector.NamespaceRegex != "" {
@@ -164,10 +164,10 @@ func matchSelector(selector *testtriggersv1.TestTriggerSelector, namespace strin
 			return false
 		}
 
-		isSameNamespace = re.MatchString(event.namespace)
+		isSameNamespace = re.MatchString(event.Namespace)
 	}
 
-	isSameTestTriggerNamespace = selector.Namespace == "" && selector.NamespaceRegex == "" && namespace == event.namespace
+	isSameTestTriggerNamespace = selector.Namespace == "" && selector.NamespaceRegex == "" && namespace == event.Namespace
 	return isSameName && (isSameNamespace || isSameTestTriggerNamespace)
 }
 
@@ -186,19 +186,19 @@ outer:
 			logger.Errorf(
 				"trigger service: matcher component: error waiting for conditions to match for trigger %s/%s by event %s on resource %s %s/%s"+
 					" because context got canceled by timeout or exit signal",
-				t.Namespace, t.Name, e.eventType, e.resource, e.namespace, e.name,
+				t.Namespace, t.Name, e.eventType, e.resource, e.Namespace, e.name,
 			)
 			return false, errors.WithStack(ErrConditionTimeout)
 		default:
 			logger.Debugf(
 				"trigger service: matcher component: running conditions check iteration for %s %s/%s",
-				e.resource, e.namespace, e.name,
+				e.resource, e.Namespace, e.name,
 			)
 			conditions, err := e.conditionsGetter()
 			if err != nil {
 				logger.Errorf(
 					"trigger service: matcher component: error getting conditions for %s %s/%s because of %v",
-					e.resource, e.namespace, e.name, err,
+					e.resource, e.Namespace, e.name, err,
 				)
 				return false, err
 			}
@@ -316,7 +316,7 @@ func (s *Service) matchProbes(ctx context.Context, e *watcherEvent, t *testtrigg
 		if err != nil {
 			logger.Errorf(
 				"trigger service: matcher component: error getting addess for %s %s/%s because of %v",
-				e.resource, e.namespace, e.name, err,
+				e.resource, e.Namespace, e.name, err,
 			)
 			return false, err
 		}
@@ -341,13 +341,13 @@ outer:
 			logger.Errorf(
 				"trigger service: matcher component: error waiting for probes to match for trigger %s/%s by event %s on resource %s %s/%s"+
 					" because context got canceled by timeout or exit signal",
-				t.Namespace, t.Name, e.eventType, e.resource, e.namespace, e.name,
+				t.Namespace, t.Name, e.eventType, e.resource, e.Namespace, e.name,
 			)
 			return false, errors.WithStack(ErrProbeTimeout)
 		default:
 			logger.Debugf(
 				"trigger service: matcher component: running probes check iteration for %s %s/%s",
-				e.resource, e.namespace, e.name,
+				e.resource, e.Namespace, e.name,
 			)
 
 			matched := checkProbes(timeoutCtx, s.httpClient, t.Spec.ProbeSpec.Probes, logger)

--- a/pkg/triggers/matcher_test.go
+++ b/pkg/triggers/matcher_test.go
@@ -23,10 +23,10 @@ func TestService_matchConditionsRetry(t *testing.T) {
 	e := &watcherEvent{
 		resource:   "deployment",
 		name:       "test-deployment",
-		namespace:  "testkube",
+		Namespace:  "testkube",
 		labels:     nil,
 		objectMeta: nil,
-		object:     nil,
+		Object:     nil,
 		eventType:  "modified",
 		causes:     nil,
 		conditionsGetter: func() ([]testtriggersv1.TestTriggerCondition, error) {
@@ -108,10 +108,10 @@ func TestService_matchConditionsTimeout(t *testing.T) {
 	e := &watcherEvent{
 		resource:   "deployment",
 		name:       "test-deployment",
-		namespace:  "testkube",
+		Namespace:  "testkube",
 		labels:     nil,
 		objectMeta: nil,
-		object:     nil,
+		Object:     nil,
 		eventType:  "modified",
 		causes:     nil,
 		conditionsGetter: func() ([]testtriggersv1.TestTriggerCondition, error) {
@@ -187,10 +187,10 @@ func TestService_matchProbesMultiple(t *testing.T) {
 	e := &watcherEvent{
 		resource:   "deployment",
 		name:       "test-deployment",
-		namespace:  "testkube",
+		Namespace:  "testkube",
 		labels:     nil,
 		objectMeta: nil,
-		object:     nil,
+		Object:     nil,
 		eventType:  "modified",
 		causes:     nil,
 	}
@@ -264,10 +264,10 @@ func TestService_matchProbesTimeout(t *testing.T) {
 	e := &watcherEvent{
 		resource:   "deployment",
 		name:       "test-deployment",
-		namespace:  "testkube",
+		Namespace:  "testkube",
 		labels:     nil,
 		objectMeta: nil,
-		object:     nil,
+		Object:     nil,
 		eventType:  "modified",
 		causes:     nil,
 	}
@@ -335,10 +335,10 @@ func TestService_match(t *testing.T) {
 	e := &watcherEvent{
 		resource:   "deployment",
 		name:       "test-deployment",
-		namespace:  "testkube",
+		Namespace:  "testkube",
 		labels:     nil,
 		objectMeta: nil,
-		object:     nil,
+		Object:     nil,
 		eventType:  "modified",
 		causes:     nil,
 		conditionsGetter: func() ([]testtriggersv1.TestTriggerCondition, error) {
@@ -443,10 +443,10 @@ func TestService_matchRegex(t *testing.T) {
 	e := &watcherEvent{
 		resource:   "deployment",
 		name:       "test-deployment",
-		namespace:  "testkube",
+		Namespace:  "testkube",
 		labels:     nil,
 		objectMeta: nil,
-		object:     nil,
+		Object:     nil,
 		eventType:  "modified",
 		causes:     nil,
 	}
@@ -497,10 +497,10 @@ func TestService_noMatch(t *testing.T) {
 	e := &watcherEvent{
 		resource:   "deployment",
 		name:       "test-deployment",
-		namespace:  "testkube",
+		Namespace:  "testkube",
 		labels:     nil,
 		objectMeta: nil,
-		object:     nil,
+		Object:     nil,
 		eventType:  "modified",
 		causes:     nil,
 	}

--- a/pkg/triggers/service.go
+++ b/pkg/triggers/service.go
@@ -77,6 +77,7 @@ type Service struct {
 	deprecatedSystem              *services.DeprecatedSystem
 	proContext                    *intconfig.ProContext
 	testTriggerControlPlane       bool
+	Agent                         watcherAgent
 }
 
 type Option func(*Service)
@@ -95,6 +96,7 @@ func NewService(
 	executionWorkerClient executionworkertypes.Worker,
 	testWorkflowExecutor testworkflowexecutor.TestWorkflowExecutor,
 	testWorkflowResultsRepository testworkflow.Repository,
+	proContext *intconfig.ProContext,
 	opts ...Option,
 ) *Service {
 	identifier := fmt.Sprintf(defaultIdentifierFormat, utils.RandAlphanum(10))
@@ -124,7 +126,7 @@ func NewService(
 		watchFromDate:                 time.Now(),
 		triggerStatus:                 make(map[statusKey]*triggerStatus),
 		deprecatedSystem:              deprecatedSystem,
-		proContext:                    &intconfig.ProContext{},
+		proContext:                    proContext,
 	}
 	if s.triggerExecutor == nil {
 		s.triggerExecutor = s.execute
@@ -132,6 +134,13 @@ func NewService(
 
 	for _, opt := range opts {
 		opt(s)
+	}
+
+	// Initialize agent snapshot from proContext if available
+	s.Agent = watcherAgent{}
+	if s.proContext != nil {
+		s.Agent.Name = s.proContext.Agent.Name
+		s.Agent.Labels = s.proContext.Agent.Labels
 	}
 
 	s.informers = newK8sInformers(clientset, testKubeClientset, s.testkubeNamespace, s.watcherNamespaces)
@@ -204,12 +213,6 @@ func WithWatcherNamespaces(namespaces string) Option {
 func WithDisableSecretCreation(disableSecretCreation bool) Option {
 	return func(s *Service) {
 		s.disableSecretCreation = disableSecretCreation
-	}
-}
-
-func WithProContext(proContext *intconfig.ProContext) Option {
-	return func(s *Service) {
-		s.proContext = proContext
 	}
 }
 

--- a/pkg/triggers/service_test.go
+++ b/pkg/triggers/service_test.go
@@ -194,6 +194,7 @@ func TestService_Run(t *testing.T) {
 		mockExecutionWorkerClient,
 		mockTestWorkflowExecutor,
 		mockTestWorkflowRepository,
+		nil,
 		WithClusterID(testClusterID),
 		WithIdentifier(testIdentifier),
 		WithScraperInterval(50*time.Millisecond),

--- a/pkg/triggers/watcher.go
+++ b/pkg/triggers/watcher.go
@@ -341,7 +341,7 @@ func (s *Service) podEventHandler(ctx context.Context) cache.ResourceEventHandle
 				return
 			}
 			s.logger.Debugf("trigger service: watcher component: emiting event: pod %s/%s created", pod.Namespace, pod.Name)
-			event := newWatcherEvent(testtrigger.EventCreated, &pod.ObjectMeta, pod, testtrigger.ResourcePod,
+			event := newWatcherEvent(testtrigger.EventCreated, &pod.ObjectMeta, pod, testtrigger.ResourcePod, s.Agent,
 				withConditionsGetter(getConditions(pod)), withAddressGetter(getAddress(pod)))
 			if err := s.match(ctx, event); err != nil {
 				s.logger.Errorf("event matcher returned an error while matching create pod event: %v", err)
@@ -354,7 +354,7 @@ func (s *Service) podEventHandler(ctx context.Context) cache.ResourceEventHandle
 				return
 			}
 			s.logger.Debugf("trigger service: watcher component: emiting event: pod %s/%s deleted", pod.Namespace, pod.Name)
-			event := newWatcherEvent(testtrigger.EventDeleted, &pod.ObjectMeta, pod, testtrigger.ResourcePod,
+			event := newWatcherEvent(testtrigger.EventDeleted, &pod.ObjectMeta, pod, testtrigger.ResourcePod, s.Agent,
 				withConditionsGetter(getConditions(pod)), withAddressGetter(getAddress(pod)))
 			if err := s.match(ctx, event); err != nil {
 				s.logger.Errorf("event matcher returned an error while matching delete pod event: %v", err)
@@ -484,7 +484,7 @@ func (s *Service) deploymentEventHandler(ctx context.Context) cache.ResourceEven
 				return
 			}
 			s.logger.Debugf("emiting event: deployment %s/%s created", deployment.Namespace, deployment.Name)
-			event := newWatcherEvent(testtrigger.EventCreated, &deployment.ObjectMeta, deployment, testtrigger.ResourceDeployment, withConditionsGetter(getConditions(deployment)))
+			event := newWatcherEvent(testtrigger.EventCreated, &deployment.ObjectMeta, deployment, testtrigger.ResourceDeployment, s.Agent, withConditionsGetter(getConditions(deployment)))
 			if err := s.match(ctx, event); err != nil {
 				s.logger.Errorf("event matcher returned an error while matching create deployment event: %v", err)
 			}
@@ -515,7 +515,7 @@ func (s *Service) deploymentEventHandler(ctx context.Context) cache.ResourceEven
 				newDeployment.Namespace, newDeployment.Name,
 			)
 			causes := diffDeployments(oldDeployment, newDeployment)
-			event := newWatcherEvent(testtrigger.EventModified, &newDeployment.ObjectMeta, newDeployment, testtrigger.ResourceDeployment, withCauses(causes), withConditionsGetter(getConditions(newDeployment)))
+			event := newWatcherEvent(testtrigger.EventModified, &newDeployment.ObjectMeta, newDeployment, testtrigger.ResourceDeployment, s.Agent, withCauses(causes), withConditionsGetter(getConditions(newDeployment)))
 			if err := s.match(ctx, event); err != nil {
 				s.logger.Errorf("event matcher returned an error while matching update deployment event: %v", err)
 			}
@@ -527,7 +527,7 @@ func (s *Service) deploymentEventHandler(ctx context.Context) cache.ResourceEven
 				return
 			}
 			s.logger.Debugf("trigger service: watcher component: emiting event: deployment %s/%s deleted", deployment.Namespace, deployment.Name)
-			event := newWatcherEvent(testtrigger.EventDeleted, &deployment.ObjectMeta, deployment, testtrigger.ResourceDeployment, withConditionsGetter(getConditions(deployment)))
+			event := newWatcherEvent(testtrigger.EventDeleted, &deployment.ObjectMeta, deployment, testtrigger.ResourceDeployment, s.Agent, withConditionsGetter(getConditions(deployment)))
 			if err := s.match(ctx, event); err != nil {
 				s.logger.Errorf("event matcher returned an error while matching delete deployment event: %v", err)
 			}
@@ -556,7 +556,7 @@ func (s *Service) statefulSetEventHandler(ctx context.Context) cache.ResourceEve
 				return
 			}
 			s.logger.Debugf("trigger service: watcher component: emiting event: statefulset %s/%s created", statefulset.Namespace, statefulset.Name)
-			event := newWatcherEvent(testtrigger.EventCreated, &statefulset.ObjectMeta, statefulset, testtrigger.ResourceStatefulSet, withConditionsGetter(getConditions(statefulset)))
+			event := newWatcherEvent(testtrigger.EventCreated, &statefulset.ObjectMeta, statefulset, testtrigger.ResourceStatefulSet, s.Agent, withConditionsGetter(getConditions(statefulset)))
 			if err := s.match(ctx, event); err != nil {
 				s.logger.Errorf("event matcher returned an error while matching create statefulset event: %v", err)
 			}
@@ -586,7 +586,7 @@ func (s *Service) statefulSetEventHandler(ctx context.Context) cache.ResourceEve
 				"trigger service: watcher component: emiting event: statefulset %s/%s updated",
 				newStatefulSet.Namespace, newStatefulSet.Name,
 			)
-			event := newWatcherEvent(testtrigger.EventModified, &newStatefulSet.ObjectMeta, newStatefulSet, testtrigger.ResourceStatefulSet, withConditionsGetter(getConditions(newStatefulSet)))
+			event := newWatcherEvent(testtrigger.EventModified, &newStatefulSet.ObjectMeta, newStatefulSet, testtrigger.ResourceStatefulSet, s.Agent, withConditionsGetter(getConditions(newStatefulSet)))
 			if err := s.match(ctx, event); err != nil {
 				s.logger.Errorf("event matcher returned an error while matching update statefulset event: %v", err)
 			}
@@ -598,7 +598,7 @@ func (s *Service) statefulSetEventHandler(ctx context.Context) cache.ResourceEve
 				return
 			}
 			s.logger.Debugf("trigger service: watcher component: emiting event: statefulset %s/%s deleted", statefulset.Namespace, statefulset.Name)
-			event := newWatcherEvent(testtrigger.EventDeleted, &statefulset.ObjectMeta, statefulset, testtrigger.ResourceStatefulSet, withConditionsGetter(getConditions(statefulset)))
+			event := newWatcherEvent(testtrigger.EventDeleted, &statefulset.ObjectMeta, statefulset, testtrigger.ResourceStatefulSet, s.Agent, withConditionsGetter(getConditions(statefulset)))
 			if err := s.match(ctx, event); err != nil {
 				s.logger.Errorf("event matcher returned an error while matching delete statefulset event: %v", err)
 			}
@@ -627,7 +627,7 @@ func (s *Service) daemonSetEventHandler(ctx context.Context) cache.ResourceEvent
 				return
 			}
 			s.logger.Debugf("trigger service: watcher component: emiting event: daemonset %s/%s created", daemonset.Namespace, daemonset.Name)
-			event := newWatcherEvent(testtrigger.EventCreated, &daemonset.ObjectMeta, daemonset, testtrigger.ResourceDaemonSet, withConditionsGetter(getConditions(daemonset)))
+			event := newWatcherEvent(testtrigger.EventCreated, &daemonset.ObjectMeta, daemonset, testtrigger.ResourceDaemonSet, s.Agent, withConditionsGetter(getConditions(daemonset)))
 			if err := s.match(ctx, event); err != nil {
 				s.logger.Errorf("event matcher returned an error while matching create daemonset event: %v", err)
 			}
@@ -657,7 +657,7 @@ func (s *Service) daemonSetEventHandler(ctx context.Context) cache.ResourceEvent
 				"trigger service: watcher component: emiting event: daemonset %s/%s updated",
 				newDaemonSet.Namespace, newDaemonSet.Name,
 			)
-			event := newWatcherEvent(testtrigger.EventModified, &newDaemonSet.ObjectMeta, newDaemonSet, testtrigger.ResourceDaemonSet, withConditionsGetter(getConditions(newDaemonSet)))
+			event := newWatcherEvent(testtrigger.EventModified, &newDaemonSet.ObjectMeta, newDaemonSet, testtrigger.ResourceDaemonSet, s.Agent, withConditionsGetter(getConditions(newDaemonSet)))
 			if err := s.match(ctx, event); err != nil {
 				s.logger.Errorf("event matcher returned an error while matching update daemonset event: %v", err)
 			}
@@ -669,7 +669,7 @@ func (s *Service) daemonSetEventHandler(ctx context.Context) cache.ResourceEvent
 				return
 			}
 			s.logger.Debugf("trigger service: watcher component: emiting event: daemonset %s/%s deleted", daemonset.Namespace, daemonset.Name)
-			event := newWatcherEvent(testtrigger.EventDeleted, &daemonset.ObjectMeta, daemonset, testtrigger.ResourceDaemonSet, withConditionsGetter(getConditions(daemonset)))
+			event := newWatcherEvent(testtrigger.EventDeleted, &daemonset.ObjectMeta, daemonset, testtrigger.ResourceDaemonSet, s.Agent, withConditionsGetter(getConditions(daemonset)))
 			if err := s.match(ctx, event); err != nil {
 				s.logger.Errorf("event matcher returned an error while matching delete daemonset event: %v", err)
 			}
@@ -703,7 +703,7 @@ func (s *Service) serviceEventHandler(ctx context.Context) cache.ResourceEventHa
 				return
 			}
 			s.logger.Debugf("trigger service: watcher component: emiting event: service %s/%s created", service.Namespace, service.Name)
-			event := newWatcherEvent(testtrigger.EventCreated, &service.ObjectMeta, service, testtrigger.ResourceService,
+			event := newWatcherEvent(testtrigger.EventCreated, &service.ObjectMeta, service, testtrigger.ResourceService, s.Agent,
 				withConditionsGetter(getConditions(service)), withAddressGetter(getAddrress(service)))
 			if err := s.match(ctx, event); err != nil {
 				s.logger.Errorf("event matcher returned an error while matching create service event: %v", err)
@@ -734,7 +734,7 @@ func (s *Service) serviceEventHandler(ctx context.Context) cache.ResourceEventHa
 				"trigger service: watcher component: emiting event: service %s/%s updated",
 				newService.Namespace, newService.Name,
 			)
-			event := newWatcherEvent(testtrigger.EventModified, &newService.ObjectMeta, newService, testtrigger.ResourceService,
+			event := newWatcherEvent(testtrigger.EventModified, &newService.ObjectMeta, newService, testtrigger.ResourceService, s.Agent,
 				withConditionsGetter(getConditions(newService)), withAddressGetter(getAddrress(newService)))
 			if err := s.match(ctx, event); err != nil {
 				s.logger.Errorf("event matcher returned an error while matching update service event: %v", err)
@@ -747,7 +747,7 @@ func (s *Service) serviceEventHandler(ctx context.Context) cache.ResourceEventHa
 				return
 			}
 			s.logger.Debugf("trigger service: watcher component: emiting event: service %s/%s deleted", service.Namespace, service.Name)
-			event := newWatcherEvent(testtrigger.EventDeleted, &service.ObjectMeta, service, testtrigger.ResourceService,
+			event := newWatcherEvent(testtrigger.EventDeleted, &service.ObjectMeta, service, testtrigger.ResourceService, s.Agent,
 				withConditionsGetter(getConditions(service)), withAddressGetter(getAddrress(service)))
 			if err := s.match(ctx, event); err != nil {
 				s.logger.Errorf("event matcher returned an error while matching delete service event: %v", err)
@@ -772,7 +772,7 @@ func (s *Service) ingressEventHandler(ctx context.Context) cache.ResourceEventHa
 				return
 			}
 			s.logger.Debugf("trigger service: watcher component: emiting event: ingress %s/%s created", ingress.Namespace, ingress.Name)
-			event := newWatcherEvent(testtrigger.EventCreated, &ingress.ObjectMeta, ingress, testtrigger.ResourceIngress)
+			event := newWatcherEvent(testtrigger.EventCreated, &ingress.ObjectMeta, ingress, testtrigger.ResourceIngress, s.Agent)
 			if err := s.match(ctx, event); err != nil {
 				s.logger.Errorf("event matcher returned an error while matching create ingress event: %v", err)
 			}
@@ -802,7 +802,7 @@ func (s *Service) ingressEventHandler(ctx context.Context) cache.ResourceEventHa
 				"trigger service: watcher component: emiting event: ingress %s/%s updated",
 				oldIngress.Namespace, newIngress.Name,
 			)
-			event := newWatcherEvent(testtrigger.EventModified, &newIngress.ObjectMeta, newIngress, testtrigger.ResourceIngress)
+			event := newWatcherEvent(testtrigger.EventModified, &newIngress.ObjectMeta, newIngress, testtrigger.ResourceIngress, s.Agent)
 			if err := s.match(ctx, event); err != nil {
 				s.logger.Errorf("event matcher returned an error while matching update ingress event: %v", err)
 			}
@@ -814,7 +814,7 @@ func (s *Service) ingressEventHandler(ctx context.Context) cache.ResourceEventHa
 				return
 			}
 			s.logger.Debugf("trigger service: watcher component: emiting event: ingress %s/%s deleted", ingress.Namespace, ingress.Name)
-			event := newWatcherEvent(testtrigger.EventDeleted, &ingress.ObjectMeta, ingress, testtrigger.ResourceIngress)
+			event := newWatcherEvent(testtrigger.EventDeleted, &ingress.ObjectMeta, ingress, testtrigger.ResourceIngress, s.Agent)
 			if err := s.match(ctx, event); err != nil {
 				s.logger.Errorf("event matcher returned an error while matching delete ingress event: %v", err)
 			}
@@ -839,7 +839,7 @@ func (s *Service) clusterEventEventHandler(ctx context.Context) cache.ResourceEv
 			}
 			s.logger.Debugf("trigger service: watcher component: emiting event: cluster event %s/%s created", clusterEvent.Namespace, clusterEvent.Name)
 			name, causes := getTestkubeEventNameAndCauses(clusterEvent)
-			event := newWatcherEvent(testtrigger.EventCreated, &clusterEvent.ObjectMeta, clusterEvent, testtrigger.ResourceEvent, withCauses(causes), withNotEmptyName(name))
+			event := newWatcherEvent(testtrigger.EventCreated, &clusterEvent.ObjectMeta, clusterEvent, testtrigger.ResourceEvent, s.Agent, withCauses(causes), withNotEmptyName(name))
 			if err := s.match(ctx, event); err != nil {
 				s.logger.Errorf("event matcher returned an error while matching create cluster event event: %v", err)
 			}
@@ -1207,7 +1207,7 @@ func (s *Service) configMapEventHandler(ctx context.Context) cache.ResourceEvent
 				return
 			}
 			s.logger.Debugf("trigger service: watcher component: emiting event: config map %s/%s created", configMap.Namespace, configMap.Name)
-			event := newWatcherEvent(testtrigger.EventCreated, &configMap.ObjectMeta, configMap, testtrigger.ResourceConfigMap)
+			event := newWatcherEvent(testtrigger.EventCreated, &configMap.ObjectMeta, configMap, testtrigger.ResourceConfigMap, s.Agent)
 			if err := s.match(ctx, event); err != nil {
 				s.logger.Errorf("event matcher returned an error while matching create config map event: %v", err)
 			}
@@ -1237,7 +1237,7 @@ func (s *Service) configMapEventHandler(ctx context.Context) cache.ResourceEvent
 				"trigger service: watcher component: emiting event: config map %s/%s updated",
 				oldConfigMap.Namespace, newConfigMap.Name,
 			)
-			event := newWatcherEvent(testtrigger.EventModified, &newConfigMap.ObjectMeta, newConfigMap, testtrigger.ResourceConfigMap)
+			event := newWatcherEvent(testtrigger.EventModified, &newConfigMap.ObjectMeta, newConfigMap, testtrigger.ResourceConfigMap, s.Agent)
 			if err := s.match(ctx, event); err != nil {
 				s.logger.Errorf("event matcher returned an error while matching update config map event: %v", err)
 			}
@@ -1249,7 +1249,7 @@ func (s *Service) configMapEventHandler(ctx context.Context) cache.ResourceEvent
 				return
 			}
 			s.logger.Debugf("trigger service: watcher component: emiting event: config map %s/%s deleted", configMap.Namespace, configMap.Name)
-			event := newWatcherEvent(testtrigger.EventDeleted, &configMap.ObjectMeta, configMap, testtrigger.ResourceConfigMap)
+			event := newWatcherEvent(testtrigger.EventDeleted, &configMap.ObjectMeta, configMap, testtrigger.ResourceConfigMap, s.Agent)
 			if err := s.match(ctx, event); err != nil {
 				s.logger.Errorf("event matcher returned an error while matching delete config map event: %v", err)
 			}


### PR DESCRIPTION
## Pull request description 

Example:

based on namespace:

```
  actionParameters:
    target:
      match:
        name:
          - '{{ .Namespace }}'

```

running execution on label:
```
  actionParameters:
    target:
      match:
        env:
          - '{{ (agent).Labels.env}}'
```

running execution on itsefl:
```
  actionParameters:
    target:
      match:
        name:
          - '{{ (agent).Name }}'
```


## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [ ] tested locally
- [ ] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Breaking changes

-

## Changes

-

## Fixes

-