### PR TITLE
fix: preserve error chain in expressions by using %w instead of %s with err.Error()

### DIFF
--- a/pkg/expressions/accessor.go
+++ b/pkg/expressions/accessor.go
@@ -68,7 +68,7 @@ func (s *accessor) SafeResolve(m ...Machine) (v Expression, changed bool, err er
 			}
 		}
 		if err != nil {
-			return nil, false, fmt.Errorf("error while accessing %s: %s", s.String(), err.Error())
+			return nil, false, fmt.Errorf("error while accessing %s: %w", s.String(), err)
 		}
 	}
 	return s, false, nil

--- a/pkg/expressions/call.go
+++ b/pkg/expressions/call.go
@@ -73,14 +73,14 @@ func (s *call) SafeResolve(m ...Machine) (v Expression, changed bool, err error)
 	result, ok, err := StdLibMachine.Call(s.name, s.args)
 	if ok {
 		if err != nil {
-			return nil, true, fmt.Errorf("error while calling %s: %s", s.String(), err.Error())
+			return nil, true, fmt.Errorf("error while calling %s: %w", s.String(), err)
 		}
 		return result, true, nil
 	}
 	for i := range m {
 		result, ok, err = m[i].Call(s.name, s.args)
 		if err != nil {
-			return nil, true, fmt.Errorf("error while calling %s: %s", s.String(), err.Error())
+			return nil, true, fmt.Errorf("error while calling %s: %w", s.String(), err)
 		}
 		if ok {
 			return result, true, nil

--- a/pkg/expressions/libs/fs.go
+++ b/pkg/expressions/libs/fs.go
@@ -73,11 +73,11 @@ func readFile(fsys fs.FS, workingDir string, values ...expressions.StaticValue) 
 	filePath, _ := values[0].StringValue()
 	file, err := fsys.Open(strings.TrimLeft(absPath(filePath, workingDir), "/"))
 	if err != nil {
-		return nil, fmt.Errorf("opening file(%s): %s", filePath, err.Error())
+		return nil, fmt.Errorf("opening file(%s): %w", filePath, err)
 	}
 	content, err := io.ReadAll(file)
 	if err != nil {
-		return nil, fmt.Errorf("reading file(%s): %s", filePath, err.Error())
+		return nil, fmt.Errorf("reading file(%s): %w", filePath, err)
 	}
 	return string(content), nil
 }

--- a/pkg/expressions/stdlib.go
+++ b/pkg/expressions/stdlib.go
@@ -90,7 +90,7 @@ var stdFunctions = map[string]StdFunction{
 			}
 			slice, err := value[0].SliceValue()
 			if err != nil {
-				return nil, fmt.Errorf(`"join" function error: reading slice: %s`, err.Error())
+				return nil, fmt.Errorf(`"join" function error: reading slice: %w`, err)
 			}
 			v := make([]string, len(slice))
 			for i := range slice {
@@ -193,7 +193,7 @@ var stdFunctions = map[string]StdFunction{
 			}
 			b, err := json.Marshal(value[0].Value())
 			if err != nil {
-				return nil, fmt.Errorf(`"tojson" function had problem marshalling: %s`, err.Error())
+				return nil, fmt.Errorf(`"tojson" function had problem marshalling: %w`, err)
 			}
 			return NewValue(string(b)), nil
 		}),
@@ -209,7 +209,7 @@ var stdFunctions = map[string]StdFunction{
 			var v interface{}
 			err := json.Unmarshal([]byte(value[0].Value().(string)), &v)
 			if err != nil {
-				return nil, fmt.Errorf(`"json" function had problem unmarshalling: %s`, err.Error())
+				return nil, fmt.Errorf(`"json" function had problem unmarshalling: %w`, err)
 			}
 			return NewValue(v), nil
 		}),
@@ -222,7 +222,7 @@ var stdFunctions = map[string]StdFunction{
 			}
 			b, err := yaml.Marshal(value[0].Value())
 			if err != nil {
-				return nil, fmt.Errorf(`"toyaml" function had problem marshalling: %s`, err.Error())
+				return nil, fmt.Errorf(`"toyaml" function had problem marshalling: %w`, err)
 			}
 			return NewValue(string(b)), nil
 		}),
@@ -238,7 +238,7 @@ var stdFunctions = map[string]StdFunction{
 			var v interface{}
 			err := yaml.Unmarshal([]byte(value[0].Value().(string)), &v)
 			if err != nil {
-				return nil, fmt.Errorf(`"yaml" function had problem unmarshalling: %s`, err.Error())
+				return nil, fmt.Errorf(`"yaml" function had problem unmarshalling: %w`, err)
 			}
 			return NewValue(v), nil
 		}),

--- a/pkg/expressions/tokenize.go
+++ b/pkg/expressions/tokenize.go
@@ -70,7 +70,7 @@ func tokenizeNext(exp string, i int) (token, int, error) {
 			var val interface{}
 			err := decoder.Decode(&val)
 			if err != nil {
-				return token{}, i, fmt.Errorf("error while decoding string from index %d in expression: %s: %s", i, exp, err.Error())
+				return token{}, i, fmt.Errorf("error while decoding string from index %d in expression: %s: %w", i, exp, err)
 			}
 			return tokenJson(val), i + originalLen, nil
 		case jsonValueRe.MatchString(exp[i:]):
@@ -98,7 +98,7 @@ func tokenizeNext(exp string, i int) (token, int, error) {
 			var val interface{}
 			err := decoder.Decode(&val)
 			if err != nil {
-				return token{}, i, fmt.Errorf("error while decoding JSON from index %d in expression: %s: %s", i, exp, err.Error())
+				return token{}, i, fmt.Errorf("error while decoding JSON from index %d in expression: %s: %w", i, exp, err)
 			}
 			return tokenJson(val), i + int(decoder.InputOffset()) - appended, nil
 		case accessorRe.MatchString(exp[i:]):


### PR DESCRIPTION
## Pull request description 

Fix error chain preservation in the expressions package. Using `fmt.Errorf("...: %s", err.Error())` breaks Go's error unwrapping, preventing `errors.Is()` and `errors.As()` from working correctly.

## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [ ] tested locally
- [ ] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Breaking changes

-

## Changes

-

## Fixes

-