### PR TITLE
feat: add status filter to test workflow execution commands

### DIFF
--- a/cmd/kubectl-testkube/commands/testworkflows/executions.go
+++ b/cmd/kubectl-testkube/commands/testworkflows/executions.go
@@ -23,6 +23,7 @@ func NewGetTestWorkflowExecutionsCmd() *cobra.Command {
 		testWorkflowName, actorName, actorType string
 		logsOnly                               bool
 		tags                                   []string
+		status                                 string
 	)
 
 	cmd := &cobra.Command{
@@ -56,6 +57,7 @@ func NewGetTestWorkflowExecutionsCmd() *cobra.Command {
 					TagSelector: strings.Join(tags, ","),
 					ActorName:   actorName,
 					ActorType:   testkube.TestWorkflowRunningContextActorType(actorType),
+					Status:      status,
 				}
 				executions, err := client.ListTestWorkflowExecutions(testWorkflowName, limit, options)
 				ui.ExitOnError("getting test workflow executions list", err)
@@ -95,6 +97,7 @@ func NewGetTestWorkflowExecutionsCmd() *cobra.Command {
 	cmd.Flags().StringSliceVarP(&tags, "tag", "", nil, "tag key value pair: --tag key1=value1")
 	cmd.Flags().StringVarP(&actorName, "actor-name", "", "", "test workflow running context actor name")
 	cmd.Flags().StringVarP(&actorType, "actor-type", "", "", "test workflow running context actor type one of cron|testtrigger|user|testworkfow|testworkflowexecution|program")
+	cmd.Flags().StringVarP(&status, "status", "", "", "test workflow execution status filter, supports comma-separated list of statuses (e.g., 'running', 'passed,failed')")
 
 	return cmd
 }

--- a/pkg/api/v1/client/interface.go
+++ b/pkg/api/v1/client/interface.go
@@ -250,6 +250,7 @@ type FilterTestWorkflowExecutionOptions struct {
 	TagSelector string
 	ActorName   string
 	ActorType   testkube.TestWorkflowRunningContextActorType
+	Status      string
 }
 
 // Gettable is an interface of gettable objects

--- a/pkg/api/v1/client/testworkflow.go
+++ b/pkg/api/v1/client/testworkflow.go
@@ -206,6 +206,7 @@ func (c TestWorkflowClient) ListTestWorkflowExecutions(id string, limit int, opt
 		"tagSelector": options.TagSelector,
 		"actorName":   options.ActorName,
 		"actorType":   string(options.ActorType),
+		"status":      options.Status,
 	}
 	return c.testWorkflowExecutionsResultTransport.Execute(http.MethodGet, uri, nil, params)
 }


### PR DESCRIPTION
## Add status filter for TestWorkflow executions CLI [ TKC-2878 ]

### Summary
Adds `--status` flag to filter TestWorkflow executions by status in the CLI.

### Changes
- Added `--status` flag to `testkube get twe` command
- Supports single status: `--status=running`
- Supports multiple statuses: `--status=passed,failed`
- Passes status parameter through client to existing API endpoint

### Files Modified
- `cmd/kubectl-testkube/commands/testworkflows/executions.go` - Added CLI flag
- `pkg/api/v1/client/interface.go` - Added Status field to filter options
- `pkg/api/v1/client/testworkflow.go` - Pass status to API query params

### Usage Examples
```bash
# Filter by single status
testkube get twe --status=running

# Filter by multiple statuses
testkube get twe --status=running,queued

# Combine with other filters
testkube get twe --status=failed --testworkflow=my-workflow
```

### Valid Status Values
`queued`, `running`, `passed`, `failed`, `aborted`, `canceled`, `paused`, etc.

### Testing
Verified filtering works correctly with actual test workflows for passed, failed, and multiple status combinations.