### PR TITLE
chore: change insecure sync log message level

### DIFF
--- a/cmd/api-server/main.go
+++ b/cmd/api-server/main.go
@@ -614,7 +614,7 @@ func main() {
 			// If the agent is running without secure gRPC TLS connection to the Control Plane then the client will not be able to
 			// connect and so we need to fallback to an implementation that doesn't do anything.
 			if cfg.TestkubeProTLSInsecure || cfg.TestkubeProSkipVerify {
-				log.DefaultLogger.Warn("Unable to create GitOps sync connection to Control Plane when running in insecure TLS mode. Kubernetes resource updates will not be synced with the Control Plane!")
+				log.DefaultLogger.Error("Unable to create GitOps sync connection to Control Plane when running in insecure TLS mode. Kubernetes resource updates will not be synced with the Control Plane!")
 				store = syncagent.NoOpStore{}
 			}
 


### PR DESCRIPTION
Logging at Error level makes the issue more clear. I'm still not sure I'm comfortable with killing the entire application at this point because this is a relatively minor sub-system and all other systems will continue to work correctly without it.
