### PR TITLE
feat: enhance agent listing command with filtering options

### DIFF
--- a/cmd/kubectl-testkube/commands/agents/enable.go
+++ b/cmd/kubectl-testkube/commands/agents/enable.go
@@ -1,7 +1,6 @@
 package agents
 
 import (
-	"fmt"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -47,7 +46,7 @@ func UiEnableAgent(cmd *cobra.Command, name string) {
 		})
 		ui.ExitOnError("updating agent", err)
 	} else {
-		fmt.Println("Agent is already enabled.")
+		ui.Print("Agent is already enabled.")
 	}
 
 	PrintControlPlaneAgent(*agent)
@@ -63,7 +62,7 @@ func UiDisableAgent(cmd *cobra.Command, name string) {
 		})
 		ui.ExitOnError("updating agent", err)
 	} else {
-		fmt.Println("Agent is already disabled.")
+		ui.Print("Agent is already disabled.")
 	}
 
 	PrintControlPlaneAgent(*agent)

--- a/cmd/kubectl-testkube/commands/agents/get.go
+++ b/cmd/kubectl-testkube/commands/agents/get.go
@@ -130,7 +130,7 @@ func UiListAgents(cmd *cobra.Command, showUnknown bool, showDeleted bool, allEnv
 	agents = filteredAgents
 
 	if len(agents) == 0 {
-		fmt.Println(ui.LightGray("\nNo agents found"))
+		ui.Print(ui.LightGray("\nNo agents found"))
 		return
 	}
 

--- a/cmd/kubectl-testkube/commands/agents/utils.go
+++ b/cmd/kubectl-testkube/commands/agents/utils.go
@@ -751,17 +751,17 @@ func PrintControlPlaneAgent(agent cloudclient.Agent) {
 	}
 
 	if agent.DeletedAt != nil {
-		fmt.Println("\n" + color.Bold.Render(color.Red.Render("These details are historical. The Runner has been deleted.")) + "\n")
+		ui.Print("\n" + color.Bold.Render(color.Red.Render("These details are historical. The Runner has been deleted.")) + "\n")
 	}
 
 	ui.Warn("Last Version:  ", agent.Version)
 	ui.Warn("Last Namespace:", agent.Namespace)
 	ui.Warn("Environments:")
 	for _, env := range agent.Environments {
-		fmt.Println("   ", env.Name, ui.LightGray("("+env.ID+")"))
+		ui.Print("   ", env.Name, ui.LightGray("("+env.ID+")"))
 	}
 	if len(agent.Environments) == 0 {
-		fmt.Println("   none")
+		ui.Print("   none")
 	}
 	ui.Warn("Labels:")
 	maxLabelSize := 0
@@ -774,7 +774,7 @@ func PrintControlPlaneAgent(agent cloudclient.Agent) {
 		ui.Warn("   "+strings.Repeat(" ", maxLabelSize-len(k))+k, ui.LightGray("= ")+v)
 	}
 	if len(agent.Labels) == 0 {
-		fmt.Println("   none")
+		ui.Print("   none")
 	}
 
 	if agent.RunnerPolicy != nil && len(agent.RunnerPolicy.RequiredMatch) > 0 {


### PR DESCRIPTION
Added flags to the `get agent` command to allow users to filter agents by unknown status, deleted status, and across all environments. Updated the UI rendering logic to accommodate these new filters and improved the handling of agent data for better output formatting.

Default output for `testkube get agents` is now similar to what you see in the Dashboard:

```
➜  testkube git:(olensmar/chore/improve-cli-agents-cmd) ✗ ./bin/app/kubectl-testkube get agents

Context: cloud (999.0.0-5c2382f56)   Namespace: testkube-dev   Org: Testkube   Env: Testkube-cloud-test-dev
-----------------------------------------------------------------------------------------------------------

  NAME                                    | CAPABILITIES                    | LABELS                | RUNNER MODE | LICENSE | AGENT ID                                | VERSION | LAST SEEN  
------------------------------------------+---------------------------------+-----------------------+-------------+---------+-----------------------------------------+---------+------------
  testkube-cloud-test-dev-runner-released | runner                          | -                     | Global      | Fixed   | tkcagent_ae2e2f0d16126763               | 2.6.3   | 0s ago     
  testkube-cloud-test-dev-listener        | listener                        | -                     | -           | -       | tkcagent_fa0f0af2c16cb510               | main    | 55m ago    
  default-agent-testkube-cloud-test-dev   | runner,listener,gitops,webhooks | runnertype=superagent | Global      | Fixed   | tkcroot_03e3ff499f13ccba                | main    | 1s ago     
  testkube-cloud-test-dev-runner-3-ind-ns | runner                          | -                     | Independent | Fixed   | tkcrun_0b45e91264d88db3647af4edcd8d9bae | main    | 2s ago     
  testkube-cloud-test-dev-runner-1-global | runner                          | -                     | Global      | Fixed   | tkcrun_a23de48cfd0404c412d7786950de6d37 | main    | 1s ago     
  testkube-cloud-test-dev-runner-2-ind    | runner                          | -                     | Independent | Fixed   | tkcrun_cd4b28d3672983bd59b474bca552f240 | main    | 2s ago     


```

Filter args have been added to show unknown (in local cluster) and deleted agents, and also to show all agents from all environments. Furthermore, support for yaml/json/go output has been added.

## Pull request description 



## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [x] tested locally
- [ ] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Breaking changes

-

## Changes

-

## Fixes

-