### PR TITLE
fix: tagSuffix in images

### DIFF
--- a/k8s/helm/testkube-api/values.yaml
+++ b/k8s/helm/testkube-api/values.yaml
@@ -78,6 +78,7 @@ image:
   pullPolicy: IfNotPresent
   ## Overrides the image tag whose default is the chart appVersion.
   # tag: "1.7.24"
+  tagSuffix: ""
   digest: ""
   pullSecrets: []
 
@@ -90,6 +91,7 @@ imageTwToolkit:
   ## Overrides the image tag whose default is the api-server version.
   # tag: "1.7.24"
   digest: ""
+  tagSuffix: ""
 
 imageTwInit:
   registry: docker.io
@@ -97,6 +99,7 @@ imageTwInit:
   ## Overrides the image tag whose default is the api-server version.
   # tag: "1.7.24"
   digest: ""
+  tagSuffix: ""
 
 ## Chart parameters
 ## nameOverride Overrides Chart name

--- a/k8s/helm/testkube-runner/values.yaml
+++ b/k8s/helm/testkube-runner/values.yaml
@@ -127,6 +127,7 @@ images:
     ## Overrides the image tag whose default is the chart appVersion.
     # tag: "2.1.147"
     digest: ""
+    tagSuffix: ""
     pullSecrets: []
 
   toolkit:
@@ -135,6 +136,7 @@ images:
     ## Overrides the image tag whose default is the api-server version.
     # tag: "2.1.147"
     digest: ""
+    tagSuffix: ""
 
   init:
     registry: docker.io
@@ -142,6 +144,7 @@ images:
     ## Overrides the image tag whose default is the api-server version.
     # tag: "2.1.147"
     digest: ""
+    tagSuffix: ""
 
 ## Persistent cache for Docker
 imageInspectionCache:


### PR DESCRIPTION
## Pull request description 

Fixes the error: `image: >-
  registry.testkube/kubeshop/testkube-api-server:2.3.0%!s(<nil>)`

## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [ ] tested locally
- [ ] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Breaking changes

-

## Changes

-

## Fixes

-