### PR TITLE
chore: attempt to enforce gRPC TLS

### DIFF
--- a/cmd/api-server/main.go
+++ b/cmd/api-server/main.go
@@ -187,7 +187,7 @@ func main() {
 
 		log.DefaultLogger.Info("connecting to embedded Control Plane...")
 		var err error
-		grpcConn, err = agentclient.NewGRPCConnectionWithTracing(ctx, true, true, fmt.Sprintf("127.0.0.1:%d", cfg.GRPCServerPort), "", "", "", log.DefaultLogger, cfg.TracingEnabled)
+		grpcConn, err = agentclient.NewGRPCConnectionWithTracing(ctx, true, true, fmt.Sprintf("127.0.0.1:%d", cfg.GRPCServerPort), "", log.DefaultLogger, cfg.TracingEnabled)
 		commons.ExitOnError("connecting to embedded Control Plane", err)
 		log.DefaultLogger.Infow("connected to embedded control plane successfully", "port", cfg.GRPCServerPort)
 	} else {
@@ -198,8 +198,6 @@ func main() {
 			cfg.TestkubeProTLSInsecure,
 			cfg.TestkubeProSkipVerify,
 			cfg.TestkubeProURL,
-			cfg.TestkubeProCertFile,
-			cfg.TestkubeProKeyFile,
 			cfg.TestkubeProCAFile, //nolint
 			log.DefaultLogger,
 			cfg.TracingEnabled,

--- a/cmd/logs-server/main.go
+++ b/cmd/logs-server/main.go
@@ -110,8 +110,6 @@ func main() {
 			cfg.TestkubeProTLSInsecure,
 			cfg.TestkubeProSkipVerify,
 			cfg.TestkubeProURL,
-			cfg.TestkubeProCertFile,
-			cfg.TestkubeProKeyFile,
 			cfg.TestkubeProCAFile,
 			log,
 		)

--- a/cmd/testworkflow-init/data/client.go
+++ b/cmd/testworkflow-init/data/client.go
@@ -28,7 +28,7 @@ func CloudClient() controlplaneclient.Client {
 		cfg := GetState().InternalConfig
 		conn := cfg.Worker.Connection
 		logger := log.NewSilent()
-		grpcConn, err := agentclient.NewGRPCConnection(context.Background(), conn.TlsInsecure, conn.SkipVerify, conn.Url, "", "", "", logger)
+		grpcConn, err := agentclient.NewGRPCConnection(context.Background(), conn.TlsInsecure, conn.SkipVerify, conn.Url, "", logger)
 		if err != nil {
 			output.ExitErrorf(constants.CodeInternal, "failed to connect with the Control Plane: %s", err.Error())
 		}

--- a/cmd/testworkflow-toolkit/env/client.go
+++ b/cmd/testworkflow-toolkit/env/client.go
@@ -232,7 +232,7 @@ func CloudInternal() (cloud.TestKubeCloudAPIClient, error) {
 		// TODO(dejan): now metrics are scrapped on each workflow exetucution and we get an error when connecting to Control Plane even with publicly trusted certificates.
 		// Until a better solution is implemented, TLS verification will be skipped.
 		cfg.SkipVerify = true
-		cloudConn, err = agentclient.NewGRPCConnection(context.Background(), cfg.TlsInsecure, cfg.SkipVerify, cfg.Url, "", "", "", logger)
+		cloudConn, err = agentclient.NewGRPCConnection(context.Background(), cfg.TlsInsecure, cfg.SkipVerify, cfg.Url, "", logger)
 		if err != nil {
 			return nil, fmt.Errorf("failed to connect with Cloud: %w", err)
 		}

--- a/pkg/agent/agent_test.go
+++ b/pkg/agent/agent_test.go
@@ -49,7 +49,7 @@ func TestCommandExecution(t *testing.T) {
 		atomic.AddInt32(&msgCnt, 1)
 	}
 
-	grpcConn, err := agentclient.NewGRPCConnection(context.Background(), true, false, url, "", "", "", log.DefaultLogger)
+	grpcConn, err := agentclient.NewGRPCConnection(context.Background(), true, false, url, "", log.DefaultLogger)
 	ui.ExitOnError("error creating gRPC connection", err)
 	defer grpcConn.Close()
 

--- a/pkg/agent/events_test.go
+++ b/pkg/agent/events_test.go
@@ -48,7 +48,7 @@ func TestEventLoop(t *testing.T) {
 
 	logger, _ := zap.NewDevelopment()
 
-	grpcConn, err := agentclient.NewGRPCConnection(context.Background(), true, false, url, "", "", "", log.DefaultLogger)
+	grpcConn, err := agentclient.NewGRPCConnection(context.Background(), true, false, url, "", log.DefaultLogger)
 	ui.ExitOnError("error creating gRPC connection", err)
 	defer grpcConn.Close()
 

--- a/pkg/agent/logs_test.go
+++ b/pkg/agent/logs_test.go
@@ -46,7 +46,7 @@ func TestLogStream(t *testing.T) {
 		fmt.Fprintf(ctx, "Hi there! RequestURI is %q", ctx.RequestURI())
 	}
 
-	grpcConn, err := agentclient.NewGRPCConnection(context.Background(), true, false, url, "", "", "", log.DefaultLogger)
+	grpcConn, err := agentclient.NewGRPCConnection(context.Background(), true, false, url, "", log.DefaultLogger)
 	ui.ExitOnError("error creating gRPC connection", err)
 	defer grpcConn.Close()
 

--- a/pkg/executor/scraper/factory/factory.go
+++ b/pkg/executor/scraper/factory/factory.go
@@ -109,8 +109,6 @@ func getRemoteStorageUploader(ctx context.Context, params envs.Params) (uploader
 		params.ProAPITLSInsecure,
 		params.ProAPISkipVerify,
 		params.ProAPIURL,
-		params.ProAPICertFile,
-		params.ProAPIKeyFile,
 		params.ProAPICAFile,
 		log.DefaultLogger,
 	)

--- a/pkg/logs/adapter/cloud_test.go
+++ b/pkg/logs/adapter/cloud_test.go
@@ -37,7 +37,7 @@ func TestCloudAdapter_Integration(t *testing.T) {
 		id := "id1"
 
 		// and connection
-		grpcConn, err := agentclient.NewGRPCConnection(ctx, true, true, ts.Url, "", "", "", log.DefaultLogger)
+		grpcConn, err := agentclient.NewGRPCConnection(ctx, true, true, ts.Url, "", log.DefaultLogger)
 		if err != nil {
 			t.Fatalf("Failed to create gRPC connection: %v", err)
 		}
@@ -82,7 +82,7 @@ func TestCloudAdapter_Integration(t *testing.T) {
 		id3 := "id3"
 
 		// and connection
-		grpcConn, err := agentclient.NewGRPCConnection(ctx, true, true, ts.Url, "", "", "", log.DefaultLogger)
+		grpcConn, err := agentclient.NewGRPCConnection(ctx, true, true, ts.Url, "", log.DefaultLogger)
 		if err != nil {
 			t.Fatalf("Failed to create gRPC connection: %v", err)
 		}
@@ -134,7 +134,7 @@ func TestCloudAdapter_Integration(t *testing.T) {
 		id := "id1M"
 
 		// and grpc connetion to the server
-		grpcConn, err := agentclient.NewGRPCConnection(ctx, true, true, ts.Url, "", "", "", log.DefaultLogger)
+		grpcConn, err := agentclient.NewGRPCConnection(ctx, true, true, ts.Url, "", log.DefaultLogger)
 		if err != nil {
 			t.Fatalf("Failed to create gRPC connection: %v", err)
 		}
@@ -171,7 +171,7 @@ func TestCloudAdapter_Integration(t *testing.T) {
 		ctx := context.Background()
 
 		// and grpc connetion to the server
-		grpcConn, err := agentclient.NewGRPCConnection(ctx, true, true, ts.Url, "", "", "", log.DefaultLogger)
+		grpcConn, err := agentclient.NewGRPCConnection(ctx, true, true, ts.Url, "", log.DefaultLogger)
 		if err != nil {
 			t.Fatalf("Failed to create gRPC connection: %v", err)
 		}


### PR DESCRIPTION
This change introduces an attempted forced gRPC
TLS connection between the agent and a control
plane, with an eventual fallback to optional
insecure connection only if TLS connection
fails.

The intention is to provide a method for
agents to automatically be able to "upgrade"
to a secure connection when connecting to a
TLS enabled Control Plane, whilst retaining some
level of backwards compatibility for users
with insecure Control Plane deployments.

There is an exception too for local connections which applies only to standalone agent deployments.