### PR TITLE
fix: CVE-2025-48384 Upgrade to `alpine:3.20.8`

### DIFF
--- a/.github/workflows/new-build.yaml
+++ b/.github/workflows/new-build.yaml
@@ -10,7 +10,7 @@ on:
     branches:
       - "*"
 env:
-  ALPINE_IMAGE: alpine:3.20.6
+  ALPINE_IMAGE: alpine:3.20.8
   BUSYBOX_IMAGE: busybox:1.36.1-musl
   GAR_PROJECT_ID: ${{ secrets.GCP_PROJECT_ID_PROD }}
   GAR_LOCATION: ${{ secrets.GAR_LOCATION }}

--- a/Makefile
+++ b/Makefile
@@ -468,7 +468,7 @@ docker-build-api: goreleaser ## Build API server Docker image
 		ANALYTICS_TRACKING_ID=** ANALYTICS_API_KEY=** \
 		SEGMENTIO_KEY=** CLOUD_SEGMENTIO_KEY=** \
 		DOCKER_BUILDX_CACHE_FROM=type=registry,ref=$(DOCKER_REGISTRY)/testkube-api-server:latest \
-		ALPINE_IMAGE=alpine:3.20.6 \
+		ALPINE_IMAGE=alpine:3.20.8 \
 		$(GORELEASER) release -f goreleaser_files/.goreleaser-docker-build-api.yml --clean --snapshot
 
 .PHONY: docker-build-cli
@@ -478,7 +478,7 @@ docker-build-cli: goreleaser ## Build CLI Docker image
 		ANALYTICS_TRACKING_ID=** ANALYTICS_API_KEY=** \
 		SEGMENTIO_KEY=** CLOUD_SEGMENTIO_KEY=** \
 		DOCKER_BUILDX_CACHE_FROM=type=registry,ref=$(DOCKER_REGISTRY)/testkube-cli:latest \
-		ALPINE_IMAGE=alpine:3.20.6 \
+		ALPINE_IMAGE=alpine:3.20.8 \
 		$(GORELEASER) release -f .builds-linux.goreleaser.yml --clean --snapshot
 
 # ==================== Kubernetes ====================

--- a/build/_local/testworkflow-toolkit.Dockerfile
+++ b/build/_local/testworkflow-toolkit.Dockerfile
@@ -1,5 +1,5 @@
 ARG BUSYBOX_IMAGE="busybox:1.36.1-musl"
-ARG ALPINE_IMAGE="alpine:3.20.6"
+ARG ALPINE_IMAGE="alpine:3.20.8"
 FROM ${BUSYBOX_IMAGE} AS busybox
 
 ###################################

--- a/build/mcp-server/Dockerfile
+++ b/build/mcp-server/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1
-ARG ALPINE_IMAGE=alpine:3.20.6
+ARG ALPINE_IMAGE=alpine:3.20.8
 
 # Build stage
 FROM --platform=$BUILDPLATFORM golang:1.25-alpine AS build

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -1,7 +1,7 @@
 variable "GOCACHE"       { default = "/go/pkg" }
 variable "GOMODCACHE"    { default = "/root/.cache/go-build" }
 variable "BUSYBOX_IMAGE" { default = "busybox:1.36.1-musl"}
-variable "ALPINE_IMAGE"  { default = "alpine:3.20.6" }
+variable "ALPINE_IMAGE"  { default = "alpine:3.20.8" }
 variable "VERSION"       { default = "0.0.0-unknown"}
 
 variable "GIT_SHA"                 { default = ""}


### PR DESCRIPTION
## Pull request description 

Upgrades the base image for several containers from `alpine:3.20.6` to `alpine:3.20.8` to mitigate [CVE-2025-48384](https://nvd.nist.gov/vuln/detail/cve-2025-48384). The latest built image currently has version `2.45.3`, and the fix for the CVE is in `v2.45.4`.

```Shell
$ docker run -ti --entrypoint /usr/bin/git docker.io/kubeshop/testkube-api-server:2.4.0 --version
git version 2.45.3
```

This ensures all images include the latest upstream security patches from Alpine Linux.

> [!NOTE]
> While `v2.45.4` is available for `alpine:3.20.6`, Docker build caching is preventing the latest APK packages from being pulled. This change will bust that cache and ensure the updated packages are fetched.

## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [ ] tested locally
- [ ] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Changes

- Upgrade from using `alpine:3.20.6` to `alpine:3.20.8`
