### PR TITLE
feat(helm): add global.testkubeVersion support for dynamic image tags

### DIFF
--- a/k8s/helm/testkube-api/templates/_helpers.tpl
+++ b/k8s/helm/testkube-api/templates/_helpers.tpl
@@ -84,6 +84,9 @@ Define API image
     {{- $tag = .Values.image.digest | toString -}}
 {{- end -}}
 {{- if .Values.global }}
+    {{- if .Values.global.testkubeVersion -}}
+        {{- $tag = .Values.global.testkubeVersion | toString -}}
+    {{- end -}}
     {{- if .Values.global.imageRegistry }}
         {{- printf "%s/%s%s%s%s" .Values.global.imageRegistry $repositoryName $separator $tag $tagSuffix -}}
     {{- else -}}
@@ -375,6 +378,9 @@ Define Test Workflows Toolkit Image
     {{- $tag = .Values.imageTwToolkit.digest | toString -}}
 {{- end -}}
 {{- if .Values.global }}
+    {{- if .Values.global.testkubeVersion -}}
+        {{- $tag = .Values.global.testkubeVersion | toString -}}
+    {{- end -}}
     {{- if .Values.global.imageRegistry }}
         {{- printf "%s/%s%s%s%s" .Values.global.imageRegistry $repositoryName $separator $tag $tagSuffix -}}
     {{- else -}}
@@ -400,6 +406,9 @@ Define Test Workflows Init Image
     {{- $tag = .Values.imageTwInit.digest | toString -}}
 {{- end -}}
 {{- if .Values.global }}
+    {{- if .Values.global.testkubeVersion -}}
+        {{- $tag = .Values.global.testkubeVersion | toString -}}
+    {{- end -}}
     {{- if .Values.global.imageRegistry }}
         {{- printf "%s/%s%s%s%s" .Values.global.imageRegistry $repositoryName $separator $tag $tagSuffix -}}
     {{- else -}}

--- a/k8s/helm/testkube-operator/templates/_helpers.tpl
+++ b/k8s/helm/testkube-operator/templates/_helpers.tpl
@@ -107,6 +107,9 @@ Define Operator image
     {{- $tag = .Values.image.digest | toString -}}
 {{- end -}}
 {{- if .Values.global }}
+    {{- if .Values.global.testkubeVersion -}}
+        {{- $tag = .Values.global.testkubeVersion | toString -}}
+    {{- end -}}
     {{- if .Values.global.imageRegistry }}
         {{- printf "%s/%s%s%s" .Values.global.imageRegistry $repositoryName $separator $tag -}}
     {{- else -}}

--- a/k8s/helm/testkube-runner/templates/_helpers.tpl
+++ b/k8s/helm/testkube-runner/templates/_helpers.tpl
@@ -31,6 +31,9 @@ app.kubernetes.io/instance: {{ .Release.Name }}
     {{- $tag = .Values.images.agent.digest | toString -}}
 {{- end -}}
 {{- if .Values.global }}
+    {{- if .Values.global.testkubeVersion -}}
+        {{- $tag = .Values.global.testkubeVersion | toString -}}
+    {{- end -}}
     {{- if .Values.global.imageRegistry }}
         {{- printf "%s/%s%s%s%s" .Values.global.imageRegistry $repositoryName $separator $tag $tagSuffix -}}
     {{- else -}}
@@ -52,6 +55,9 @@ app.kubernetes.io/instance: {{ .Release.Name }}
     {{- $tag = .Values.images.toolkit.digest | toString -}}
 {{- end -}}
 {{- if .Values.global }}
+    {{- if .Values.global.testkubeVersion -}}
+        {{- $tag = .Values.global.testkubeVersion | toString -}}
+    {{- end -}}
     {{- if .Values.global.imageRegistry }}
         {{- printf "%s/%s%s%s%s" .Values.global.imageRegistry $repositoryName $separator $tag $tagSuffix -}}
     {{- else -}}
@@ -73,6 +79,9 @@ app.kubernetes.io/instance: {{ .Release.Name }}
     {{- $tag = .Values.images.init.digest | toString -}}
 {{- end -}}
 {{- if .Values.global }}
+    {{- if .Values.global.testkubeVersion -}}
+        {{- $tag = .Values.global.testkubeVersion | toString -}}
+    {{- end -}}
     {{- if .Values.global.imageRegistry }}
         {{- printf "%s/%s%s%s%s" .Values.global.imageRegistry $repositoryName $separator $tag $tagSuffix -}}
     {{- else -}}


### PR DESCRIPTION
## Pull request description 

Adds `global.testkubeVersion` support to all image helpers in testkube-api, testkube-runner, and testkube-operator charts.

This allows ArgoCD to pass `$ARGOCD_APP_REVISION_SHORT` as the image tag, enabling automatic deployments from Depot on every push to release branches.

## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [ ] tested locally
- [ ] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Breaking changes

-

## Changes

-

## Fixes

-