### PR TITLE
fix: fixed MCP tool telemetry to send org/envid when running in env-mode

### DIFF
--- a/pkg/mcp/server.go
+++ b/pkg/mcp/server.go
@@ -24,7 +24,7 @@ func NewMCPServer(cfg MCPServerConfig, client Client) (*server.MCPServer, error)
 		cfg.Version,
 		server.WithToolCapabilities(true),
 		server.WithToolHandlerMiddleware(DebugMiddleware(cfg.Debug)),
-		server.WithToolHandlerMiddleware(TelemetryMiddleware(cfg.TelemetryEnabled)),
+		server.WithToolHandlerMiddleware(TelemetryMiddleware(&cfg)),
 	)
 
 	// If no client is provided, use the default API client

--- a/pkg/telemetry/mcp.go
+++ b/pkg/telemetry/mcp.go
@@ -7,14 +7,14 @@ import (
 	"github.com/kubeshop/testkube/pkg/utils/text"
 )
 
-// SendMCPToolEvent sends telemetry for MCP tool execution
-func SendMCPToolEvent(toolName string, duration time.Duration, hasError bool, version string) (string, error) {
-	payload := NewMCPToolPayload(toolName, "testkube_mcp_tool_execution", duration, version, hasError)
+// SendMCPToolEventWithContext sends telemetry for MCP tool execution with explicit context
+func SendMCPToolEventWithContext(toolName string, duration time.Duration, hasError bool, version string, runContext RunContext) (string, error) {
+	payload := NewMCPToolPayloadWithContext(toolName, "testkube_mcp_tool_execution", duration, version, hasError, runContext)
 	return sendData(senders, payload)
 }
 
-// NewMCPToolPayload creates a payload for MCP tool telemetry events
-func NewMCPToolPayload(toolName, eventName string, duration time.Duration, version string, hasError bool) Payload {
+// NewMCPToolPayloadWithContext creates a payload for MCP tool telemetry events with custom context
+func NewMCPToolPayloadWithContext(toolName, eventName string, duration time.Duration, version string, hasError bool, runContext RunContext) Payload {
 	machineID := GetMachineID()
 	return Payload{
 		ClientID: machineID,
@@ -29,7 +29,7 @@ func NewMCPToolPayload(toolName, eventName string, duration time.Duration, versi
 				MachineID:       machineID,
 				OperatingSystem: runtime.GOOS,
 				Architecture:    runtime.GOARCH,
-				Context:         getCurrentContext(),
+				Context:         runContext, // Use the provided context instead of getCurrentContext()
 				ClusterType:     GetClusterType(),
 				Status: func() string {
 					if hasError {

--- a/pkg/telemetry/telemetry.go
+++ b/pkg/telemetry/telemetry.go
@@ -202,6 +202,11 @@ func getCurrentContext() RunContext {
 	}
 }
 
+// GetCurrentContext returns the current run context, making it accessible from other packages
+func GetCurrentContext() RunContext {
+	return getCurrentContext()
+}
+
 func getUserID(cmd *cobra.Command) string {
 	id := "command-cli-user"
 	client, _, err := common.GetClient(cmd)


### PR DESCRIPTION
- Changed TelemetryMiddleware to accept MCPServerConfig instead of a boolean flag for telemetry enabling.
- Enhanced telemetry event sending to include context based on MCP configuration (organization and environment IDs).
- Updated telemetry payload creation to support custom context for better tracking of tool execution.

## Pull request description 



## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [x] tested locally
- [ ] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Breaking changes

-

## Changes

-

## Fixes

-