### PR TITLE
feat: add support for new credential types in expressions

### DIFF
--- a/pkg/credentials/expressions.go
+++ b/pkg/credentials/expressions.go
@@ -8,22 +8,11 @@ import (
 )
 
 func NewCredentialMachine(repository CredentialRepository, observers ...func(name string, value string)) expressions.Machine {
-	return expressions.NewMachine().RegisterFunction("credential", func(values ...expressions.StaticValue) (interface{}, bool, error) {
-		computed := false
-		if len(values) == 2 {
-			if values[1].IsBool() {
-				computed, _ = values[1].BoolValue()
-			} else {
-				return nil, true, fmt.Errorf(`"credential" function expects 2nd argument to be boolean, %s provided`, values[1].String())
-			}
-		} else if len(values) != 1 {
-			return nil, true, fmt.Errorf(`"credential" function expects 1-2 arguments, %d provided`, len(values))
-		}
-
-		name, _ := values[0].StringValue()
+	// Helper function to handle credential fetching logic
+	fetchCredential := func(name string, computed bool) (interface{}, error) {
 		value, err := repository.Get(context.Background(), name)
 		if err != nil {
-			return nil, true, err
+			return nil, err
 		}
 		if computed {
 			expr, err := expressions.CompileAndResolveTemplate(string(value))
@@ -34,12 +23,78 @@ func NewCredentialMachine(repository CredentialRepository, observers ...func(nam
 					observers[i](name, strValue)
 				}
 			}
-			return expr, true, err
+			return expr, err
 		}
 		valueStr := string(value)
 		for i := range observers {
 			observers[i](name, valueStr)
 		}
-		return valueStr, true, nil
-	})
+		return valueStr, nil
+	}
+
+	return expressions.NewMachine().
+		RegisterFunction("credential", func(values ...expressions.StaticValue) (interface{}, bool, error) {
+			computed := false
+			if len(values) == 2 {
+				if values[1].IsBool() {
+					computed, _ = values[1].BoolValue()
+				} else {
+					return nil, true, fmt.Errorf(`"credential" function expects 2nd argument to be boolean, %s provided`, values[1].String())
+				}
+			} else if len(values) != 1 {
+				return nil, true, fmt.Errorf(`"credential" function expects 1-2 arguments, %d provided`, len(values))
+			}
+
+			name, _ := values[0].StringValue()
+			result, err := fetchCredential(name, computed)
+			return result, true, err
+		}).
+		RegisterFunction("encrypted", func(values ...expressions.StaticValue) (interface{}, bool, error) {
+			computed := false
+			if len(values) == 2 {
+				if values[1].IsBool() {
+					computed, _ = values[1].BoolValue()
+				} else {
+					return nil, true, fmt.Errorf(`"encrypted" function expects 2nd argument to be boolean, %s provided`, values[1].String())
+				}
+			} else if len(values) != 1 {
+				return nil, true, fmt.Errorf(`"encrypted" function expects 1-2 arguments, %d provided`, len(values))
+			}
+
+			name, _ := values[0].StringValue()
+			result, err := fetchCredential(name, computed)
+			return result, true, err
+		}).
+		RegisterFunction("variable", func(values ...expressions.StaticValue) (interface{}, bool, error) {
+			computed := false
+			if len(values) == 2 {
+				if values[1].IsBool() {
+					computed, _ = values[1].BoolValue()
+				} else {
+					return nil, true, fmt.Errorf(`"variable" function expects 2nd argument to be boolean, %s provided`, values[1].String())
+				}
+			} else if len(values) != 1 {
+				return nil, true, fmt.Errorf(`"variable" function expects 1-2 arguments, %d provided`, len(values))
+			}
+
+			name, _ := values[0].StringValue()
+			result, err := fetchCredential(name, computed)
+			return result, true, err
+		}).
+		RegisterFunction("vault", func(values ...expressions.StaticValue) (interface{}, bool, error) {
+			computed := false
+			if len(values) == 2 {
+				if values[1].IsBool() {
+					computed, _ = values[1].BoolValue()
+				} else {
+					return nil, true, fmt.Errorf(`"vault" function expects 2nd argument to be boolean, %s provided`, values[1].String())
+				}
+			} else if len(values) != 1 {
+				return nil, true, fmt.Errorf(`"vault" function expects 1-2 arguments, %d provided`, len(values))
+			}
+
+			name, _ := values[0].StringValue()
+			result, err := fetchCredential(name, computed)
+			return result, true, err
+		})
 }


### PR DESCRIPTION
## Pull request description 

Add support for `encrypted`, `variable` and `vault` expression functions.

## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [ ] tested locally
- [ ] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Breaking changes

-

## Changes

-

## Fixes

-