### PR TITLE
feat: MCP wait_for_executions tool

### DIFF
--- a/pkg/mcp/api.go
+++ b/pkg/mcp/api.go
@@ -554,6 +554,7 @@ func (c *APIClient) WaitForExecutions(ctx context.Context, executionIds []string
 	// Polling loop
 	ticker := time.Tick(5 * time.Second) // Check every 5 seconds
 
+	// TODO: improve inner loop / polling logic in line with suggestion at https://github.com/kubeshop/testkube/pull/6706#discussion_r2381356579
 	for {
 		select {
 		case <-ctx.Done():

--- a/pkg/mcp/api.go
+++ b/pkg/mcp/api.go
@@ -546,7 +546,7 @@ func (c *APIClient) GetWorkflowMetrics(ctx context.Context, workflowName string)
 	})
 }
 
-func (c *APIClient) WaitForExecutions(ctx context.Context, executionIds []string, timeoutMinutes int) (string, error) {
+func (c *APIClient) WaitForExecutions(ctx context.Context, executionIds []string) (string, error) {
 	// Track completed executions to avoid re-checking them
 	completedExecutions := make(map[string]bool)
 	allResults := make(map[string]map[string]interface{})

--- a/pkg/mcp/api.go
+++ b/pkg/mcp/api.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/kubeshop/testkube/pkg/api/v1/testkube"
 	"github.com/kubeshop/testkube/pkg/mcp/tools"
 )
 
@@ -582,7 +583,12 @@ func (c *APIClient) checkExecutionStatuses(ctx context.Context, executionIds []s
 	var allComplete = true
 
 	// Final status values that indicate execution has completed
-	finalStatuses := []string{"passed", "failed", "aborted", "timeout", "skipped", "canceled"}
+	finalStatuses := []string{
+		string(testkube.PASSED_TestWorkflowStatus),
+		string(testkube.FAILED_TestWorkflowStatus),
+		string(testkube.ABORTED_TestWorkflowStatus),
+		string(testkube.CANCELED_TestWorkflowStatus),
+	}
 
 	// Only check executions that haven't completed yet
 	var remainingExecutions []string

--- a/pkg/mcp/client.go
+++ b/pkg/mcp/client.go
@@ -10,6 +10,7 @@ type Client interface {
 	tools.ExecutionLister
 	tools.ExecutionInfoGetter
 	tools.ExecutionLookup
+	tools.ExecutionWaiter
 	tools.WorkflowExecutionAborter
 
 	tools.LabelsLister

--- a/pkg/mcp/server.go
+++ b/pkg/mcp/server.go
@@ -56,6 +56,7 @@ func NewMCPServer(cfg MCPServerConfig, client Client) (*server.MCPServer, error)
 	mcpServer.AddTool(tools.ListExecutions(client))
 	mcpServer.AddTool(tools.LookupExecutionId(client))
 	mcpServer.AddTool(tools.GetExecutionInfo(client))
+	mcpServer.AddTool(tools.WaitForExecutions(client))
 	mcpServer.AddTool(tools.AbortWorkflowExecution(client))
 
 	// Artifact tools

--- a/pkg/mcp/tools/descriptions.go
+++ b/pkg/mcp/tools/descriptions.go
@@ -44,7 +44,12 @@ to find items containing all terms`
 	ListExecutionsDescription         = "List executions for a specific test workflow with filtering and pagination options. Returns execution summaries with status, timing, and results."
 	GetExecutionInfoDescription       = "Get detailed information about a specific test workflow execution, including status, timing, results, and configuration."
 	LookupExecutionIdDescription      = "Resolves an execution name to its corresponding execution ID. Use this tool when you have an execution name (e.g., 'my-workflow-123', 'my-test-987-1') but need the execution ID. Many other tools require execution IDs (MongoDB format) rather than names."
+	WaitForExecutionsDescription      = "Wait for a list of workflow executions to complete (pass, fail, or timeout). Returns the final status of all executions. Useful for synchronizing multiple test runs or waiting for dependent workflows to finish."
 	AbortWorkflowExecutionDescription = "Abort a running test workflow execution. This will stop the execution and mark it as aborted. Use this tool to cancel long-running or stuck workflow executions."
+
+	// Additional parameter descriptions
+	ExecutionIdsDescription   = "Comma-separated list of execution IDs to wait for (e.g., 'exec1,exec2,exec3')."
+	TimeoutMinutesDescription = "Maximum time to wait in minutes before timing out (default: 30). Set to 0 for no timeout."
 
 	// Artifact tool descriptions
 	ListArtifactsDescription = "Retrieves all artifacts generated during a workflow execution. Use this tool to discover available outputs, reports, logs, or other files produced by test runs. These artifacts provide valuable context for understanding test results, accessing detailed reports, or examining generated data. The response includes artifact names, sizes, and their current status."

--- a/pkg/mcp/tools/executions.go
+++ b/pkg/mcp/tools/executions.go
@@ -259,7 +259,7 @@ func AbortWorkflowExecution(client WorkflowExecutionAborter) (tool mcp.Tool, han
 }
 
 type ExecutionWaiter interface {
-	WaitForExecutions(ctx context.Context, executionIds []string, timeoutMinutes int) (string, error)
+	WaitForExecutions(ctx context.Context, executionIds []string) (string, error)
 }
 
 func WaitForExecutions(client ExecutionWaiter) (tool mcp.Tool, handler server.ToolHandlerFunc) {
@@ -295,7 +295,7 @@ func WaitForExecutions(client ExecutionWaiter) (tool mcp.Tool, handler server.To
 			defer cancel()
 		}
 
-		result, err := client.WaitForExecutions(ctx, executionIds, timeoutMinutes)
+		result, err := client.WaitForExecutions(ctx, executionIds)
 		if err != nil {
 			return mcp.NewToolResultError(fmt.Sprintf("Failed to wait for executions: %v", err)), nil
 		}

--- a/pkg/mcp/tools/executions.go
+++ b/pkg/mcp/tools/executions.go
@@ -7,6 +7,7 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
@@ -285,6 +286,13 @@ func WaitForExecutions(client ExecutionWaiter) (tool mcp.Tool, handler server.To
 			if timeout, err := strconv.Atoi(timeoutStr); err == nil && timeout > 0 {
 				timeoutMinutes = timeout
 			}
+		}
+
+		// Create a context with timeout
+		if timeoutMinutes > 0 {
+			var cancel context.CancelFunc
+			ctx, cancel = context.WithTimeout(ctx, time.Duration(timeoutMinutes)*time.Minute)
+			defer cancel()
 		}
 
 		result, err := client.WaitForExecutions(ctx, executionIds, timeoutMinutes)


### PR DESCRIPTION
## Pull request description 

Adds a "wait_for_executions" tool to the MCP server that waits for the specified executions to finish, helpful when launching multiple executions and wanting the agent/llm to wait 

## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [x] tested locally
- [ ] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Breaking changes

-

## Changes

-

## Fixes

-