### PR TITLE
fix: missing return

### DIFF
--- a/pkg/runner/grpc/client.go
+++ b/pkg/runner/grpc/client.go
@@ -249,6 +249,7 @@ func (c Client) executeResponse(ctx context.Context, response *executionv1.GetEx
 				c.logger.Errorw("Failed to start execution.",
 					"executionId", start.GetExecutionId(),
 					"error", err)
+				return
 			}
 
 			if result.Redundant {


### PR DESCRIPTION
Not returning after an error
attempting to execute the workflow
here can lead to a nil pointer
dereference and panic.
