### PR TITLE
fix: add required metadata to super agent migration RPC calls

### DIFF
--- a/cmd/api-server/main.go
+++ b/cmd/api-server/main.go
@@ -340,6 +340,7 @@ func main() {
 	migrateSuperAgent(ctx, log.DefaultLogger,
 		superAgentMigrationConfig{
 			agentId: proContext.Agent.ID,
+			apiKey:  proContext.APIKey,
 			proContextControlPlaneHasSourceOfTruthCapability: proContext.HasSourceOfTruthCapability,
 			proContextAgentIsSuperAgent:                      proContext.Agent.IsSuperAgent,
 			forceSuperAgentMode:                              cfg.ForceSuperAgentMode,


### PR DESCRIPTION
These are required for use on the legacy RPC which is using the simple client rather than the extended one used by the sync functions.