### PR TITLE
chore: update mcp schema version

### DIFF
--- a/build/mcp-server/server.json
+++ b/build/mcp-server/server.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-10-17/server.schema.json",
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.kubeshop/testkube-mcp",
   "description": "MCP server for Testkube - Manage test workflows, executions, and artifacts via AI assistants",
   "icons": [


### PR DESCRIPTION
This pull request makes a minor update to the `build/mcp-server/server.json` file, updating the `$schema` reference to point to a newer schema version. 

* Updated the `$schema` URL to use the `2025-12-11` schema, ensuring compatibility with the latest schema definitions.