### PR TITLE
docs: Revise 'Getting Started' section for Enterprise users

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ To get started with the open source agent:
 Check out the [Testkube Open Source Overview](https://docs.testkube.io/articles/open-source) to learn
 more about the open source deployment architecture.
 
-### Getting Started with Commercial Control Plane
+### Getting Started with the Commercial Control Plane
 
 Looking for more than single environment test execution? Do you need orchestration accross clusters, support for different trigger points, and high level reporting and artifact collection? Enterprise may be for your team - there are several ways to get started:
 


### PR DESCRIPTION
Updated the 'Getting Started' section to include Enterprise options and clarified the Quickstart link.

## Pull request description 



## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [ ] tested locally
- [ ] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Breaking changes

-

## Changes

-

## Fixes

-