### PR TITLE
fix: add back missing owner field for gh app token in manual cli release; remove 'v' prefix for run on tag in release workflow

### DIFF
--- a/.github/workflows/release-cli-manual.yaml
+++ b/.github/workflows/release-cli-manual.yaml
@@ -109,6 +109,7 @@ jobs:
         with:
           app-id: 253113
           private-key: ${{ secrets.TESTKUBE_GH_APP_GITOPS_KEY }}
+          owner: kubeshop
       - name: Get GitHub App User ID
         id: get-user-id
         run: echo "user-id=$(gh api "/users/${{ steps.app-token.outputs.app-slug }}[bot]" --jq .id)" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -3,7 +3,7 @@ name: Release kubectl-testkube
 on:
   push:
     tags:
-      - "v[0-9]+.[0-9]+.[0-9]+"
+      - "[0-9]+.[0-9]+.[0-9]+"
 
 permissions:
   id-token: write # needed for keyless signing


### PR DESCRIPTION
## Pull request description 



## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [ ] tested locally
- [ ] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Breaking changes

-

## Changes

-

## Fixes

-