### PR TITLE
chore: Add cleanup of dirs created during tests

### DIFF
--- a/cmd/kubectl-testkube/config/config_test.go
+++ b/cmd/kubectl-testkube/config/config_test.go
@@ -11,6 +11,9 @@ func TestSave(t *testing.T) {
 	// override default directory
 	dir, err := os.MkdirTemp("", "test-config-save")
 	assert.NoError(t, err)
+	t.Cleanup(func() {
+		_ = os.RemoveAll(dir)
+	})
 	defaultDirectory = dir
 
 	t.Run("test save into default storage", func(t *testing.T) {
@@ -29,9 +32,11 @@ func TestSave(t *testing.T) {
 }
 
 func TestSaveTelemetryEnabled(t *testing.T) {
-
 	dir, err := os.MkdirTemp("", "test-config-save")
 	assert.NoError(t, err)
+	t.Cleanup(func() {
+		_ = os.RemoveAll(dir)
+	})
 
 	// create homedir config file
 	s := Storage{Dir: dir}
@@ -45,7 +50,6 @@ func TestSaveTelemetryEnabled(t *testing.T) {
 		// then
 		assert.NoError(t, err)
 		assert.Equal(t, true, d.TelemetryEnabled)
-
 	})
 
 	t.Run("check if telemetry system is disabled", func(t *testing.T) {
@@ -63,7 +67,5 @@ func TestSaveTelemetryEnabled(t *testing.T) {
 		// then
 		assert.NoError(t, err)
 		assert.Equal(t, false, d.TelemetryEnabled)
-
 	})
-
 }

--- a/pkg/event/bus/testserver.go
+++ b/pkg/event/bus/testserver.go
@@ -2,13 +2,16 @@ package bus
 
 import (
 	"os"
+	"testing"
 
 	"github.com/nats-io/nats-server/v2/server"
 	natsserver "github.com/nats-io/nats-server/v2/test"
 	"github.com/nats-io/nats.go"
 )
 
-func TestServerWithConnection() (*server.Server, *nats.Conn) {
+func TestServerWithConnection(t *testing.T) (*server.Server, *nats.Conn) {
+	t.Helper()
+
 	opts := &natsserver.DefaultTestOptions
 	opts.JetStream = true
 	opts.Port = -1
@@ -18,6 +21,9 @@ func TestServerWithConnection() (*server.Server, *nats.Conn) {
 	if err != nil {
 		panic(err)
 	}
+	t.Cleanup(func() {
+		_ = os.RemoveAll(dir)
+	})
 	opts.StoreDir = dir
 
 	ns := natsserver.RunServer(opts)

--- a/pkg/event/bus/testserver_test.go
+++ b/pkg/event/bus/testserver_test.go
@@ -9,7 +9,7 @@ import (
 
 func TestServerRestart(t *testing.T) {
 	// given NATS server
-	s, nc := TestServerWithConnection()
+	s, nc := TestServerWithConnection(t)
 	defer s.Shutdown()
 
 	// and NATS Subscription


### PR DESCRIPTION
os package does not handle cleanup of temporary diretories, so users are expected to cleanup after they are done.

It's a non functional change, but IMO it's beneficial to clean either whatever go tmp is set to or `/tmp` that pollutes RAM space in most default installations.

## Pull request description 



## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [ ] tested locally
- [ ] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [x] added a test

## Breaking changes

-

## Changes

-

## Fixes

-