### PR TITLE
fix: [TKC-4714] add event matching so listeners receive env-scoped events

### DIFF
--- a/pkg/api/v1/testkube/model_event_extended.go
+++ b/pkg/api/v1/testkube/model_event_extended.go
@@ -158,7 +158,7 @@ func (e Event) Log() []any {
 }
 
 func (e Event) Valid(groupId, selector string, types []EventType) (matchedTypes []EventType, valid bool) {
-	if e.GroupId != groupId {
+	if groupId != "" && e.GroupId != groupId {
 		return nil, false
 	}
 

--- a/pkg/api/v1/testkube/model_event_extended_test.go
+++ b/pkg/api/v1/testkube/model_event_extended_test.go
@@ -56,6 +56,21 @@ func TestEmitter_IsValidEvent_ForTestWorkflow(t *testing.T) {
 		assert.True(t, valid)
 	})
 
+	t.Run("should treat empty group as wildcard", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		execution := &TestWorkflowExecution{Workflow: &TestWorkflow{}}
+		e := Event{Type_: EventStartTestWorkflow, TestWorkflowExecution: execution, GroupId: "env-1"}
+
+		// when
+		types, valid := e.Valid("", "", AllEventTypes)
+
+		// then
+		assert.Equal(t, []EventType{START_TESTWORKFLOW_EventType}, types)
+		assert.True(t, valid)
+	})
+
 	t.Run("should pass events with become events", func(t *testing.T) {
 		t.Parallel()
 


### PR DESCRIPTION
## Pull request description 

  - Treat empty listener group as a wildcard in Event.Valid, so env-scoped events still match group-agnostic listeners.
  - Restores agent workflow execution/step metrics (and other group-agnostic listeners)
  - Regression introduced when #6843 added strict group matching
  
  https://github.com/kubeshop/testkube/pull/6843/changes#diff-28b701d7d23a32c953c7a1edbb8a519cf7ba27a8d4a33e176bf81c4f88db4021R161
  
  - Adds a test to cover empty-group matching.


## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [ ] tested locally
- [ ] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Breaking changes

-

## Changes

-

## Fixes

-