### PR TITLE
fix: [TKC-4563] add logger to ECR helper in cranefetcher.go

### DIFF
--- a/pkg/imageinspector/cranefetcher.go
+++ b/pkg/imageinspector/cranefetcher.go
@@ -51,7 +51,7 @@ func (c *craneFetcher) Fetch(ctx context.Context, registry, image string, pullSe
 		return nil, err
 	}
 
-	amazonKeychain := authn.NewKeychainFromHelper(ecr.NewECRHelper(ecr.WithLogger(io.Discard))
+	amazonKeychain := authn.NewKeychainFromHelper(ecr.NewECRHelper(ecr.WithLogger(io.Discard)))
 	azureKeychain := authn.NewKeychainFromHelper(credhelper.NewACRCredentialsHelper())
 	keychain := authn.NewMultiKeychain(
 		authn.DefaultKeychain,


### PR DESCRIPTION
## Pull request description 

Disable AWS ECR warning that is concerning customers that are not using AWS ECR.

## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [ ] tested locally
- [ ] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Fixes

- Disable AWS ECR warning that is concerning customers that are not using AWS ECR.