### PR TITLE
fix: disable cloud storage in devbox to prevent circular RPC timeouts

### DIFF
--- a/cmd/tcl/kubectl-testkube/devbox/command.go
+++ b/cmd/tcl/kubectl-testkube/devbox/command.go
@@ -55,7 +55,6 @@ func NewDevBoxCommand() *cobra.Command {
 		runnersCount         uint16
 		gitopsEnabled        bool
 		disableDefaultAgent  bool
-		disableCloudStorage  bool
 		enableTestTriggers   bool
 		enableCronjobs       bool
 		enableK8sControllers bool
@@ -153,7 +152,7 @@ func NewDevBoxCommand() *cobra.Command {
 
 			// Initialize wrappers over cluster resources
 			interceptor := devutils.NewInterceptor(interceptorPod, baseInitImage, baseToolkitImage, interceptorBin, executionNamespace)
-			agent := devutils.NewAgent(agentPod, cloud, baseAgentImage, baseInitImage, baseToolkitImage, disableCloudStorage, enableCronjobs, enableTestTriggers, enableK8sControllers, enableWebhooks, executionNamespace)
+			agent := devutils.NewAgent(agentPod, cloud, baseAgentImage, baseInitImage, baseToolkitImage, enableCronjobs, enableTestTriggers, enableK8sControllers, enableWebhooks, executionNamespace)
 			binaryStorage := devutils.NewBinaryStorage(binaryStoragePod, binaryStorageBin)
 			mongo := devutils.NewMongo(mongoPod)
 			minio := devutils.NewMinio(minioPod)
@@ -199,7 +198,7 @@ func NewDevBoxCommand() *cobra.Command {
 			// Create environment in the Cloud
 			if !oss {
 				fmt.Println("Creating environment in Cloud...")
-				env, err = cloud.CreateEnvironment(namespace.Name(), disableCloudStorage)
+				env, err = cloud.CreateEnvironment(namespace.Name())
 				if err != nil {
 					fail(errors.Wrap(err, "failed to create Cloud environment"))
 				}
@@ -882,7 +881,6 @@ func NewDevBoxCommand() *cobra.Command {
 	cmd.Flags().StringVarP(&executionNamespace, "execution-namespace", "N", "", "where runners should execute test workflows")
 	cmd.Flags().Uint16Var(&runnersCount, "runners", 0, "additional runners count")
 	cmd.Flags().BoolVar(&disableDefaultAgent, "disable-agent", false, "should disable default agent")
-	cmd.Flags().BoolVar(&disableCloudStorage, "disable-cloud-storage", false, "should disable storage in Cloud")
 	cmd.Flags().BoolVar(&enableTestTriggers, "enable-test-triggers", false, "should enable Test Triggers (remember to install CRDs)")
 	cmd.Flags().BoolVar(&enableCronjobs, "enable-cronjobs", false, "should enable cron resolution of Test Workflows")
 	cmd.Flags().BoolVar(&enableWebhooks, "enable-webhooks", false, "should enable webhooks")

--- a/cmd/tcl/kubectl-testkube/devbox/devutils/agent.go
+++ b/cmd/tcl/kubectl-testkube/devbox/devutils/agent.go
@@ -25,7 +25,6 @@ type Agent struct {
 	agentImage           string
 	initProcessImage     string
 	toolkitImage         string
-	disableCloudStorage  bool
 	enableCronjobs       bool
 	enableTestTriggers   bool
 	enableK8sControllers bool
@@ -34,14 +33,13 @@ type Agent struct {
 	env                  *client.Environment // Store environment for pod recreation
 }
 
-func NewAgent(pod *PodObject, cloud *CloudObject, agentImage, initProcessImage, toolkitImage string, disableCloudStorage, enableCronjobs, enableTestTriggers, enableK8sControllers, enableWebhooks bool, executionNamespace string) *Agent {
+func NewAgent(pod *PodObject, cloud *CloudObject, agentImage, initProcessImage, toolkitImage string, enableCronjobs, enableTestTriggers, enableK8sControllers, enableWebhooks bool, executionNamespace string) *Agent {
 	return &Agent{
 		pod:                  pod,
 		cloud:                cloud,
 		agentImage:           agentImage,
 		initProcessImage:     initProcessImage,
 		toolkitImage:         toolkitImage,
-		disableCloudStorage:  disableCloudStorage,
 		enableCronjobs:       enableCronjobs,
 		enableTestTriggers:   enableTestTriggers,
 		enableK8sControllers: enableK8sControllers,
@@ -66,7 +64,7 @@ func (r *Agent) generatePodSpec(env *client.Environment) *corev1.Pod {
 		{Name: "TESTKUBE_IMAGE_DATA_PERSISTENT_CACHE_KEY", Value: "testkube-image-cache"},
 		{Name: "TESTKUBE_TW_TOOLKIT_IMAGE", Value: r.toolkitImage},
 		{Name: "TESTKUBE_TW_INIT_IMAGE", Value: r.initProcessImage},
-		{Name: "FEATURE_CLOUD_STORAGE", Value: fmt.Sprintf("%v", !r.disableCloudStorage)},
+		{Name: "FEATURE_CLOUD_STORAGE", Value: "false"},
 	}
 	if !r.enableTestTriggers {
 		envVariables = append(envVariables, corev1.EnvVar{Name: "DISABLE_TEST_TRIGGERS", Value: "true"})


### PR DESCRIPTION
## Pull request description 

After control plane commit `494a52c86` changed routing from `env.CloudStorage` to `env.IsSourceOfTruth()`, devbox agents with cloud storage enabled cause circular RPC calls:

  1. Agent (with `FEATURE_CLOUD_STORAGE=true`) calls control plane to list workflows
  2. Control plane sees `IsSourceOfTruth()=false` (SourceOfTruthSince not set)
  3. Control plane proxies request back to agent
  4. Timeout

## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [ ] tested locally
- [ ] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Breaking changes

-

## Changes

-

## Fixes

-