### PR TITLE
fix: build agent locally

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -246,7 +246,7 @@ build-api-server: ## Build API server binary
 		$(GOFLAGS) \
 		-ldflags='$(LD_FLAGS_API)' \
 		-o $(API_SERVER_BIN) \
-		cmd/api-server/main.go
+		./cmd/api-server/
 	@echo "API server built: $(API_SERVER_BIN)"
 
 .PHONY: build-testkube-cli


### PR DESCRIPTION
## Pull request description 
Command `make build-api-server` failed with the error: 
```
# command-line-arguments
cmd/api-server/main.go:342:2: undefined: migrateSuperAgent
cmd/api-server/main.go:343:3: undefined: superAgentMigrationConfig
```


## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [x] tested locally
- [ ] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Breaking changes

-

## Changes

-

## Fixes

-