### PR TITLE
fix: docker bake and build workflow to right push public cli images

### DIFF
--- a/.github/workflows/new-build.yaml
+++ b/.github/workflows/new-build.yaml
@@ -69,10 +69,10 @@ jobs:
             type=semver,pattern={{version}}
 
       - name: Create Docker tags and metadata for tw-init
-        id: tw-init
+        id: tw-init-meta
         uses: docker/metadata-action@v5
         with:
-          bake-target: "tw-init"
+          bake-target: "tw-init-meta"
           images: |
             kubeshop/testkube-tw-init
             ${{ env.GAR_LOCATION }}-docker.pkg.dev/${{ env.GAR_PROJECT_ID }}/${{ env.GAR_REPOSITORY }}/tw-init
@@ -81,10 +81,10 @@ jobs:
             type=semver,pattern={{version}}
 
       - name: Create Docker tags and metadata for tw-toolkit
-        id: tw-toolkit
+        id: tw-toolkit-meta
         uses: docker/metadata-action@v5
         with:
-          bake-target: "tw-toolkit"
+          bake-target: "tw-toolkit-meta"
           images: |
             kubeshop/testkube-tw-toolkit
             ${{ env.GAR_LOCATION }}-docker.pkg.dev/${{ env.GAR_PROJECT_ID }}/${{ env.GAR_REPOSITORY }}/tw-toolkit
@@ -93,7 +93,7 @@ jobs:
             type=semver,pattern={{version}}
 
       - name: Create Docker tags and metadata for mcp-server
-        id: mcp-meta
+        id: mcp-server-meta
         uses: docker/metadata-action@v5
         with:
           bake-target: "mcp-server-meta"
@@ -114,11 +114,11 @@ jobs:
           files: |
             ./docker-bake.hcl
             ${{ steps.api-meta.outputs.bake-file }}
-            ${{ steps.tw-toolkit.outputs.bake-file }}
-            ${{ steps.tw-init.outputs.bake-file }}
             ${{ steps.cli-meta.outputs.bake-file }}
-            ${{ steps.mcp-meta.outputs.bake-file }}
-          targets: api,tw-toolkit,tw-init,mcp-server,cli
+            ${{ steps.tw-init-meta.outputs.bake-file }}
+            ${{ steps.tw-toolkit-meta.outputs.bake-file }}
+            ${{ steps.mcp-server-meta.outputs.bake-file }}
+          targets: api,cli,tw-init,tw-toolkit,mcp-server
           provenance: mode=max
           sbom: true
           # Only tags are pushed, pushes to branches test whether app can be built.

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -14,7 +14,7 @@ variable "CLOUD_SEGMENTIO_KEY"     { default = ""}
 variable "KEYGEN_PUBLIC_KEY"       { default = ""}
 
 group "default" {
-  targets = ["agent-server", "testworkflow-init", "testworkflow-toolkit", "mcp-server", "cli"]
+  targets = ["api", "cli", "tw-init", "tw-toolkit", "mcp-server"]
 }
 
 target "api-meta" {}
@@ -39,7 +39,7 @@ target "api" {
 
 target "cli-meta" {}
 target "cli" {
-  inherits = ["testworkflow-init-meta"]
+  inherits = ["cli-meta"]
   context="."
   dockerfile = "build/new/cli.Dockerfile"
   platforms = ["linux/arm64", "linux/amd64"]
@@ -55,7 +55,7 @@ target "cli" {
 
 target "tw-init-meta" {}
 target "tw-init" {
-  inherits = ["testworkflow-init-meta"]
+  inherits = ["tw-init-meta"]
   context="."
   dockerfile = "build/new/tw-init.Dockerfile"
   platforms = ["linux/arm64", "linux/amd64"]
@@ -67,7 +67,7 @@ target "tw-init" {
 
 target "tw-toolkit-meta" {}
 target "tw-toolkit" {
-  inherits = ["testworkflow-toolkit-meta"]
+  inherits = ["tw-toolkit-meta"]
   context="."
   dockerfile = "build/new/tw-toolkit.Dockerfile"
   platforms = ["linux/arm64", "linux/amd64"]


### PR DESCRIPTION
## Pull request description 

Fixing docker build to use in "cli" target the right metadata, also reorganizing to have same order in both places docker bake file and build workflow.

## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [x] tested locally
- [ ] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test


## Fixes

- Fixing inheritance of "cli" target into docker bake file.
- Re-organizing build workflow to follow same naming and order of all container images that will be built. 