### PR TITLE
enhance error handling and status updates in TestWorkflowExecutionExecutor

### DIFF
--- a/pkg/controller/testworkflowexecutionexecutor_test.go
+++ b/pkg/controller/testworkflowexecutionexecutor_test.go
@@ -2,6 +2,8 @@ package controller
 
 import (
 	"context"
+	"errors"
+	"strings"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -32,10 +34,14 @@ var scheduleCmpOpts = []cmp.Option{
 
 type fakeTestWorkflowExecutor struct {
 	req *cloud.ScheduleRequest
+	err error
 }
 
 func (f *fakeTestWorkflowExecutor) Execute(_ context.Context, request *cloud.ScheduleRequest) ([]testkubev1.TestWorkflowExecution, error) {
 	f.req = request
+	if f.err != nil {
+		return nil, f.err
+	}
 	return []testkubev1.TestWorkflowExecution{}, nil
 }
 
@@ -78,6 +84,7 @@ func TestWorkflowExecutionExecutorController(t *testing.T) {
 					Name: "test-workflow-execution",
 					Type: cloud.RunningContextType_KUBERNETESOBJECT,
 				},
+				KubernetesObjectName: "test-workflow-execution",
 			},
 		},
 		// Should pass through a basic test workflow execution with target selectors.
@@ -135,6 +142,7 @@ func TestWorkflowExecutionExecutorController(t *testing.T) {
 					Name: "test-workflow-execution",
 					Type: cloud.RunningContextType_KUBERNETESOBJECT,
 				},
+				KubernetesObjectName: "test-workflow-execution",
 			},
 		},
 		// Should not execute if the generation has not changed.
@@ -187,7 +195,11 @@ func TestWorkflowExecutionExecutorController(t *testing.T) {
 			if err := testworkflowsv1.AddToScheme(scheme); err != nil {
 				t.Fatalf("failed to add testworkflowsv1 to scheme: %v", err)
 			}
-			k8sClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(test.objs...).Build()
+			k8sClient := fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithObjects(test.objs...).
+				WithStatusSubresource(&testworkflowsv1.TestWorkflowExecution{}).
+				Build()
 			reconciler := testWorkflowExecutionExecutor(k8sClient, exec)
 
 			_, err := reconciler.Reconcile(context.Background(), test.request)
@@ -200,4 +212,77 @@ func TestWorkflowExecutionExecutorController(t *testing.T) {
 		})
 	}
 
+}
+
+func TestWorkflowExecutionExecutorController_ErrorHandling(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := testworkflowsv1.AddToScheme(scheme); err != nil {
+		t.Fatalf("failed to add testworkflowsv1 to scheme: %v", err)
+	}
+
+	twe := &testworkflowsv1.TestWorkflowExecution{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "TestWorkflowExecution",
+			APIVersion: "testworkflows.testkube.io/v1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       "test-workflow-execution",
+			Namespace:  "test-namespace",
+			Generation: 1,
+		},
+		Spec: testworkflowsv1.TestWorkflowExecutionSpec{
+			TestWorkflow: &v1.LocalObjectReference{Name: "test-workflow"},
+		},
+		Status: testworkflowsv1.TestWorkflowExecutionStatus{},
+	}
+
+	k8sClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(twe).
+		WithStatusSubresource(&testworkflowsv1.TestWorkflowExecution{}).
+		Build()
+
+	exec := &fakeTestWorkflowExecutor{err: errors.New("workflow not found")}
+	reconciler := testWorkflowExecutionExecutor(k8sClient, exec)
+
+	_, err := reconciler.Reconcile(context.Background(), reconcile.Request{
+		NamespacedName: client.ObjectKey{
+			Name:      "test-workflow-execution",
+			Namespace: "test-namespace",
+		},
+	})
+
+	// Reconcile should return an error
+	if err == nil {
+		t.Error("expected reconcile to return an error")
+	}
+
+	// Check that the status was updated with the error
+	var updated testworkflowsv1.TestWorkflowExecution
+	if err := k8sClient.Get(context.Background(), client.ObjectKey{
+		Name:      "test-workflow-execution",
+		Namespace: "test-namespace",
+	}, &updated); err != nil {
+		t.Fatalf("failed to get updated TestWorkflowExecution: %v", err)
+	}
+
+	// Verify the status reflects the error
+	if updated.Status.LatestExecution == nil {
+		t.Fatal("expected LatestExecution to be set")
+	}
+	if updated.Status.LatestExecution.Result == nil {
+		t.Fatal("expected Result to be set")
+	}
+	if updated.Status.LatestExecution.Result.Status == nil || *updated.Status.LatestExecution.Result.Status != testworkflowsv1.FAILED_TestWorkflowStatus {
+		t.Errorf("expected status to be failed, got: %v", updated.Status.LatestExecution.Result.Status)
+	}
+	if updated.Status.LatestExecution.Result.Initialization == nil {
+		t.Fatal("expected Initialization to be set")
+	}
+	if !strings.Contains(updated.Status.LatestExecution.Result.Initialization.ErrorMessage, "workflow not found") {
+		t.Errorf("expected error message to contain 'workflow not found', got: %s", updated.Status.LatestExecution.Result.Initialization.ErrorMessage)
+	}
+	if updated.Status.Generation != 1 {
+		t.Errorf("expected generation to be 1, got: %d", updated.Status.Generation)
+	}
 }


### PR DESCRIPTION

- Added error handling in the TestWorkflowExecutionExecutor to update the status of TestWorkflowExecution when execution fails.
- Introduced new functions to update the status with execution details and errors
- Updated tests to cover error scenarios and validate status updates accordingly.

This basically writes the entire TestWorkflowExecutionDetails into the status - perhaps that's taking it too far?

An example: 

```yaml
apiVersion: testworkflows.testkube.io/v1
kind: TestWorkflowExecution
metadata:
  annotations:
    kubectl.kubernetes.io/last-applied-configuration: >
      {"apiVersion":"testworkflows.testkube.io/v1","kind":"TestWorkflowExecution","metadata":{"annotations":{},"name":"curl-testworkflowexecution","namespace":"testkube-dev"},"spec":{"testWorkflow":{"name":"curl-workflow-smoke"}}}
  creationTimestamp: '2026-01-14T21:39:27Z'
  generation: 1
  name: curl-testworkflowexecution
  namespace: testkube-dev
  resourceVersion: '29860846'
  uid: 374ee75d-31fe-4232-9792-21b5707b3036
  selfLink: >-
    /apis/testworkflows.testkube.io/v1/namespaces/testkube-dev/testworkflowexecutions/curl-testworkflowexecution
status:
  generation: 1
  latestExecution:
    id: 69680d0fa1ed746b06b8a7c5
    name: curl-workflow-smoke-5
    number: 5
    output:
      - name: pod
        ref: tktw-init
        value:
          agent: dev
          init: ''
          name: 69680d0fa1ed746b06b8a7c5-cn5tm
          namespace: testkube-dev
          nodeName: kind-control-plane
          serviceAccountName: testkube-api-server-tests-job
          toolkit: ''
      - name: resource-metrics-warning
        ref: r5r5mq9
        value:
          component: resource-metrics
          error: Resource Metrics Issue
          reason: >-
            failed to save stream to
            "metrics/curl-workflow-smoke_r5r5mq9_69680d0fa1ed746b06b8a7c5.influx":
            upload failed
          type: warning
    resolvedWorkflow:
      apiVersion: testworkflows.testkube.io/v1
      kind: TestWorkflow
      metadata:
        annotations:
          kubectl.kubernetes.io/last-applied-configuration: >
            {"apiVersion":"testworkflows.testkube.io/v1","kind":"TestWorkflow","metadata":{"annotations":{"testkube.io/icon":"curl"},"labels":{"category":"api-testing","core-tests":"workflows","tool":"curl"},"name":"curl-workflow-smoke","namespace":"testkube-dev"},"spec":{"container":{"resources":{"requests":{"cpu":"32m","memory":"32Mi"}}},"job":{"activeDeadlineSeconds":300},"steps":[{"container":{"image":"curlimages/curl:8.7.1"},"name":"Run
            tests","shell":"curl -f -LI
            https://testkube-test-page-lipsum.pages.dev/"}]}}
          testkube.io/icon: curl
        creationTimestamp: '2026-01-14T21:39:10Z'
        labels:
          category: api-testing
          core-tests: workflows
          tool: curl
        name: curl-workflow-smoke
        namespace: testkube-dev
      spec:
        container:
          resources:
            requests:
              cpu: 32m
              memory: 32Mi
        job:
          activeDeadlineSeconds: 300
        steps:
          - container:
              image: curlimages/curl:8.7.1
            name: Run tests
            shell: curl -f -LI https://testkube-test-page-lipsum.pages.dev/
      status: {}
    result:
      duration: 1.474s
      durationMs: 1474
      finishedAt: '2026-01-14T21:39:28Z'
      initialization:
        finishedAt: '2026-01-14T21:39:27Z'
        queuedAt: '2026-01-14T21:39:27Z'
        startedAt: '2026-01-14T21:39:27Z'
        status: passed
      predictedStatus: passed
      queuedAt: '2026-01-14T21:39:27Z'
      startedAt: '2026-01-14T21:39:27Z'
      status: passed
      steps:
        r5r5mq9:
          finishedAt: '2026-01-14T21:39:28Z'
          queuedAt: '2026-01-14T21:39:27Z'
          startedAt: '2026-01-14T21:39:28Z'
          status: passed
      totalDuration: 1.474s
      totalDurationMs: 1474
    runningContext:
      actor:
        name: curl-testworkflowexecution
        type: testworkflowexecution
      interface:
        type: internal
    scheduledAt: '2026-01-14T21:39:27Z'
    signature:
      - category: Run shell command
        name: Run tests
        ref: r5r5mq9
    statusAt: '2026-01-14T21:39:28Z'
    testWorkflowExecutionName: curl-testworkflowexecution
    workflow:
      apiVersion: testworkflows.testkube.io/v1
      kind: TestWorkflow
      metadata:
        annotations:
          kubectl.kubernetes.io/last-applied-configuration: >
            {"apiVersion":"testworkflows.testkube.io/v1","kind":"TestWorkflow","metadata":{"annotations":{"testkube.io/icon":"curl"},"labels":{"category":"api-testing","core-tests":"workflows","tool":"curl"},"name":"curl-workflow-smoke","namespace":"testkube-dev"},"spec":{"container":{"resources":{"requests":{"cpu":"32m","memory":"32Mi"}}},"job":{"activeDeadlineSeconds":300},"steps":[{"container":{"image":"curlimages/curl:8.7.1"},"name":"Run
            tests","shell":"curl -f -LI
            https://testkube-test-page-lipsum.pages.dev/"}]}}
          testkube.io/icon: curl
        creationTimestamp: '2026-01-14T21:39:10Z'
        labels:
          category: api-testing
          core-tests: workflows
          tool: curl
        name: curl-workflow-smoke
        namespace: testkube-dev
      spec:
        container:
          resources:
            requests:
              cpu: 32m
              memory: 32Mi
        job:
          activeDeadlineSeconds: 300
        steps:
          - container:
              image: curlimages/curl:8.7.1
            name: Run tests
            shell: curl -f -LI https://testkube-test-page-lipsum.pages.dev/
      status: {}
spec:
  testWorkflow:
    name: curl-workflow-smoke

```

## Pull request description 



## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [X] tested locally
- [ ] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [X] added a test

## Breaking changes

-

## Changes

-

## Fixes

-