### PR TITLE
feat: testkube check command feature

### DIFF
--- a/cmd/kubectl-testkube/commands/check.go
+++ b/cmd/kubectl-testkube/commands/check.go
@@ -1,0 +1,35 @@
+package commands
+
+import (
+	"github.com/kubeshop/testkube/pkg/checker"
+	"github.com/spf13/cobra"
+)
+
+var (
+	outputFormat  string
+	ignoreBlocker bool
+)
+
+func NewCheckCMD() *cobra.Command {
+
+	cmd := &cobra.Command{
+		Use:     "check",
+		Aliases: []string{"check", "ch"},
+		Args:    cobra.MaximumNArgs(1),
+		Short:   "Run diagnostic checks on your Testkube installation",
+		Run: func(cmd *cobra.Command, args []string) {
+			CheckSuite := []checker.CheckSuiteName{
+				checker.ClusterCheck,
+				checker.TestkubeAPICheck,
+				checker.TestkubePermissionCheck,
+			}
+			sc := checker.NewSystemChecker(CheckSuite)
+			success := sc.ExecuteSuite(ignoreBlocker)
+			checker.PrintFinalResults(success, sc.SuiteResults, outputFormat)
+		},
+	}
+
+	cmd.Flags().StringVarP(&outputFormat, "output", "o", "table", "output format. One of: table, json")
+	cmd.Flags().BoolVar(&ignoreBlocker, "ignore-blocker", false, "continue running all checks even if a blocker fails")
+	return cmd
+}

--- a/cmd/kubectl-testkube/commands/root.go
+++ b/cmd/kubectl-testkube/commands/root.go
@@ -39,6 +39,7 @@ func init() {
 	// New commands
 	RootCmd.AddCommand(NewCreateCmd())
 	RootCmd.AddCommand(NewUpdateCmd())
+	RootCmd.AddCommand(NewCheckCMD())
 
 	RootCmd.AddCommand(NewGetCmd())
 	RootCmd.AddCommand(NewSetCmd())

--- a/pkg/checker/checker.go
+++ b/pkg/checker/checker.go
@@ -1,0 +1,191 @@
+package checker
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/kubeshop/testkube/pkg/k8sclient"
+	"k8s.io/client-go/kubernetes"
+)
+
+const (
+	checkPass = "Passed"
+	checkFail = "Failed"
+
+	apiServerDeploymentSelector = "app.kubernetes.io/name=api-server"
+	operatorDeploymentSelector  = "control-plane=controller-manager"
+
+	ClusterCheck            = "Cluster Check"
+	TestkubeAPICheck        = "Testkube API Check"
+	TestkubePermissionCheck = "Testkube Permission Check"
+)
+
+// essential checks will run even if ignore-blocker is true for any check
+// belonging to a checksuite which needs to be success before any other checksuite's checks
+var essentialChecks = map[string]bool{
+	ClusterCheck: true,
+}
+
+type Checker struct {
+	Description string                      // description of the check
+	Blocker     bool                        // subsequent checks blocked if this check fails
+	Run         func(context.Context) error // executable function for the check
+}
+
+type CheckSuiteName string
+
+type CheckSuite struct {
+	Name   CheckSuiteName // name of the check
+	Checks []Checker      // list of checks to be performed
+	Enable bool           // if true, suite will be executed
+}
+
+type SystemChecker struct {
+	Suites       []CheckSuite // list of check suites
+	SuiteResults []CheckSuiteOutput
+	Client       *kubernetes.Clientset // k8s client
+}
+
+func NewSystemChecker(enabledSuites []CheckSuiteName) *SystemChecker {
+	sc := &SystemChecker{}
+	sc.Suites = sc.loadAllSuites()
+
+	enabled := make(map[CheckSuiteName]bool)
+	for _, name := range enabledSuites {
+		enabled[name] = true
+	}
+
+	for i, suite := range sc.Suites {
+		if enabled[suite.Name] {
+			sc.Suites[i].Enable = true
+		}
+	}
+
+	return sc
+}
+
+func (sc *SystemChecker) ExecuteSuite(ignoreBlocker bool) bool {
+	ctx := context.Background()
+	allSuccess := true
+	stopExecution := false
+	checkSuiteOutputs := []CheckSuiteOutput{}
+	for _, suite := range sc.Suites {
+		if !suite.Enable {
+			continue
+		}
+		checkResults := []CheckResult{}
+		for _, check := range suite.Checks {
+			err := check.Run(ctx)
+			checkOutput := CheckResult{
+				Description: check.Description,
+			}
+
+			if err != nil {
+				checkOutput.Error = err.Error()
+				checkOutput.Result = checkFail
+				allSuccess = false
+				if check.Blocker && !ignoreBlocker || essentialChecks[string(suite.Name)] {
+					stopExecution = true
+				}
+			} else {
+				checkOutput.Result = checkPass
+			}
+
+			checkResults = append(checkResults, checkOutput)
+			if stopExecution {
+				break
+			}
+		}
+		checkSuiteOutputs = append(checkSuiteOutputs, CheckSuiteOutput{
+			CheckSuiteName: suite.Name,
+			CheckResults:   checkResults,
+		})
+		sc.SuiteResults = checkSuiteOutputs
+		if stopExecution {
+			break
+		}
+	}
+	return allSuccess
+}
+
+func (sc *SystemChecker) loadAllSuites() []CheckSuite {
+	return []CheckSuite{
+		{
+			Name: ClusterCheck,
+			Checks: []Checker{
+				{
+					Description: "Check if cluster is reachable",
+					Run: func(ctx context.Context) error {
+						clientSet, err := k8sclient.ConnectToK8s()
+						if err != nil {
+							return fmt.Errorf("%s", err.Error())
+						}
+						sc.Client = clientSet
+						return nil
+					},
+					Blocker: true,
+				},
+				{
+					Description: "Check if Kubernetes version is compatible",
+					Run: func(ctx context.Context) error {
+						version, err := k8sclient.GetClusterVersion(sc.Client)
+						if err != nil {
+							return err
+						}
+						return k8sclient.IsRunningMinKubeVersion(version)
+					},
+					Blocker: true,
+				},
+			},
+		},
+		{
+			Name: TestkubeAPICheck,
+			Checks: []Checker{
+				{
+					Description: "Check if Testkube API is reachable",
+					Run: func(ctx context.Context) error {
+						isReady, err := k8sclient.CheckDeploymentReady(ctx, sc.Client, "testkube", apiServerDeploymentSelector)
+						if err != nil {
+							return err
+						}
+						if !isReady {
+							return fmt.Errorf("Testkube api-server deployment not ready")
+						}
+						return nil
+					},
+					Blocker: true,
+				},
+				{
+					Description: "Check if Testkube Operator is reachable",
+					Run: func(ctx context.Context) error {
+						isReady, err := k8sclient.CheckDeploymentReady(ctx, sc.Client, "testkube", operatorDeploymentSelector)
+						if err != nil {
+							return err
+						}
+						if !isReady {
+							return fmt.Errorf("Testkube operator deployment not ready")
+						}
+						return nil
+					},
+					Blocker: false,
+				},
+			},
+		},
+		{
+			Name: TestkubePermissionCheck,
+			Checks: []Checker{
+				{
+					Description: "Check if Testkube has necessary permissions",
+					Run: func(ctx context.Context) error {
+						expectedBindings := []string{
+							"watchers-rb-testkube",
+						}
+						_, err := k8sclient.CheckClusterRoleBindingExists(ctx, sc.Client, expectedBindings)
+						return err
+					},
+					Blocker: false,
+				},
+			},
+		},
+	}
+}

--- a/pkg/checker/checker_print.go
+++ b/pkg/checker/checker_print.go
@@ -1,0 +1,67 @@
+package checker
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/kubeshop/testkube/pkg/ui"
+)
+
+type CheckResult struct {
+	Description string `json:"description"`
+	Result      string `json:"result"`
+	Error       string `json:"error,omitempty"`
+}
+
+type CheckSuiteOutput struct {
+	CheckSuiteName CheckSuiteName `json:"checksuitename"`
+	CheckResults   []CheckResult  `json:"checkresults"`
+}
+
+func PrintTableResults(checkSuiteOutputs []CheckSuiteOutput) {
+	for _, suite := range checkSuiteOutputs {
+		ui.Info(string(suite.CheckSuiteName))
+		underline := ""
+		for i := 0; i < len(suite.CheckSuiteName); i++ {
+			underline += "-"
+		}
+		ui.Info(underline)
+		for _, check := range suite.CheckResults {
+			if len(check.Error) != 0 {
+				fmt.Printf("%s %s - %s %s\n", ui.IconCross, check.Description, ui.Red("Check Failed:"), check.Error)
+			} else {
+				fmt.Printf("%s %s - %s\n", ui.IconCheckMark, check.Description, ui.Green("Check Passed"))
+			}
+		}
+		ui.NL()
+	}
+}
+
+func PrintJSONResults(success bool, checkSuiteOutputs []CheckSuiteOutput) {
+	finalJSONOutput := map[string]interface{}{
+		"success":           success,
+		"checkSuiteResults": checkSuiteOutputs,
+	}
+
+	resultJSON, err := json.MarshalIndent(finalJSONOutput, "", "  ")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Failed to serialize JSON output for check results: %v\n", err)
+		return
+	}
+
+	fmt.Fprintf(os.Stdout, "%s\n", resultJSON)
+}
+
+func PrintFinalResults(success bool, suiteResults []CheckSuiteOutput, outputFormat string) {
+	if outputFormat == "json" {
+		PrintJSONResults(success, suiteResults)
+		return
+	}
+	PrintTableResults(suiteResults)
+	if success {
+		ui.Success("All checks passed successfully!")
+	} else {
+		ui.Alert(ui.LightRed("Checks completed with errors. Please review the output above.") + ui.IconError)
+	}
+}


### PR DESCRIPTION
## Pull request description 
This PR introduces the new Testkube check diagnostic and troubleshooting command, which validates the Testkube installation, the Kubernetes cluster's readiness, and other related checks (can be extended in the future). It is inspired by the linkerd check command as it was requested and addressed as feature request #3517.

This PR lays foundation for providing Testkube a support for adding more diagnostic and troubleshooting checks. Currently it supports checks like CheckSuites, which consists a number of checks belonging to a particular group or category.

- Cluster Check Cluster Connectivity, Minimum Version (can be set to a particular one after discussion)
- Testkube API Checks - API-Server health, Operator Readiness
- Permission Checks

We can add more CheckSuites with a number of checks in future!

## Usage
`testkube check`

## Flags

1. `--output `- It has multiple output formats like Table and JSON format.
2. `--ignore-blocker` - If this flag is true and if any check fails for which blocker field is true, then all subsequent checks will not be executed and execution will stop. However, there can be certain checks belonging to certain CheckSuite which bypass this flag as those CheckSuite can't afford to have any check to  fail or all subsequent checks will eventually fail. Eg - Cluster Check is an essential check that bypasses the -`-ignore-blocker ` flag.

## Proof Manifests
Here are some screenshots from my console for different scenarios - 
1. Cluster not available -
<img width="1312" height="172" alt="image" src="https://github.com/user-attachments/assets/81a1361a-e848-4f9f-8829-d05016a4479b" />
<img width="940" height="114" alt="image" src="https://github.com/user-attachments/assets/8256ed31-9854-446f-94a3-de17ecb935f4" />



2.  Testkube not installed - 
<img width="940" height="185" alt="image" src="https://github.com/user-attachments/assets/34dec366-3694-42f7-bc46-8bbf19b6054f" />


Ran `testkube check` for same scenario but with ignore-blocker flag - 
<img width="940" height="259" alt="image" src="https://github.com/user-attachments/assets/791029fd-ae4f-49f6-9f12-9b5ae73710c6" />



3. Testkube Operator not running - 
<img width="940" height="263" alt="image" src="https://github.com/user-attachments/assets/917d3e68-496f-4ab6-a221-61da44b1f283" />



4. All Checks successful - 
<img width="940" height="285" alt="image" src="https://github.com/user-attachments/assets/2f2a92e7-3847-4855-8d76-cbafe3a695c9" />

5. JSON output -
```
$ testkube check -o json
{
  "checkSuiteResults": [
    {
      "checksuitename": "Cluster Check",
      "checkresults": [
        {
          "description": "Check if cluster is reachable",
          "result": "Passed"
        },
        {
          "description": "Check if Kubernetes version is compatible",
          "result": "Passed"
        }
      ]
    },
    {
      "checksuitename": "Testkube API Check",
      "checkresults": [
        {
          "description": "Check if Testkube API is reachable",
          "result": "Failed",
          "error": "No Pods found for selector app.kubernetes.io/name=api-server in testkube namespace"
        },
        {
          "description": "Check if Testkube Operator is reachable",
          "result": "Failed",
          "error": "No Pods found for selector control-plane=controller-manager in testkube namespace"
        }
      ]
    },
    {
      "checksuitename": "Testkube Permission Check",
      "checkresults": [
        {
          "description": "Check if Testkube has necessary permissions",
          "result": "Failed",
          "error": "ClusterRoleBinding watchers-rb-testkube not found"
        }
      ]
    }
  ],
  "success": false
}

```

## Open For Discussion

1. What more CheckSuites and checks can be added?
2. What Minimum Version is required for testkube?
3. What checksuites should be in essentialChecks?
4. What other output formats are desirable?