### PR TITLE
fix: Update MongoDB image tag to version 8.0.15

### DIFF
--- a/k8s/helm/testkube/values.yaml
+++ b/k8s/helm/testkube/values.yaml
@@ -112,7 +112,7 @@ mongodb:
     # -- MongoDB image repository
     repository: testkube-cloud-372110/testkube/mongodb
     # -- MongoDB image tag
-    tag: 8.0.13
+    tag: 8.0.15
     # -- MongoDB image pull Secret
     pullSecrets: []
   # ref: https://cloud.google.com/kubernetes-engine/docs/how-to/prepare-arm-workloads-for-deployment#node-affinity-multi-arch-arm


### PR DESCRIPTION

## Checklist (choose whats happened)

- [x] breaking change! (describe)
- [ ] tested locally
- [ ] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Breaking changes
the 8.0.13 tag doesn't exist anymore, causing installation of the standalone agent (`testkube init`) to fail
<img width="1330" height="204" alt="image" src="https://github.com/user-attachments/assets/20310b5f-98ad-495c-b732-a8c260bd5863" />

it appears that the 8.0.13 tag of mongodb doesnt exist anymore in the testkube registry

```
docker pull us-east1-docker.pkg.dev/testkube-cloud-372110/testkube/mongodb:8.0.13
Error response from daemon: failed to resolve reference "us-east1-docker.pkg.dev/testkube-cloud-372110/testkube/mongodb:8.0.13": us-east1-docker.pkg.dev/testkube-cloud-372110/testkube/mongodb:8.0.13: not found

 docker pull us-east1-docker.pkg.dev/testkube-cloud-372110/testkube/mongodb:8.0.15
8.0.15: Pulling from testkube-cloud-372110/testkube/mongodb
bb57c08b7862: Download complete
7e16b8192cbe: Download complete
bcbb6594dfa9: Download complete
b64beab89b6b: Download complete
bb57c08b7862: Pull complete
7e16b8192cbe: Pull complete
bcbb6594dfa9: Pull complete
b64beab89b6b: Pull complete
932ca08fcbfd: Pull complete
afea435a1e56: Pull complete
45c79c89dd49: Pull complete
e87f95d38081: Pull complete
6a691b4967e9: Pull complete
7b6fc11aa5bc: Pull complete
69f658836d73: Pull complete
8712cd0f8529: Pull complete
11a4f29c5bab: Pull complete
5bc54a64c50e: Pull complete
6df6dcf72b07: Pull complete
20043066d3d5: Pull complete
63ed9b6d76ba: Pull complete
dfe494462d1a: Pull complete
Digest: sha256:c26bd3d3cff0ee9ac273c5c3b1ebdbbecfd697caf678e3cc5d5b7925214fce4d
Status: Downloaded newer image for us-east1-docker.pkg.dev/testkube-cloud-372110/testkube/mongodb:8.0.15
us-east1-docker.pkg.dev/testkube-cloud-372110/testkube/mongodb:8.0.15
```

## Fixes

- bumping mongodb version from 8.0.13  -> 8.0.15