### PR TITLE
fix(devbox): add lease permissions for agent leader election

### DIFF
--- a/cmd/tcl/kubectl-testkube/devbox/devutils/namespace.go
+++ b/cmd/tcl/kubectl-testkube/devbox/devutils/namespace.go
@@ -146,6 +146,11 @@ func (n *NamespaceObject) createRole() error {
 				Resources: []string{"secrets", "configmaps"},
 			},
 			{
+				Verbs:     []string{"get", "watch", "list", "create", "patch", "update", "delete"},
+				APIGroups: []string{"coordination.k8s.io"},
+				Resources: []string{"leases"},
+			},
+			{
 				Verbs:     []string{"get", "watch", "list", "create", "patch", "update", "delete", "deletecollection"},
 				APIGroups: []string{"testworkflows.testkube.io"},
 				Resources: []string{"testworkflows", "testworkflows/status", "testworkflowtemplates", "testworkflowexecutions"},


### PR DESCRIPTION
## Pull request description 

- Add RBAC permissions for `coordination.k8s.io/leases` to devbox role

Agent uses leader election which requires lease create/update permissions. Without this, devbox fails with:
```
leases.coordination.k8s.io is forbidden: User cannot create resource "leases"
```

## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [ ] tested locally
- [ ] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Breaking changes

-

## Changes

-

## Fixes

-