### PR TITLE
chore: add contextcheck linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -8,6 +8,7 @@ linters:
     - staticcheck
     - unused
     - ineffassign
+    - contextcheck
   exclusions:
     generated: lax
     paths:

--- a/cmd/api-server/commons/commons.go
+++ b/cmd/api-server/commons/commons.go
@@ -153,7 +153,7 @@ func runMongoMigrations(ctx context.Context, db *mongo.Database) error {
 
 func MustGetMongoDatabase(ctx context.Context, cfg *config.Config, secretClient secret.Interface, migrate bool) *mongo.Database {
 	mongoSSLConfig := getMongoSSLConfig(cfg, secretClient)
-	db, err := storage.GetMongoDatabase(cfg.APIMongoDSN, cfg.APIMongoDB, cfg.APIMongoDBType, cfg.APIMongoAllowTLS, mongoSSLConfig)
+	db, err := storage.GetMongoDatabase(cfg.APIMongoDSN, cfg.APIMongoDB, cfg.APIMongoDBType, cfg.APIMongoAllowTLS, mongoSSLConfig) //nolint:contextcheck // GetMongoDatabase does not accept a context parameter
 	ExitOnError("getting mongo database", err)
 	if migrate {
 		if err = runMongoMigrations(ctx, db); err != nil {
@@ -202,7 +202,7 @@ func getMongoSSLConfig(cfg *config.Config, secretClient secret.Interface) *stora
 
 func MustGetPostgresDatabase(ctx context.Context, cfg *config.Config, migrate bool) *pgxpool.Pool {
 	// Connect to PostgreSQL
-	pool, err := pgxpool.New(context.Background(), cfg.APIPostgresDSN)
+	pool, err := pgxpool.New(ctx, cfg.APIPostgresDSN)
 	ExitOnError("Getting Postgres database", err)
 
 	if migrate {

--- a/cmd/api-server/services/controlplane.go
+++ b/cmd/api-server/services/controlplane.go
@@ -58,7 +58,7 @@ func CreateControlPlane(ctx context.Context, cfg *config.Config, eventsEmitter *
 	// Build repositories
 	repoManager := repository.NewRepositoryManager(factory)
 	testWorkflowResultsRepository := repoManager.TestWorkflow()
-	storageClient := commons.MustGetMinioClient(cfg)
+	storageClient := commons.MustGetMinioClient(cfg) //nolint:contextcheck // MustGetMinioClient does not accept a context parameter
 	testWorkflowOutputRepository := miniorepo.NewMinioOutputRepository(storageClient, testWorkflowResultsRepository, cfg.LogsBucket)
 	artifactStorage := minio.NewMinIOArtifactClient(storageClient)
 	commands := controlplane.CreateCommands(cfg.StorageBucket, storageClient, testWorkflowOutputRepository, testWorkflowResultsRepository, artifactStorage)

--- a/cmd/api-server/services/telemetry.go
+++ b/cmd/api-server/services/telemetry.go
@@ -19,7 +19,7 @@ const (
 func HandleTelemetryHeartbeat(ctx context.Context, clusterId string, configMapConfig configRepo.Repository) {
 	telemetryEnabled, _ := configMapConfig.GetTelemetryEnabled(ctx)
 	if telemetryEnabled {
-		out, err := telemetry.SendServerStartEvent(clusterId, version.Version)
+		out, err := telemetry.SendServerStartEvent(clusterId, version.Version) //nolint:contextcheck // telemetry API does not accept context
 		if err != nil {
 			log.DefaultLogger.Debug("telemetry send error", "error", err.Error())
 		} else {
@@ -42,7 +42,7 @@ func HandleTelemetryHeartbeat(ctx context.Context, clusterId string, configMapCo
 				if err != nil {
 					l.Debugw("getting hostname error", "hostname", host, "error", err)
 				}
-				out, err := telemetry.SendHeartbeatEvent(host, version.Version, clusterId)
+				out, err := telemetry.SendHeartbeatEvent(host, version.Version, clusterId) //nolint:contextcheck // telemetry API does not accept context
 				if err != nil {
 					l.Debugw("sending heartbeat telemetry event error", "error", err)
 				} else {

--- a/cmd/kubectl-testkube/commands/agents/delete.go
+++ b/cmd/kubectl-testkube/commands/agents/delete.go
@@ -115,6 +115,7 @@ func UiDeleteAgent(cmd *cobra.Command, name string, uninstall, deleteAgent bool)
 		}
 		if kubernetesAgent == nil {
 			ui.Failf("kubernetes agent not found: namespaces: %s", strings.Join(nses, ", "))
+			return
 		}
 
 		spinner := ui.NewSpinner("Running Helm command...")

--- a/cmd/kubectl-testkube/commands/agents/install.go
+++ b/cmd/kubectl-testkube/commands/agents/install.go
@@ -304,6 +304,7 @@ func UiInstallAgent(cmd *cobra.Command, name string) {
 	// Fail if there is no matching agent available
 	if agent == nil {
 		ui.Failf("agent %s not found", name)
+		return
 	}
 
 	if secretKey, _ := cmd.Flags().GetString("secret"); agent.SecretKey == "" && secretKey != "" {
@@ -414,6 +415,7 @@ func UiInstallAgent(cmd *cobra.Command, name string) {
 
 	if foundAgent == nil {
 		ui.Failf("not found the agent installed in namespace '%s'", ns)
+		return
 	}
 
 	PrintKubernetesAgent(*foundAgent)

--- a/pkg/mcp/middleware.go
+++ b/pkg/mcp/middleware.go
@@ -53,7 +53,7 @@ func TelemetryMiddleware(cfg *MCPServerConfig) server.ToolHandlerMiddleware {
 				toolName := request.Params.Name
 
 				// Send telemetry asynchronously to avoid blocking tool execution
-				go func() {
+				go func() { //nolint:contextcheck // fire-and-forget telemetry goroutine, intentionally not propagating request context
 					// Determine context source based on how MCP was configured
 					var runContext telemetry.RunContext
 

--- a/pkg/mcp/tools/query.go
+++ b/pkg/mcp/tools/query.go
@@ -84,7 +84,7 @@ func QueryWorkflows(client WorkflowDefinitionBulkGetter) (tool mcp.Tool, handler
 			}
 
 			// Apply expression to the combined array
-			queryResult, err := jsonpath.Query(expression, allWorkflows)
+			queryResult, err := jsonpath.QueryWithContext(ctx, expression, allWorkflows, jsonpath.DefaultOptions())
 			if err != nil {
 				return mcp.NewToolResultError(fmt.Sprintf("Failed to execute JSONPath query: %v", err)), nil
 			}
@@ -105,7 +105,7 @@ func QueryWorkflows(client WorkflowDefinitionBulkGetter) (tool mcp.Tool, handler
 					continue
 				}
 
-				queryResult, err := jsonpath.Query(expression, parsed)
+				queryResult, err := jsonpath.QueryWithContext(ctx, expression, parsed, jsonpath.DefaultOptions())
 				if err != nil {
 					results[name] = fmt.Sprintf("ERROR: %v", err)
 				} else {
@@ -184,7 +184,7 @@ func QueryExecutions(client ExecutionBulkGetter) (tool mcp.Tool, handler server.
 			}
 
 			// Apply expression to the combined array
-			queryResult, err := jsonpath.Query(expression, allExecutions)
+			queryResult, err := jsonpath.QueryWithContext(ctx, expression, allExecutions, jsonpath.DefaultOptions())
 			if err != nil {
 				return mcp.NewToolResultError(fmt.Sprintf("Failed to execute JSONPath query: %v", err)), nil
 			}
@@ -205,7 +205,7 @@ func QueryExecutions(client ExecutionBulkGetter) (tool mcp.Tool, handler server.
 					continue
 				}
 
-				queryResult, err := jsonpath.Query(expression, parsed)
+				queryResult, err := jsonpath.QueryWithContext(ctx, expression, parsed, jsonpath.DefaultOptions())
 				if err != nil {
 					results[id] = fmt.Sprintf("ERROR: %v", err)
 				} else {

--- a/pkg/oauth/oauth.go
+++ b/pkg/oauth/oauth.go
@@ -192,7 +192,7 @@ func (p Provider) startHTTPServer(ctx context.Context, clientChan chan *Authoriz
 	srv := &http.Server{Addr: ":" + strconv.Itoa(p.port)}
 
 	// handle server shutdown signal
-	go func() {
+	go func() { //nolint:contextcheck // shutdown goroutine intentionally uses a fresh context for graceful server shutdown
 		<-shutdownChan
 
 		ui.Info("Shutting down server...")

--- a/pkg/runner/agent.go
+++ b/pkg/runner/agent.go
@@ -222,7 +222,7 @@ func (a *agentLoop) loopRunnerRequests(ctx context.Context) error {
 	var wg sync.WaitGroup
 	for req := range watcher.Channel() {
 		wg.Add(1)
-		go func(req controlplaneclient.RunnerRequest) {
+		go func(req controlplaneclient.RunnerRequest) { //nolint:contextcheck // intentionally detached from stream context for independent request handling
 			defer wg.Done()
 			switch req.Type() {
 			case cloud.RunnerRequestType_CONSIDER:

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -283,7 +283,7 @@ func (r *runner) monitor(ctx context.Context, organizationId string, environment
 		return errors.Wrapf(err, "failed to save execution '%s' data", execution.Id)
 	}
 
-	err = r.worker.Destroy(context.Background(), execution.Id, executionworkertypes.DestroyOptions{})
+	err = r.worker.Destroy(context.Background(), execution.Id, executionworkertypes.DestroyOptions{}) //nolint:contextcheck // intentionally using background context to ensure cleanup completes regardless of caller context
 	if err != nil {
 		// TODO: what to do on error?
 		log.DefaultLogger.Errorw("failed to cleanup TestWorkflow resources", "id", execution.Id, "error", err)
@@ -532,7 +532,7 @@ func (r *runner) execute(request executionworkertypes.ExecuteRequest) (*executio
 
 // abortExecution aborts fetches the execution, updates its result to aborted and finishes it.
 func (r *runner) abortExecution(ctx context.Context, environmentID, executionID string) error {
-	execution, err := r.client.GetExecution(context.Background(), environmentID, executionID)
+	execution, err := r.client.GetExecution(ctx, environmentID, executionID)
 	if err != nil {
 		return errors.Wrapf(err, "failed to get execution '%s'", executionID)
 	}
@@ -548,7 +548,7 @@ func (r *runner) abortExecution(ctx context.Context, environmentID, executionID 
 		return errors.Wrapf(err, "failed to finish execution result '%s'", executionID)
 	}
 
-	if err = r.Abort(executionID); err != nil {
+	if err = r.Abort(executionID); err != nil { //nolint:contextcheck // Abort is a Runner interface method that manages its own context
 		return errors.Wrapf(err, "failed to destroy execution '%s'", executionID)
 	}
 

--- a/pkg/runner/service.go
+++ b/pkg/runner/service.go
@@ -76,7 +76,7 @@ func (s *service) reattach(ctx context.Context) (err error) {
 
 	for _, exec := range executions {
 		go func(environmentId string, executionId string) {
-			err := s.runner.Monitor(context.Background(), s.proContext.OrgID, environmentId, executionId)
+			err := s.runner.Monitor(context.Background(), s.proContext.OrgID, environmentId, executionId) //nolint:contextcheck // intentionally uses background context for long-running monitoring independent of parent
 			if err == nil {
 				s.logger.Infow("Reattached execution", "executionId", executionId)
 				return

--- a/pkg/testworkflows/executionworker/controller/watchers/job_watcher.go
+++ b/pkg/testworkflows/executionworker/controller/watchers/job_watcher.go
@@ -46,7 +46,7 @@ func NewJobWatcher(parentCtx context.Context, client kubernetesClient[batchv1.Jo
 		ctx:       ctx,
 		cancel:    ctxCancel,
 	}
-	go watcher.cycle()
+	go watcher.cycle() //nolint:contextcheck // cycle uses the watcher's internal context (e.ctx) derived from parentCtx
 	return watcher
 }
 

--- a/pkg/testworkflows/executionworker/controller/watchers/pod_watcher.go
+++ b/pkg/testworkflows/executionworker/controller/watchers/pod_watcher.go
@@ -46,7 +46,7 @@ func NewPodWatcher(parentCtx context.Context, client kubernetesClient[corev1.Pod
 		ctx:       ctx,
 		cancel:    ctxCancel,
 	}
-	go watcher.cycle()
+	go watcher.cycle() //nolint:contextcheck // cycle uses the watcher's internal context (e.ctx) derived from parentCtx
 	return watcher
 }
 

--- a/pkg/testworkflows/executionworker/kubernetesworker/worker.go
+++ b/pkg/testworkflows/executionworker/kubernetesworker/worker.go
@@ -171,7 +171,7 @@ func (w *worker) Execute(ctx context.Context, request executionworkertypes.Execu
 	w.registry.RegisterNamespace(cfg.Resource.Id, cfg.Worker.Namespace)
 
 	// Deploy required resources
-	err = bundle.Deploy(context.Background(), w.clientSet, cfg.Worker.Namespace)
+	err = bundle.Deploy(context.Background(), w.clientSet, cfg.Worker.Namespace) //nolint:contextcheck // intentionally using background context so deployment completes even if request context is canceled
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to deploy test workflow")
 	}
@@ -246,7 +246,7 @@ func (w *worker) Service(ctx context.Context, request executionworkertypes.Servi
 	w.registry.RegisterNamespace(cfg.Resource.Id, cfg.Worker.Namespace)
 
 	// Deploy required resources
-	err = bundle.Deploy(context.Background(), w.clientSet, cfg.Worker.Namespace)
+	err = bundle.Deploy(context.Background(), w.clientSet, cfg.Worker.Namespace) //nolint:contextcheck // intentionally using background context so deployment completes even if request context is canceled
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to deploy test workflow")
 	}
@@ -671,7 +671,7 @@ func (w *worker) ResumeMany(ctx context.Context, ids []string, options execution
 	wg.Add(len(ips))
 	var errsMu sync.Mutex
 	for id, podIp := range ips {
-		go func(id, address string) {
+		go func(id, address string) { //nolint:contextcheck // goroutine manages its own connection lifecycle independent of parent context
 			cond.L.Lock()
 			defer cond.L.Unlock()
 

--- a/pkg/triggers/executor.go
+++ b/pkg/triggers/executor.go
@@ -65,7 +65,7 @@ func (s *Service) execute(ctx context.Context, e *watcherEvent, t *testtriggersv
 		return errors.New("deprecated: please upgrade to test workflows")
 	}
 
-	testWorkflows, err := s.getTestWorkflows(t)
+	testWorkflows, err := s.getTestWorkflows(ctx, t)
 	if err != nil {
 		return err
 	}
@@ -328,12 +328,12 @@ func (s *Service) getEnvironmentId() string {
 	return ""
 }
 
-func (s *Service) getTestWorkflows(t *testtriggersv1.TestTrigger) ([]testworkflowsv1.TestWorkflow, error) {
+func (s *Service) getTestWorkflows(ctx context.Context, t *testtriggersv1.TestTrigger) ([]testworkflowsv1.TestWorkflow, error) {
 	var testWorkflows []testworkflowsv1.TestWorkflow
 	if t.Spec.TestSelector.Name != "" {
 		s.logger.Debugf("trigger service: executor component: fetching testworkflowsv3.TestWorkflow with name %s", t.Spec.TestSelector.Name)
 
-		testWorkflow, err := s.testWorkflowsClient.Get(context.Background(), s.getEnvironmentId(), t.Spec.TestSelector.Name)
+		testWorkflow, err := s.testWorkflowsClient.Get(ctx, s.getEnvironmentId(), t.Spec.TestSelector.Name)
 		if err != nil {
 			return nil, err
 		}
@@ -342,7 +342,7 @@ func (s *Service) getTestWorkflows(t *testtriggersv1.TestTrigger) ([]testworkflo
 
 	if t.Spec.TestSelector.NameRegex != "" {
 		s.logger.Debugf("trigger service: executor component: fetching testworkflosv1.TestWorkflow with name regex %s", t.Spec.TestSelector.NameRegex)
-		testWorkflowsList, err := s.testWorkflowsClient.List(context.Background(), s.getEnvironmentId(), testworkflowclient.ListOptions{})
+		testWorkflowsList, err := s.testWorkflowsClient.List(ctx, s.getEnvironmentId(), testworkflowclient.ListOptions{})
 		if err != nil {
 			return nil, err
 		}
@@ -364,7 +364,7 @@ func (s *Service) getTestWorkflows(t *testtriggersv1.TestTrigger) ([]testworkflo
 			return nil, errors.New("error creating selector from test resource label selector: MatchExpressions not supported")
 		}
 		s.logger.Debugf("trigger service: executor component: fetching testworkflowsv1.TestWorkflow with label %s", t.Spec.TestSelector.LabelSelector.MatchLabels)
-		testWorkflowsList, err := s.testWorkflowsClient.List(context.Background(), s.getEnvironmentId(), testworkflowclient.ListOptions{
+		testWorkflowsList, err := s.testWorkflowsClient.List(ctx, s.getEnvironmentId(), testworkflowclient.ListOptions{
 			Labels: t.Spec.TestSelector.LabelSelector.MatchLabels,
 		})
 		if err != nil {


### PR DESCRIPTION
## Summary
Enable the `contextcheck` linter and fix context propagation issues across the codebase.

This PR enables the `contextcheck` linter in `.golangci.yml` and takes a mixed approach:
- **Fixes straightforward violations** where context can be threaded through directly (e.g. replacing `context.Background()` with the available `ctx`, switching to context-aware API variants)
- **Suppresses remaining violations with `//nolint:contextcheck`** where the fix requires upstream API changes or where context is intentionally not propagated (fire-and-forget goroutines, background cleanup, APIs that don't accept context yet)

The `nolint` comments include explanations and serve as markers for follow-up work. Split from #7026 which handles `noctx`.

## What's fixed
- `cmd/api-server/commons/commons.go` — `MustGetPostgresDatabase` now uses the caller's `ctx` instead of `context.Background()`
- `pkg/mcp/tools/query.go` — switched from `jsonpath.Query` to `jsonpath.QueryWithContext`
- `pkg/runner/runner.go` — `abortExecution` now passes `ctx` to `GetExecution`
- `pkg/triggers/executor.go` — threads `ctx` through `getTestWorkflows`

## What's suppressed (for follow-up)
These require upstream API changes or are intentional design choices:
- **Telemetry calls** — `SendServerStartEvent`, `SendHeartbeatEvent` APIs don't accept context
- **Fire-and-forget goroutines** — telemetry middleware, runner request handling, monitoring reattach
- **Background cleanup** — `Destroy` and `Deploy` intentionally use `context.Background()` to complete regardless of caller cancellation
- **Watcher `cycle()` methods** — use internal context derived from `parentCtx`, opaque to the linter
- **`MustGetMinioClient`/`Abort`** — interface methods that don't accept context

## Dead code `return` after `Failf`
`cmd/kubectl-testkube/commands/agents/delete.go` and `install.go` add `return` statements after `ui.Failf()` calls. `Failf` calls `os.Exit(1)` so the `return` is unreachable at runtime, but the linter can't see through `os.Exit` and flags subsequent code as reachable without proper context. The `return` satisfies static analysis and makes control flow explicit for readers.

## CI status
- [x] Lint passes
- [x] Unit tests pass
- [x] Integration tests pass
- [x] Build passes
- [x] CodeQL passes

Related: #7025, #7026
