### PR TITLE
fix: check for required tools before installing, use sudo if needed to install executables

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -10,7 +10,7 @@ fi
 _check_required_tools() {
   local MISSING_TOOLS=""
   for CMD in curl jq; do
-    if !(which ${CMD} &>/dev/null); then
+    if ! which "${CMD}" &>/dev/null; then
       MISSING_TOOLS="${MISSING_TOOLS}${CMD} "
     fi
   done
@@ -121,7 +121,7 @@ echo "- ${INSTALL_DIR}/testkube"
 echo "- ${INSTALL_DIR}/tk"
 echo ""
 
-if ! (which helm  &>/dev/null) || ! (which kubectl &>/dev/null); then
+if ! which helm &>/dev/null || ! which kubectl &>/dev/null; then
   echo "You'll also need to install \`helm\` and \`kubectl\`."
   echo "- Install Helm: https://helm.sh/docs/intro/install/"
   echo "- Install kubectl: https://kubernetes.io/docs/tasks/tools/#kubectl"


### PR DESCRIPTION
## Pull request description

Just a quality of life improvement to the install script.

When first installing testkube on my system I encountered a few issues:

- It failed because `jq` wasn't installed
- It continued trying to install after a command had failed
- After installing `jq`, it failed to install the binaries because `/usr/local/bin` is not writable by my user
- Tried to run helm and kubectl because they were inadvertently backticked in the print statement (backticks execute commands in a subshell in bash)
- It didn't report an error at the end and exited with status 0

This PR should change it so that:

- The script exits as soon as a command fails (`set -eo pipefail`)
- It checks if all the required commands (currently just curl and jq) are present, and fails early if not
- It checks if the install dir (`/usr/local/bin`) is user-writable, and if not it will use `sudo` to install (warning the user that the password prompt is in fact sudo and not us doing anything sketchy)
- Only print instructions for installing `helm` and `kubectl` if the commands aren't present on the system already.

## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [x] tested locally
- [ ] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Breaking changes

-

## Changes

-

## Fixes

-