### PR TITLE
fix: use full replacement for YAML updates in TestTrigger handler

### DIFF
--- a/internal/app/api/v1/testtriggers.go
+++ b/internal/app/api/v1/testtriggers.go
@@ -82,7 +82,8 @@ func (s *TestkubeAPI) UpdateTestTriggerHandler() fiber.Handler {
 	return func(c *fiber.Ctx) error {
 		errPrefix := "failed to update test trigger"
 		var request testkube.TestTriggerUpsertRequest
-		if string(c.Request().Header.ContentType()) == mediaTypeYAML {
+		isYAML := string(c.Request().Header.ContentType()) == mediaTypeYAML
+		if isYAML {
 			var testTrigger testtriggersv1.TestTrigger
 			testTriggerSpec := string(c.Body())
 			decoder := yaml.NewYAMLOrJSONDecoder(bytes.NewBufferString(testTriggerSpec), len(testTriggerSpec))
@@ -104,57 +105,85 @@ func (s *TestkubeAPI) UpdateTestTriggerHandler() fiber.Handler {
 		}
 		errPrefix = errPrefix + " " + request.Name
 
-		// we need to get resource first
-		apiTrigger, err := s.TestTriggersClient.Get(c.Context(), s.getEnvironmentId(), request.Name, namespace)
+		// we need to get resource first to validate it exists
+		existingTrigger, err := s.TestTriggersClient.Get(c.Context(), s.getEnvironmentId(), request.Name, namespace)
 		if err != nil {
 			return s.Error(c, http.StatusBadGateway, fmt.Errorf("%s: client could not get test trigger: %w", errPrefix, err))
 		}
 
-		// Update the trigger with new values from request
-		apiTrigger.Name = request.Name
-		apiTrigger.Namespace = namespace
-		if request.Labels != nil {
-			apiTrigger.Labels = request.Labels
-		}
-		if request.Annotations != nil {
-			apiTrigger.Annotations = request.Annotations
-		}
+		var apiTrigger *testkube.TestTrigger
 
-		// Update individual fields from the request
-		if request.Selector != nil {
-			apiTrigger.Selector = request.Selector
+		// YAML requests do full replacement (Definition tab sends complete YAML)
+		// JSON requests do merge (form-based updates send partial JSON)
+		if isYAML {
+			apiTrigger = &testkube.TestTrigger{
+				Name:              request.Name,
+				Namespace:         namespace,
+				Labels:            request.Labels,
+				Annotations:       request.Annotations,
+				Selector:          request.Selector,
+				Resource:          request.Resource,
+				ResourceSelector:  request.ResourceSelector,
+				Event:             request.Event,
+				ConditionSpec:     request.ConditionSpec,
+				ProbeSpec:         request.ProbeSpec,
+				Action:            request.Action,
+				ActionParameters:  request.ActionParameters,
+				Execution:         request.Execution,
+				TestSelector:      request.TestSelector,
+				ConcurrencyPolicy: request.ConcurrencyPolicy,
+				Disabled:          request.Disabled,
+				Sync:              request.Sync,
+			}
+		} else {
+			// JSON merge: only update fields that are present in the request
+			apiTrigger = existingTrigger
+			apiTrigger.Name = request.Name
+			apiTrigger.Namespace = namespace
+			if request.Labels != nil {
+				apiTrigger.Labels = request.Labels
+			}
+			if request.Annotations != nil {
+				apiTrigger.Annotations = request.Annotations
+			}
+			if request.Selector != nil {
+				apiTrigger.Selector = request.Selector
+			}
+			if request.Resource != nil {
+				apiTrigger.Resource = request.Resource
+			}
+			if request.ResourceSelector != nil {
+				apiTrigger.ResourceSelector = request.ResourceSelector
+			}
+			if request.Event != "" {
+				apiTrigger.Event = request.Event
+			}
+			if request.ConditionSpec != nil {
+				apiTrigger.ConditionSpec = request.ConditionSpec
+			}
+			if request.ProbeSpec != nil {
+				apiTrigger.ProbeSpec = request.ProbeSpec
+			}
+			if request.Action != nil {
+				apiTrigger.Action = request.Action
+			}
+			if request.ActionParameters != nil {
+				apiTrigger.ActionParameters = request.ActionParameters
+			}
+			if request.Execution != nil {
+				apiTrigger.Execution = request.Execution
+			}
+			if request.TestSelector != nil {
+				apiTrigger.TestSelector = request.TestSelector
+			}
+			if request.ConcurrencyPolicy != nil {
+				apiTrigger.ConcurrencyPolicy = request.ConcurrencyPolicy
+			}
+			if request.Sync != nil {
+				apiTrigger.Sync = request.Sync
+			}
+			apiTrigger.Disabled = request.Disabled
 		}
-		if request.Resource != nil {
-			apiTrigger.Resource = request.Resource
-		}
-		if request.ResourceSelector != nil {
-			apiTrigger.ResourceSelector = request.ResourceSelector
-		}
-		if request.Event != "" {
-			apiTrigger.Event = request.Event
-		}
-		if request.ConditionSpec != nil {
-			apiTrigger.ConditionSpec = request.ConditionSpec
-		}
-		if request.ProbeSpec != nil {
-			apiTrigger.ProbeSpec = request.ProbeSpec
-		}
-		if request.Action != nil {
-			apiTrigger.Action = request.Action
-		}
-		if request.ActionParameters != nil {
-			apiTrigger.ActionParameters = request.ActionParameters
-		}
-		if request.Execution != nil {
-			apiTrigger.Execution = request.Execution
-		}
-		if request.TestSelector != nil {
-			apiTrigger.TestSelector = request.TestSelector
-		}
-		if request.ConcurrencyPolicy != nil {
-			apiTrigger.ConcurrencyPolicy = request.ConcurrencyPolicy
-		}
-		apiTrigger.Disabled = request.Disabled
 
 		err = s.TestTriggersClient.Update(c.Context(), s.getEnvironmentId(), *apiTrigger)
 		s.Metrics.IncUpdateTestTrigger(err)

--- a/internal/app/api/v1/testtriggers_test.go
+++ b/internal/app/api/v1/testtriggers_test.go
@@ -453,6 +453,369 @@ spec:
 		assert.NoError(t, err)
 		assert.Equal(t, http.StatusBadGateway, resp.StatusCode)
 	})
+
+	t.Run("should clear conditionSpec when yaml update removes it", func(t *testing.T) {
+		// given - YAML without conditionSpec
+		requestBody := `
+apiVersion: tests.testkube.io/v1
+kind: TestTrigger
+metadata:
+  name: test-trigger
+  namespace: default
+spec:
+  resource: deployment
+  resourceSelector:
+    name: test-resource
+  event: created
+  action: run
+  execution: testworkflow
+  testSelector:
+    name: my-test
+`
+		// existing trigger HAS conditionSpec
+		existingTrigger := &testkube.TestTrigger{
+			Name:      "test-trigger",
+			Namespace: "default",
+			Resource:  resourcePtr("deployment"),
+			Event:     "created",
+			Action:    actionPtr("run"),
+			Execution: executionPtr("testworkflow"),
+			ConditionSpec: &testkube.TestTriggerConditionSpec{
+				Timeout: 100,
+				Conditions: []testkube.TestTriggerCondition{
+					{Type_: "Ready", Status: conditionStatusPtr("True")},
+				},
+			},
+		}
+
+		mockClient.EXPECT().
+			Get(gomock.Any(), "test-env", "test-trigger", "default").
+			Return(existingTrigger, nil).
+			Times(1)
+
+		mockClient.EXPECT().
+			Update(gomock.Any(), "test-env", gomock.Any()).
+			DoAndReturn(func(ctx context.Context, envId string, trigger testkube.TestTrigger) error {
+				// conditionSpec should be nil (cleared) since YAML doesn't include it
+				assert.Nil(t, trigger.ConditionSpec, "conditionSpec should be nil after YAML update without it")
+				return nil
+			}).
+			Times(1)
+
+		req := httptest.NewRequest("PUT", "/test-triggers", bytes.NewReader([]byte(requestBody)))
+		req.Header.Set("Content-Type", "text/yaml")
+
+		// when
+		resp, err := app.Test(req)
+
+		// then
+		assert.NoError(t, err)
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
+	})
+
+	t.Run("should preserve conditionSpec when json update does not include it", func(t *testing.T) {
+		// given - JSON update without conditionSpec (merge behavior)
+		request := testkube.TestTriggerUpsertRequest{
+			Name:      "test-trigger",
+			Namespace: "default",
+			Event:     "updated", // only changing event
+		}
+
+		// existing trigger HAS conditionSpec
+		existingTrigger := &testkube.TestTrigger{
+			Name:      "test-trigger",
+			Namespace: "default",
+			Resource:  resourcePtr("deployment"),
+			Event:     "created",
+			Action:    actionPtr("run"),
+			Execution: executionPtr("testworkflow"),
+			ConditionSpec: &testkube.TestTriggerConditionSpec{
+				Timeout: 100,
+				Conditions: []testkube.TestTriggerCondition{
+					{Type_: "Ready", Status: conditionStatusPtr("True")},
+				},
+			},
+		}
+
+		mockClient.EXPECT().
+			Get(gomock.Any(), "test-env", "test-trigger", "default").
+			Return(existingTrigger, nil).
+			Times(1)
+
+		mockClient.EXPECT().
+			Update(gomock.Any(), "test-env", gomock.Any()).
+			DoAndReturn(func(ctx context.Context, envId string, trigger testkube.TestTrigger) error {
+				// conditionSpec should be preserved since JSON uses merge behavior
+				assert.NotNil(t, trigger.ConditionSpec, "conditionSpec should be preserved in JSON merge update")
+				assert.Equal(t, int32(100), trigger.ConditionSpec.Timeout)
+				// event should be updated
+				assert.Equal(t, "updated", trigger.Event)
+				return nil
+			}).
+			Times(1)
+
+		requestBody, _ := json.Marshal(request)
+		req := httptest.NewRequest("PUT", "/test-triggers", bytes.NewReader(requestBody))
+		req.Header.Set("Content-Type", "application/json")
+
+		// when
+		resp, err := app.Test(req)
+
+		// then
+		assert.NoError(t, err)
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
+	})
+
+	t.Run("should clear all optional fields when yaml update removes them", func(t *testing.T) {
+		// given - minimal YAML with only required fields
+		requestBody := `
+apiVersion: tests.testkube.io/v1
+kind: TestTrigger
+metadata:
+  name: test-trigger
+  namespace: default
+spec:
+  resource: deployment
+  event: created
+  action: run
+  execution: testworkflow
+  testSelector:
+    name: my-test
+`
+		// existing trigger has ALL optional fields populated
+		existingTrigger := &testkube.TestTrigger{
+			Name:        "test-trigger",
+			Namespace:   "default",
+			Labels:      map[string]string{"env": "test", "team": "platform"},
+			Annotations: map[string]string{"description": "my trigger"},
+			Resource:    resourcePtr("deployment"),
+			ResourceSelector: &testkube.TestTriggerSelector{
+				Name:          "specific-deployment",
+				Namespace:     "apps",
+				LabelSelector: &testkube.IoK8sApimachineryPkgApisMetaV1LabelSelector{MatchLabels: map[string]string{"app": "test"}},
+			},
+			Event:     "created",
+			Action:    actionPtr("run"),
+			Execution: executionPtr("testworkflow"),
+			ConditionSpec: &testkube.TestTriggerConditionSpec{
+				Timeout: 100,
+				Conditions: []testkube.TestTriggerCondition{
+					{Type_: "Ready", Status: conditionStatusPtr("True")},
+				},
+			},
+			ProbeSpec: &testkube.TestTriggerProbeSpec{
+				Timeout: 60,
+				Probes: []testkube.TestTriggerProbe{
+					{Scheme: "http", Host: "localhost", Port: 8080},
+				},
+			},
+			ActionParameters: &testkube.TestTriggerActionParameters{
+				Config: map[string]string{"key": "value"},
+				Tags:   map[string]string{"env": "test"},
+			},
+			TestSelector: &testkube.TestTriggerSelector{
+				Name: "old-test",
+			},
+			ConcurrencyPolicy: concurrencyPolicyPtr(testkube.FORBID_TestTriggerConcurrencyPolicies),
+			Disabled:          true,
+		}
+
+		mockClient.EXPECT().
+			Get(gomock.Any(), "test-env", "test-trigger", "default").
+			Return(existingTrigger, nil).
+			Times(1)
+
+		mockClient.EXPECT().
+			Update(gomock.Any(), "test-env", gomock.Any()).
+			DoAndReturn(func(ctx context.Context, envId string, trigger testkube.TestTrigger) error {
+				// All optional fields should be cleared (nil or zero value) since YAML doesn't include them
+				assert.Nil(t, trigger.Labels, "labels should be nil after YAML update without it")
+				assert.Nil(t, trigger.Annotations, "annotations should be nil after YAML update without it")
+				// Note: ResourceSelector is returned as empty struct by the CRD mapper, not nil
+				// This is expected behavior from mapSelectorFromCRD which always returns a pointer
+				if trigger.ResourceSelector != nil {
+					assert.Empty(t, trigger.ResourceSelector.Name, "resourceSelector.Name should be empty")
+					assert.Empty(t, trigger.ResourceSelector.Namespace, "resourceSelector.Namespace should be empty")
+				}
+				assert.Nil(t, trigger.ConditionSpec, "conditionSpec should be nil after YAML update without it")
+				assert.Nil(t, trigger.ProbeSpec, "probeSpec should be nil after YAML update without it")
+				assert.Nil(t, trigger.ActionParameters, "actionParameters should be nil after YAML update without it")
+				assert.Nil(t, trigger.ConcurrencyPolicy, "concurrencyPolicy should be nil after YAML update without it")
+				assert.False(t, trigger.Disabled, "disabled should be false after YAML update without it")
+				// Required fields should still be set
+				assert.Equal(t, "test-trigger", trigger.Name)
+				assert.Equal(t, "default", trigger.Namespace)
+				assert.NotNil(t, trigger.Resource)
+				assert.Equal(t, "created", trigger.Event)
+				assert.NotNil(t, trigger.TestSelector)
+				assert.Equal(t, "my-test", trigger.TestSelector.Name)
+				return nil
+			}).
+			Times(1)
+
+		req := httptest.NewRequest("PUT", "/test-triggers", bytes.NewReader([]byte(requestBody)))
+		req.Header.Set("Content-Type", "text/yaml")
+
+		// when
+		resp, err := app.Test(req)
+
+		// then
+		assert.NoError(t, err)
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
+	})
+
+	t.Run("should preserve all optional fields when json update only changes event", func(t *testing.T) {
+		// given - JSON update only changing event field
+		request := testkube.TestTriggerUpsertRequest{
+			Name:      "test-trigger",
+			Namespace: "default",
+			Event:     "updated", // only changing event
+		}
+
+		// existing trigger has ALL optional fields populated
+		existingTrigger := &testkube.TestTrigger{
+			Name:        "test-trigger",
+			Namespace:   "default",
+			Labels:      map[string]string{"env": "test", "team": "platform"},
+			Annotations: map[string]string{"description": "my trigger"},
+			Resource:    resourcePtr("deployment"),
+			ResourceSelector: &testkube.TestTriggerSelector{
+				Name:      "specific-deployment",
+				Namespace: "apps",
+			},
+			Event:     "created",
+			Action:    actionPtr("run"),
+			Execution: executionPtr("testworkflow"),
+			ConditionSpec: &testkube.TestTriggerConditionSpec{
+				Timeout: 100,
+			},
+			ProbeSpec: &testkube.TestTriggerProbeSpec{
+				Timeout: 60,
+			},
+			ActionParameters: &testkube.TestTriggerActionParameters{
+				Config: map[string]string{"key": "value"},
+				Tags:   map[string]string{"env": "test"},
+			},
+			TestSelector: &testkube.TestTriggerSelector{
+				Name: "old-test",
+			},
+			ConcurrencyPolicy: concurrencyPolicyPtr(testkube.FORBID_TestTriggerConcurrencyPolicies),
+			Disabled:          true,
+		}
+
+		mockClient.EXPECT().
+			Get(gomock.Any(), "test-env", "test-trigger", "default").
+			Return(existingTrigger, nil).
+			Times(1)
+
+		mockClient.EXPECT().
+			Update(gomock.Any(), "test-env", gomock.Any()).
+			DoAndReturn(func(ctx context.Context, envId string, trigger testkube.TestTrigger) error {
+				// All optional fields should be PRESERVED since JSON uses merge behavior
+				assert.Equal(t, map[string]string{"env": "test", "team": "platform"}, trigger.Labels, "labels should be preserved")
+				assert.Equal(t, map[string]string{"description": "my trigger"}, trigger.Annotations, "annotations should be preserved")
+				assert.NotNil(t, trigger.ResourceSelector, "resourceSelector should be preserved")
+				assert.Equal(t, "specific-deployment", trigger.ResourceSelector.Name)
+				assert.NotNil(t, trigger.ConditionSpec, "conditionSpec should be preserved")
+				assert.Equal(t, int32(100), trigger.ConditionSpec.Timeout)
+				assert.NotNil(t, trigger.ProbeSpec, "probeSpec should be preserved")
+				assert.Equal(t, int32(60), trigger.ProbeSpec.Timeout)
+				assert.NotNil(t, trigger.ActionParameters, "actionParameters should be preserved")
+				assert.Equal(t, map[string]string{"key": "value"}, trigger.ActionParameters.Config)
+				assert.NotNil(t, trigger.ConcurrencyPolicy, "concurrencyPolicy should be preserved")
+				assert.Equal(t, testkube.FORBID_TestTriggerConcurrencyPolicies, *trigger.ConcurrencyPolicy)
+				// Note: Disabled is a bool, not *bool, so it cannot distinguish "not set" from "false"
+				// This is a known limitation of the API design. For YAML updates this works correctly.
+				// For JSON merge updates, if the user sends disabled:false (or omits it), it resets to false.
+				// Event should be updated
+				assert.Equal(t, "updated", trigger.Event)
+				return nil
+			}).
+			Times(1)
+
+		requestBody, _ := json.Marshal(request)
+		req := httptest.NewRequest("PUT", "/test-triggers", bytes.NewReader(requestBody))
+		req.Header.Set("Content-Type", "application/json")
+
+		// when
+		resp, err := app.Test(req)
+
+		// then
+		assert.NoError(t, err)
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
+	})
+
+	t.Run("should add new fields when yaml update includes them", func(t *testing.T) {
+		// given - YAML with new conditionSpec and probeSpec
+		requestBody := `
+apiVersion: tests.testkube.io/v1
+kind: TestTrigger
+metadata:
+  name: test-trigger
+  namespace: default
+  labels:
+    env: production
+    team: devops
+spec:
+  resource: deployment
+  event: created
+  action: run
+  execution: testworkflow
+  testSelector:
+    name: my-test
+  conditionSpec:
+    timeout: 120
+    conditions:
+      - type: Ready
+        status: "True"
+  probeSpec:
+    timeout: 30
+  disabled: true
+`
+		// existing trigger has minimal fields
+		existingTrigger := &testkube.TestTrigger{
+			Name:      "test-trigger",
+			Namespace: "default",
+			Resource:  resourcePtr("deployment"),
+			Event:     "created",
+			Action:    actionPtr("run"),
+			Execution: executionPtr("testworkflow"),
+			TestSelector: &testkube.TestTriggerSelector{
+				Name: "old-test",
+			},
+		}
+
+		mockClient.EXPECT().
+			Get(gomock.Any(), "test-env", "test-trigger", "default").
+			Return(existingTrigger, nil).
+			Times(1)
+
+		mockClient.EXPECT().
+			Update(gomock.Any(), "test-env", gomock.Any()).
+			DoAndReturn(func(ctx context.Context, envId string, trigger testkube.TestTrigger) error {
+				// New fields from YAML should be added
+				assert.Equal(t, map[string]string{"env": "production", "team": "devops"}, trigger.Labels, "labels should be set from YAML")
+				assert.NotNil(t, trigger.ConditionSpec, "conditionSpec should be set from YAML")
+				assert.Equal(t, int32(120), trigger.ConditionSpec.Timeout)
+				assert.NotNil(t, trigger.ProbeSpec, "probeSpec should be set from YAML")
+				assert.Equal(t, int32(30), trigger.ProbeSpec.Timeout)
+				assert.True(t, trigger.Disabled, "disabled should be set from YAML")
+				// testSelector should be updated
+				assert.Equal(t, "my-test", trigger.TestSelector.Name)
+				return nil
+			}).
+			Times(1)
+
+		req := httptest.NewRequest("PUT", "/test-triggers", bytes.NewReader([]byte(requestBody)))
+		req.Header.Set("Content-Type", "text/yaml")
+
+		// when
+		resp, err := app.Test(req)
+
+		// then
+		assert.NoError(t, err)
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
+	})
 }
 
 func TestBulkUpdateTestTriggersHandler(t *testing.T) {
@@ -1022,6 +1385,15 @@ func actionPtr(s string) *testkube.TestTriggerActions {
 func executionPtr(s string) *testkube.TestTriggerExecutions {
 	e := testkube.TestTriggerExecutions(s)
 	return &e
+}
+
+func conditionStatusPtr(s string) *testkube.TestTriggerConditionStatuses {
+	c := testkube.TestTriggerConditionStatuses(s)
+	return &c
+}
+
+func concurrencyPolicyPtr(p testkube.TestTriggerConcurrencyPolicies) *testkube.TestTriggerConcurrencyPolicies {
+	return &p
 }
 
 // MetricsInterface defines the methods we need from metrics for testing

--- a/pkg/mapper/testtriggers/kube_openapi.go
+++ b/pkg/mapper/testtriggers/kube_openapi.go
@@ -149,6 +149,7 @@ func MapTestTriggerCRDToTestTriggerUpsertRequest(request testsv1.TestTrigger) te
 		Name:              request.Name,
 		Namespace:         request.Namespace,
 		Labels:            request.Labels,
+		Annotations:       request.Annotations,
 		Selector:          mapLabelSelectorFromCRD(request.Spec.Selector),
 		Resource:          resource,
 		ResourceSelector:  mapSelectorFromCRD(request.Spec.ResourceSelector),


### PR DESCRIPTION
## Problem
When editing a TestTrigger in the Definition tab (YAML editor), removing a field (e.g., `conditionSpec`) would not actually delete it. The old value was preserved because the handler used merge semantics for all update requests.

## Solution
Changed the `UpdateTestTriggerHandler` to distinguish between YAML and JSON requests based on `Content-Type`:

- YAML (`text/yaml`): Full replacement — the YAML definition becomes the complete trigger state. Removed fields are cleared.
- JSON (`application/json`): Merge — only explicitly provided fields are updated, preserving existing values.

This matches user expectations: the Definition tab shows the complete trigger, so saving it should result in exactly what's shown.

## Additional Fixes
- Added missing `Sync` field handling in the update handler
- Added missing `Annotations` mapping from CRD to request