### PR TITLE
fix: add timeout for stuck log streaming

### DIFF
--- a/pkg/testworkflows/executionworker/controller/logs_test.go
+++ b/pkg/testworkflows/executionworker/controller/logs_test.go
@@ -3,11 +3,16 @@ package controller
 import (
 	"bufio"
 	"bytes"
+	"context"
 	"io"
+	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"k8s.io/client-go/kubernetes"
+
+	"github.com/kubeshop/testkube/cmd/testworkflow-init/instructions"
 )
 
 func Test_ReadTimestamp_UTC_Initial(t *testing.T) {
@@ -64,4 +69,146 @@ func Test_ReadTimestamp_NonUTC_Recurring(t *testing.T) {
 	assert.Equal(t, []byte(prefix), reader.Prefix())
 	assert.Equal(t, []byte(message), rest)
 	assert.Equal(t, time.Date(2024, 6, 7, 12, 41, 49, 37275300, time.UTC), reader.ts)
+}
+
+type blockingReader struct {
+	ctx context.Context
+}
+
+func (r *blockingReader) Read(p []byte) (int, error) {
+	<-r.ctx.Done()
+	return 0, r.ctx.Err()
+}
+
+func TestWatchContainerLogsIdleTimeoutCancelsWhenDone(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	idleTimeout := 50 * time.Millisecond
+	ch := watchContainerLogsWithStream(
+		ctx,
+		func(ctx context.Context, _ kubernetes.Interface, _, _, _ string, _ func() bool, _ *time.Time) (io.Reader, error) {
+			return &blockingReader{ctx: ctx}, nil
+		},
+		nil,
+		"default",
+		"pod",
+		"container",
+		1,
+		func() bool { return true },
+		func(*instructions.Instruction) bool { return false },
+		idleTimeout,
+	)
+
+	deadline := time.NewTimer(500 * time.Millisecond)
+	defer deadline.Stop()
+
+	var gotErr bool
+	for {
+		select {
+		case msg, ok := <-ch:
+			if !ok {
+				assert.True(t, gotErr, "expected idle timeout error before channel close")
+				return
+			}
+			if msg.Error != nil {
+				gotErr = true
+				assert.Contains(t, msg.Error.Error(), "idle timeout")
+			}
+		case <-deadline.C:
+			t.Fatal("timed out waiting for idle timeout to close the channel")
+		}
+	}
+}
+
+func TestWatchContainerLogsReopensOnEOF(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	var calls int32
+	line := "2024-06-07T12:41:49.037275300Z hello\n"
+	ch := watchContainerLogsWithStream(
+		ctx,
+		func(_ context.Context, _ kubernetes.Interface, _, _, _ string, _ func() bool, _ *time.Time) (io.Reader, error) {
+			call := atomic.AddInt32(&calls, 1)
+			if call == 1 {
+				return bytes.NewBufferString(line), nil
+			}
+			return bytes.NewBuffer(nil), nil
+		},
+		nil,
+		"default",
+		"pod",
+		"container",
+		5,
+		func() bool { return false },
+		func(*instructions.Instruction) bool { return false },
+		500*time.Millisecond,
+	)
+
+	deadline := time.NewTimer(2 * time.Second)
+	defer deadline.Stop()
+
+	var gotLog bool
+	for {
+		select {
+		case msg, ok := <-ch:
+			if !ok {
+				assert.True(t, gotLog, "expected at least one log message before channel close")
+				assert.GreaterOrEqual(t, atomic.LoadInt32(&calls), int32(2))
+				return
+			}
+			if msg.Error != nil {
+				t.Fatalf("unexpected error from logs channel: %v", msg.Error)
+			}
+			if bytes.Contains(msg.Value.Log, []byte("hello")) {
+				gotLog = true
+			}
+		case <-deadline.C:
+			t.Fatal("timed out waiting for log stream to close")
+		}
+	}
+}
+
+func TestWatchContainerLogsDoneWithNoLogsCloses(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	ch := watchContainerLogsWithStream(
+		ctx,
+		func(_ context.Context, _ kubernetes.Interface, _, _, _ string, _ func() bool, _ *time.Time) (io.Reader, error) {
+			return bytes.NewBuffer(nil), nil
+		},
+		nil,
+		"default",
+		"pod",
+		"container",
+		1,
+		func() bool { return true },
+		func(*instructions.Instruction) bool { return false },
+		500*time.Millisecond,
+	)
+
+	deadline := time.NewTimer(500 * time.Millisecond)
+	defer deadline.Stop()
+
+	for {
+		select {
+		case msg, ok := <-ch:
+			if !ok {
+				return
+			}
+			if msg.Error != nil {
+				t.Fatalf("unexpected error from logs channel: %v", msg.Error)
+			}
+		case <-deadline.C:
+			t.Fatal("timed out waiting for log stream to close")
+		}
+	}
 }


### PR DESCRIPTION
## Pull request description 

Adding timeout to watching logs it can stall without  sending bytes but keeps the stream open, which can create backpressure as logs are sent through a small buffer and unbuffered watcher channels, which might block grpc stream, leaving the stream open but idle.   

## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [ ] tested locally
- [ ] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Breaking changes

-

## Changes

-

## Fixes

-