### PR TITLE
fix: allow execution pods to bypass gRPC security

### DIFF
--- a/cmd/testworkflow-init/data/client.go
+++ b/cmd/testworkflow-init/data/client.go
@@ -28,7 +28,7 @@ func CloudClient() controlplaneclient.Client {
 		cfg := GetState().InternalConfig
 		conn := cfg.Worker.Connection
 		logger := log.NewSilent()
-		grpcConn, err := agentclient.NewGRPCConnectionWithTracingAndVeryInsecureClientOperationOption(context.Background(), conn.TlsInsecure, conn.SkipVerify, conn.Url, "", logger, false, agentclient.IHaveFullyReadUpOnTheConsequencesOfEnablingAnInsecureGRPCConnectionAndTripleCheckedThatIReallyDefinitelyWantToDoThis)
+		grpcConn, err := agentclient.NewVeryInsecureGRPCClientDoNotUseThisClientUnlessYouAreReallySureYouKnowWhatYouAreDoing(context.Background(), conn.TlsInsecure, conn.Url, logger)
 		if err != nil {
 			output.ExitErrorf(constants.CodeInternal, "failed to connect with the Control Plane: %s", err.Error())
 		}

--- a/cmd/testworkflow-toolkit/env/client.go
+++ b/cmd/testworkflow-toolkit/env/client.go
@@ -232,7 +232,7 @@ func CloudInternal() (cloud.TestKubeCloudAPIClient, error) {
 		// TODO(dejan): now metrics are scrapped on each workflow exetucution and we get an error when connecting to Control Plane even with publicly trusted certificates.
 		// Until a better solution is implemented, TLS verification will be skipped.
 		cfg.SkipVerify = true
-		cloudConn, err = agentclient.NewGRPCConnectionWithTracingAndVeryInsecureClientOperationOption(context.Background(), cfg.TlsInsecure, cfg.SkipVerify, cfg.Url, "", logger, false, agentclient.IHaveFullyReadUpOnTheConsequencesOfEnablingAnInsecureGRPCConnectionAndTripleCheckedThatIReallyDefinitelyWantToDoThis)
+		cloudConn, err = agentclient.NewVeryInsecureGRPCClientDoNotUseThisClientUnlessYouAreReallySureYouKnowWhatYouAreDoing(context.Background(), cfg.TlsInsecure, cfg.Url, logger)
 		if err != nil {
 			return nil, fmt.Errorf("failed to connect with Cloud: %w", err)
 		}

--- a/pkg/executor/scraper/factory/factory.go
+++ b/pkg/executor/scraper/factory/factory.go
@@ -104,15 +104,11 @@ func getRemoteStorageUploader(ctx context.Context, params envs.Params) (uploader
 	output.PrintLogf(
 		"%s Uploading artifacts using Remote Storage Uploader (timeout:%ds, agentInsecure:%v, agentSkipVerify: %v, url: %s, scraperSkipVerify: %v)",
 		ui.IconCheckMark, params.ProConnectionTimeoutSec, params.ProAPITLSInsecure, params.ProAPISkipVerify, params.ProAPIURL, params.SkipVerify)
-	grpcConn, err := agentclient.NewGRPCConnectionWithTracingAndVeryInsecureClientOperationOption(
+	grpcConn, err := agentclient.NewVeryInsecureGRPCClientDoNotUseThisClientUnlessYouAreReallySureYouKnowWhatYouAreDoing(
 		ctxTimeout,
 		params.ProAPITLSInsecure,
-		params.ProAPISkipVerify,
 		params.ProAPIURL,
-		params.ProAPICAFile,
 		log.DefaultLogger,
-		false,
-		agentclient.IHaveFullyReadUpOnTheConsequencesOfEnablingAnInsecureGRPCConnectionAndTripleCheckedThatIReallyDefinitelyWantToDoThis,
 	)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
This is terrible and we should never have been
allowing this in the first place but now it is
very difficult to do this without a breaking
change.
