### PR TITLE
feat: [TKC-4154] allow adding custom agent data

### DIFF
--- a/cmd/api-server/main.go
+++ b/cmd/api-server/main.go
@@ -717,6 +717,7 @@ func main() {
 			triggers.WithWatcherNamespaces(cfg.TestkubeWatcherNamespaces),
 			triggers.WithDisableSecretCreation(!secretConfig.AutoCreate),
 			triggers.WithTestTriggerControlPlane(cfg.TestTriggerControlPlane),
+			triggers.WithAgentDataFile(cfg.AgentDataFile),
 		)
 		log.DefaultLogger.Info("starting trigger service")
 		g.Go(func() error {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -226,6 +226,7 @@ type Config struct {
 	DisableWebhooks                 bool     `envconfig:"DISABLE_WEBHOOKS" default:"false"`
 	AllowLowSecurityFields          bool     `envconfig:"ALLOW_LOW_SECURITY_FIELDS" default:"false"`
 	EnableK8sControllers            bool     `envconfig:"ENABLE_K8S_CONTROLLERS" default:"false"`
+	AgentDataFile                   string   `envconfig:"TESTKUBE_AGENT_DATA_FILE" default:""`
 
 	FeatureNewArchitecture  bool `envconfig:"FEATURE_NEW_ARCHITECTURE" default:"false"`
 	FeatureCloudStorage     bool `envconfig:"FEATURE_CLOUD_STORAGE" default:"false"`

--- a/pkg/triggers/event_test.go
+++ b/pkg/triggers/event_test.go
@@ -1,0 +1,144 @@
+package triggers
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestLoadDataFromFile(t *testing.T) {
+	// Test with empty file path
+	t.Run("empty file path", func(t *testing.T) {
+		data, err := loadDataFromFile("")
+		if err != nil {
+			t.Errorf("expected no error for empty path, got: %v", err)
+		}
+		if data != nil {
+			t.Errorf("expected nil data for empty path, got: %v", data)
+		}
+	})
+
+	// Test with non-existent file
+	t.Run("non-existent file", func(t *testing.T) {
+		data, err := loadDataFromFile("/non/existent/file.txt")
+		if err != nil {
+			t.Errorf("expected no error for non-existent file, got: %v", err)
+		}
+		if len(data) != 0 {
+			t.Errorf("expected empty map for non-existent file, got: %v", data)
+		}
+	})
+
+	// Test with valid file
+	t.Run("valid file", func(t *testing.T) {
+		// Create a temporary file
+		tmpDir := t.TempDir()
+		tmpFile := filepath.Join(tmpDir, "test-data.txt")
+
+		content := `# This is a comment
+environment=production
+region=us-west-2
+
+# Another comment
+app_version=1.2.3
+custom_key=custom_value
+`
+		if err := os.WriteFile(tmpFile, []byte(content), 0644); err != nil {
+			t.Fatalf("failed to create test file: %v", err)
+		}
+
+		data, err := loadDataFromFile(tmpFile)
+		if err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+
+		expected := map[string]string{
+			"environment": "production",
+			"region":      "us-west-2",
+			"app_version": "1.2.3",
+			"custom_key":  "custom_value",
+		}
+
+		if len(data) != len(expected) {
+			t.Errorf("expected %d keys, got %d", len(expected), len(data))
+		}
+
+		for key, expectedValue := range expected {
+			if actualValue, exists := data[key]; !exists {
+				t.Errorf("expected key %s not found", key)
+			} else if actualValue != expectedValue {
+				t.Errorf("for key %s: expected %s, got %s", key, expectedValue, actualValue)
+			}
+		}
+	})
+
+	// Test with invalid format
+	t.Run("invalid format", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		tmpFile := filepath.Join(tmpDir, "invalid-data.txt")
+
+		content := `valid_key=valid_value
+invalid_line_without_equals
+another_key=another_value
+`
+		if err := os.WriteFile(tmpFile, []byte(content), 0644); err != nil {
+			t.Fatalf("failed to create test file: %v", err)
+		}
+
+		_, err := loadDataFromFile(tmpFile)
+		if err == nil {
+			t.Error("expected error for invalid format, got nil")
+		}
+	})
+
+	// Test with empty key
+	t.Run("empty key", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		tmpFile := filepath.Join(tmpDir, "empty-key.txt")
+
+		content := `valid_key=valid_value
+=empty_key_value
+`
+		if err := os.WriteFile(tmpFile, []byte(content), 0644); err != nil {
+			t.Fatalf("failed to create test file: %v", err)
+		}
+
+		_, err := loadDataFromFile(tmpFile)
+		if err == nil {
+			t.Error("expected error for empty key, got nil")
+		}
+	})
+
+	// Test with whitespace handling
+	t.Run("whitespace handling", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		tmpFile := filepath.Join(tmpDir, "whitespace-data.txt")
+
+		content := `  key1  =  value1  
+	key2	=	value2	
+key3=value3
+`
+		if err := os.WriteFile(tmpFile, []byte(content), 0644); err != nil {
+			t.Fatalf("failed to create test file: %v", err)
+		}
+
+		data, err := loadDataFromFile(tmpFile)
+		if err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+
+		expected := map[string]string{
+			"key1": "value1",
+			"key2": "value2",
+			"key3": "value3",
+		}
+
+		for key, expectedValue := range expected {
+			if actualValue, exists := data[key]; !exists {
+				t.Errorf("expected key %s not found", key)
+			} else if actualValue != expectedValue {
+				t.Errorf("for key %s: expected %s, got %s", key, expectedValue, actualValue)
+			}
+		}
+	})
+}

--- a/pkg/triggers/executor.go
+++ b/pkg/triggers/executor.go
@@ -276,15 +276,28 @@ func (s *Service) getJsonPathData(e *watcherEvent, value string) (string, error)
 
 func (s *Service) getTemplateData(e *watcherEvent, value string) ([]byte, error) {
 	var tmpl *template.Template
-	tmpl, err := utils.NewTemplate("field").Funcs(template.FuncMap{
-		"agent": func() watcherAgent { return e.Agent },
-	}).Parse(value)
+	tmpl, err := utils.NewTemplate("field").Parse(value)
 	if err != nil {
 		return nil, err
 	}
 
 	var buffer bytes.Buffer
 	if err = tmpl.ExecuteTemplate(&buffer, "field", e.Object); err != nil {
+		return nil, err
+	}
+
+	return buffer.Bytes(), nil
+}
+
+func (s *Service) getTemplateDataFromEvent(e *watcherEvent, value string) ([]byte, error) {
+	var tmpl *template.Template
+	tmpl, err := utils.NewTemplate("field").Parse(value)
+	if err != nil {
+		return nil, err
+	}
+
+	var buffer bytes.Buffer
+	if err = tmpl.ExecuteTemplate(&buffer, "field", e); err != nil {
 		return nil, err
 	}
 
@@ -328,7 +341,7 @@ func (s *Service) mapTargetKubeToGrpcWithEvent(e *watcherEvent, t *testtriggersv
 
 		s.logger.Debugf("trigger service: executor component: trigger %s/%s parsing template %s for %s %s",
 			t.Namespace, t.Name, key, kind, value)
-		data, err := s.getTemplateData(e, value)
+		data, err := s.getTemplateDataFromEvent(e, value)
 		if err != nil {
 			s.logger.Errorf("trigger service: executor component: trigger %s/%s parsing template %s for %s %s error %v",
 				t.Namespace, t.Name, key, value, kind, err)

--- a/pkg/triggers/service.go
+++ b/pkg/triggers/service.go
@@ -223,6 +223,27 @@ func WithTestTriggerControlPlane(enabled bool) Option {
 	}
 }
 
+// WithAgentDataFile sets the path to the agent data file
+func WithAgentDataFile(filePath string) Option {
+	return func(s *Service) {
+		if filePath != "" {
+			data, err := loadDataFromFile(filePath)
+			if err != nil {
+				s.logger.Errorw("failed to load agent data from file", "file", filePath, "error", err)
+				return
+			}
+			if s.Agent.Data == nil {
+				s.Agent.Data = make(map[string]string)
+			}
+			// Merge the loaded data with existing data
+			for k, v := range data {
+				s.Agent.Data[k] = v
+			}
+			s.logger.Debugw("loaded agent data from file", "file", filePath, "keys", len(data))
+		}
+	}
+}
+
 func (s *Service) Run(ctx context.Context) {
 	leaseChan := make(chan bool)
 


### PR DESCRIPTION
## Pull request description 

Allows passing custom agent data to testkube for targeting. Example:

```
  actionParameters:
    target:
      match:
        env:
          - '{{ .Agent.Data.environment}}' # renders production from below configmap
```

Assuming you mount configmap as file like this:
```
   apiVersion: v1
   kind: ConfigMap
   metadata:
     name: agent-data
   data:
     agent-data.txt: |
       # Agent configuration
       environment=production
       region=us-west-2
       cluster_id=prod-cluster-01
       app_version=1.2.3
```

We mount this is a file:
```
   apiVersion: apps/v1
   kind: Deployment
   metadata:
     name: testkube-api-server
   spec:
     template:
       spec:
         containers:
         - name: api-server
           env:
           - name: TESTKUBE_AGENT_DATA_FILE
             value: "/etc/agent-data/agent-data.txt"
           volumeMounts:
           - name: agent-data
             mountPath: /etc/agent-data
         volumes:
         - name: agent-data
           configMap:
             name: agent-data
```

## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [ ] tested locally
- [ ] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Breaking changes

-

## Changes

-

## Fixes

-