### PR TITLE
fix: include timezone data in application

### DIFF
--- a/cmd/api-server/main.go
+++ b/cmd/api-server/main.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"strings"
 	"time"
+	_ "time/tzdata" // Import timezone database to be used in case the host OS does not have a tzdb available.
 
 	"github.com/go-logr/zapr"
 	"github.com/gofiber/fiber/v2/middleware/cors"


### PR DESCRIPTION
Not all hosts will have the tzdb configured,
this provides a fallback but does increase
binary size quite significantly.

It _should_ only be imported by the `main`
package and was not previously, as a result
it was erroneously removed.

A better way to ensure this cannot happen again
would be to add the `-tags timetzdata` flag to
build arguments as then it cannot be removed
by code changes.
