### PR TITLE
feat: Implement sync Kubernetes controllers

### DIFF
--- a/internal/sync/controller/fakes_test.go
+++ b/internal/sync/controller/fakes_test.go
@@ -1,0 +1,103 @@
+package controller
+
+import (
+	"context"
+
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	executorv1 "github.com/kubeshop/testkube/api/executor/v1"
+	testtriggersv1 "github.com/kubeshop/testkube/api/testtriggers/v1"
+	testworkflowsv1 "github.com/kubeshop/testkube/api/testworkflows/v1"
+)
+
+var fakeNotFoundErr = errors.NewNotFound(schema.GroupResource{}, "test-error")
+
+type fakeKubernetesClient struct {
+	Err                  error
+	TestTrigger          testtriggersv1.TestTrigger
+	TestWorkflow         testworkflowsv1.TestWorkflow
+	TestWorkflowTemplate testworkflowsv1.TestWorkflowTemplate
+	Webhook              executorv1.Webhook
+	WebhookTemplate      executorv1.WebhookTemplate
+}
+
+func (t fakeKubernetesClient) Get(_ context.Context, _ client.ObjectKey, obj client.Object, _ ...client.GetOption) error {
+	switch v := obj.(type) {
+	case *testtriggersv1.TestTrigger:
+		t.TestTrigger.DeepCopyInto(v)
+	case *testworkflowsv1.TestWorkflow:
+		t.TestWorkflow.DeepCopyInto(v)
+	case *testworkflowsv1.TestWorkflowTemplate:
+		t.TestWorkflowTemplate.DeepCopyInto(v)
+	case *executorv1.Webhook:
+		t.Webhook.DeepCopyInto(v)
+	case *executorv1.WebhookTemplate:
+		t.WebhookTemplate.DeepCopyInto(v)
+	}
+	return t.Err
+}
+
+func (t fakeKubernetesClient) List(_ context.Context, _ client.ObjectList, _ ...client.ListOption) error {
+	return nil
+}
+
+type fakeStore struct {
+	TestTrigger          testtriggersv1.TestTrigger
+	TestWorkflow         testworkflowsv1.TestWorkflow
+	TestWorkflowTemplate testworkflowsv1.TestWorkflowTemplate
+	Webhook              executorv1.Webhook
+	WebhookTemplate      executorv1.WebhookTemplate
+	Deleted              string
+}
+
+func (t *fakeStore) UpdateOrCreateTestTrigger(_ context.Context, trigger testtriggersv1.TestTrigger) error {
+	trigger.DeepCopyInto(&t.TestTrigger)
+	return nil
+}
+
+func (t *fakeStore) DeleteTestTrigger(_ context.Context, s string) error {
+	t.Deleted = s
+	return nil
+}
+
+func (t *fakeStore) UpdateOrCreateTestWorkflow(_ context.Context, workflow testworkflowsv1.TestWorkflow) error {
+	workflow.DeepCopyInto(&t.TestWorkflow)
+	return nil
+}
+
+func (t *fakeStore) DeleteTestWorkflow(_ context.Context, s string) error {
+	t.Deleted = s
+	return nil
+}
+
+func (t *fakeStore) UpdateOrCreateTestWorkflowTemplate(_ context.Context, template testworkflowsv1.TestWorkflowTemplate) error {
+	template.DeepCopyInto(&t.TestWorkflowTemplate)
+	return nil
+}
+
+func (t *fakeStore) DeleteTestWorkflowTemplate(_ context.Context, s string) error {
+	t.Deleted = s
+	return nil
+}
+
+func (t *fakeStore) UpdateOrCreateWebhook(_ context.Context, webhook executorv1.Webhook) error {
+	webhook.DeepCopyInto(&t.Webhook)
+	return nil
+}
+
+func (t *fakeStore) DeleteWebhook(_ context.Context, s string) error {
+	t.Deleted = s
+	return nil
+}
+
+func (t *fakeStore) UpdateOrCreateWebhookTemplate(_ context.Context, template executorv1.WebhookTemplate) error {
+	template.DeepCopyInto(&t.WebhookTemplate)
+	return nil
+}
+
+func (t *fakeStore) DeleteWebhookTemplate(_ context.Context, s string) error {
+	t.Deleted = s
+	return nil
+}

--- a/internal/sync/controller/testtrigger.go
+++ b/internal/sync/controller/testtrigger.go
@@ -1,0 +1,81 @@
+package controller
+
+import (
+	"context"
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/api/errors"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	testtriggersv1 "github.com/kubeshop/testkube/api/testtriggers/v1"
+)
+
+type testTriggerStore interface {
+	UpdateOrCreateTestTrigger(context.Context, testtriggersv1.TestTrigger) error
+	DeleteTestTrigger(context.Context, string) error
+}
+
+func NewTestTriggerSyncController(mgr ctrl.Manager, store testTriggerStore) error {
+	if err := ctrl.NewControllerManagedBy(mgr).
+		For(&testtriggersv1.TestTrigger{}).
+		Complete(testTriggerSyncReconciler(mgr.GetClient(), store)); err != nil {
+		return fmt.Errorf("create new sync controller for TestTrigger: %w", err)
+	}
+	return nil
+}
+
+func testTriggerSyncReconciler(client client.Reader, store testTriggerStore) reconcile.Reconciler {
+	return reconcile.Func(func(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+		var trigger testtriggersv1.TestTrigger
+		err := client.Get(ctx, req.NamespacedName, &trigger)
+		switch {
+		case errors.IsNotFound(err):
+			// Deleted, request deletion from store.
+			// Passing the name here rather than the namespaced name as generally we refer to objects
+			// purely by their name.
+			if err := store.DeleteTestTrigger(ctx, req.Name); err != nil {
+				// Unable to delete for some reason, request a retry.
+				// We might want to selectively handle different errors here, but ideally they should
+				// be handled in the store implementation. If we return abstracted error messages from
+				// the store then we should handle them here.
+				return ctrl.Result{}, fmt.Errorf("delete TestTrigger %q from store: %w", req.Name, err)
+			}
+			return ctrl.Result{}, nil
+		case err != nil:
+			return ctrl.Result{}, fmt.Errorf("retrieve TestTrigger %q from Kubernetes: %w", req.NamespacedName, err)
+		}
+
+		// Resource has been marked for deletion, we may not get an event when it finally goes so this
+		// is the moment when we should update the Control Plane.
+		// Kubernetes is a funny thing, when a resource is marked for deletion then the DeletionTimestamp
+		// is set, but the resource is not yet removed, giving a chance for controllers to do their thing
+		// run finalizers etc. before the resources is removed entirely. Once DeletionTimestamp is set
+		// there is no going back so we know this resource is about to be deleted.
+		if !trigger.DeletionTimestamp.IsZero() {
+			// About to be deleted, request deletion from store.
+			// Passing the name here rather than the namespaced name as generally we refer to objects
+			// purely by their name.
+			if err := store.DeleteTestTrigger(ctx, req.Name); err != nil {
+				// Unable to delete for some reason, request a retry.
+				// We might want to selectively handle different errors here, but ideally they should
+				// be handled in the store implementation. If we return abstracted error messages from
+				// the store then we should handle them here.
+				return ctrl.Result{}, fmt.Errorf("delete TestTrigger %q from store: %w", req.Name, err)
+			}
+			return ctrl.Result{}, nil
+		}
+
+		// Regular update so send the new object into the store.
+		if err := store.UpdateOrCreateTestTrigger(ctx, trigger); err != nil {
+			// Unable to update or create for some reason, request a retry.
+			// We might want to selectively handle different errors here, but ideally they should
+			// be handled in the store implementation. If we return abstracted error messages from
+			// the store then we should handle them here.
+			return ctrl.Result{}, fmt.Errorf("update TestTrigger %q in store: %w", trigger.Name, err)
+		}
+
+		return ctrl.Result{}, nil
+	})
+}

--- a/internal/sync/controller/testtrigger_test.go
+++ b/internal/sync/controller/testtrigger_test.go
@@ -1,0 +1,59 @@
+package controller
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	testtriggersv1 "github.com/kubeshop/testkube/api/testtriggers/v1"
+)
+
+func TestTestTriggerSyncReconcilerUpdateOrCreate(t *testing.T) {
+	input := testtriggersv1.TestTrigger{
+		Spec: testtriggersv1.TestTriggerSpec{
+			Resource:  "foo",
+			Event:     "bar",
+			Action:    "baz",
+			Execution: "qux",
+		},
+	}
+
+	store := &fakeStore{}
+
+	reconciler := testTriggerSyncReconciler(
+		fakeKubernetesClient{
+			TestTrigger: input,
+		},
+		store,
+	)
+
+	if _, err := reconciler.Reconcile(t.Context(), reconcile.Request{}); err != nil {
+		t.Errorf("reconciliation failed: %v", err)
+	}
+
+	if diff := cmp.Diff(input, store.TestTrigger); diff != "" {
+		t.Errorf("TestTriggerSyncReconcilerUpdateOrCreate: -want, +got:\n%s", diff)
+	}
+}
+
+func TestTestTriggerSyncReconcilerDelete(t *testing.T) {
+	store := &fakeStore{}
+	name := "foobar"
+
+	reconciler := testTriggerSyncReconciler(
+		fakeKubernetesClient{
+			Err: fakeNotFoundErr,
+		},
+		store,
+	)
+
+	if _, err := reconciler.Reconcile(t.Context(), reconcile.Request{NamespacedName: types.NamespacedName{Name: name}}); err != nil {
+		t.Errorf("reconciliation failed: %v", err)
+	}
+
+	if diff := cmp.Diff(name, store.Deleted); diff != "" {
+		t.Errorf("TestTriggerSyncReconcilerUpdateOrCreate: -want, +got:\n%s", diff)
+	}
+}

--- a/internal/sync/controller/testworkflow.go
+++ b/internal/sync/controller/testworkflow.go
@@ -1,0 +1,81 @@
+package controller
+
+import (
+	"context"
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/api/errors"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	testworkflowsv1 "github.com/kubeshop/testkube/api/testworkflows/v1"
+)
+
+type testWorkflowStore interface {
+	UpdateOrCreateTestWorkflow(context.Context, testworkflowsv1.TestWorkflow) error
+	DeleteTestWorkflow(context.Context, string) error
+}
+
+func NewTestWorkflowSyncController(mgr ctrl.Manager, store testWorkflowStore) error {
+	if err := ctrl.NewControllerManagedBy(mgr).
+		For(&testworkflowsv1.TestWorkflow{}).
+		Complete(testWorkflowSyncReconciler(mgr.GetClient(), store)); err != nil {
+		return fmt.Errorf("create new sync controller for TestWorkflow: %w", err)
+	}
+	return nil
+}
+
+func testWorkflowSyncReconciler(client client.Reader, store testWorkflowStore) reconcile.Reconciler {
+	return reconcile.Func(func(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+		var workflow testworkflowsv1.TestWorkflow
+		err := client.Get(ctx, req.NamespacedName, &workflow)
+		switch {
+		case errors.IsNotFound(err):
+			// Deleted, request deletion from store.
+			// Passing the name here rather than the namespaced name as generally we refer to objects
+			// purely by their name.
+			if err := store.DeleteTestWorkflow(ctx, req.Name); err != nil {
+				// Unable to delete for some reason, request a retry.
+				// We might want to selectively handle different errors here, but ideally they should
+				// be handled in the store implementation. If we return abstracted error messages from
+				// the store then we should handle them here.
+				return ctrl.Result{}, fmt.Errorf("delete TestWorkflow %q from store: %w", req.Name, err)
+			}
+			return ctrl.Result{}, nil
+		case err != nil:
+			return ctrl.Result{}, fmt.Errorf("retrieve TestWorkflow %q from Kubernetes: %w", req.NamespacedName, err)
+		}
+
+		// Resource has been marked for deletion, we may not get an event when it finally goes so this
+		// is the moment when we should update the Control Plane.
+		// Kubernetes is a funny thing, when a resource is marked for deletion then the DeletionTimestamp
+		// is set, but the resource is not yet removed, giving a chance for controllers to do their thing
+		// run finalizers etc. before the resources is removed entirely. Once DeletionTimestamp is set
+		// there is no going back so we know this resource is about to be deleted.
+		if !workflow.DeletionTimestamp.IsZero() {
+			// About to be deleted, request deletion from store.
+			// Passing the name here rather than the namespaced name as generally we refer to objects
+			// purely by their name.
+			if err := store.DeleteTestWorkflow(ctx, req.Name); err != nil {
+				// Unable to delete for some reason, request a retry.
+				// We might want to selectively handle different errors here, but ideally they should
+				// be handled in the store implementation. If we return abstracted error messages from
+				// the store then we should handle them here.
+				return ctrl.Result{}, fmt.Errorf("delete TestWorkflow %q from store: %w", req.Name, err)
+			}
+			return ctrl.Result{}, nil
+		}
+
+		// Regular update so send the new object into the store.
+		if err := store.UpdateOrCreateTestWorkflow(ctx, workflow); err != nil {
+			// Unable to update or create for some reason, request a retry.
+			// We might want to selectively handle different errors here, but ideally they should
+			// be handled in the store implementation. If we return abstracted error messages from
+			// the store then we should handle them here.
+			return ctrl.Result{}, fmt.Errorf("update TestWorkflow %q in store: %w", workflow.Name, err)
+		}
+
+		return ctrl.Result{}, nil
+	})
+}

--- a/internal/sync/controller/testworkflow_test.go
+++ b/internal/sync/controller/testworkflow_test.go
@@ -1,0 +1,71 @@
+package controller
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	testworkflowsv1 "github.com/kubeshop/testkube/api/testworkflows/v1"
+)
+
+func TestTestWorkflowSyncReconcilerUpdateOrCreate(t *testing.T) {
+	input := testworkflowsv1.TestWorkflow{
+		Spec: testworkflowsv1.TestWorkflowSpec{
+			TestWorkflowSpecBase: testworkflowsv1.TestWorkflowSpecBase{
+				Config: map[string]testworkflowsv1.ParameterSchema{
+					"foo": {
+						Description: "foo",
+						Type:        "bar",
+					},
+					"baz": {
+						Description: "baz",
+						Type:        "qux",
+					},
+				},
+				Concurrency: &testworkflowsv1.ConcurrencyPolicy{
+					Group: "foo",
+					Max:   5,
+				},
+			},
+		},
+	}
+
+	store := &fakeStore{}
+
+	reconciler := testWorkflowSyncReconciler(
+		fakeKubernetesClient{
+			TestWorkflow: input,
+		},
+		store,
+	)
+
+	if _, err := reconciler.Reconcile(t.Context(), reconcile.Request{}); err != nil {
+		t.Errorf("reconciliation failed: %v", err)
+	}
+
+	if diff := cmp.Diff(input, store.TestWorkflow); diff != "" {
+		t.Errorf("TestWorkflowSyncReconcilerUpdateOrCreate: -want, +got:\n%s", diff)
+	}
+}
+
+func TestTestWorkflowSyncReconcilerDelete(t *testing.T) {
+	store := &fakeStore{}
+	name := "foobar"
+
+	reconciler := testWorkflowSyncReconciler(
+		fakeKubernetesClient{
+			Err: fakeNotFoundErr,
+		},
+		store,
+	)
+
+	if _, err := reconciler.Reconcile(t.Context(), reconcile.Request{NamespacedName: types.NamespacedName{Name: name}}); err != nil {
+		t.Errorf("reconciliation failed: %v", err)
+	}
+
+	if diff := cmp.Diff(name, store.Deleted); diff != "" {
+		t.Errorf("TestWorkflowSyncReconcilerUpdateOrCreate: -want, +got:\n%s", diff)
+	}
+}

--- a/internal/sync/controller/testworkflowtemplate.go
+++ b/internal/sync/controller/testworkflowtemplate.go
@@ -1,0 +1,81 @@
+package controller
+
+import (
+	"context"
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/api/errors"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	testworkflowsv1 "github.com/kubeshop/testkube/api/testworkflows/v1"
+)
+
+type testWorkflowTemplateStore interface {
+	UpdateOrCreateTestWorkflowTemplate(context.Context, testworkflowsv1.TestWorkflowTemplate) error
+	DeleteTestWorkflowTemplate(context.Context, string) error
+}
+
+func NewTestWorkflowTemplateSyncController(mgr ctrl.Manager, store testWorkflowTemplateStore) error {
+	if err := ctrl.NewControllerManagedBy(mgr).
+		For(&testworkflowsv1.TestWorkflowTemplate{}).
+		Complete(testWorkflowTemplateSyncReconciler(mgr.GetClient(), store)); err != nil {
+		return fmt.Errorf("create new sync controller for TestWorkflowTemplate: %w", err)
+	}
+	return nil
+}
+
+func testWorkflowTemplateSyncReconciler(client client.Reader, store testWorkflowTemplateStore) reconcile.Reconciler {
+	return reconcile.Func(func(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+		var workflowTemplate testworkflowsv1.TestWorkflowTemplate
+		err := client.Get(ctx, req.NamespacedName, &workflowTemplate)
+		switch {
+		case errors.IsNotFound(err):
+			// Deleted, request deletion from store.
+			// Passing the name here rather than the namespaced name as generally we refer to objects
+			// purely by their name.
+			if err := store.DeleteTestWorkflowTemplate(ctx, req.Name); err != nil {
+				// Unable to delete for some reason, request a retry.
+				// We might want to selectively handle different errors here, but ideally they should
+				// be handled in the store implementation. If we return abstracted error messages from
+				// the store then we should handle them here.
+				return ctrl.Result{}, fmt.Errorf("delete TestWorkflowTemplate %q from store: %w", req.Name, err)
+			}
+			return ctrl.Result{}, nil
+		case err != nil:
+			return ctrl.Result{}, fmt.Errorf("retrieve TestWorkflowTemplate %q from Kubernetes: %w", req.NamespacedName, err)
+		}
+
+		// Resource has been marked for deletion, we may not get an event when it finally goes so this
+		// is the moment when we should update the Control Plane.
+		// Kubernetes is a funny thing, when a resource is marked for deletion then the DeletionTimestamp
+		// is set, but the resource is not yet removed, giving a chance for controllers to do their thing
+		// run finalizers etc. before the resources is removed entirely. Once DeletionTimestamp is set
+		// there is no going back so we know this resource is about to be deleted.
+		if !workflowTemplate.DeletionTimestamp.IsZero() {
+			// About to be deleted, request deletion from store.
+			// Passing the name here rather than the namespaced name as generally we refer to objects
+			// purely by their name.
+			if err := store.DeleteTestWorkflowTemplate(ctx, req.Name); err != nil {
+				// Unable to delete for some reason, request a retry.
+				// We might want to selectively handle different errors here, but ideally they should
+				// be handled in the store implementation. If we return abstracted error messages from
+				// the store then we should handle them here.
+				return ctrl.Result{}, fmt.Errorf("delete TestWorkflowTemplate %q from store: %w", req.Name, err)
+			}
+			return ctrl.Result{}, nil
+		}
+
+		// Regular update so send the new object into the store.
+		if err := store.UpdateOrCreateTestWorkflowTemplate(ctx, workflowTemplate); err != nil {
+			// Unable to update or create for some reason, request a retry.
+			// We might want to selectively handle different errors here, but ideally they should
+			// be handled in the store implementation. If we return abstracted error messages from
+			// the store then we should handle them here.
+			return ctrl.Result{}, fmt.Errorf("update TestWorkflowTemplate %q in store: %w", workflowTemplate.Name, err)
+		}
+
+		return ctrl.Result{}, nil
+	})
+}

--- a/internal/sync/controller/testworkflowtemplate_test.go
+++ b/internal/sync/controller/testworkflowtemplate_test.go
@@ -1,0 +1,71 @@
+package controller
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	testworkflowsv1 "github.com/kubeshop/testkube/api/testworkflows/v1"
+)
+
+func TestTestWorkflowTemplateSyncReconcilerUpdateOrCreate(t *testing.T) {
+	input := testworkflowsv1.TestWorkflowTemplate{
+		Spec: testworkflowsv1.TestWorkflowTemplateSpec{
+			TestWorkflowSpecBase: testworkflowsv1.TestWorkflowSpecBase{
+				Config: map[string]testworkflowsv1.ParameterSchema{
+					"foo": {
+						Description: "foo",
+						Type:        "bar",
+					},
+					"baz": {
+						Description: "baz",
+						Type:        "qux",
+					},
+				},
+				Concurrency: &testworkflowsv1.ConcurrencyPolicy{
+					Group: "foo",
+					Max:   5,
+				},
+			},
+		},
+	}
+
+	store := &fakeStore{}
+
+	reconciler := testWorkflowTemplateSyncReconciler(
+		fakeKubernetesClient{
+			TestWorkflowTemplate: input,
+		},
+		store,
+	)
+
+	if _, err := reconciler.Reconcile(t.Context(), reconcile.Request{}); err != nil {
+		t.Errorf("reconciliation failed: %v", err)
+	}
+
+	if diff := cmp.Diff(input, store.TestWorkflowTemplate); diff != "" {
+		t.Errorf("TestWorkflowTemplateSyncReconcilerUpdateOrCreate: -want, +got:\n%s", diff)
+	}
+}
+
+func TestTestWorkflowTemplateSyncReconcilerDelete(t *testing.T) {
+	store := &fakeStore{}
+	name := "foobar"
+
+	reconciler := testWorkflowTemplateSyncReconciler(
+		fakeKubernetesClient{
+			Err: fakeNotFoundErr,
+		},
+		store,
+	)
+
+	if _, err := reconciler.Reconcile(t.Context(), reconcile.Request{NamespacedName: types.NamespacedName{Name: name}}); err != nil {
+		t.Errorf("reconciliation failed: %v", err)
+	}
+
+	if diff := cmp.Diff(name, store.Deleted); diff != "" {
+		t.Errorf("TestWorkflowTemplateSyncReconcilerUpdateOrCreate: -want, +got:\n%s", diff)
+	}
+}

--- a/internal/sync/controller/webhook.go
+++ b/internal/sync/controller/webhook.go
@@ -1,0 +1,81 @@
+package controller
+
+import (
+	"context"
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/api/errors"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	executorv1 "github.com/kubeshop/testkube/api/executor/v1"
+)
+
+type webhookStore interface {
+	UpdateOrCreateWebhook(context.Context, executorv1.Webhook) error
+	DeleteWebhook(context.Context, string) error
+}
+
+func NewWebhookSyncController(mgr ctrl.Manager, store webhookStore) error {
+	if err := ctrl.NewControllerManagedBy(mgr).
+		For(&executorv1.Webhook{}).
+		Complete(webhookSyncReconciler(mgr.GetClient(), store)); err != nil {
+		return fmt.Errorf("create new sync controller for Webhook: %w", err)
+	}
+	return nil
+}
+
+func webhookSyncReconciler(client client.Reader, store webhookStore) reconcile.Reconciler {
+	return reconcile.Func(func(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+		var webhook executorv1.Webhook
+		err := client.Get(ctx, req.NamespacedName, &webhook)
+		switch {
+		case errors.IsNotFound(err):
+			// Deleted, request deletion from store.
+			// Passing the name here rather than the namespaced name as generally we refer to objects
+			// purely by their name.
+			if err := store.DeleteWebhook(ctx, req.Name); err != nil {
+				// Unable to delete for some reason, request a retry.
+				// We might want to selectively handle different errors here, but ideally they should
+				// be handled in the store implementation. If we return abstracted error messages from
+				// the store then we should handle them here.
+				return ctrl.Result{}, fmt.Errorf("delete Webhook %q from store: %w", req.Name, err)
+			}
+			return ctrl.Result{}, nil
+		case err != nil:
+			return ctrl.Result{}, fmt.Errorf("retrieve Webhook %q from Kubernetes: %w", req.NamespacedName, err)
+		}
+
+		// Resource has been marked for deletion, we may not get an event when it finally goes so this
+		// is the moment when we should update the Control Plane.
+		// Kubernetes is a funny thing, when a resource is marked for deletion then the DeletionTimestamp
+		// is set, but the resource is not yet removed, giving a chance for controllers to do their thing
+		// run finalizers etc. before the resources is removed entirely. Once DeletionTimestamp is set
+		// there is no going back so we know this resource is about to be deleted.
+		if !webhook.DeletionTimestamp.IsZero() {
+			// About to be deleted, request deletion from store.
+			// Passing the name here rather than the namespaced name as generally we refer to objects
+			// purely by their name.
+			if err := store.DeleteWebhook(ctx, req.Name); err != nil {
+				// Unable to delete for some reason, request a retry.
+				// We might want to selectively handle different errors here, but ideally they should
+				// be handled in the store implementation. If we return abstracted error messages from
+				// the store then we should handle them here.
+				return ctrl.Result{}, fmt.Errorf("delete Webhook %q from store: %w", req.Name, err)
+			}
+			return ctrl.Result{}, nil
+		}
+
+		// Regular update so send the new object into the store.
+		if err := store.UpdateOrCreateWebhook(ctx, webhook); err != nil {
+			// Unable to update or create for some reason, request a retry.
+			// We might want to selectively handle different errors here, but ideally they should
+			// be handled in the store implementation. If we return abstracted error messages from
+			// the store then we should handle them here.
+			return ctrl.Result{}, fmt.Errorf("update Webhook %q in store: %w", webhook.Name, err)
+		}
+
+		return ctrl.Result{}, nil
+	})
+}

--- a/internal/sync/controller/webhook_test.go
+++ b/internal/sync/controller/webhook_test.go
@@ -1,0 +1,59 @@
+package controller
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	executorv1 "github.com/kubeshop/testkube/api/executor/v1"
+)
+
+func TestWebhookSyncReconcilerUpdateOrCreate(t *testing.T) {
+	input := executorv1.Webhook{
+		Spec: executorv1.WebhookSpec{
+			Uri:                "foo",
+			Selector:           "bar",
+			PayloadObjectField: "baz",
+			PayloadTemplate:    "qux",
+		},
+	}
+
+	store := &fakeStore{}
+
+	reconciler := webhookSyncReconciler(
+		fakeKubernetesClient{
+			Webhook: input,
+		},
+		store,
+	)
+
+	if _, err := reconciler.Reconcile(t.Context(), reconcile.Request{}); err != nil {
+		t.Errorf("reconciliation failed: %v", err)
+	}
+
+	if diff := cmp.Diff(input, store.Webhook); diff != "" {
+		t.Errorf("WebhookSyncReconcilerUpdateOrCreate: -want, +got:\n%s", diff)
+	}
+}
+
+func TestWebhookSyncReconcilerDelete(t *testing.T) {
+	store := &fakeStore{}
+	name := "foobar"
+
+	reconciler := webhookSyncReconciler(
+		fakeKubernetesClient{
+			Err: fakeNotFoundErr,
+		},
+		store,
+	)
+
+	if _, err := reconciler.Reconcile(t.Context(), reconcile.Request{NamespacedName: types.NamespacedName{Name: name}}); err != nil {
+		t.Errorf("reconciliation failed: %v", err)
+	}
+
+	if diff := cmp.Diff(name, store.Deleted); diff != "" {
+		t.Errorf("WebhookSyncReconcilerUpdateOrCreate: -want, +got:\n%s", diff)
+	}
+}

--- a/internal/sync/controller/webhooktemplate.go
+++ b/internal/sync/controller/webhooktemplate.go
@@ -1,0 +1,81 @@
+package controller
+
+import (
+	"context"
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/api/errors"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	executorv1 "github.com/kubeshop/testkube/api/executor/v1"
+)
+
+type webhookTemplateStore interface {
+	UpdateOrCreateWebhookTemplate(context.Context, executorv1.WebhookTemplate) error
+	DeleteWebhookTemplate(context.Context, string) error
+}
+
+func NewWebhookTemplateSyncController(mgr ctrl.Manager, store webhookTemplateStore) error {
+	if err := ctrl.NewControllerManagedBy(mgr).
+		For(&executorv1.WebhookTemplate{}).
+		Complete(webhookTemplateSyncReconciler(mgr.GetClient(), store)); err != nil {
+		return fmt.Errorf("create new sync controller for WebhookTemplate: %w", err)
+	}
+	return nil
+}
+
+func webhookTemplateSyncReconciler(client client.Reader, store webhookTemplateStore) reconcile.Reconciler {
+	return reconcile.Func(func(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+		var template executorv1.WebhookTemplate
+		err := client.Get(ctx, req.NamespacedName, &template)
+		switch {
+		case errors.IsNotFound(err):
+			// Deleted, request deletion from store.
+			// Passing the name here rather than the namespaced name as generally we refer to objects
+			// purely by their name.
+			if err := store.DeleteWebhookTemplate(ctx, req.Name); err != nil {
+				// Unable to delete for some reason, request a retry.
+				// We might want to selectively handle different errors here, but ideally they should
+				// be handled in the store implementation. If we return abstracted error messages from
+				// the store then we should handle them here.
+				return ctrl.Result{}, fmt.Errorf("delete WebhookTemplate %q from store: %w", req.Name, err)
+			}
+			return ctrl.Result{}, nil
+		case err != nil:
+			return ctrl.Result{}, fmt.Errorf("retrieve WebhookTemplate %q from Kubernetes: %w", req.NamespacedName, err)
+		}
+
+		// Resource has been marked for deletion, we may not get an event when it finally goes so this
+		// is the moment when we should update the Control Plane.
+		// Kubernetes is a funny thing, when a resource is marked for deletion then the DeletionTimestamp
+		// is set, but the resource is not yet removed, giving a chance for controllers to do their thing
+		// run finalizers etc. before the resources is removed entirely. Once DeletionTimestamp is set
+		// there is no going back so we know this resource is about to be deleted.
+		if !template.DeletionTimestamp.IsZero() {
+			// About to be deleted, request deletion from store.
+			// Passing the name here rather than the namespaced name as generally we refer to objects
+			// purely by their name.
+			if err := store.DeleteWebhookTemplate(ctx, req.Name); err != nil {
+				// Unable to delete for some reason, request a retry.
+				// We might want to selectively handle different errors here, but ideally they should
+				// be handled in the store implementation. If we return abstracted error messages from
+				// the store then we should handle them here.
+				return ctrl.Result{}, fmt.Errorf("delete WebhookTemplate %q from store: %w", req.Name, err)
+			}
+			return ctrl.Result{}, nil
+		}
+
+		// Regular update so send the new object into the store.
+		if err := store.UpdateOrCreateWebhookTemplate(ctx, template); err != nil {
+			// Unable to update or create for some reason, request a retry.
+			// We might want to selectively handle different errors here, but ideally they should
+			// be handled in the store implementation. If we return abstracted error messages from
+			// the store then we should handle them here.
+			return ctrl.Result{}, fmt.Errorf("update WebhookTemplate %q in store: %w", template.Name, err)
+		}
+
+		return ctrl.Result{}, nil
+	})
+}

--- a/internal/sync/controller/webhooktemplate_test.go
+++ b/internal/sync/controller/webhooktemplate_test.go
@@ -1,0 +1,59 @@
+package controller
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	executorv1 "github.com/kubeshop/testkube/api/executor/v1"
+)
+
+func TestWebhookTemplateSyncReconcilerUpdateOrCreate(t *testing.T) {
+	input := executorv1.WebhookTemplate{
+		Spec: executorv1.WebhookTemplateSpec{
+			Uri:                "foo",
+			Selector:           "bar",
+			PayloadObjectField: "baz",
+			PayloadTemplate:    "qux",
+		},
+	}
+
+	store := &fakeStore{}
+
+	reconciler := webhookTemplateSyncReconciler(
+		fakeKubernetesClient{
+			WebhookTemplate: input,
+		},
+		store,
+	)
+
+	if _, err := reconciler.Reconcile(t.Context(), reconcile.Request{}); err != nil {
+		t.Errorf("reconciliation failed: %v", err)
+	}
+
+	if diff := cmp.Diff(input, store.WebhookTemplate); diff != "" {
+		t.Errorf("WebhookTemplateSyncReconcilerUpdateOrCreate: -want, +got:\n%s", diff)
+	}
+}
+
+func TestWebhookTemplateSyncReconcilerDelete(t *testing.T) {
+	store := &fakeStore{}
+	name := "foobar"
+
+	reconciler := webhookTemplateSyncReconciler(
+		fakeKubernetesClient{
+			Err: fakeNotFoundErr,
+		},
+		store,
+	)
+
+	if _, err := reconciler.Reconcile(t.Context(), reconcile.Request{NamespacedName: types.NamespacedName{Name: name}}); err != nil {
+		t.Errorf("reconciliation failed: %v", err)
+	}
+
+	if diff := cmp.Diff(name, store.Deleted); diff != "" {
+		t.Errorf("WebhookTemplateSyncReconcilerUpdateOrCreate: -want, +got:\n%s", diff)
+	}
+}


### PR DESCRIPTION
These controllers listen for changes on objects
that we wish to sync and then update an
abstract store interface depending on the
observed state of the object.

That abstract store interface is implemented by
the grpc client so these can all be neatly
aligned with the previous work.