### PR TITLE
fix(release): update testkube-runner appVersion in Chart.yaml not values.yaml

### DIFF
--- a/js/scripts/tk-release/src/utils/helm.js
+++ b/js/scripts/tk-release/src/utils/helm.js
@@ -37,7 +37,7 @@ export async function editHelmChartOfRunner(appVersion, releaseStrategy) {
     const chartPath = `./k8s/helm/testkube-runner/Chart.yaml`;
     const valuesPath = `./k8s/helm/testkube-runner/values.yaml`;
     await bumpChartVersion(chartPath, releaseStrategy);
-    await bumpChartAppVersion(valuesPath, appVersion);
+    await bumpChartAppVersion(chartPath, appVersion);
 
     info("helm dependency updating for testkube-runner…");
     await $({ cwd: "./k8s/helm/testkube-runner" })`helm dependency update`;


### PR DESCRIPTION
## Pull request description 

Fixes testkube-runner appVersion being stuck at 2.3.0 since the helm-charts merge.

The release script was calling `bumpChartAppVersion(valuesPath, ...)` instead of `bumpChartAppVersion(chartPath, ...)`, so the sed regex `^appVersion:.*$` never matched anything in values.yaml.

## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [ ] tested locally
- [ ] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Breaking changes

-

## Changes

-

## Fixes

-