### PR TITLE
fix: avoid warning of insecure grpc connections from execution pods

### DIFF
--- a/cmd/testworkflow-init/data/client.go
+++ b/cmd/testworkflow-init/data/client.go
@@ -28,7 +28,7 @@ func CloudClient() controlplaneclient.Client {
 		cfg := GetState().InternalConfig
 		conn := cfg.Worker.Connection
 		logger := log.NewSilent()
-		grpcConn, err := agentclient.NewGRPCConnection(context.Background(), conn.TlsInsecure, conn.SkipVerify, conn.Url, "", logger)
+		grpcConn, err := agentclient.NewGRPCConnectionWithTracingAndVeryInsecureClientOperationOption(context.Background(), conn.TlsInsecure, conn.SkipVerify, conn.Url, "", logger, false, agentclient.IHaveFullyReadUpOnTheConsequencesOfEnablingAnInsecureGRPCConnectionAndTripleCheckedThatIReallyDefinitelyWantToDoThis)
 		if err != nil {
 			output.ExitErrorf(constants.CodeInternal, "failed to connect with the Control Plane: %s", err.Error())
 		}

--- a/cmd/testworkflow-toolkit/env/client.go
+++ b/cmd/testworkflow-toolkit/env/client.go
@@ -232,7 +232,7 @@ func CloudInternal() (cloud.TestKubeCloudAPIClient, error) {
 		// TODO(dejan): now metrics are scrapped on each workflow exetucution and we get an error when connecting to Control Plane even with publicly trusted certificates.
 		// Until a better solution is implemented, TLS verification will be skipped.
 		cfg.SkipVerify = true
-		cloudConn, err = agentclient.NewGRPCConnection(context.Background(), cfg.TlsInsecure, cfg.SkipVerify, cfg.Url, "", logger)
+		cloudConn, err = agentclient.NewGRPCConnectionWithTracingAndVeryInsecureClientOperationOption(context.Background(), cfg.TlsInsecure, cfg.SkipVerify, cfg.Url, "", logger, false, agentclient.IHaveFullyReadUpOnTheConsequencesOfEnablingAnInsecureGRPCConnectionAndTripleCheckedThatIReallyDefinitelyWantToDoThis)
 		if err != nil {
 			return nil, fmt.Errorf("failed to connect with Cloud: %w", err)
 		}

--- a/pkg/executor/scraper/factory/factory.go
+++ b/pkg/executor/scraper/factory/factory.go
@@ -104,13 +104,15 @@ func getRemoteStorageUploader(ctx context.Context, params envs.Params) (uploader
 	output.PrintLogf(
 		"%s Uploading artifacts using Remote Storage Uploader (timeout:%ds, agentInsecure:%v, agentSkipVerify: %v, url: %s, scraperSkipVerify: %v)",
 		ui.IconCheckMark, params.ProConnectionTimeoutSec, params.ProAPITLSInsecure, params.ProAPISkipVerify, params.ProAPIURL, params.SkipVerify)
-	grpcConn, err := agentclient.NewGRPCConnection(
+	grpcConn, err := agentclient.NewGRPCConnectionWithTracingAndVeryInsecureClientOperationOption(
 		ctxTimeout,
 		params.ProAPITLSInsecure,
 		params.ProAPISkipVerify,
 		params.ProAPIURL,
 		params.ProAPICAFile,
 		log.DefaultLogger,
+		false,
+		agentclient.IHaveFullyReadUpOnTheConsequencesOfEnablingAnInsecureGRPCConnectionAndTripleCheckedThatIReallyDefinitelyWantToDoThis,
 	)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Yes the variable name is long; no I do not think
we should change it. See the comment for that
variable. People don't read docs, and shorter
variable names still get missed. TLS is "hard"
but that is not really a good excuse for just
not doing any security at all.