### PR TITLE
feat: detect failure when service exits with non-zero code; cleanup services logic and add tests

### DIFF
--- a/cmd/tcl/testworkflow-toolkit/commands/services.go
+++ b/cmd/tcl/testworkflow-toolkit/commands/services.go
@@ -13,12 +13,15 @@ import (
 	"encoding/json"
 	"fmt"
 	"math"
-	"os"
 	"strings"
 	"time"
 
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
+
+	"github.com/kubeshop/testkube/cmd/testworkflow-toolkit/env/config"
+	"github.com/kubeshop/testkube/pkg/testworkflows/testworkflowprocessor/constants"
+
+	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -27,20 +30,20 @@ import (
 	"github.com/kubeshop/testkube/cmd/tcl/testworkflow-toolkit/spawn"
 	"github.com/kubeshop/testkube/cmd/testworkflow-init/data"
 	"github.com/kubeshop/testkube/cmd/testworkflow-init/instructions"
-	"github.com/kubeshop/testkube/cmd/testworkflow-toolkit/env/config"
 	"github.com/kubeshop/testkube/cmd/testworkflow-toolkit/transfer"
 	"github.com/kubeshop/testkube/internal/common"
+	"github.com/kubeshop/testkube/pkg/api/v1/testkube"
 	"github.com/kubeshop/testkube/pkg/expressions"
 	"github.com/kubeshop/testkube/pkg/mapper/testworkflows"
 	"github.com/kubeshop/testkube/pkg/tcl/expressionstcl"
 	"github.com/kubeshop/testkube/pkg/testworkflows/executionworker/executionworkertypes"
 	"github.com/kubeshop/testkube/pkg/testworkflows/testworkflowconfig"
-	"github.com/kubeshop/testkube/pkg/testworkflows/testworkflowprocessor/constants"
 	"github.com/kubeshop/testkube/pkg/testworkflows/testworkflowprocessor/stage"
 	"github.com/kubeshop/testkube/pkg/testworkflows/testworkflowresolver"
 	"github.com/kubeshop/testkube/pkg/ui"
 )
 
+// ServiceInstance contains all configuration needed to deploy and monitor a service.
 type ServiceInstance struct {
 	Index          int64
 	Name           string
@@ -51,6 +54,7 @@ type ServiceInstance struct {
 	Spec           testworkflowsv1.TestWorkflowSpec
 }
 
+// ServiceState tracks IP assignment and description for service discovery.
 type ServiceState struct {
 	Ip          string `json:"ip"`
 	Description string `json:"description"`
@@ -65,6 +69,7 @@ const (
 	ServiceStatusFailed  ServiceStatus = "failed"
 )
 
+// ServiceInfo is serialized as JSON and sent via PrintOutput for UI updates.
 type ServiceInfo struct {
 	Group       string        `json:"group"`
 	Index       int64         `json:"index"`
@@ -81,6 +86,47 @@ func (s ServiceInfo) AsMap() (v map[string]interface{}) {
 	return
 }
 
+// ServiceExecutionResult contains the outcome of monitoring a single service.
+type ServiceExecutionResult struct {
+	Started bool
+	Ready   bool
+	Failed  bool
+	Error   error
+}
+
+const (
+	UnlimitedParallelism = math.MaxInt64
+
+	// How long to wait for Kubernetes to report a container exit after startup.
+	// The kubelet syncs pod status every 10s by default.
+	serviceFailureCheckTimeout = 15 * time.Second
+)
+
+type ServicesDependencies struct {
+	Config          *testworkflowconfig.InternalConfig
+	BaseMachine     expressions.Machine
+	TransferSrv     transfer.Server
+	ExecutionWorker executionworkertypes.Worker
+	Ref             string
+	Namespace       string
+}
+
+// ServicesExecutor handles the full services lifecycle:
+// parsing, preparation, execution, and result reporting.
+type ServicesExecutor struct {
+	groupRef      string
+	base64Encoded bool
+	deps          ServicesDependencies
+}
+
+func NewServicesExecutor(groupRef string, base64Encoded bool, deps ServicesDependencies) *ServicesExecutor {
+	return &ServicesExecutor{
+		groupRef:      groupRef,
+		base64Encoded: base64Encoded,
+		deps:          deps,
+	}
+}
+
 func NewServicesCmd() *cobra.Command {
 	var (
 		groupRef      string
@@ -91,342 +137,19 @@ func NewServicesCmd() *cobra.Command {
 		Short: "Start accompanying service(s)",
 
 		Run: func(cmd *cobra.Command, args []string) {
-			// Initialize basic adapters
-			baseMachine := spawn.CreateBaseMachine()
-			transferSrv := transfer.NewServer(constants.DefaultTransferDirPath, config.IP(), constants.DefaultTransferPort)
-
-			// Validate data
-			if groupRef == "" {
-				ui.Fail(errors.New("missing required --group for starting the services"))
+			// Initialize dependencies from singletons in the command handler only
+			deps := ServicesDependencies{
+				Config:          config.Config(),
+				BaseMachine:     spawn.CreateBaseMachine(),
+				TransferSrv:     transfer.NewServer(constants.DefaultTransferDirPath, config.IP(), constants.DefaultTransferPort),
+				ExecutionWorker: spawn.ExecutionWorker(),
+				Ref:             config.Ref(),
+				Namespace:       config.Namespace(),
 			}
 
-			// Read the services to start
-			services := make(map[string]testworkflowsv1.ServiceSpec)
-
-			if base64Encoded && len(args) > 0 {
-				// Decode base64 input. The processor base64-encodes service specs to prevent
-				// testworkflow-init from prematurely resolving expressions like {{ matrix.browser.driver }}.
-				// We decode here where we have the proper context to evaluate these expressions.
-				// Decode the services map
-				var servicesMap map[string]json.RawMessage
-				err := expressionstcl.DecodeBase64JSON(args[0], &servicesMap)
-				ui.ExitOnError("decoding services", err)
-
-				// Parse each service spec
-				for name, raw := range servicesMap {
-					var svc testworkflowsv1.ServiceSpec
-					err := json.Unmarshal(raw, &svc)
-					ui.ExitOnError(fmt.Sprintf("parsing service spec for %s", name), err)
-					services[name] = svc
-				}
-			} else {
-				// Legacy format: name=spec pairs (kept for backward compatibility)
-				for i := range args {
-					name, v, found := strings.Cut(args[i], "=")
-					if !found {
-						ui.Fail(fmt.Errorf("invalid service declaration: %s", args[i]))
-					}
-					var svc *testworkflowsv1.ServiceSpec
-					err := json.Unmarshal([]byte(v), &svc)
-					ui.ExitOnError("parsing service spec", err)
-					services[name] = *svc
-				}
-			}
-
-			// Apply default service account and initialize details for each service
-			for name := range services {
-				if services[name].Pod == nil {
-					svc := services[name]
-					svc.Pod = &testworkflowsv1.PodConfig{}
-					services[name] = svc
-				}
-				if services[name].Pod.ServiceAccountName == "" {
-					services[name].Pod.ServiceAccountName = "{{internal.serviceaccount.default}}"
-				}
-
-				// Initialize empty array of details for each of the services
-				instructions.PrintHintDetails(config.Ref(), data.ServicesPrefix+name, []ServiceState{})
-			}
-
-			// Analyze instances to run
-			state := make(map[string][]ServiceState)
-			instances := make([]ServiceInstance, 0)
-			namespaces := make([]string, 0)
-			svcParams := make(map[string]*commontcl.ParamsSpec)
-			for name, svc := range services {
-				// Resolve the params
-				params, err := commontcl.GetParamsSpec(svc.Matrix, svc.Shards, svc.Count, svc.MaxCount, baseMachine)
-				ui.ExitOnError(fmt.Sprintf("%s: compute matrix and sharding", commontcl.ServiceLabel(name)), err)
-				svcParams[name] = params
-
-				// Ignore no instances
-				if params.Count == 0 {
-					fmt.Printf("%s: 0 instances requested (combinations=%d, count=%d), skipping\n", commontcl.ServiceLabel(name), params.MatrixCount, params.ShardCount)
-					continue
-				}
-
-				// Print information about the number of params
-				fmt.Printf("%s: %s\n", commontcl.ServiceLabel(name), params.String(math.MaxInt64))
-
-				svcInstances := make([]ServiceInstance, params.Count)
-				svcNamespaces := make([]string, params.Count)
-				for index := int64(0); index < params.Count; index++ {
-					machines := []expressions.Machine{baseMachine, params.MachineAt(index)}
-
-					// Clone the spec
-					svcSpec := svc.DeepCopy()
-					err = expressions.Simplify(&svcSpec, machines...)
-					ui.ExitOnError(fmt.Sprintf("%s: %d: error", commontcl.ServiceLabel(name), index), err)
-
-					// Build the spec
-					spec := testworkflowsv1.TestWorkflowSpec{
-						TestWorkflowSpecBase: testworkflowsv1.TestWorkflowSpecBase{
-							Content:   svcSpec.Content,
-							Container: common.Ptr(svcSpec.ContainerConfig),
-							Pod:       svcSpec.Pod,
-						},
-						Steps: []testworkflowsv1.Step{
-							{StepOperations: testworkflowsv1.StepOperations{Run: common.Ptr(svcSpec.StepRun)}},
-						},
-						Pvcs: svcSpec.Pvcs,
-					}
-					spec.Steps[0].Run.ContainerConfig = testworkflowsv1.ContainerConfig{}
-					spec.Container.Env = testworkflowresolver.DedupeEnvVars(append(config.Config().Execution.GlobalEnv, spec.Container.Env...))
-
-					// Transfer the data
-					if spec.Content == nil {
-						spec.Content = &testworkflowsv1.Content{}
-					}
-					tarballs, err := spawn.ProcessTransfer(transferSrv, svcSpec.Transfer, machines...)
-					ui.ExitOnError(fmt.Sprintf("%s: %d: error: transfer", commontcl.ServiceLabel(name), index), err)
-					spec.Content.Tarball = append(spec.Content.Tarball, tarballs...)
-
-					// Save the instance
-					svcInstances[index] = ServiceInstance{
-						Index:          index,
-						Name:           name,
-						Description:    svcSpec.Description,
-						RestartPolicy:  corev1.RestartPolicy(svcSpec.RestartPolicy),
-						ReadinessProbe: svcSpec.ReadinessProbe,
-						Spec:           spec,
-					}
-					svcNamespaces[index] = config.Namespace()
-					if spec.Job != nil && spec.Job.Namespace != "" {
-						svcNamespaces[index] = spec.Job.Namespace
-					}
-
-					// Save the timeout
-					if svcSpec.Timeout != "" {
-						v, err := expressions.EvalTemplate(svcSpec.Timeout, machines...)
-						ui.ExitOnError(fmt.Sprintf("%s: %d: error: timeout expression", commontcl.ServiceLabel(name), index), err)
-						d, err := time.ParseDuration(strings.ReplaceAll(v, " ", ""))
-						ui.ExitOnError(fmt.Sprintf("%s: %d: error: invalid timeout: %s", commontcl.ServiceLabel(name), index, v), err)
-						svcInstances[index].Timeout = &d
-					}
-				}
-				instances = append(instances, svcInstances...)
-				namespaces = append(namespaces, svcNamespaces...)
-
-				// Update the state
-				state[name] = make([]ServiceState, len(svcInstances))
-				for i := range svcInstances {
-					state[name][i].Description = svcInstances[i].Description
-				}
-				instructions.PrintHintDetails(config.Ref(), data.ServicesPrefix+name, state)
-			}
-
-			// Inform about each service instance
-			for _, instance := range instances {
-				instructions.PrintOutput(config.Ref(), "service", ServiceInfo{
-					Group:       groupRef,
-					Index:       instance.Index,
-					Name:        instance.Name,
-					Description: instance.Description,
-					Status:      ServiceStatusQueued,
-				})
-			}
-
-			// Initialize transfer server if expected
-			if transferSrv.Count() > 0 || transferSrv.RequestsCount() > 0 {
-				infos := make([]string, 0)
-				if transferSrv.Count() > 0 {
-					infos = append(infos, fmt.Sprintf("sending %d tarballs", transferSrv.Count()))
-				}
-				if transferSrv.RequestsCount() > 0 {
-					infos = append(infos, fmt.Sprintf("fetching %d requests", transferSrv.RequestsCount()))
-				}
-				fmt.Printf("Starting transfer server for %s...\n", strings.Join(infos, " and "))
-				if _, err := transferSrv.Listen(); err != nil {
-					ui.Fail(errors.Wrap(err, "failed to start transfer server"))
-				}
-				fmt.Printf("Transfer server started.\n")
-			}
-
-			// Validate if there is anything to run
-			if len(instances) == 0 {
-				ui.SuccessAndExit("nothing to run")
-			}
-
-			run := func(_ int64, _ string, instance *ServiceInstance) bool {
-				info := ServiceInfo{
-					Group:       groupRef,
-					Index:       instance.Index,
-					Name:        instance.Name,
-					Description: instance.Description,
-					Status:      ServiceStatusQueued,
-				}
-				index := instance.Index
-
-				// Determine the namespace
-				namespace := config.Namespace()
-				if instance.Spec.Job != nil && instance.Spec.Job.Namespace != "" {
-					namespace = instance.Spec.Job.Namespace
-				}
-
-				params := svcParams[instance.Name]
-				log := spawn.CreateLogger(instance.Name, instance.Description, index, params.Count)
-
-				// Build the configuration
-				cfg := *config.Config()
-				cfg.Resource = spawn.CreateResourceConfig(instance.Name+"-", index) // TODO: Think if it should be there
-				cfg.Worker.Namespace = namespace
-				machine := expressions.CombinedMachines(
-					testworkflowconfig.CreateResourceMachine(&cfg.Resource),
-					testworkflowconfig.CreateWorkerMachine(&cfg.Worker),
-					baseMachine,
-					testworkflowconfig.CreatePvcMachine(cfg.Execution.PvcNames),
-					params.MachineAt(index),
-				)
-
-				// Simplify the workflow
-				_ = expressions.Simplify(&instance.Spec, machine)
-
-				// Build the resources bundle
-				scheduledAt := time.Now()
-				result, err := spawn.ExecutionWorker().Service(context.Background(), executionworkertypes.ServiceRequest{
-					ResourceId:     cfg.Resource.Id,
-					GroupId:        groupRef,
-					Execution:      cfg.Execution,
-					Workflow:       testworkflowsv1.TestWorkflow{ObjectMeta: metav1.ObjectMeta{Name: cfg.Workflow.Name, Labels: cfg.Workflow.Labels}, Spec: instance.Spec},
-					ScheduledAt:    &scheduledAt,
-					RestartPolicy:  string(instance.RestartPolicy),
-					ReadinessProbe: common.MapPtr(instance.ReadinessProbe, testworkflows.MapProbeKubeToAPI),
-
-					ControlPlane:        cfg.ControlPlane,
-					ArtifactsPathPrefix: cfg.Resource.FsPrefix,
-				})
-				if err != nil {
-					fmt.Printf("%d: failed to prepare resources: %s\n", index, err.Error())
-					return false
-				}
-
-				// Compute the bundle instructions
-				signatureSeq := stage.MapSignatureToSequence(stage.MapSignatureList(result.Signature))
-				mainRef := signatureSeq[len(signatureSeq)-1].Ref()
-
-				// Handle timeout
-				timeoutCtx, timeoutCtxCancel := context.WithCancel(context.Background())
-				defer timeoutCtxCancel()
-				if instance.Timeout != nil {
-					go func() {
-						select {
-						case <-timeoutCtx.Done():
-						case <-time.After(*instance.Timeout):
-							log("timed out", instance.Timeout.String()+" elapsed")
-							timeoutCtxCancel()
-						}
-					}()
-				}
-
-				// Control the execution
-				// TODO: Consider aggregated controller to limit number of watchers
-				ctx, ctxCancel := context.WithCancel(timeoutCtx)
-				defer ctxCancel()
-
-				// TODO: Use more lightweight notifications
-				notifications := spawn.ExecutionWorker().StatusNotifications(ctx, cfg.Resource.Id, executionworkertypes.StatusNotificationsOptions{
-					Hints: executionworkertypes.Hints{
-						Namespace:   result.Namespace,
-						Signature:   result.Signature,
-						ScheduledAt: common.Ptr(scheduledAt),
-					},
-				})
-				if notifications.Err() != nil {
-					log("error", "failed to connect to the service", notifications.Err().Error())
-					return false
-				}
-				log("created")
-
-				scheduled := false
-				started := false
-				ready := instance.ReadinessProbe == nil
-				for v := range notifications.Channel() {
-					// Inform about the node assignment
-					if !scheduled && v.NodeName != "" {
-						scheduled = true
-						log(fmt.Sprintf("assigned to %s node", ui.LightBlue(v.NodeName)))
-					}
-
-					if state[instance.Name][index].Ip == "" && v.PodIp != "" {
-						state[instance.Name][index].Ip = v.PodIp
-						log(fmt.Sprintf("assigned to %s IP", ui.LightBlue(v.PodIp)))
-						info.Status = ServiceStatusRunning
-						instructions.PrintOutput(config.Ref(), "service", info)
-					}
-
-					ready = v.Ready
-					if !started && v.Ref == mainRef && state[instance.Name][index].Ip != "" {
-						started = true
-						if instance.ReadinessProbe == nil {
-							log("container started")
-						} else {
-							log("container started, waiting for readiness")
-						}
-					}
-
-					if started && ready {
-						break
-					}
-				}
-				ctxCancel()
-				if !ready {
-					log("container did not reach readiness")
-					info.Status = ServiceStatusFailed
-				} else {
-					log("container ready")
-					info.Status = ServiceStatusReady
-				}
-				if notifications.Err() != nil {
-					log("error", notifications.Err().Error())
-				}
-
-				// Fail if the container has not started
-				if !started {
-					info.Status = ServiceStatusFailed
-					log("container failed")
-					instructions.PrintOutput(config.Ref(), "service", info)
-					return false
-				}
-
-				instructions.PrintOutput(config.Ref(), "service", info)
-
-				return ready
-			}
-
-			// Start all the services
-			failed := spawn.ExecuteParallel(run, instances, namespaces, int64(len(instances)))
-
-			// Inform about the services state
-			for k := range state {
-				instructions.PrintHintDetails(config.Ref(), data.ServicesPrefix+k, state[k])
-			}
-
-			// Notify the results
-			if failed == 0 {
-				fmt.Printf("Successfully started %d workers.\n", len(instances))
-			} else {
-				fmt.Printf("Failed to start %d out of %d expected workers.\n", failed, len(instances))
-				os.Exit(1)
+			executor := NewServicesExecutor(groupRef, base64Encoded, deps)
+			if err := executor.Execute(args); err != nil {
+				ui.Fail(err)
 			}
 		},
 	}
@@ -435,4 +158,549 @@ func NewServicesCmd() *cobra.Command {
 	cmd.Flags().BoolVar(&base64Encoded, "base64", false, "input is base64 encoded")
 
 	return cmd
+}
+
+// RunServicesWithOptions executes services with the provided configuration.
+// This is the testable entry point for integration tests.
+func RunServicesWithOptions(specContent string, cfg *config.ConfigV2, base64Encoded bool, groupRef string) error {
+	internalCfg := cfg.Internal()
+
+	deps := ServicesDependencies{
+		Config:          internalCfg,
+		BaseMachine:     spawn.CreateBaseMachine(),
+		TransferSrv:     transfer.NewServer(constants.DefaultTransferDirPath, cfg.IP(), constants.DefaultTransferPort),
+		ExecutionWorker: spawn.ParallelExecutionWorker(cfg),
+		Ref:             internalCfg.Resource.Id,
+		Namespace:       cfg.Namespace(),
+	}
+
+	executor := NewServicesExecutor(groupRef, base64Encoded, deps)
+	return executor.Execute([]string{specContent})
+}
+
+// Execute runs all services and returns an error if any fail.
+func (e *ServicesExecutor) Execute(args []string) error {
+	if e.groupRef == "" {
+		return errors.New("missing required --group for starting the services")
+	}
+
+	services, err := e.parseServices(args)
+	if err != nil {
+		return err
+	}
+
+	e.initializeServiceDefaults(services)
+
+	instances, namespaces, state, svcParams, err := e.prepareInstances(services)
+	if err != nil {
+		return err
+	}
+
+	e.notifyQueuedInstances(instances)
+
+	if err := e.startTransferServer(); err != nil {
+		return err
+	}
+
+	if len(instances) == 0 {
+		fmt.Println("nothing to run")
+		return nil
+	}
+
+	failed := e.runServices(instances, namespaces, state, svcParams)
+	e.reportFinalState(state)
+
+	if failed == 0 {
+		fmt.Printf("Successfully started %d workers.\n", len(instances))
+		return nil
+	}
+	fmt.Printf("Failed to start %d out of %d expected workers.\n", failed, len(instances))
+	return fmt.Errorf("%d services failed to start", failed)
+}
+
+// parseServices supports two input formats:
+//   - Base64 encoded JSON (--base64 flag): prevents premature expression resolution
+//   - Raw JSON key=value pairs: legacy format for backward compatibility
+func (e *ServicesExecutor) parseServices(args []string) (map[string]testworkflowsv1.ServiceSpec, error) {
+	services := make(map[string]testworkflowsv1.ServiceSpec)
+
+	if e.base64Encoded && len(args) > 0 {
+		// The processor base64-encodes service specs to prevent testworkflow-init
+		// from prematurely resolving expressions like {{ matrix.browser.driver }}.
+		var servicesMap map[string]json.RawMessage
+		if err := expressionstcl.DecodeBase64JSON(args[0], &servicesMap); err != nil {
+			return nil, errors.Wrap(err, "decoding services")
+		}
+		for name, raw := range servicesMap {
+			var svc testworkflowsv1.ServiceSpec
+			if err := json.Unmarshal(raw, &svc); err != nil {
+				return nil, errors.Wrapf(err, "parsing service spec for %s", name)
+			}
+			services[name] = svc
+		}
+	} else {
+		// Legacy format: name=spec pairs (kept for backward compatibility)
+		for i := range args {
+			name, v, found := strings.Cut(args[i], "=")
+			if !found {
+				return nil, fmt.Errorf("invalid service declaration: %s", args[i])
+			}
+			var svc *testworkflowsv1.ServiceSpec
+			if err := json.Unmarshal([]byte(v), &svc); err != nil {
+				return nil, errors.Wrap(err, "parsing service spec")
+			}
+			services[name] = *svc
+		}
+	}
+
+	return services, nil
+}
+
+// initializeServiceDefaults applies default values to service specs.
+func (e *ServicesExecutor) initializeServiceDefaults(services map[string]testworkflowsv1.ServiceSpec) {
+	for name := range services {
+		if services[name].Pod == nil {
+			svc := services[name]
+			svc.Pod = &testworkflowsv1.PodConfig{}
+			services[name] = svc
+		}
+		if services[name].Pod.ServiceAccountName == "" {
+			services[name].Pod.ServiceAccountName = "{{internal.serviceaccount.default}}"
+		}
+		// Initialize empty array of details for each service
+		instructions.PrintHintDetails(e.deps.Ref, data.ServicesPrefix+name, []ServiceState{})
+	}
+}
+
+// prepareInstances analyzes services and creates instances for execution.
+func (e *ServicesExecutor) prepareInstances(services map[string]testworkflowsv1.ServiceSpec) (
+	[]ServiceInstance,
+	[]string,
+	map[string][]ServiceState,
+	map[string]*commontcl.ParamsSpec,
+	error,
+) {
+	state := make(map[string][]ServiceState)
+	instances := make([]ServiceInstance, 0)
+	namespaces := make([]string, 0)
+	svcParams := make(map[string]*commontcl.ParamsSpec)
+
+	for name, svc := range services {
+		params, err := commontcl.GetParamsSpec(svc.Matrix, svc.Shards, svc.Count, svc.MaxCount, e.deps.BaseMachine)
+		if err != nil {
+			return nil, nil, nil, nil, errors.Wrapf(err, "%s: compute matrix and sharding", commontcl.ServiceLabel(name))
+		}
+		svcParams[name] = params
+
+		if params.Count == 0 {
+			fmt.Printf("%s: 0 instances requested (combinations=%d, count=%d), skipping\n",
+				commontcl.ServiceLabel(name), params.MatrixCount, params.ShardCount)
+			continue
+		}
+
+		fmt.Printf("%s: %s\n", commontcl.ServiceLabel(name), params.String(UnlimitedParallelism))
+
+		svcInstances, svcNamespaces, err := e.buildServiceInstances(name, svc, params)
+		if err != nil {
+			return nil, nil, nil, nil, err
+		}
+		instances = append(instances, svcInstances...)
+		namespaces = append(namespaces, svcNamespaces...)
+
+		state[name] = make([]ServiceState, len(svcInstances))
+		for i := range svcInstances {
+			state[name][i].Description = svcInstances[i].Description
+		}
+		instructions.PrintHintDetails(e.deps.Ref, data.ServicesPrefix+name, state)
+	}
+
+	return instances, namespaces, state, svcParams, nil
+}
+
+// buildServiceInstances creates instances for a single service definition.
+func (e *ServicesExecutor) buildServiceInstances(
+	name string,
+	svc testworkflowsv1.ServiceSpec,
+	params *commontcl.ParamsSpec,
+) ([]ServiceInstance, []string, error) {
+	svcInstances := make([]ServiceInstance, params.Count)
+	svcNamespaces := make([]string, params.Count)
+
+	for index := int64(0); index < params.Count; index++ {
+		machines := []expressions.Machine{e.deps.BaseMachine, params.MachineAt(index)}
+
+		svcSpec := svc.DeepCopy()
+		if err := expressions.Simplify(&svcSpec, machines...); err != nil {
+			return nil, nil, errors.Wrapf(err, "%s: %d: simplify", commontcl.ServiceLabel(name), index)
+		}
+
+		spec := testworkflowsv1.TestWorkflowSpec{
+			TestWorkflowSpecBase: testworkflowsv1.TestWorkflowSpecBase{
+				Content:   svcSpec.Content,
+				Container: common.Ptr(svcSpec.ContainerConfig),
+				Pod:       svcSpec.Pod,
+			},
+			Steps: []testworkflowsv1.Step{
+				{StepOperations: testworkflowsv1.StepOperations{Run: common.Ptr(svcSpec.StepRun)}},
+			},
+			Pvcs: svcSpec.Pvcs,
+		}
+		spec.Steps[0].Run.ContainerConfig = testworkflowsv1.ContainerConfig{}
+		spec.Container.Env = testworkflowresolver.DedupeEnvVars(append(e.deps.Config.Execution.GlobalEnv, spec.Container.Env...))
+
+		if spec.Content == nil {
+			spec.Content = &testworkflowsv1.Content{}
+		}
+		tarballs, err := spawn.ProcessTransfer(e.deps.TransferSrv, svcSpec.Transfer, machines...)
+		if err != nil {
+			return nil, nil, errors.Wrapf(err, "%s: %d: transfer", commontcl.ServiceLabel(name), index)
+		}
+		spec.Content.Tarball = append(spec.Content.Tarball, tarballs...)
+
+		svcInstances[index] = ServiceInstance{
+			Index:          index,
+			Name:           name,
+			Description:    svcSpec.Description,
+			RestartPolicy:  corev1.RestartPolicy(svcSpec.RestartPolicy),
+			ReadinessProbe: svcSpec.ReadinessProbe,
+			Spec:           spec,
+		}
+		svcNamespaces[index] = e.deps.Namespace
+		if spec.Job != nil && spec.Job.Namespace != "" {
+			svcNamespaces[index] = spec.Job.Namespace
+		}
+
+		if svcSpec.Timeout != "" {
+			v, err := expressions.EvalTemplate(svcSpec.Timeout, machines...)
+			if err != nil {
+				return nil, nil, errors.Wrapf(err, "%s: %d: timeout expression", commontcl.ServiceLabel(name), index)
+			}
+			d, err := time.ParseDuration(strings.ReplaceAll(v, " ", ""))
+			if err != nil {
+				return nil, nil, errors.Wrapf(err, "%s: %d: invalid timeout: %s", commontcl.ServiceLabel(name), index, v)
+			}
+			svcInstances[index].Timeout = &d
+		}
+	}
+
+	return svcInstances, svcNamespaces, nil
+}
+
+// notifyQueuedInstances sends queued status for each instance.
+func (e *ServicesExecutor) notifyQueuedInstances(instances []ServiceInstance) {
+	for _, instance := range instances {
+		instructions.PrintOutput(e.deps.Ref, "service", ServiceInfo{
+			Group:       e.groupRef,
+			Index:       instance.Index,
+			Name:        instance.Name,
+			Description: instance.Description,
+			Status:      ServiceStatusQueued,
+		})
+	}
+}
+
+// startTransferServer starts the file transfer server if needed.
+func (e *ServicesExecutor) startTransferServer() error {
+	if e.deps.TransferSrv.Count() == 0 && e.deps.TransferSrv.RequestsCount() == 0 {
+		return nil
+	}
+
+	infos := make([]string, 0)
+	if e.deps.TransferSrv.Count() > 0 {
+		infos = append(infos, fmt.Sprintf("sending %d tarballs", e.deps.TransferSrv.Count()))
+	}
+	if e.deps.TransferSrv.RequestsCount() > 0 {
+		infos = append(infos, fmt.Sprintf("fetching %d requests", e.deps.TransferSrv.RequestsCount()))
+	}
+
+	fmt.Printf("Starting transfer server for %s...\n", strings.Join(infos, " and "))
+	if _, err := e.deps.TransferSrv.Listen(); err != nil {
+		return errors.Wrap(err, "failed to start transfer server")
+	}
+	fmt.Printf("Transfer server started.\n")
+	return nil
+}
+
+// runServices executes all service instances in parallel.
+func (e *ServicesExecutor) runServices(
+	instances []ServiceInstance,
+	namespaces []string,
+	state map[string][]ServiceState,
+	svcParams map[string]*commontcl.ParamsSpec,
+) int64 {
+	run := func(_ int64, _ string, instance *ServiceInstance) bool {
+		runner := NewServiceRunner(instance, e.groupRef, e.deps, svcParams[instance.Name], state)
+		return runner.Run()
+	}
+
+	return spawn.ExecuteParallel(run, instances, namespaces, int64(len(instances)))
+}
+
+// reportFinalState reports the final state of all services.
+func (e *ServicesExecutor) reportFinalState(state map[string][]ServiceState) {
+	for k := range state {
+		instructions.PrintHintDetails(e.deps.Ref, data.ServicesPrefix+k, state[k])
+	}
+}
+
+// ServiceRunner executes and monitors a single service instance.
+type ServiceRunner struct {
+	instance *ServiceInstance
+	groupRef string
+	deps     ServicesDependencies
+	params   *commontcl.ParamsSpec
+	state    map[string][]ServiceState
+	log      func(...string)
+	info     ServiceInfo
+}
+
+func NewServiceRunner(
+	instance *ServiceInstance,
+	groupRef string,
+	deps ServicesDependencies,
+	params *commontcl.ParamsSpec,
+	state map[string][]ServiceState,
+) *ServiceRunner {
+	return &ServiceRunner{
+		instance: instance,
+		groupRef: groupRef,
+		deps:     deps,
+		params:   params,
+		state:    state,
+		log:      spawn.CreateLogger(instance.Name, instance.Description, instance.Index, params.Count),
+		info: ServiceInfo{
+			Group:       groupRef,
+			Index:       instance.Index,
+			Name:        instance.Name,
+			Description: instance.Description,
+			Status:      ServiceStatusQueued,
+		},
+	}
+}
+
+// Run executes the service and returns true if successful.
+func (r *ServiceRunner) Run() bool {
+	namespace := r.deps.Namespace
+	if r.instance.Spec.Job != nil && r.instance.Spec.Job.Namespace != "" {
+		namespace = r.instance.Spec.Job.Namespace
+	}
+
+	cfg := *r.deps.Config
+	cfg.Resource = spawn.CreateResourceConfig(r.instance.Name+"-", r.instance.Index)
+	cfg.Worker.Namespace = namespace
+	machine := expressions.CombinedMachines(
+		testworkflowconfig.CreateResourceMachine(&cfg.Resource),
+		testworkflowconfig.CreateWorkerMachine(&cfg.Worker),
+		r.deps.BaseMachine,
+		testworkflowconfig.CreatePvcMachine(cfg.Execution.PvcNames),
+		r.params.MachineAt(r.instance.Index),
+	)
+
+	_ = expressions.Simplify(&r.instance.Spec, machine)
+
+	result, err := r.deployService(cfg)
+	if err != nil {
+		r.log("failed to prepare resources", err.Error())
+		return false
+	}
+
+	execResult := r.monitorService(cfg, result)
+	return r.evaluateResult(execResult)
+}
+
+// deployService deploys the service to the cluster.
+func (r *ServiceRunner) deployService(cfg testworkflowconfig.InternalConfig) (*executionworkertypes.ServiceResult, error) {
+	scheduledAt := time.Now()
+	return r.deps.ExecutionWorker.Service(context.Background(), executionworkertypes.ServiceRequest{
+		ResourceId:          cfg.Resource.Id,
+		GroupId:             r.groupRef,
+		Execution:           cfg.Execution,
+		Workflow:            testworkflowsv1.TestWorkflow{ObjectMeta: metav1.ObjectMeta{Name: cfg.Workflow.Name, Labels: cfg.Workflow.Labels}, Spec: r.instance.Spec},
+		ScheduledAt:         &scheduledAt,
+		RestartPolicy:       string(r.instance.RestartPolicy),
+		ReadinessProbe:      common.MapPtr(r.instance.ReadinessProbe, testworkflows.MapProbeKubeToAPI),
+		ControlPlane:        cfg.ControlPlane,
+		ArtifactsPathPrefix: cfg.Resource.FsPrefix,
+	})
+}
+
+// monitorService monitors the service execution and returns the result.
+func (r *ServiceRunner) monitorService(cfg testworkflowconfig.InternalConfig, result *executionworkertypes.ServiceResult) ServiceExecutionResult {
+	signatureSeq := stage.MapSignatureToSequence(stage.MapSignatureList(result.Signature))
+	mainRef := signatureSeq[len(signatureSeq)-1].Ref()
+
+	timeoutCtx, timeoutCtxCancel := context.WithCancel(context.Background())
+	defer timeoutCtxCancel()
+	if r.instance.Timeout != nil {
+		go func() {
+			select {
+			case <-timeoutCtx.Done():
+			case <-time.After(*r.instance.Timeout):
+				r.log("timed out", r.instance.Timeout.String()+" elapsed")
+				timeoutCtxCancel()
+			}
+		}()
+	}
+
+	ctx, ctxCancel := context.WithCancel(timeoutCtx)
+	defer ctxCancel()
+
+	notifications := r.deps.ExecutionWorker.StatusNotifications(ctx, cfg.Resource.Id, executionworkertypes.StatusNotificationsOptions{
+		Hints: executionworkertypes.Hints{
+			Namespace:   result.Namespace,
+			Signature:   result.Signature,
+			ScheduledAt: &result.ScheduledAt,
+		},
+	})
+	if notifications.Err() != nil {
+		r.log("error", "failed to connect to the service", notifications.Err().Error())
+		return ServiceExecutionResult{Error: notifications.Err()}
+	}
+	r.log("created")
+
+	execResult := r.processNotifications(notifications, mainRef)
+
+	// For services without readiness probe, do a brief post-startup check
+	// to catch services that fail immediately after starting
+	if r.instance.ReadinessProbe == nil && execResult.Started && !execResult.Failed {
+		execResult = r.checkForImmediateFailure(cfg, result, execResult)
+	}
+
+	return execResult
+}
+
+// checkForImmediateFailure polls to detect services that fail immediately after starting.
+// Services without readiness probes exit the monitoring loop on startup, so we need
+// a secondary check to catch fast failures before declaring success.
+func (r *ServiceRunner) checkForImmediateFailure(
+	cfg testworkflowconfig.InternalConfig,
+	result *executionworkertypes.ServiceResult,
+	execResult ServiceExecutionResult,
+) ServiceExecutionResult {
+	ctx, cancel := context.WithTimeout(context.Background(), serviceFailureCheckTimeout)
+	defer cancel()
+
+	notifications := r.deps.ExecutionWorker.StatusNotifications(ctx, cfg.Resource.Id, executionworkertypes.StatusNotificationsOptions{
+		Hints: executionworkertypes.Hints{
+			Namespace:   result.Namespace,
+			Signature:   result.Signature,
+			ScheduledAt: &result.ScheduledAt,
+		},
+	})
+	if notifications.Err() != nil {
+		return execResult
+	}
+
+	for v := range notifications.Channel() {
+		if v.Result != nil && v.Result.IsFinished() {
+			if !v.Result.IsPassed() {
+				execResult.Failed = true
+				r.log("service failed immediately after starting")
+			}
+			break
+		}
+	}
+
+	return execResult
+}
+
+// processNotifications processes status notifications and tracks service state.
+func (r *ServiceRunner) processNotifications(
+	notifications executionworkertypes.StatusNotificationsWatcher,
+	mainRef string,
+) ServiceExecutionResult {
+	execResult := ServiceExecutionResult{
+		Ready: r.instance.ReadinessProbe == nil,
+	}
+	var lastWorkflowResult *testkube.TestWorkflowResult
+
+	scheduled := false
+	index := r.instance.Index
+
+	for v := range notifications.Channel() {
+		if !scheduled && v.NodeName != "" {
+			scheduled = true
+			r.log(fmt.Sprintf("assigned to %s node", ui.LightBlue(v.NodeName)))
+		}
+
+		if r.state[r.instance.Name][index].Ip == "" && v.PodIp != "" {
+			r.state[r.instance.Name][index].Ip = v.PodIp
+			r.log(fmt.Sprintf("assigned to %s IP", ui.LightBlue(v.PodIp)))
+			r.info.Status = ServiceStatusRunning
+			instructions.PrintOutput(r.deps.Ref, "service", r.info)
+		}
+
+		if v.Result != nil {
+			lastWorkflowResult = v.Result
+		}
+
+		execResult.Ready = v.Ready || r.instance.ReadinessProbe == nil
+
+		if !execResult.Started && v.Ref == mainRef && r.state[r.instance.Name][index].Ip != "" {
+			execResult.Started = true
+			if r.instance.ReadinessProbe == nil {
+				r.log("container started")
+			} else {
+				r.log("container started, waiting for readiness")
+			}
+		}
+
+		if lastWorkflowResult != nil && lastWorkflowResult.IsFinished() {
+			if !lastWorkflowResult.IsPassed() {
+				execResult.Failed = true
+				r.log("service execution failed")
+			}
+			break
+		}
+
+		if execResult.Started && execResult.Ready && r.instance.ReadinessProbe != nil {
+			break
+		}
+
+		// For services without readiness probe, break once started
+		if execResult.Started && r.instance.ReadinessProbe == nil {
+			break
+		}
+	}
+
+	if notifications.Err() != nil {
+		r.log("error", notifications.Err().Error())
+		execResult.Error = notifications.Err()
+	}
+
+	return execResult
+}
+
+// evaluateResult determines the final status and returns success/failure.
+func (r *ServiceRunner) evaluateResult(execResult ServiceExecutionResult) bool {
+	success := true
+
+	// Check for failures in order of priority
+	if execResult.Error != nil {
+		r.info.Status = ServiceStatusFailed
+		r.log("error during monitoring")
+		success = false
+	} else if execResult.Failed {
+		// Service execution finished with non-PASSED status
+		r.info.Status = ServiceStatusFailed
+		r.log("service failed")
+		success = false
+	} else if !execResult.Started {
+		// Container never started
+		r.info.Status = ServiceStatusFailed
+		r.log("container failed to start")
+		success = false
+	} else if !execResult.Ready && r.instance.ReadinessProbe != nil {
+		// Container started but never became ready (only relevant for services with readiness probes)
+		r.info.Status = ServiceStatusFailed
+		r.log("container did not reach readiness")
+		success = false
+	} else {
+		// All checks passed - service is ready
+		r.info.Status = ServiceStatusReady
+		r.log("container ready")
+	}
+
+	instructions.PrintOutput(r.deps.Ref, "service", r.info)
+	return success
 }

--- a/cmd/tcl/testworkflow-toolkit/commands/services_test.go
+++ b/cmd/tcl/testworkflow-toolkit/commands/services_test.go
@@ -1,0 +1,246 @@
+// Copyright 2025 Testkube.
+//
+// Licensed as a Testkube Pro file under the Testkube Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+// 	https://github.com/kubeshop/testkube/blob/main/licenses/TCL.txt
+
+package commands
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+
+	"github.com/kubeshop/testkube/internal/common"
+	"github.com/kubeshop/testkube/pkg/api/v1/testkube"
+	"github.com/kubeshop/testkube/pkg/testworkflows/executionworker/executionworkertypes"
+	"github.com/kubeshop/testkube/pkg/testworkflows/testworkflowconfig"
+)
+
+func TestServicesExecutor_RequiresGroupRef(t *testing.T) {
+	executor := NewServicesExecutor("", false, ServicesDependencies{})
+	err := executor.Execute([]string{`{}`})
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "missing required --group")
+}
+
+func TestProcessNotifications(t *testing.T) {
+	tests := []struct {
+		name          string
+		notifications []executionworkertypes.StatusNotification
+		hasReadiness  bool
+		want          ServiceExecutionResult
+	}{
+		{
+			name: "detects failure when result arrives before service starts",
+			notifications: []executionworkertypes.StatusNotification{
+				{Result: finishedResult(testkube.FAILED_TestWorkflowStatus)},
+			},
+			want: ServiceExecutionResult{Started: false, Ready: true, Failed: true},
+		},
+		{
+			name: "detects success when started without readiness probe",
+			notifications: []executionworkertypes.StatusNotification{
+				{PodIp: "10.0.0.1", Ref: "main"},
+			},
+			want: ServiceExecutionResult{Started: true, Ready: true, Failed: false},
+		},
+		{
+			name: "detects success with readiness probe when ready",
+			notifications: []executionworkertypes.StatusNotification{
+				{PodIp: "10.0.0.1", Ref: "main"},
+				{Ready: true},
+			},
+			hasReadiness: true,
+			want:         ServiceExecutionResult{Started: true, Ready: true, Failed: false},
+		},
+		{
+			name: "not started without IP",
+			notifications: []executionworkertypes.StatusNotification{
+				{Ref: "main"},
+			},
+			want: ServiceExecutionResult{Started: false, Ready: true, Failed: false},
+		},
+		{
+			name: "breaks on start without readiness probe",
+			notifications: []executionworkertypes.StatusNotification{
+				{PodIp: "10.0.0.1", Ref: "main"},
+				{Result: finishedResult(testkube.PASSED_TestWorkflowStatus)},
+			},
+			want: ServiceExecutionResult{Started: true, Ready: true, Failed: false},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			runner := newTestRunner(tt.hasReadiness)
+			watcher := newMockWatcher(tt.notifications)
+
+			got := runner.processNotifications(watcher, "main")
+
+			assert.Equal(t, tt.want.Started, got.Started, "Started")
+			assert.Equal(t, tt.want.Ready, got.Ready, "Ready")
+			assert.Equal(t, tt.want.Failed, got.Failed, "Failed")
+		})
+	}
+}
+
+func TestEvaluateResult(t *testing.T) {
+	tests := []struct {
+		name         string
+		result       ServiceExecutionResult
+		hasReadiness bool
+		wantSuccess  bool
+	}{
+		{
+			name:        "error takes priority",
+			result:      ServiceExecutionResult{Started: true, Ready: true, Failed: false, Error: errors.New("err")},
+			wantSuccess: false,
+		},
+		{
+			name:        "failed takes priority over started",
+			result:      ServiceExecutionResult{Started: true, Ready: true, Failed: true},
+			wantSuccess: false,
+		},
+		{
+			name:        "not started is failure",
+			result:      ServiceExecutionResult{Started: false, Ready: true, Failed: false},
+			wantSuccess: false,
+		},
+		{
+			name:         "not ready with readiness probe is failure",
+			result:       ServiceExecutionResult{Started: true, Ready: false, Failed: false},
+			hasReadiness: true,
+			wantSuccess:  false,
+		},
+		{
+			name:         "not ready without readiness probe is success",
+			result:       ServiceExecutionResult{Started: true, Ready: false, Failed: false},
+			hasReadiness: false,
+			wantSuccess:  true,
+		},
+		{
+			name:        "started and ready is success",
+			result:      ServiceExecutionResult{Started: true, Ready: true, Failed: false},
+			wantSuccess: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			runner := newTestRunner(tt.hasReadiness)
+
+			got := runner.evaluateResult(tt.result)
+
+			assert.Equal(t, tt.wantSuccess, got)
+		})
+	}
+}
+
+func TestCheckForImmediateFailure(t *testing.T) {
+	tests := []struct {
+		name          string
+		notifications []executionworkertypes.StatusNotification
+		inputResult   ServiceExecutionResult
+		wantFailed    bool
+	}{
+		{
+			name: "detects failure",
+			notifications: []executionworkertypes.StatusNotification{
+				{Result: finishedResult(testkube.FAILED_TestWorkflowStatus)},
+			},
+			inputResult: ServiceExecutionResult{Started: true},
+			wantFailed:  true,
+		},
+		{
+			name: "no failure on passed",
+			notifications: []executionworkertypes.StatusNotification{
+				{Result: finishedResult(testkube.PASSED_TestWorkflowStatus)},
+			},
+			inputResult: ServiceExecutionResult{Started: true},
+			wantFailed:  false,
+		},
+		{
+			name:          "no failure on timeout (healthy service)",
+			notifications: []executionworkertypes.StatusNotification{},
+			inputResult:   ServiceExecutionResult{Started: true},
+			wantFailed:    false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			worker := &mockWorker{notifications: tt.notifications}
+			runner := &ServiceRunner{
+				deps:     ServicesDependencies{ExecutionWorker: worker},
+				instance: &ServiceInstance{Name: "test", Index: 0},
+				state:    map[string][]ServiceState{"test": {{}}},
+				info:     ServiceInfo{},
+				log:      func(...string) {},
+			}
+
+			got := runner.checkForImmediateFailure(
+				testworkflowconfig.InternalConfig{},
+				&executionworkertypes.ServiceResult{},
+				tt.inputResult,
+			)
+
+			assert.Equal(t, tt.wantFailed, got.Failed)
+		})
+	}
+}
+
+func newTestRunner(hasReadiness bool) *ServiceRunner {
+	var probe *corev1.Probe
+	if hasReadiness {
+		probe = &corev1.Probe{}
+	}
+	return &ServiceRunner{
+		instance: &ServiceInstance{Name: "test", Index: 0, ReadinessProbe: probe},
+		state:    map[string][]ServiceState{"test": {{}}},
+		info:     ServiceInfo{},
+		deps:     ServicesDependencies{},
+		log:      func(...string) {},
+	}
+}
+
+func finishedResult(status testkube.TestWorkflowStatus) *testkube.TestWorkflowResult {
+	return &testkube.TestWorkflowResult{
+		Status:     common.Ptr(status),
+		FinishedAt: time.Now(),
+	}
+}
+
+type mockWatcher struct {
+	ch  chan executionworkertypes.StatusNotification
+	err error
+}
+
+func newMockWatcher(notifications []executionworkertypes.StatusNotification) *mockWatcher {
+	ch := make(chan executionworkertypes.StatusNotification, len(notifications))
+	for _, n := range notifications {
+		ch <- n
+	}
+	close(ch)
+	return &mockWatcher{ch: ch}
+}
+
+func (m *mockWatcher) Channel() <-chan executionworkertypes.StatusNotification { return m.ch }
+func (m *mockWatcher) All() ([]executionworkertypes.StatusNotification, error) { return nil, nil }
+func (m *mockWatcher) Err() error                                              { return m.err }
+
+type mockWorker struct {
+	executionworkertypes.Worker
+	notifications []executionworkertypes.StatusNotification
+}
+
+func (m *mockWorker) StatusNotifications(ctx context.Context, id string, opts executionworkertypes.StatusNotificationsOptions) executionworkertypes.StatusNotificationsWatcher {
+	return newMockWatcher(m.notifications)
+}

--- a/test/integration/components/toolkit/services_test.go
+++ b/test/integration/components/toolkit/services_test.go
@@ -1,0 +1,108 @@
+package toolkit_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/kubeshop/testkube/internal/common"
+	"github.com/kubeshop/testkube/pkg/utils/test"
+)
+
+func TestServicePodLifecycle_Integration(t *testing.T) {
+	test.IntegrationTest(t)
+
+	tests := []struct {
+		name         string
+		command      string
+		wantPhase    corev1.PodPhase
+		wantRunning  bool
+		wantExitCode *int32
+	}{
+		{
+			name:      "failing pod is detected",
+			command:   "exit 1",
+			wantPhase: corev1.PodFailed,
+		},
+		{
+			name:        "running pod has IP",
+			command:     "sleep 300",
+			wantRunning: true,
+		},
+		{
+			name:         "exit code is preserved",
+			command:      "exit 42",
+			wantPhase:    corev1.PodFailed,
+			wantExitCode: common.Ptr(int32(42)),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			namespace := createTestNamespace(t)
+			t.Cleanup(func() { deleteTestNamespace(t, namespace) })
+
+			pod := &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-service",
+					Namespace: namespace,
+				},
+				Spec: corev1.PodSpec{
+					RestartPolicy: corev1.RestartPolicyNever,
+					Containers: []corev1.Container{{
+						Name:    "main",
+						Image:   "busybox:1.36",
+						Command: []string{"sh", "-c", tt.command},
+					}},
+				},
+			}
+
+			ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+			defer cancel()
+
+			_, err := globalK8sClient.CoreV1().Pods(namespace).Create(ctx, pod, metav1.CreateOptions{})
+			require.NoError(t, err)
+
+			p := waitForPod(t, ctx, namespace, pod.Name, tt.wantRunning)
+
+			if tt.wantPhase != "" {
+				assert.Equal(t, tt.wantPhase, p.Status.Phase)
+			}
+			if tt.wantRunning {
+				assert.Equal(t, corev1.PodRunning, p.Status.Phase)
+				assert.NotEmpty(t, p.Status.PodIP, "running pod should have IP")
+			}
+			if tt.wantExitCode != nil {
+				require.Len(t, p.Status.ContainerStatuses, 1)
+				terminated := p.Status.ContainerStatuses[0].State.Terminated
+				require.NotNil(t, terminated)
+				assert.Equal(t, *tt.wantExitCode, terminated.ExitCode)
+			}
+		})
+	}
+}
+
+func waitForPod(t *testing.T, ctx context.Context, namespace, name string, wantRunning bool) *corev1.Pod {
+	for {
+		p, err := globalK8sClient.CoreV1().Pods(namespace).Get(ctx, name, metav1.GetOptions{})
+		require.NoError(t, err)
+
+		if wantRunning && p.Status.Phase == corev1.PodRunning {
+			return p
+		}
+		if !wantRunning && (p.Status.Phase == corev1.PodFailed || p.Status.Phase == corev1.PodSucceeded) {
+			return p
+		}
+
+		select {
+		case <-ctx.Done():
+			t.Fatalf("timeout waiting for pod %s", name)
+		case <-time.After(500 * time.Millisecond):
+		}
+	}
+}


### PR DESCRIPTION
## Pull request description 

- Fix bug where services exiting with non-zero code were incorrectly reported as passed
- Refactor monolithic `Run()` into `ServicesExecutor` and `ServiceRunner` components
- Add unit tests with mocks for `processNotifications`, `evaluateResult`, and `checkForImmediateFailure`
- Add K8s integration tests for service failure detection

The following workflow should fail:
```
kind: TestWorkflow
apiVersion: testworkflows.testkube.io/v1
metadata:
  name: expected-fail-service-exit-code
  namespace: testkube-agent
  labels:
    argocd.argoproj.io/instance: testkube-dev-agent
    core-tests: expected-fail
spec:
  container:
    image: alpine:3.22.0
  job:
    activeDeadlineSeconds: 30
  services:
    slave:
      use:
      - name: distribute/evenly
      count: 2
      logs: always
      image: alpine:3.22.0
      shell: echo "expected fail - non-zero exit code" && exit 1
  steps:
  - name: Step
    run:
      shell: echo "step"
```

## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [ ] tested locally
- [ ] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Breaking changes

-

## Changes

-

## Fixes

-