### PR TITLE
feat: add --ignore-not-found flag for delete command

### DIFF
--- a/cmd/kubectl-testkube/commands/delete.go
+++ b/cmd/kubectl-testkube/commands/delete.go
@@ -34,6 +34,7 @@ func NewDeleteCmd() *cobra.Command {
 
 	cmd.PersistentFlags().StringVarP(&client, "client", "c", "proxy", "Client used for connecting to testkube API one of proxy|direct|cluster")
 	cmd.PersistentFlags().BoolVarP(&verbose, "verbose", "", false, "should I show additional debug messages")
+	cmd.PersistentFlags().Bool("ignore-not-found", false, "ignore 'not found' errors and non-zero exit code if the specified resource does not exist")
 
 	cmd.AddCommand(webhooks.NewDeleteWebhookCmd())
 	cmd.AddCommand(webhooktemplates.NewDeleteWebhookTemplateCmd())

--- a/cmd/kubectl-testkube/commands/testworkflows/delete.go
+++ b/cmd/kubectl-testkube/commands/testworkflows/delete.go
@@ -1,7 +1,6 @@
 package testworkflows
 
 import (
-	"fmt"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -30,7 +29,6 @@ func NewDeleteTestWorkflowCmd() *cobra.Command {
 				if len(selectors) > 0 {
 					selector := strings.Join(selectors, ",")
 					err = client.DeleteTestWorkflows(selector)
-					fmt.Println("error is", err)
 					if ignoreNotFound && apiutils.IsNotFound(err) {
 						ui.Info("Testworkflow not found for matching selector '" + selector + "', but ignoring since --ignore-not-found was passed")
 						ui.SuccessAndExit("Operation completed")

--- a/cmd/kubectl-testkube/commands/testworkflowtemplates/delete.go
+++ b/cmd/kubectl-testkube/commands/testworkflowtemplates/delete.go
@@ -6,6 +6,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/kubeshop/testkube/cmd/kubectl-testkube/commands/common"
+	"github.com/kubeshop/testkube/internal/app/api/apiutils"
 	"github.com/kubeshop/testkube/pkg/ui"
 )
 
@@ -18,8 +19,8 @@ func NewDeleteTestWorkflowTemplateCmd() *cobra.Command {
 		Aliases: []string{"testworkflowtemplates", "twt"},
 		Args:    cobra.MaximumNArgs(1),
 		Short:   "Delete test workflow templates",
-
 		Run: func(cmd *cobra.Command, args []string) {
+			ignoreNotFound, _ := cmd.Flags().GetBool("ignore-not-found")
 			namespace := cmd.Flag("namespace").Value.String()
 			client, _, err := common.GetClient(cmd)
 			ui.ExitOnError("getting client", err)
@@ -28,6 +29,10 @@ func NewDeleteTestWorkflowTemplateCmd() *cobra.Command {
 				if len(selectors) > 0 {
 					selector := strings.Join(selectors, ",")
 					err = client.DeleteTestWorkflowTemplates(selector)
+					if ignoreNotFound && apiutils.IsNotFound(err) {
+						ui.Info("Testworkflowtemplates not found for matching selector '" + selector + "', but ignoring since --ignore-not-found was passed")
+						ui.SuccessAndExit("Operation completed")
+					}
 					ui.ExitOnError("deleting test workflow templates by labels: "+selector, err)
 					ui.SuccessAndExit("Successfully deleted test workflow templates by labels", selector)
 				} else if deleteAll {
@@ -42,6 +47,10 @@ func NewDeleteTestWorkflowTemplateCmd() *cobra.Command {
 
 			name := args[0]
 			err = client.DeleteTestWorkflowTemplate(name)
+			if ignoreNotFound && apiutils.IsNotFound(err) {
+				ui.Info("Testworkflowtemplate '" + name + "' not found, but ignoring since --ignore-not-found was passed")
+				ui.SuccessAndExit("Operation completed")
+			}
 			ui.ExitOnError("delete test workflow template "+name+" from namespace "+namespace, err)
 			ui.SuccessAndExit("Successfully deleted test workflow template", name)
 		},

--- a/cmd/kubectl-testkube/commands/webhooks/delete.go
+++ b/cmd/kubectl-testkube/commands/webhooks/delete.go
@@ -6,6 +6,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/kubeshop/testkube/cmd/kubectl-testkube/commands/common"
+	"github.com/kubeshop/testkube/internal/app/api/apiutils"
 	"github.com/kubeshop/testkube/pkg/ui"
 )
 
@@ -14,18 +15,22 @@ func NewDeleteWebhookCmd() *cobra.Command {
 	var selectors []string
 
 	cmd := &cobra.Command{
-
 		Use:     "webhook <webhookName>",
 		Aliases: []string{"wh"},
 		Short:   "Delete webhook",
 		Long:    `Delete webhook, pass webhook name which should be deleted`,
 		Run: func(cmd *cobra.Command, args []string) {
+			ignoreNotFound, _ := cmd.Flags().GetBool("ignore-not-found")
 			client, _, err := common.GetClient(cmd)
 			ui.ExitOnError("getting client", err)
 
 			if len(args) > 0 {
 				name = args[0]
 				err := client.DeleteWebhook(name)
+				if ignoreNotFound && apiutils.IsNotFound(err) {
+					ui.Info("Webhook '" + name + "' not found, but ignoring since --ignore-not-found was passed")
+					ui.SuccessAndExit("Operation completed")
+				}
 				ui.ExitOnError("deleting webhook: "+name, err)
 				ui.SuccessAndExit("Succesfully deleted webhook", name)
 			}
@@ -33,6 +38,10 @@ func NewDeleteWebhookCmd() *cobra.Command {
 			if len(selectors) != 0 {
 				selector := strings.Join(selectors, ",")
 				err := client.DeleteWebhooks(selector)
+				if ignoreNotFound && apiutils.IsNotFound(err) {
+					ui.Info("Webhook not found for matching selector '" + selector + "', but ignoring since --ignore-not-found was passed")
+					ui.SuccessAndExit("Operation completed")
+				}
 				ui.ExitOnError("deleting webhooks by labels: "+selector, err)
 				ui.SuccessAndExit("Succesfully deleted webhooks by labels", selector)
 			}


### PR DESCRIPTION
## Pull request description 
This PR introduces the `--ignore-not-found` flag to the testkube delete command. When enabled, this flag suppresses the error and non-zero exit code if the specified resource is does not exist.

This improves usability in scripting and CI/CD environments by preventing unnecessary command failures when attempting to delete non-existent resources as descrinbed in [#2304](https://github.com/kubeshop/testkube/issues/2304) 

## Changes
- **Added persistent flag** to parent delete command
- **Implemented ignore logic** in all delete subcommands:
  - `testkube delete test` 
  - `testkube delete testsuite`
  - `testkube delete testworkflow`
  - `testkube delete executor`
  - `testkube delete template`
  - `testkube delete testsource`
  - `testkube delete webhook`
  - `testkube delete webhooktemplate`
  - `testkube delete testworkflowtemplate`

## Proof Manifests

#### Before
```
$ testkube delete testworkflow idonotexist

Context:  (999.0.0-a378893ba)   Namespace: testkube
---------------------------------------------------

delete test workflow idonotexist from namespace testkube (error: api/DELETE-v1/test-workflows/idonotexist returned error: api server problem: failed to delete test workflow 'idonotexist': client not found: testworkflows.testworkflows.testkube.io "idonotexist" not found, context: null;
resp error:the server could not find the requested resource (delete services testkube-api-server:8088))

```

#### After
```
$ testkube delete testworkflow idonotexist --ignore-not-found

Context:  (999.0.0-a378893ba)   Namespace: testkube
---------------------------------------------------
Testworkflow 'idonotexist' not found, but ignoring since --ignore-not-found was passed
Operation completed 🥇
```