### PR TITLE
fix: testkube pro param for runner helm chart

### DIFF
--- a/k8s/helm/testkube-runner/templates/deployment.yaml
+++ b/k8s/helm/testkube-runner/templates/deployment.yaml
@@ -178,6 +178,7 @@ spec:
               value: "true"
             {{- end }}
             {{- if .Values.runner.secretRef.name }}
+            {{- if not ( or .Values.runner.register.token .Values.runner.register.tokenSecret.name ) }}
             - name: "TESTKUBE_PRO_AGENT_ID"
               valueFrom:
                 secretKeyRef:
@@ -187,12 +188,13 @@ spec:
               valueFrom:
                 secretKeyRef:
                   name: "{{ .Values.runner.secretRef.name }}"
-                  key: "{{ .Values.runner.secretRef.orgIdKey }}"
+                  key: "{{ .Values.runner.secretRef.secretKey }}"
+            {{- end }}
             - name: "TESTKUBE_PRO_ORG_ID"
               valueFrom:
                 secretKeyRef:
                   name: "{{ .Values.runner.secretRef.name }}"
-                  key: "{{ .Values.runner.secretRef.secretKey }}"
+                  key: "{{ .Values.runner.secretRef.orgIdKey }}"
             - name: "TESTKUBE_PRO_ENV_ID"
               valueFrom:
                 secretKeyRef:


### PR DESCRIPTION
## Pull request description 

Fixing runner helm chart.

## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [x] tested locally
- [ ] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Breaking changes

- Change wrong order to set OrgId and ApiKey for runner when using Secrets.

## Fixes

- Change wrong order to set OrgId and ApiKey for runner when using Secrets.
- Exclude API_KEY when registration token is informed.