### PR TITLE
feat: [TKC-4129] refactor agent installation cli

### DIFF
--- a/cmd/kubectl-testkube/commands/agents/create.go
+++ b/cmd/kubectl-testkube/commands/agents/create.go
@@ -2,44 +2,79 @@ package agents
 
 import (
 	"fmt"
-	"os"
-	"strings"
 
 	"github.com/spf13/cobra"
 
-	"github.com/kubeshop/testkube/cmd/kubectl-testkube/config"
-	"github.com/kubeshop/testkube/internal/common"
-	cloudclient "github.com/kubeshop/testkube/pkg/cloud/client"
 	"github.com/kubeshop/testkube/pkg/ui"
 )
 
 func NewCreateAgentCommand() *cobra.Command {
 	var (
-		agentType      string
 		labelPairs     []string
 		environmentIds []string
+		global         bool
+		group          string
+		floating       bool
+		agentType      string
 	)
 	cmd := &cobra.Command{
 		Use:  "agent",
 		Args: cobra.ExactArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
-			agent := UiCreateAgent(cmd, agentType, args[0], labelPairs, environmentIds, false, "", false)
-			cliType, _ := GetCliAgentType(agent.Type)
+			// Check for deprecated --type flag usage
+			if cmd.Flags().Changed("type") {
+				ui.Warn("⚠️  The --type/-t flag is deprecated.")
+				ui.Info("Please use --runner and/or --listener flags instead:")
+				ui.Info("  --runner    : Enable runner capability")
+				ui.Info("  --listener  : Enable listener capability")
+				ui.Info("  (both flags): Enable both capabilities")
+				ui.NL()
+				return
+			}
+
+			runnerChanged := cmd.Flags().Changed("runner")
+			listenerChanged := cmd.Flags().Changed("listener")
+			anyChanged := runnerChanged || listenerChanged
+			enableRunner, _ := cmd.Flags().GetBool("runner")
+			enableListener, _ := cmd.Flags().GetBool("listener")
+			// we default to both capabilities if none flags are set
+			if !anyChanged {
+				enableRunner = true
+				enableListener = true
+			}
+
+			agent := UiCreateAgent(cmd, args[0], labelPairs, environmentIds, global, group, floating, enableRunner, enableListener)
 			ui.NL()
 			ui.Info("Install the agent with command:")
-			ui.ShellCommand(
-				fmt.Sprintf("kubectl testkube install %s %s --secret %s", cliType, agent.Name, agent.SecretKey),
-			)
+			installCmd := fmt.Sprintf("kubectl testkube install agent %s --secret %s", agent.Name, agent.SecretKey)
+			if enableRunner {
+				installCmd += " --runner"
+			}
+			if enableListener {
+				installCmd += " --listener"
+			}
+			ui.ShellCommand(installCmd)
 		},
 	}
 
-	cmd.Flags().StringVarP(&agentType, "type", "t", "", "agent type, one of: runner, gitops")
 	cmd.Flags().StringSliceVarP(&environmentIds, "env", "e", nil, "environment ID or slug that the agent have access to")
 	cmd.Flags().StringSliceVarP(&labelPairs, "label", "l", nil, "label key value pair: --label key1=value1")
+	cmd.Flags().BoolVar(&global, "global", false, "make it global agent")
+	cmd.Flags().StringVar(&group, "group", "", "make it grouped agent")
+	cmd.Flags().BoolVar(&floating, "floating", false, "create as a floating agent")
+
+	// Components selection
+	cmd.Flags().Bool("runner", false, "enable runner capability (default: enabled when no component flags are set)")
+	cmd.Flags().Bool("listener", false, "enable listener capability (default: enabled when no component flags are set)")
+
+	// Deprecated flag
+	cmd.Flags().StringVarP(&agentType, "type", "t", "", "[DEPRECATED] agent type - use --runner and/or --listener instead")
+	cmd.Flags().MarkDeprecated("type", "use --runner and/or --listener flags instead")
 
 	return cmd
 }
 
+// NewCreateRunnerCommand creates an agent with runner-only capability (no listener).
 func NewCreateRunnerCommand() *cobra.Command {
 	var (
 		labelPairs     []string
@@ -47,150 +82,40 @@ func NewCreateRunnerCommand() *cobra.Command {
 		global         bool
 		group          string
 		floating       bool
+		agentType      string
 	)
+
 	cmd := &cobra.Command{
 		Use:  "runner",
 		Args: cobra.ExactArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
-			agent := UiCreateAgent(cmd, "runner", args[0], labelPairs, environmentIds, global, group, floating)
-			cliType, _ := GetCliAgentType(agent.Type)
+			// Check for deprecated --type flag usage
+			if cmd.Flags().Changed("type") {
+				ui.Warn("⚠️  The --type/-t flag is deprecated.")
+				ui.Info("This command creates a runner-only agent by default.")
+				ui.Info("For more flexibility, use 'kubectl testkube create agent' with:")
+				ui.Info("  --runner    : Enable runner capability")
+				ui.Info("  --listener  : Enable listener capability")
+				ui.NL()
+			}
+
+			agent := UiCreateAgent(cmd, args[0], labelPairs, environmentIds, global, group, floating, true, false)
 			ui.NL()
 			ui.Info("Install the agent with command:")
-			ui.ShellCommand(
-				fmt.Sprintf("kubectl testkube install %s %s --secret %s", cliType, agent.Name, agent.SecretKey),
-			)
+			installCmd := fmt.Sprintf("kubectl testkube install agent %s --secret %s --runner", agent.Name, agent.SecretKey)
+			ui.ShellCommand(installCmd)
 		},
 	}
 
 	cmd.Flags().StringSliceVarP(&environmentIds, "env", "e", nil, "environment ID or slug that the agent have access to")
 	cmd.Flags().StringSliceVarP(&labelPairs, "label", "l", nil, "label key value pair: --label key1=value1")
-	cmd.Flags().BoolVar(&global, "global", false, "make it global runner")
-	cmd.Flags().StringVar(&group, "group", "", "make it grouped runner")
-	cmd.Flags().BoolVar(&floating, "floating", false, "create as a floating runner")
+	cmd.Flags().BoolVar(&global, "global", false, "make it global agent")
+	cmd.Flags().StringVar(&group, "group", "", "make it grouped agent")
+	cmd.Flags().BoolVar(&floating, "floating", false, "create as a floating agent")
+
+	// Deprecated flag
+	cmd.Flags().StringVarP(&agentType, "type", "t", "", "[DEPRECATED] agent type - this command creates runner-only agents")
+	cmd.Flags().MarkDeprecated("type", "this command creates runner-only agents by default")
 
 	return cmd
-}
-
-func NewCreateGitOpsCommand() *cobra.Command {
-	var (
-		labelPairs     []string
-		environmentIds []string
-	)
-	cmd := &cobra.Command{
-		Use:  "gitops",
-		Args: cobra.ExactArgs(1),
-		Run: func(cmd *cobra.Command, args []string) {
-			agent := UiCreateAgent(cmd, "gitops", args[0], labelPairs, environmentIds, false, "", false)
-			cliType, _ := GetCliAgentType(agent.Type)
-			ui.NL()
-			ui.Info("Install the agent with command:")
-			ui.ShellCommand(
-				fmt.Sprintf("kubectl testkube install %s %s --secret %s", cliType, agent.Name, agent.SecretKey),
-			)
-		},
-	}
-
-	cmd.Flags().StringSliceVarP(&environmentIds, "env", "e", nil, "environment ID or slug that the agent have access to")
-	cmd.Flags().StringSliceVarP(&labelPairs, "label", "l", nil, "label key value pair: --label key1=value1")
-
-	return cmd
-}
-
-func UiCreateAgent(cmd *cobra.Command, agentType string, name string, labelPairs []string, environmentIds []string, isGlobalRunner bool, runnerGroup string, floating bool) *cloudclient.Agent {
-	if name == "" {
-		name = ui.TextInput("agent name")
-		if name == "" {
-			ui.Failf("agent name is required")
-		}
-	}
-
-	// Get existing agent of that name
-	if existing, err := GetControlPlaneAgent(cmd, name); err == nil {
-		ui.Failf("agent '%s' already exists", existing.Name)
-	}
-
-	if agentType == "" {
-		agentType = ui.Select("select type", []string{
-			"runner",
-			"gitops",
-		})
-		if name == "" {
-			ui.Failf("agent type is required")
-		}
-	}
-
-	input := cloudclient.AgentInput{
-		Name:         name,
-		Labels:       common.Ptr(make(map[string]string)),
-		Environments: environmentIds,
-		Floating:     floating,
-	}
-
-	if runnerGroup != "" {
-		(*input.Labels)["group"] = runnerGroup
-		input.RunnerPolicy = &cloudclient.RunnerPolicy{
-			RequiredMatch: []string{"group"},
-		}
-	} else if !isGlobalRunner {
-		input.RunnerPolicy = &cloudclient.RunnerPolicy{
-			RequiredMatch: []string{"name"},
-		}
-	}
-
-	input.Type, _ = GetInternalAgentType(agentType)
-
-	for _, label := range labelPairs {
-		k, v, _ := strings.Cut(label, "=")
-		(*input.Labels)[k] = v
-	}
-
-	envs, err := GetControlPlaneEnvironments(cmd)
-	ui.ExitOnError("getting environments", err)
-
-	if len(input.Environments) == 0 {
-		cfg, err := config.Load()
-		ui.ExitOnError("loading config", err)
-		envOpts := []string{envs[cfg.CloudContext.EnvironmentId].Slug}
-		for id := range envs {
-			if id != cfg.CloudContext.EnvironmentId {
-				envOpts = append(envOpts, id)
-			}
-		}
-		input.Environments = []string{ui.Select("select environment", envOpts)}
-	}
-
-	for i, envId := range input.Environments {
-		_, ok := envs[envId]
-		if !ok {
-			for _, env := range envs {
-				if env.Slug == envId {
-					input.Environments[i] = env.Id
-					break
-				}
-			}
-		}
-	}
-
-	// Validate if the environments have the next architecture enabled
-	for _, envId := range input.Environments {
-		env, ok := envs[envId]
-		if !ok {
-			ui.Failf("unknown environment: %s", envId)
-		}
-		if !env.NewArchitecture {
-			ui.Warn(fmt.Sprintf("Environment '%s' (%s) does not support new architecture.", env.Name, env.Id))
-			if !ui.Confirm("do you want to enable it?") {
-				os.Exit(1)
-			}
-			err := EnableNewArchitecture(cmd, env)
-			ui.ExitOnError("enabling new architecture", err)
-		}
-	}
-
-	agent, err := CreateAgent(cmd, input)
-	ui.ExitOnError("creating agent", err)
-
-	PrintControlPlaneAgent(*agent)
-
-	return agent
 }

--- a/cmd/kubectl-testkube/commands/agents/delete.go
+++ b/cmd/kubectl-testkube/commands/agents/delete.go
@@ -17,9 +17,8 @@ func NewDeleteAgentCommand() *cobra.Command {
 		deleteAgent, noDeleteAgent bool
 	)
 	cmd := &cobra.Command{
-		Use:     "agent",
-		Aliases: []string{"runner", "gitops"},
-		Args:    cobra.ExactArgs(1),
+		Use:  "agent",
+		Args: cobra.ExactArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
 			if !uninstall && !noUninstall {
 				uninstall = ui.Confirm("should it uninstall agent?")

--- a/cmd/kubectl-testkube/commands/agents/get.go
+++ b/cmd/kubectl-testkube/commands/agents/get.go
@@ -20,51 +20,7 @@ func NewGetAgentCommand() *cobra.Command {
 		Aliases: []string{"agents", "a"},
 		Run: func(cmd *cobra.Command, args []string) {
 			if len(args) == 0 {
-				UiListAgents(cmd, "")
-			} else {
-				UiGetAgent(cmd, args[0], decryptSecretKey)
-			}
-		},
-	}
-
-	cmd.Flags().BoolVar(&decryptSecretKey, "decrypted-secret", false, "should it fetch decrypted secret key")
-
-	return cmd
-}
-
-func NewGetRunnerCommand() *cobra.Command {
-	var (
-		decryptSecretKey bool
-	)
-	cmd := &cobra.Command{
-		Args:    cobra.MaximumNArgs(1),
-		Use:     "runner [name]",
-		Aliases: []string{"runners"},
-		Run: func(cmd *cobra.Command, args []string) {
-			if len(args) == 0 {
-				UiListAgents(cmd, "runner")
-			} else {
-				UiGetAgent(cmd, args[0], decryptSecretKey)
-			}
-		},
-	}
-
-	cmd.Flags().BoolVar(&decryptSecretKey, "decrypted-secret", false, "should it fetch decrypted secret key")
-
-	return cmd
-}
-
-func NewGetGitOpsCommand() *cobra.Command {
-	var (
-		decryptSecretKey bool
-	)
-	cmd := &cobra.Command{
-		Args:    cobra.MaximumNArgs(1),
-		Use:     "gitops [name]",
-		Aliases: []string{},
-		Run: func(cmd *cobra.Command, args []string) {
-			if len(args) == 0 {
-				UiListAgents(cmd, "gitops")
+				UiListAgents(cmd)
 			} else {
 				UiGetAgent(cmd, args[0], decryptSecretKey)
 			}
@@ -77,7 +33,7 @@ func NewGetGitOpsCommand() *cobra.Command {
 }
 
 func UiGetAgent(cmd *cobra.Command, agentId string, decryptSecretKey bool) {
-	registeredAgents, err := GetControlPlaneAgents(cmd, "", true)
+	registeredAgents, err := GetControlPlaneAgents(cmd, true)
 	ui.ExitOnError("getting agents", err)
 
 	namespaces, err := GetKubernetesNamespaces()
@@ -108,10 +64,8 @@ func UiGetAgent(cmd *cobra.Command, agentId string, decryptSecretKey bool) {
 	PrintControlPlaneAgent(*agent.Registered)
 }
 
-func UiListAgents(cmd *cobra.Command, agentType string) {
-	agentType, _ = GetInternalAgentType(agentType)
-
-	registeredAgents, err := GetControlPlaneAgents(cmd, "", false)
+func UiListAgents(cmd *cobra.Command) {
+	registeredAgents, err := GetControlPlaneAgents(cmd, false)
 	ui.ExitOnError("getting agents", err)
 
 	agents, err := GetKubernetesAgents([]string{""})
@@ -121,9 +75,6 @@ func UiListAgents(cmd *cobra.Command, agentType string) {
 
 	var recognizedAgents, externalAgents, unknownAgents internalAgents
 	for i := range agents {
-		if agentType != "" && agents[i].Registered != nil && agents[i].Registered.Type != agentType {
-			continue
-		}
 		if agents[i].Registered != nil && agents[i].Pod.Name != "" {
 			recognizedAgents = append(recognizedAgents, agents[i])
 		} else if agents[i].Registered != nil {

--- a/cmd/kubectl-testkube/commands/agents/update.go
+++ b/cmd/kubectl-testkube/commands/agents/update.go
@@ -17,9 +17,8 @@ func NewUpdateAgentCommand() *cobra.Command {
 	)
 
 	cmd := &cobra.Command{
-		Use:     "agent <name>",
-		Aliases: []string{"runner", "gitops"},
-		Args:    cobra.ExactArgs(1),
+		Use:  "agent <name>",
+		Args: cobra.ExactArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
 			UiUpdateAgent(cmd, strings.Join(args, ""), setLabels, deleteLabels)
 		},

--- a/cmd/kubectl-testkube/commands/agents/utils.go
+++ b/cmd/kubectl-testkube/commands/agents/utils.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"io"
 	"maps"
+	"os"
 	"strings"
 	"time"
 
@@ -43,51 +44,17 @@ type internalAgent struct {
 	Registered *cloudclient.Agent
 }
 
-var agentLabelMap = map[string]string{
-	"run":  "Runner",
-	"sync": "GitOps",
-	"agnt": "SuperAgent",
-}
-
-var agentKnownTypeMap = map[string]string{
-	"gitops":     "sync",
-	"runner":     "run",
-	"superagent": "agnt",
-}
-
-func GetInternalAgentType(name string) (string, error) {
-	name = strings.ToLower(name)
-	for k, v := range agentKnownTypeMap {
-		if v == name || k == name {
-			return v, nil
-		}
-	}
-	return name, errors.New("unknown agent type")
-}
-
-func GetCliAgentType(internalType string) (string, error) {
-	internalType = strings.ToLower(internalType)
-	for k, v := range agentKnownTypeMap {
-		if v == internalType || k == internalType {
-			return k, nil
-		}
-	}
-	return internalType, errors.New("unknown agent type")
-}
-
 type internalAgents []internalAgent
 
 func (list internalAgents) Table() (header []string, output [][]string) {
-	header = []string{"Type", "Name", "Version", "Namespace", "Environments", "Labels"}
+	header = []string{"Name", "Version", "Namespace", "Environments", "Labels"}
 	for _, e := range list {
-		agentType := "-"
 		agentVersion := "-"
 		agentName := e.AgentID.Value
 		agentEnvironments := "-"
 		agentLabels := "-"
 		namespace := e.Pod.Namespace
 		if e.Registered != nil {
-			agentType = e.Registered.Type
 			agentName = e.Registered.Name
 			agentVersion = e.Registered.Version
 			agentEnvironments = strings.Join(common.MapSlice(e.Registered.Environments, func(t cloudclient.AgentEnvironment) string {
@@ -102,9 +69,6 @@ func (list internalAgents) Table() (header []string, output [][]string) {
 			}
 			agentLabels = strings.Join(agentLabelsEntries, " ")
 		}
-		if agentLabelMap[agentType] != "" {
-			agentType = agentLabelMap[agentType]
-		}
 		if e.Detected {
 			if e.Ready {
 				namespace = fmt.Sprintf("%s:%s", ui.Green("•"), namespace)
@@ -115,7 +79,6 @@ func (list internalAgents) Table() (header []string, output [][]string) {
 			namespace = e.Registered.Namespace
 		}
 		output = append(output, []string{
-			agentType,
 			agentName,
 			agentVersion,
 			namespace,
@@ -181,8 +144,7 @@ func EnableNewArchitecture(cmd *cobra.Command, env cloudclient.Environment) erro
 	return common2.EnableNewArchitecture(cfg.CloudContext.ApiUri, cfg.CloudContext.ApiKey, cfg.CloudContext.OrganizationId, env)
 }
 
-func GetControlPlaneAgents(cmd *cobra.Command, agentType string, includeDeleted bool) ([]cloudclient.Agent, error) {
-	agentType, _ = GetInternalAgentType(agentType)
+func GetControlPlaneAgents(cmd *cobra.Command, includeDeleted bool) ([]cloudclient.Agent, error) {
 	_, _, err := common2.GetClient(cmd)
 	if err != nil {
 		return nil, errors.Wrap(err, "connecting to cloud")
@@ -195,7 +157,7 @@ func GetControlPlaneAgents(cmd *cobra.Command, agentType string, includeDeleted 
 		return nil, errors.New("no api key found in config")
 	}
 
-	registeredAgents, err := common2.GetAgents(cfg.CloudContext.ApiUri, cfg.CloudContext.ApiKey, cfg.CloudContext.OrganizationId, agentType, includeDeleted)
+	registeredAgents, err := common2.GetAgents(cfg.CloudContext.ApiUri, cfg.CloudContext.ApiKey, cfg.CloudContext.OrganizationId, "run", includeDeleted)
 	if err != nil {
 		return nil, errors.Wrap(err, "getting agents")
 	}
@@ -430,19 +392,15 @@ func CreateHelmOptions(
 		"minio.enabled":   false,
 		"enableK8sEvents": false,
 
-		// Enable GitOps runner
-		"multinamespace.enabled":              true, // TODO: Make its behavior default on next.enabled?
-		"next.enabled":                        true,
-		"next.cloudStorage":                   true,
-		"next.gitops.syncCloudToKubernetes":   false,
-		"next.gitops.syncKubernetesToCloud":   false,
-		"next.gitops.namePatterns.cloud":      false,
-		"next.gitops.namePatterns.kubernetes": false,
-		"next.legacyAgent.enabled":            false,
-		"next.webhooks.enabled":               false,
-		"next.testTriggers.enabled":           false,
-		"next.runner.enabled":                 false,
-		"next.legacyTests.enabled":            false,
+		// Enable runner
+		"multinamespace.enabled":    true, // TODO: Make its behavior default on next.enabled?
+		"next.enabled":              true,
+		"next.cloudStorage":         true,
+		"next.legacyAgent.enabled":  false,
+		"next.webhooks.enabled":     false,
+		"next.testTriggers.enabled": false,
+		"next.runner.enabled":       false,
+		"next.legacyTests.enabled":  false,
 	}
 	maps.Copy(values, additionalValues)
 	if version != "" {
@@ -522,23 +480,12 @@ func CreateCRDsHelmOptions(
 }
 
 func PrintControlPlaneAgent(agent cloudclient.Agent) {
-	agentTypeLabel := agent.Type
-	if agentLabelMap[agentTypeLabel] != "" {
-		agentTypeLabel = agentLabelMap[agentTypeLabel]
-	}
 	agentSecretKey := agent.SecretKey
 	if agent.SecretKey == "" {
 		agentSecretKey = ui.LightGray("<encrypted>")
 	}
 	ui.Warn("ID:            ", agent.ID)
 	ui.Warn("Name:          ", agent.Name)
-	if agent.Type == "run" && agent.Floating {
-		ui.Warn("Type:          ", agentTypeLabel+" (floating)")
-	} else if agent.Type == "run" && !agent.Floating {
-		ui.Warn("Type:          ", agentTypeLabel+" (reserved)")
-	} else {
-		ui.Warn("Type:          ", agentTypeLabel)
-	}
 	ui.Warn("Created:       ", agent.CreatedAt.In(time.Local).Format(time.RFC822Z)+" "+ui.LightGray("("+time.Since(agent.CreatedAt).Truncate(time.Second).String()+")"))
 	if agent.DeletedAt != nil {
 		ui.Warn(ui.Red("Deleted:       "), agent.DeletedAt.In(time.Local).Format(time.RFC822Z)+" "+ui.LightGray("("+time.Since(*agent.DeletedAt).Truncate(time.Second).String()+")"))
@@ -556,7 +503,7 @@ func PrintControlPlaneAgent(agent cloudclient.Agent) {
 	}
 
 	if agent.DeletedAt != nil {
-		fmt.Println("\n" + color.Bold.Render(color.Red.Render("These details are historical. The Agent has been deleted.")) + "\n")
+		fmt.Println("\n" + color.Bold.Render(color.Red.Render("These details are historical. The Runner has been deleted.")) + "\n")
 	}
 
 	ui.Warn("Last Version:  ", agent.Version)
@@ -586,6 +533,102 @@ func PrintControlPlaneAgent(agent cloudclient.Agent) {
 		ui.Warn("Policy:")
 		ui.Warn("   Required Matching Labels:", strings.Join(agent.RunnerPolicy.RequiredMatch, ", "))
 	}
+}
+
+func UiCreateAgent(cmd *cobra.Command, name string, labelPairs []string, environmentIds []string, isGlobalRunner bool, runnerGroup string, floating bool, enableRunner bool, enableListener bool) *cloudclient.Agent {
+	if name == "" {
+		name = ui.TextInput("agent name")
+		if name == "" {
+			ui.Failf("agent name is required")
+		}
+	}
+
+	// Get existing agent of that name
+	if existing, err := GetControlPlaneAgent(cmd, name); err == nil {
+		ui.Failf("agent '%s' already exists", existing.Name)
+	}
+
+	input := cloudclient.AgentInput{
+		Name:         name,
+		Labels:       common.Ptr(make(map[string]string)),
+		Environments: environmentIds,
+		Floating:     floating,
+		Type:         "run",
+	}
+
+	// Set capabilities based on resolved flags
+	if enableRunner {
+		input.Capabilities = append(input.Capabilities, cloudclient.AgentCapabilityRunner)
+	}
+	if enableListener {
+		input.Capabilities = append(input.Capabilities, cloudclient.AgentCapabilityListener)
+	}
+
+	if runnerGroup != "" {
+		(*input.Labels)["group"] = runnerGroup
+		input.RunnerPolicy = &cloudclient.RunnerPolicy{
+			RequiredMatch: []string{"group"},
+		}
+	} else if !isGlobalRunner {
+		input.RunnerPolicy = &cloudclient.RunnerPolicy{
+			RequiredMatch: []string{"name"},
+		}
+	}
+
+	for _, label := range labelPairs {
+		k, v, _ := strings.Cut(label, "=")
+		(*input.Labels)[k] = v
+	}
+
+	envs, err := GetControlPlaneEnvironments(cmd)
+	ui.ExitOnError("getting environments", err)
+
+	if len(input.Environments) == 0 {
+		cfg, err := config.Load()
+		ui.ExitOnError("loading config", err)
+		envOpts := []string{envs[cfg.CloudContext.EnvironmentId].Slug}
+		for id := range envs {
+			if id != cfg.CloudContext.EnvironmentId {
+				envOpts = append(envOpts, id)
+			}
+		}
+		input.Environments = []string{ui.Select("select environment", envOpts)}
+	}
+
+	for i, envId := range input.Environments {
+		_, ok := envs[envId]
+		if !ok {
+			for _, env := range envs {
+				if env.Slug == envId {
+					input.Environments[i] = env.Id
+					break
+				}
+			}
+		}
+	}
+
+	// Validate if the environments have the next architecture enabled
+	for _, envId := range input.Environments {
+		env, ok := envs[envId]
+		if !ok {
+			ui.Failf("unknown environment: %s", envId)
+		}
+		if !env.NewArchitecture {
+			ui.Warn(fmt.Sprintf("Environment '%s' (%s) does not support new architecture.", env.Name, env.Id))
+			if !ui.Confirm("do you want to enable it?") {
+				os.Exit(1)
+			}
+			err := EnableNewArchitecture(cmd, env)
+			ui.ExitOnError("enabling new architecture", err)
+		}
+	}
+
+	agent, err := CreateAgent(cmd, input)
+	ui.ExitOnError("creating agent", err)
+
+	PrintControlPlaneAgent(*agent)
+
+	return agent
 }
 
 func PrintKubernetesAgent(agent internalAgent) {

--- a/cmd/kubectl-testkube/commands/create.go
+++ b/cmd/kubectl-testkube/commands/create.go
@@ -52,7 +52,6 @@ func NewCreateCmd() *cobra.Command {
 	cmd.AddCommand(testworkflowtemplates.NewCreateTestWorkflowTemplateCmd())
 	cmd.AddCommand(agents.NewCreateAgentCommand())
 	cmd.AddCommand(agents.NewCreateRunnerCommand())
-	cmd.AddCommand(agents.NewCreateGitOpsCommand())
 
 	cmd.PersistentFlags().BoolVar(&crdOnly, "crd-only", false, "generate only crd")
 

--- a/cmd/kubectl-testkube/commands/get.go
+++ b/cmd/kubectl-testkube/commands/get.go
@@ -57,8 +57,6 @@ func NewGetCmd() *cobra.Command {
 	cmd.AddCommand(testworkflows.NewGetTestWorkflowExecutionsCmd())
 	cmd.AddCommand(testworkflowtemplates.NewGetTestWorkflowTemplatesCmd())
 	cmd.AddCommand(agents.NewGetAgentCommand())
-	cmd.AddCommand(agents.NewGetRunnerCommand())
-	cmd.AddCommand(agents.NewGetGitOpsCommand())
 
 	cmd.PersistentFlags().StringP("output", "o", "pretty", "output type can be one of json|yaml|pretty|go")
 	cmd.PersistentFlags().StringP("go-template", "", "{{.}}", "go template to render")

--- a/cmd/kubectl-testkube/commands/install.go
+++ b/cmd/kubectl-testkube/commands/install.go
@@ -17,7 +17,6 @@ func NewInstallCmd() *cobra.Command {
 
 	cmd.AddCommand(agents.NewInstallAgentCommand())
 	cmd.AddCommand(agents.NewInstallRunnerCommand())
-	cmd.AddCommand(agents.NewInstallGitOpsCommand())
 	cmd.AddCommand(agents.NewInstallCRDCommand())
 
 	return cmd

--- a/pkg/cloud/client/agents.go
+++ b/pkg/cloud/client/agents.go
@@ -35,7 +35,16 @@ type AgentInput struct {
 	Environments []string           `json:"environments,omitempty"`
 	RunnerPolicy *RunnerPolicy      `json:"runnerPolicy,omitempty"`
 	Floating     bool               `json:"floating,omitempty"`
+	Capabilities []AgentCapability  `json:"capabilities"`
 }
+
+type AgentCapability string
+
+const (
+	AgentCapabilityRunner   AgentCapability = "runner"
+	AgentCapabilityListener AgentCapability = "listener"
+	AgentCapabilityGitops   AgentCapability = "gitops"
+)
 
 type RunnerPolicy struct {
 	RequiredMatch []string `json:"requiredMatch,omitempty"`
@@ -54,6 +63,7 @@ type Agent struct {
 	Type         string             `json:"type"`
 	Labels       map[string]string  `json:"labels"`
 	Environments []AgentEnvironment `json:"environments"`
+	Capabilities []AgentCapability  `json:"capabilities,omitempty"`
 	AccessedAt   *time.Time         `json:"accessedAt,omitempty"`
 	DeletedAt    *time.Time         `json:"deletedAt,omitempty"`
 	CreatedAt    time.Time          `json:"createdAt"`
@@ -105,6 +115,7 @@ func (c AgentsClient) CreateRunner(envId string, name string, labels map[string]
 		Type:         AgentRunnerType,
 		Labels:       common.Ptr(labels),
 		Floating:     floating,
+		Capabilities: []AgentCapability{AgentCapabilityRunner},
 	}
 	return c.RESTClient.Create(agent)
 }
@@ -115,6 +126,7 @@ func (c AgentsClient) CreateGitOpsAgent(envId string, name string, labels map[st
 		Name:         name,
 		Type:         AgentGitOpsType,
 		Labels:       common.Ptr(labels),
+		Capabilities: []AgentCapability{AgentCapabilityGitops},
 	}
 	return c.RESTClient.Create(agent)
 }


### PR DESCRIPTION
## Pull request description 

Refactor cli commands to use new capabilities instead of agentTypes. Main idea:

testkube install agent --runner --listener

Added a bunch of fallbacks like:

testkube install runner, which is testkube install agent --runner


## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [ ] tested locally
- [ ] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Breaking changes

-

## Changes

-

## Fixes

-