### PR TITLE
feat: Implement sync gRPC client

### DIFF
--- a/internal/sync/docs.go
+++ b/internal/sync/docs.go
@@ -1,0 +1,2 @@
+// Package sync contains the implementation of a Sync (or GitOps) capability for a Testkube Agent.
+package sync

--- a/internal/sync/grpc/client.go
+++ b/internal/sync/grpc/client.go
@@ -1,0 +1,110 @@
+// Package grpc provides simple to use functions that call Contrl Plane gRPC endpoints
+// for updating the Control Plane about changes made to synchronised objects.
+package grpc
+
+import (
+	"context"
+	"time"
+
+	"github.com/cloudflare/backoff"
+	"go.uber.org/zap"
+	"golang.org/x/oauth2"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials/oauth"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
+
+	syncv1 "github.com/kubeshop/testkube/pkg/proto/testkube/sync/v1"
+)
+
+const defaultCallTimeout = time.Second * 30
+
+type Client struct {
+	OrganisationId string
+
+	client      syncv1.SyncServiceClient
+	logger      *zap.SugaredLogger
+	callOpts    []grpc.CallOption
+	callTimeout time.Duration
+}
+
+func NewClient(conn grpc.ClientConnInterface, logger *zap.SugaredLogger, apiToken, organisationId string) Client {
+	c := syncv1.NewSyncServiceClient(conn)
+	return Client{
+		OrganisationId: organisationId,
+
+		client: c,
+		logger: logger,
+		callOpts: []grpc.CallOption{
+			// Note: This requires TLS to be correctly configured, otherwise the gRPC library will
+			// abort the connection. It is not secure to send authentication tokens over an
+			// unencrypted connection so this is appropriate behaviour.
+			grpc.PerRPCCredentials(oauth.TokenSource{
+				TokenSource: oauth2.StaticTokenSource(&oauth2.Token{
+					AccessToken: apiToken,
+				}),
+			}),
+			// In the event of a transient failure on the server wait for it to come back rather than
+			// failing immediately.
+			grpc.WaitForReady(true),
+		},
+		callTimeout: defaultCallTimeout,
+	}
+}
+
+// IsSupported attempts to contact the Control Plane to determine whether or not there is an implementation
+// of the required server to support this client.
+// It will block until it receives either a successful response, returning true and indicating that the server
+// supports this client.
+// Or it receives an "Unimplemented" response, returning false and indicating that the server does not support
+// this client and a fallback should be used instead.
+// In the event of any other error, such as an authentication failure or a network failure, it will continue
+// to loop, using a backoff mechanism, until one of the above cases is satisfied.
+func (c Client) IsSupported(ctx context.Context) bool {
+	b := backoff.New(backoff.DefaultMaxDuration, backoff.DefaultInterval)
+	for {
+		if ctx.Err() != nil {
+			return false
+		}
+		// Execute with our own call timeout context to prevent stalling out.
+		callCtx, cancel := context.WithTimeout(ctx, c.callTimeout)
+		// Add metadata to the call.
+		callCtx = metadata.AppendToOutgoingContext(callCtx, "organisation-id", c.OrganisationId)
+		// Attempt to call delete with a workflow that should not exist.
+		// This means that we should expect to receive a NotFound response
+		// from the server, and any other response represents an error of
+		// some form.
+		testId := "id-that-should-not-exist-vgyxwqavpd"
+		_, err := c.client.Delete(callCtx, &syncv1.DeleteRequest{
+			Id: &syncv1.DeleteRequest_TestWorkflow{
+				TestWorkflow: &syncv1.TestWorkflowId{
+					Id: &testId,
+				},
+			},
+		}, c.callOpts...)
+		cancel()
+		code, ok := status.FromError(err)
+		switch {
+		case ok && code.Code() == codes.Unimplemented:
+			// Server does not have the implementation for this client.
+			return false
+		case ok && code.Code() == codes.NotFound:
+			// Correctly implemented server.
+			return true
+		case err != nil:
+			c.logger.Warnw("Failed to check if server supports polling execution updates, backing off before retrying.",
+				"backoff", b.Duration(),
+				"error", err)
+			// In the event of an error wait for backoff before trying again.
+			<-time.After(b.Duration())
+			continue
+		}
+
+		// Server has implementation but for some reason it accepted our Id that should not exist...
+		c.logger.Warnw("Server has support but claims to have deleted an object that should not exist.",
+			"object type", "TestWorkflow",
+			"object id", testId)
+		return true
+	}
+}

--- a/internal/sync/grpc/client_test.go
+++ b/internal/sync/grpc/client_test.go
@@ -1,0 +1,91 @@
+package grpc_test
+
+import (
+	"context"
+	"net"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"go.uber.org/zap"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/local"
+
+	syncgrpc "github.com/kubeshop/testkube/internal/sync/grpc"
+	syncv1 "github.com/kubeshop/testkube/pkg/proto/testkube/sync/v1"
+)
+
+type testSrv struct {
+	syncv1.UnimplementedSyncServiceServer
+
+	TestTrigger          *syncv1.TestTrigger
+	TestWorkflow         *syncv1.TestWorkflow
+	TestWorkflowTemplate *syncv1.TestWorkflowTemplate
+	Webhook              *syncv1.Webhook
+	WebhookTemplate      *syncv1.WebhookTemplate
+}
+
+func (t *testSrv) UpdateOrCreate(_ context.Context, req *syncv1.UpdateOrCreateRequest) (*syncv1.UpdateOrCreateResponse, error) {
+	switch v := req.Payload.(type) {
+	case *syncv1.UpdateOrCreateRequest_TestTrigger:
+		t.TestTrigger = v.TestTrigger
+	case *syncv1.UpdateOrCreateRequest_TestWorkflow:
+		t.TestWorkflow = v.TestWorkflow
+	case *syncv1.UpdateOrCreateRequest_TestWorkflowTemplate:
+		t.TestWorkflowTemplate = v.TestWorkflowTemplate
+	case *syncv1.UpdateOrCreateRequest_Webhook:
+		t.Webhook = v.Webhook
+	case *syncv1.UpdateOrCreateRequest_WebhookTemplate:
+		t.WebhookTemplate = v.WebhookTemplate
+	}
+	return nil, nil
+}
+
+func (t *testSrv) Delete(_ context.Context, req *syncv1.DeleteRequest) (*syncv1.DeleteResponse, error) {
+	return nil, nil
+}
+
+func startGRPCTestConnection(t *testing.T, ts *testSrv) syncgrpc.Client {
+	t.Helper()
+
+	srv := grpc.NewServer(grpc.Creds(local.NewCredentials()))
+
+	syncv1.RegisterSyncServiceServer(srv, ts)
+
+	socketAddr := filepath.Join(os.TempDir(), t.Name()+".sock")
+	t.Cleanup(func() {
+		os.Remove(socketAddr)
+	})
+
+	listener, err := net.Listen("unix", socketAddr)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	go func() {
+		if err := srv.Serve(listener); err != nil {
+			t.Error(err)
+			return
+		}
+	}()
+
+	t.Cleanup(srv.Stop)
+
+	// Connecting over a unix socket requires three slashes.
+	// - Two for the schema (standard).
+	// - One after the "authority", which for UDS doesnt exist.
+	conn, err := grpc.NewClient("unix:///"+socketAddr, grpc.WithTransportCredentials(local.NewCredentials()))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return syncgrpc.NewClient(conn, zap.NewExample().Sugar(), "foo", "bar")
+}
+
+func TestIsSupported(t *testing.T) {
+	client := startGRPCTestConnection(t, &testSrv{})
+
+	if !client.IsSupported(t.Context()) {
+		t.Errorf("client should be supported")
+	}
+}

--- a/internal/sync/grpc/testtrigger.go
+++ b/internal/sync/grpc/testtrigger.go
@@ -1,0 +1,61 @@
+package grpc
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"google.golang.org/grpc/metadata"
+
+	testtriggersv1 "github.com/kubeshop/testkube/api/testtriggers/v1"
+	syncv1 "github.com/kubeshop/testkube/pkg/proto/testkube/sync/v1"
+)
+
+// UpdateOrCreateTestTrigger sends a request to the Control Plane informing that an change has occurred
+// to a TestTrigger object on this Agent.
+func (c Client) UpdateOrCreateTestTrigger(ctx context.Context, obj testtriggersv1.TestTrigger) error {
+	jsonEncodedObj, err := json.Marshal(obj)
+	if err != nil {
+		return fmt.Errorf("json encode testtrigger object: %w", err)
+	}
+
+	// Execute with our own call timeout context to prevent stalling out.
+	callCtx, cancel := context.WithTimeout(ctx, c.callTimeout)
+	defer cancel()
+	// Add metadata to the call.
+	callCtx = metadata.AppendToOutgoingContext(callCtx, "organisation-id", c.OrganisationId)
+
+	if _, err := c.client.UpdateOrCreate(callCtx, &syncv1.UpdateOrCreateRequest{
+		Payload: &syncv1.UpdateOrCreateRequest_TestTrigger{
+			TestTrigger: &syncv1.TestTrigger{
+				Payload: jsonEncodedObj,
+			},
+		},
+	}); err != nil {
+		return fmt.Errorf("send request to update or create testtrigger: %w", err)
+	}
+
+	return nil
+}
+
+// DeleteTestTrigger sends a request to the Control Plane informing that a TestTrigger object has
+// been removed from the observable scope of this Agent.
+func (c Client) DeleteTestTrigger(ctx context.Context, name string) error {
+	// Execute with our own call timeout context to prevent stalling out.
+	callCtx, cancel := context.WithTimeout(ctx, c.callTimeout)
+	defer cancel()
+	// Add metadata to the call.
+	callCtx = metadata.AppendToOutgoingContext(callCtx, "organisation-id", c.OrganisationId)
+
+	if _, err := c.client.Delete(callCtx, &syncv1.DeleteRequest{
+		Id: &syncv1.DeleteRequest_TestTrigger{
+			TestTrigger: &syncv1.TestTriggerId{
+				Id: &name,
+			},
+		},
+	}); err != nil {
+		return fmt.Errorf("send request to delete testtrigger: %w", err)
+	}
+
+	return nil
+}

--- a/internal/sync/grpc/testtrigger_test.go
+++ b/internal/sync/grpc/testtrigger_test.go
@@ -1,0 +1,35 @@
+package grpc_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+
+	testtriggersv1 "github.com/kubeshop/testkube/api/testtriggers/v1"
+)
+
+func TestUpdateOrCreateTestTrigger(t *testing.T) {
+	var srv testSrv
+	client := startGRPCTestConnection(t, &srv)
+
+	input := testtriggersv1.TestTrigger{
+		Spec: testtriggersv1.TestTriggerSpec{
+			Resource:  "foo",
+			Event:     "bar",
+			Action:    "baz",
+			Execution: "qux",
+		},
+	}
+	expect, err := json.Marshal(input)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := client.UpdateOrCreateTestTrigger(t.Context(), input); err != nil {
+		t.Fatal(err)
+	}
+
+	if !bytes.Equal(expect, srv.TestTrigger.GetPayload()) {
+		t.Errorf("expect %v, got %v", expect, srv.TestTrigger.GetPayload())
+	}
+}

--- a/internal/sync/grpc/testworkflow.go
+++ b/internal/sync/grpc/testworkflow.go
@@ -1,0 +1,61 @@
+package grpc
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"google.golang.org/grpc/metadata"
+
+	testworkflowsv1 "github.com/kubeshop/testkube/api/testworkflows/v1"
+	syncv1 "github.com/kubeshop/testkube/pkg/proto/testkube/sync/v1"
+)
+
+// UpdateOrCreateTestWorkflow sends a request to the Control Plane informing that an change has occurred
+// to a TestWorkflow object on this Agent.
+func (c Client) UpdateOrCreateTestWorkflow(ctx context.Context, obj testworkflowsv1.TestWorkflow) error {
+	jsonEncodedObj, err := json.Marshal(obj)
+	if err != nil {
+		return fmt.Errorf("json encode testworkflow object: %w", err)
+	}
+
+	// Execute with our own call timeout context to prevent stalling out.
+	callCtx, cancel := context.WithTimeout(ctx, c.callTimeout)
+	defer cancel()
+	// Add metadata to the call.
+	callCtx = metadata.AppendToOutgoingContext(callCtx, "organisation-id", c.OrganisationId)
+
+	if _, err := c.client.UpdateOrCreate(callCtx, &syncv1.UpdateOrCreateRequest{
+		Payload: &syncv1.UpdateOrCreateRequest_TestWorkflow{
+			TestWorkflow: &syncv1.TestWorkflow{
+				Payload: jsonEncodedObj,
+			},
+		},
+	}); err != nil {
+		return fmt.Errorf("send request to update or create testworkflow: %w", err)
+	}
+
+	return nil
+}
+
+// DeleteTestWorkflow sends a request to the Control Plane informing that a TestWorkflow object has
+// been removed from the observable scope of this Agent.
+func (c Client) DeleteTestWorkflow(ctx context.Context, name string) error {
+	// Execute with our own call timeout context to prevent stalling out.
+	callCtx, cancel := context.WithTimeout(ctx, c.callTimeout)
+	defer cancel()
+	// Add metadata to the call.
+	callCtx = metadata.AppendToOutgoingContext(callCtx, "organisation-id", c.OrganisationId)
+
+	if _, err := c.client.Delete(callCtx, &syncv1.DeleteRequest{
+		Id: &syncv1.DeleteRequest_TestWorkflow{
+			TestWorkflow: &syncv1.TestWorkflowId{
+				Id: &name,
+			},
+		},
+	}); err != nil {
+		return fmt.Errorf("send request to delete testworkflow: %w", err)
+	}
+
+	return nil
+}

--- a/internal/sync/grpc/testworkflow_test.go
+++ b/internal/sync/grpc/testworkflow_test.go
@@ -1,0 +1,47 @@
+package grpc_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+
+	testworkflowsv1 "github.com/kubeshop/testkube/api/testworkflows/v1"
+)
+
+func TestUpdateOrCreateTestWorkflow(t *testing.T) {
+	var srv testSrv
+	client := startGRPCTestConnection(t, &srv)
+
+	input := testworkflowsv1.TestWorkflow{
+		Spec: testworkflowsv1.TestWorkflowSpec{
+			TestWorkflowSpecBase: testworkflowsv1.TestWorkflowSpecBase{
+				Config: map[string]testworkflowsv1.ParameterSchema{
+					"foo": {
+						Description: "foo",
+						Type:        "bar",
+					},
+					"baz": {
+						Description: "baz",
+						Type:        "qux",
+					},
+				},
+				Concurrency: &testworkflowsv1.ConcurrencyPolicy{
+					Group: "foo",
+					Max:   5,
+				},
+			},
+		},
+	}
+	expect, err := json.Marshal(input)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := client.UpdateOrCreateTestWorkflow(t.Context(), input); err != nil {
+		t.Fatal(err)
+	}
+
+	if !bytes.Equal(expect, srv.TestWorkflow.GetPayload()) {
+		t.Errorf("expect %v, got %v", expect, srv.TestWorkflow.GetPayload())
+	}
+}

--- a/internal/sync/grpc/testworkflowtemplate.go
+++ b/internal/sync/grpc/testworkflowtemplate.go
@@ -1,0 +1,61 @@
+package grpc
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"google.golang.org/grpc/metadata"
+
+	testworkflowsv1 "github.com/kubeshop/testkube/api/testworkflows/v1"
+	syncv1 "github.com/kubeshop/testkube/pkg/proto/testkube/sync/v1"
+)
+
+// UpdateOrCreateTestWorkflowTemplate sends a request to the Control Plane informing that an change has occurred
+// to a TestWorkflowTemplate object on this Agent.
+func (c Client) UpdateOrCreateTestWorkflowTemplate(ctx context.Context, obj testworkflowsv1.TestWorkflowTemplate) error {
+	jsonEncodedObj, err := json.Marshal(obj)
+	if err != nil {
+		return fmt.Errorf("json encode testworkflow object: %w", err)
+	}
+
+	// Execute with our own call timeout context to prevent stalling out.
+	callCtx, cancel := context.WithTimeout(ctx, c.callTimeout)
+	defer cancel()
+	// Add metadata to the call.
+	callCtx = metadata.AppendToOutgoingContext(callCtx, "organisation-id", c.OrganisationId)
+
+	if _, err := c.client.UpdateOrCreate(callCtx, &syncv1.UpdateOrCreateRequest{
+		Payload: &syncv1.UpdateOrCreateRequest_TestWorkflowTemplate{
+			TestWorkflowTemplate: &syncv1.TestWorkflowTemplate{
+				Payload: jsonEncodedObj,
+			},
+		},
+	}); err != nil {
+		return fmt.Errorf("send request to update or create testworkflowtemplate: %w", err)
+	}
+
+	return nil
+}
+
+// DeleteTestWorkflowTemplate sends a request to the Control Plane informing that a TestWorkflowTemplate object has
+// been removed from the observable scope of this Agent.
+func (c Client) DeleteTestWorkflowTemplate(ctx context.Context, name string) error {
+	// Execute with our own call timeout context to prevent stalling out.
+	callCtx, cancel := context.WithTimeout(ctx, c.callTimeout)
+	defer cancel()
+	// Add metadata to the call.
+	callCtx = metadata.AppendToOutgoingContext(callCtx, "organisation-id", c.OrganisationId)
+
+	if _, err := c.client.Delete(callCtx, &syncv1.DeleteRequest{
+		Id: &syncv1.DeleteRequest_TestWorkflowTemplate{
+			TestWorkflowTemplate: &syncv1.TestWorkflowTemplateId{
+				Id: &name,
+			},
+		},
+	}); err != nil {
+		return fmt.Errorf("send request to delete testworkflowtemplate: %w", err)
+	}
+
+	return nil
+}

--- a/internal/sync/grpc/testworkflowtemplate_test.go
+++ b/internal/sync/grpc/testworkflowtemplate_test.go
@@ -1,0 +1,47 @@
+package grpc_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+
+	testworkflowsv1 "github.com/kubeshop/testkube/api/testworkflows/v1"
+)
+
+func TestUpdateOrCreateTestWorkflowTemplate(t *testing.T) {
+	var srv testSrv
+	client := startGRPCTestConnection(t, &srv)
+
+	input := testworkflowsv1.TestWorkflowTemplate{
+		Spec: testworkflowsv1.TestWorkflowTemplateSpec{
+			TestWorkflowSpecBase: testworkflowsv1.TestWorkflowSpecBase{
+				Config: map[string]testworkflowsv1.ParameterSchema{
+					"foo": {
+						Description: "foo",
+						Type:        "bar",
+					},
+					"baz": {
+						Description: "baz",
+						Type:        "qux",
+					},
+				},
+				Concurrency: &testworkflowsv1.ConcurrencyPolicy{
+					Group: "foo",
+					Max:   5,
+				},
+			},
+		},
+	}
+	expect, err := json.Marshal(input)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := client.UpdateOrCreateTestWorkflowTemplate(t.Context(), input); err != nil {
+		t.Fatal(err)
+	}
+
+	if !bytes.Equal(expect, srv.TestWorkflowTemplate.GetPayload()) {
+		t.Errorf("expect %v, got %v", expect, srv.TestWorkflowTemplate.GetPayload())
+	}
+}

--- a/internal/sync/grpc/webhook.go
+++ b/internal/sync/grpc/webhook.go
@@ -1,0 +1,61 @@
+package grpc
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"google.golang.org/grpc/metadata"
+
+	executorv1 "github.com/kubeshop/testkube/api/executor/v1"
+	syncv1 "github.com/kubeshop/testkube/pkg/proto/testkube/sync/v1"
+)
+
+// UpdateOrCreateWebhook sends a request to the Control Plane informing that an change has occurred
+// to a Webhook object on this Agent.
+func (c Client) UpdateOrCreateWebhook(ctx context.Context, obj executorv1.Webhook) error {
+	jsonEncodedObj, err := json.Marshal(obj)
+	if err != nil {
+		return fmt.Errorf("json encode webhook object: %w", err)
+	}
+
+	// Execute with our own call timeout context to prevent stalling out.
+	callCtx, cancel := context.WithTimeout(ctx, c.callTimeout)
+	defer cancel()
+	// Add metadata to the call.
+	callCtx = metadata.AppendToOutgoingContext(callCtx, "organisation-id", c.OrganisationId)
+
+	if _, err := c.client.UpdateOrCreate(callCtx, &syncv1.UpdateOrCreateRequest{
+		Payload: &syncv1.UpdateOrCreateRequest_Webhook{
+			Webhook: &syncv1.Webhook{
+				Payload: jsonEncodedObj,
+			},
+		},
+	}); err != nil {
+		return fmt.Errorf("send request to update or create webhook: %w", err)
+	}
+
+	return nil
+}
+
+// DeleteWebhook sends a request to the Control Plane informing that a Webhook object has
+// been removed from the observable scope of this Agent.
+func (c Client) DeleteWebhook(ctx context.Context, name string) error {
+	// Execute with our own call timeout context to prevent stalling out.
+	callCtx, cancel := context.WithTimeout(ctx, c.callTimeout)
+	defer cancel()
+	// Add metadata to the call.
+	callCtx = metadata.AppendToOutgoingContext(callCtx, "organisation-id", c.OrganisationId)
+
+	if _, err := c.client.Delete(callCtx, &syncv1.DeleteRequest{
+		Id: &syncv1.DeleteRequest_Webhook{
+			Webhook: &syncv1.WebhookId{
+				Id: &name,
+			},
+		},
+	}); err != nil {
+		return fmt.Errorf("send request to delete webhook: %w", err)
+	}
+
+	return nil
+}

--- a/internal/sync/grpc/webhook_test.go
+++ b/internal/sync/grpc/webhook_test.go
@@ -1,0 +1,35 @@
+package grpc_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+
+	executorv1 "github.com/kubeshop/testkube/api/executor/v1"
+)
+
+func TestUpdateOrCreateWebhook(t *testing.T) {
+	var srv testSrv
+	client := startGRPCTestConnection(t, &srv)
+
+	input := executorv1.Webhook{
+		Spec: executorv1.WebhookSpec{
+			Uri:                "foo",
+			Selector:           "bar",
+			PayloadObjectField: "baz",
+			PayloadTemplate:    "qux",
+		},
+	}
+	expect, err := json.Marshal(input)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := client.UpdateOrCreateWebhook(t.Context(), input); err != nil {
+		t.Fatal(err)
+	}
+
+	if !bytes.Equal(expect, srv.Webhook.GetPayload()) {
+		t.Errorf("expect %v, got %v", expect, srv.Webhook.GetPayload())
+	}
+}

--- a/internal/sync/grpc/webhooktemplate.go
+++ b/internal/sync/grpc/webhooktemplate.go
@@ -1,0 +1,61 @@
+package grpc
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"google.golang.org/grpc/metadata"
+
+	executorv1 "github.com/kubeshop/testkube/api/executor/v1"
+	syncv1 "github.com/kubeshop/testkube/pkg/proto/testkube/sync/v1"
+)
+
+// UpdateOrCreateWebhookTemplate sends a request to the Control Plane informing that an change has occurred
+// to a WebhookTemplate object on this Agent.
+func (c Client) UpdateOrCreateWebhookTemplate(ctx context.Context, obj executorv1.WebhookTemplate) error {
+	jsonEncodedObj, err := json.Marshal(obj)
+	if err != nil {
+		return fmt.Errorf("json encode webhooktemplate object: %w", err)
+	}
+
+	// Execute with our own call timeout context to prevent stalling out.
+	callCtx, cancel := context.WithTimeout(ctx, c.callTimeout)
+	defer cancel()
+	// Add metadata to the call.
+	callCtx = metadata.AppendToOutgoingContext(callCtx, "organisation-id", c.OrganisationId)
+
+	if _, err := c.client.UpdateOrCreate(callCtx, &syncv1.UpdateOrCreateRequest{
+		Payload: &syncv1.UpdateOrCreateRequest_WebhookTemplate{
+			WebhookTemplate: &syncv1.WebhookTemplate{
+				Payload: jsonEncodedObj,
+			},
+		},
+	}); err != nil {
+		return fmt.Errorf("send request to update or create webhooktemplate: %w", err)
+	}
+
+	return nil
+}
+
+// DeleteWebhookTemplate sends a request to the Control Plane informing that a WebhookTemplate object has
+// been removed from the observable scope of this Agent.
+func (c Client) DeleteWebhookTemplate(ctx context.Context, name string) error {
+	// Execute with our own call timeout context to prevent stalling out.
+	callCtx, cancel := context.WithTimeout(ctx, c.callTimeout)
+	defer cancel()
+	// Add metadata to the call.
+	callCtx = metadata.AppendToOutgoingContext(callCtx, "organisation-id", c.OrganisationId)
+
+	if _, err := c.client.Delete(callCtx, &syncv1.DeleteRequest{
+		Id: &syncv1.DeleteRequest_WebhookTemplate{
+			WebhookTemplate: &syncv1.WebhookTemplateId{
+				Id: &name,
+			},
+		},
+	}); err != nil {
+		return fmt.Errorf("send request to delete webhooktemplate: %w", err)
+	}
+
+	return nil
+}

--- a/internal/sync/grpc/webhooktemplate_test.go
+++ b/internal/sync/grpc/webhooktemplate_test.go
@@ -1,0 +1,35 @@
+package grpc_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+
+	executorv1 "github.com/kubeshop/testkube/api/executor/v1"
+)
+
+func TestUpdateOrCreateWebhookTemplate(t *testing.T) {
+	var srv testSrv
+	client := startGRPCTestConnection(t, &srv)
+
+	input := executorv1.WebhookTemplate{
+		Spec: executorv1.WebhookTemplateSpec{
+			Uri:                "foo",
+			Selector:           "bar",
+			PayloadObjectField: "baz",
+			PayloadTemplate:    "qux",
+		},
+	}
+	expect, err := json.Marshal(input)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := client.UpdateOrCreateWebhookTemplate(t.Context(), input); err != nil {
+		t.Fatal(err)
+	}
+
+	if !bytes.Equal(expect, srv.WebhookTemplate.GetPayload()) {
+		t.Errorf("expect %v, got %v", expect, srv.WebhookTemplate.GetPayload())
+	}
+}


### PR DESCRIPTION
This implementation adds a layer of type
specificity on top of the RPC so that it is
easier to implement the controllers for
individual types.

These are not yet being initialised as the
controller implementations will need to be
completed first.
