### PR TITLE
fix: [TKC-4722] GitOps delete sync to avoid empty-name objects

### DIFF
--- a/internal/sync/controller/fakes_test.go
+++ b/internal/sync/controller/fakes_test.go
@@ -50,9 +50,11 @@ type fakeStore struct {
 	Webhook              executorv1.Webhook
 	WebhookTemplate      executorv1.WebhookTemplate
 	Deleted              string
+	UpdateCalls          int
 }
 
 func (t *fakeStore) UpdateOrCreateTestTrigger(_ context.Context, trigger testtriggersv1.TestTrigger) error {
+	t.UpdateCalls++
 	trigger.DeepCopyInto(&t.TestTrigger)
 	return nil
 }
@@ -63,6 +65,7 @@ func (t *fakeStore) DeleteTestTrigger(_ context.Context, s string) error {
 }
 
 func (t *fakeStore) UpdateOrCreateTestWorkflow(_ context.Context, workflow testworkflowsv1.TestWorkflow) error {
+	t.UpdateCalls++
 	workflow.DeepCopyInto(&t.TestWorkflow)
 	return nil
 }
@@ -73,6 +76,7 @@ func (t *fakeStore) DeleteTestWorkflow(_ context.Context, s string) error {
 }
 
 func (t *fakeStore) UpdateOrCreateTestWorkflowTemplate(_ context.Context, template testworkflowsv1.TestWorkflowTemplate) error {
+	t.UpdateCalls++
 	template.DeepCopyInto(&t.TestWorkflowTemplate)
 	return nil
 }
@@ -83,6 +87,7 @@ func (t *fakeStore) DeleteTestWorkflowTemplate(_ context.Context, s string) erro
 }
 
 func (t *fakeStore) UpdateOrCreateWebhook(_ context.Context, webhook executorv1.Webhook) error {
+	t.UpdateCalls++
 	webhook.DeepCopyInto(&t.Webhook)
 	return nil
 }
@@ -93,6 +98,7 @@ func (t *fakeStore) DeleteWebhook(_ context.Context, s string) error {
 }
 
 func (t *fakeStore) UpdateOrCreateWebhookTemplate(_ context.Context, template executorv1.WebhookTemplate) error {
+	t.UpdateCalls++
 	template.DeepCopyInto(&t.WebhookTemplate)
 	return nil
 }

--- a/internal/sync/controller/testtrigger.go
+++ b/internal/sync/controller/testtrigger.go
@@ -42,6 +42,7 @@ func testTriggerSyncReconciler(client client.Reader, store TestTriggerStore) rec
 				// the store then we should handle them here.
 				return ctrl.Result{}, fmt.Errorf("delete TestTrigger %q from store: %w", req.Name, err)
 			}
+			return ctrl.Result{}, nil
 		case err != nil:
 			return ctrl.Result{}, fmt.Errorf("retrieve TestTrigger %q from Kubernetes: %w", req.NamespacedName, err)
 		}
@@ -63,6 +64,7 @@ func testTriggerSyncReconciler(client client.Reader, store TestTriggerStore) rec
 				// the store then we should handle them here.
 				return ctrl.Result{}, fmt.Errorf("delete TestTrigger %q from store: %w", req.Name, err)
 			}
+			return ctrl.Result{}, nil
 		}
 
 		// Regular update so send the new object into the store.

--- a/internal/sync/controller/testtrigger_test.go
+++ b/internal/sync/controller/testtrigger_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
@@ -36,6 +37,10 @@ func TestTestTriggerSyncReconcilerUpdateOrCreate(t *testing.T) {
 	if diff := cmp.Diff(input, store.TestTrigger); diff != "" {
 		t.Errorf("TestTriggerSyncReconcilerUpdateOrCreate: -want, +got:\n%s", diff)
 	}
+
+	if store.UpdateCalls != 1 {
+		t.Errorf("TestTriggerSyncReconcilerUpdateOrCreate: expected 1 update call, got %d", store.UpdateCalls)
+	}
 }
 
 func TestTestTriggerSyncReconcilerDelete(t *testing.T) {
@@ -55,5 +60,39 @@ func TestTestTriggerSyncReconcilerDelete(t *testing.T) {
 
 	if diff := cmp.Diff(name, store.Deleted); diff != "" {
 		t.Errorf("TestTriggerSyncReconcilerUpdateOrCreate: -want, +got:\n%s", diff)
+	}
+
+	if store.UpdateCalls != 0 {
+		t.Errorf("TestTriggerSyncReconcilerDelete: expected 0 update calls, got %d", store.UpdateCalls)
+	}
+}
+
+func TestTestTriggerSyncReconcilerDeleteWhenMarkedForDeletion(t *testing.T) {
+	store := &fakeStore{}
+	name := "foobar"
+	now := metav1.Now()
+
+	reconciler := testTriggerSyncReconciler(
+		fakeKubernetesClient{
+			TestTrigger: testtriggersv1.TestTrigger{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:              name,
+					DeletionTimestamp: &now,
+				},
+			},
+		},
+		store,
+	)
+
+	if _, err := reconciler.Reconcile(t.Context(), reconcile.Request{NamespacedName: types.NamespacedName{Name: name}}); err != nil {
+		t.Errorf("reconciliation failed: %v", err)
+	}
+
+	if diff := cmp.Diff(name, store.Deleted); diff != "" {
+		t.Errorf("TestTriggerSyncReconcilerDeleteWhenMarkedForDeletion: -want, +got:\n%s", diff)
+	}
+
+	if store.UpdateCalls != 0 {
+		t.Errorf("TestTriggerSyncReconcilerDeleteWhenMarkedForDeletion: expected 0 update calls, got %d", store.UpdateCalls)
 	}
 }

--- a/internal/sync/controller/testworkflow.go
+++ b/internal/sync/controller/testworkflow.go
@@ -42,6 +42,7 @@ func testWorkflowSyncReconciler(client client.Reader, store TestWorkflowStore) r
 				// the store then we should handle them here.
 				return ctrl.Result{}, fmt.Errorf("delete TestWorkflow %q from store: %w", req.Name, err)
 			}
+			return ctrl.Result{}, nil
 		case err != nil:
 			return ctrl.Result{}, fmt.Errorf("retrieve TestWorkflow %q from Kubernetes: %w", req.NamespacedName, err)
 		}
@@ -63,6 +64,7 @@ func testWorkflowSyncReconciler(client client.Reader, store TestWorkflowStore) r
 				// the store then we should handle them here.
 				return ctrl.Result{}, fmt.Errorf("delete TestWorkflow %q from store: %w", req.Name, err)
 			}
+			return ctrl.Result{}, nil
 		}
 
 		// Regular update so send the new object into the store.

--- a/internal/sync/controller/testworkflowtemplate.go
+++ b/internal/sync/controller/testworkflowtemplate.go
@@ -42,6 +42,7 @@ func testWorkflowTemplateSyncReconciler(client client.Reader, store TestWorkflow
 				// the store then we should handle them here.
 				return ctrl.Result{}, fmt.Errorf("delete TestWorkflowTemplate %q from store: %w", req.Name, err)
 			}
+			return ctrl.Result{}, nil
 		case err != nil:
 			return ctrl.Result{}, fmt.Errorf("retrieve TestWorkflowTemplate %q from Kubernetes: %w", req.NamespacedName, err)
 		}
@@ -63,6 +64,7 @@ func testWorkflowTemplateSyncReconciler(client client.Reader, store TestWorkflow
 				// the store then we should handle them here.
 				return ctrl.Result{}, fmt.Errorf("delete TestWorkflowTemplate %q from store: %w", req.Name, err)
 			}
+			return ctrl.Result{}, nil
 		}
 
 		// Regular update so send the new object into the store.

--- a/internal/sync/controller/testworkflowtemplate_test.go
+++ b/internal/sync/controller/testworkflowtemplate_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
@@ -48,6 +49,10 @@ func TestTestWorkflowTemplateSyncReconcilerUpdateOrCreate(t *testing.T) {
 	if diff := cmp.Diff(input, store.TestWorkflowTemplate); diff != "" {
 		t.Errorf("TestWorkflowTemplateSyncReconcilerUpdateOrCreate: -want, +got:\n%s", diff)
 	}
+
+	if store.UpdateCalls != 1 {
+		t.Errorf("TestWorkflowTemplateSyncReconcilerUpdateOrCreate: expected 1 update call, got %d", store.UpdateCalls)
+	}
 }
 
 func TestTestWorkflowTemplateSyncReconcilerDelete(t *testing.T) {
@@ -67,5 +72,39 @@ func TestTestWorkflowTemplateSyncReconcilerDelete(t *testing.T) {
 
 	if diff := cmp.Diff(name, store.Deleted); diff != "" {
 		t.Errorf("TestWorkflowTemplateSyncReconcilerUpdateOrCreate: -want, +got:\n%s", diff)
+	}
+
+	if store.UpdateCalls != 0 {
+		t.Errorf("TestWorkflowTemplateSyncReconcilerDelete: expected 0 update calls, got %d", store.UpdateCalls)
+	}
+}
+
+func TestTestWorkflowTemplateSyncReconcilerDeleteWhenMarkedForDeletion(t *testing.T) {
+	store := &fakeStore{}
+	name := "foobar"
+	now := metav1.Now()
+
+	reconciler := testWorkflowTemplateSyncReconciler(
+		fakeKubernetesClient{
+			TestWorkflowTemplate: testworkflowsv1.TestWorkflowTemplate{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:              name,
+					DeletionTimestamp: &now,
+				},
+			},
+		},
+		store,
+	)
+
+	if _, err := reconciler.Reconcile(t.Context(), reconcile.Request{NamespacedName: types.NamespacedName{Name: name}}); err != nil {
+		t.Errorf("reconciliation failed: %v", err)
+	}
+
+	if diff := cmp.Diff(name, store.Deleted); diff != "" {
+		t.Errorf("TestWorkflowTemplateSyncReconcilerDeleteWhenMarkedForDeletion: -want, +got:\n%s", diff)
+	}
+
+	if store.UpdateCalls != 0 {
+		t.Errorf("TestWorkflowTemplateSyncReconcilerDeleteWhenMarkedForDeletion: expected 0 update calls, got %d", store.UpdateCalls)
 	}
 }

--- a/internal/sync/controller/webhook.go
+++ b/internal/sync/controller/webhook.go
@@ -42,6 +42,7 @@ func webhookSyncReconciler(client client.Reader, store WebhookStore) reconcile.R
 				// the store then we should handle them here.
 				return ctrl.Result{}, fmt.Errorf("delete Webhook %q from store: %w", req.Name, err)
 			}
+			return ctrl.Result{}, nil
 		case err != nil:
 			return ctrl.Result{}, fmt.Errorf("retrieve Webhook %q from Kubernetes: %w", req.NamespacedName, err)
 		}
@@ -63,6 +64,7 @@ func webhookSyncReconciler(client client.Reader, store WebhookStore) reconcile.R
 				// the store then we should handle them here.
 				return ctrl.Result{}, fmt.Errorf("delete Webhook %q from store: %w", req.Name, err)
 			}
+			return ctrl.Result{}, nil
 		}
 
 		// Regular update so send the new object into the store.

--- a/internal/sync/controller/webhook_test.go
+++ b/internal/sync/controller/webhook_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
@@ -36,6 +37,10 @@ func TestWebhookSyncReconcilerUpdateOrCreate(t *testing.T) {
 	if diff := cmp.Diff(input, store.Webhook); diff != "" {
 		t.Errorf("WebhookSyncReconcilerUpdateOrCreate: -want, +got:\n%s", diff)
 	}
+
+	if store.UpdateCalls != 1 {
+		t.Errorf("WebhookSyncReconcilerUpdateOrCreate: expected 1 update call, got %d", store.UpdateCalls)
+	}
 }
 
 func TestWebhookSyncReconcilerDelete(t *testing.T) {
@@ -55,5 +60,39 @@ func TestWebhookSyncReconcilerDelete(t *testing.T) {
 
 	if diff := cmp.Diff(name, store.Deleted); diff != "" {
 		t.Errorf("WebhookSyncReconcilerUpdateOrCreate: -want, +got:\n%s", diff)
+	}
+
+	if store.UpdateCalls != 0 {
+		t.Errorf("WebhookSyncReconcilerDelete: expected 0 update calls, got %d", store.UpdateCalls)
+	}
+}
+
+func TestWebhookSyncReconcilerDeleteWhenMarkedForDeletion(t *testing.T) {
+	store := &fakeStore{}
+	name := "foobar"
+	now := metav1.Now()
+
+	reconciler := webhookSyncReconciler(
+		fakeKubernetesClient{
+			Webhook: executorv1.Webhook{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:              name,
+					DeletionTimestamp: &now,
+				},
+			},
+		},
+		store,
+	)
+
+	if _, err := reconciler.Reconcile(t.Context(), reconcile.Request{NamespacedName: types.NamespacedName{Name: name}}); err != nil {
+		t.Errorf("reconciliation failed: %v", err)
+	}
+
+	if diff := cmp.Diff(name, store.Deleted); diff != "" {
+		t.Errorf("WebhookSyncReconcilerDeleteWhenMarkedForDeletion: -want, +got:\n%s", diff)
+	}
+
+	if store.UpdateCalls != 0 {
+		t.Errorf("WebhookSyncReconcilerDeleteWhenMarkedForDeletion: expected 0 update calls, got %d", store.UpdateCalls)
 	}
 }

--- a/internal/sync/controller/webhooktemplate.go
+++ b/internal/sync/controller/webhooktemplate.go
@@ -42,6 +42,7 @@ func webhookTemplateSyncReconciler(client client.Reader, store WebhookTemplateSt
 				// the store then we should handle them here.
 				return ctrl.Result{}, fmt.Errorf("delete WebhookTemplate %q from store: %w", req.Name, err)
 			}
+			return ctrl.Result{}, nil
 		case err != nil:
 			return ctrl.Result{}, fmt.Errorf("retrieve WebhookTemplate %q from Kubernetes: %w", req.NamespacedName, err)
 		}
@@ -63,6 +64,7 @@ func webhookTemplateSyncReconciler(client client.Reader, store WebhookTemplateSt
 				// the store then we should handle them here.
 				return ctrl.Result{}, fmt.Errorf("delete WebhookTemplate %q from store: %w", req.Name, err)
 			}
+			return ctrl.Result{}, nil
 		}
 
 		// Regular update so send the new object into the store.

--- a/internal/sync/controller/webhooktemplate_test.go
+++ b/internal/sync/controller/webhooktemplate_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
@@ -36,6 +37,10 @@ func TestWebhookTemplateSyncReconcilerUpdateOrCreate(t *testing.T) {
 	if diff := cmp.Diff(input, store.WebhookTemplate); diff != "" {
 		t.Errorf("WebhookTemplateSyncReconcilerUpdateOrCreate: -want, +got:\n%s", diff)
 	}
+
+	if store.UpdateCalls != 1 {
+		t.Errorf("WebhookTemplateSyncReconcilerUpdateOrCreate: expected 1 update call, got %d", store.UpdateCalls)
+	}
 }
 
 func TestWebhookTemplateSyncReconcilerDelete(t *testing.T) {
@@ -55,5 +60,39 @@ func TestWebhookTemplateSyncReconcilerDelete(t *testing.T) {
 
 	if diff := cmp.Diff(name, store.Deleted); diff != "" {
 		t.Errorf("WebhookTemplateSyncReconcilerUpdateOrCreate: -want, +got:\n%s", diff)
+	}
+
+	if store.UpdateCalls != 0 {
+		t.Errorf("WebhookTemplateSyncReconcilerDelete: expected 0 update calls, got %d", store.UpdateCalls)
+	}
+}
+
+func TestWebhookTemplateSyncReconcilerDeleteWhenMarkedForDeletion(t *testing.T) {
+	store := &fakeStore{}
+	name := "foobar"
+	now := metav1.Now()
+
+	reconciler := webhookTemplateSyncReconciler(
+		fakeKubernetesClient{
+			WebhookTemplate: executorv1.WebhookTemplate{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:              name,
+					DeletionTimestamp: &now,
+				},
+			},
+		},
+		store,
+	)
+
+	if _, err := reconciler.Reconcile(t.Context(), reconcile.Request{NamespacedName: types.NamespacedName{Name: name}}); err != nil {
+		t.Errorf("reconciliation failed: %v", err)
+	}
+
+	if diff := cmp.Diff(name, store.Deleted); diff != "" {
+		t.Errorf("WebhookTemplateSyncReconcilerDeleteWhenMarkedForDeletion: -want, +got:\n%s", diff)
+	}
+
+	if store.UpdateCalls != 0 {
+		t.Errorf("WebhookTemplateSyncReconcilerDeleteWhenMarkedForDeletion: expected 0 update calls, got %d", store.UpdateCalls)
 	}
 }


### PR DESCRIPTION
## Pull request description 

 - Stop sync reconcilers from issuing UpdateOrCreate after delete/DeletionTimestamp, preventing empty-name entries in the control plane.

<img width="1185" height="334" alt="image" src="https://github.com/user-attachments/assets/0bcae6b7-064d-411a-a864-7d2a2897acf4" />


  - Add tests asserting no update calls on delete and DeletionTimestamp paths for all synced resources.
  -

## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [ ] tested locally
- [ ] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Breaking changes

-

## Changes

-

## Fixes

-