### PR TITLE
feat: Soft-delete for testworkflow executions

### DIFF
--- a/pkg/cloud/data/testworkflow/execution.go
+++ b/pkg/cloud/data/testworkflow/execution.go
@@ -248,3 +248,11 @@ func (r *CloudRepository) AbortIfQueued(ctx context.Context, id string) (bool, e
 func (r *CloudRepository) UpdateResourceAggregations(ctx context.Context, id string, resourceAggregations *testkube.TestWorkflowExecutionResourceAggregationsReport) error {
 	return errors.New("not supported")
 }
+
+func (r *CloudRepository) GetSoftDeletedExecutionIDs(ctx context.Context, olderThan time.Time, limit int32) ([]string, error) {
+	return nil, errors.New("not supported")
+}
+
+func (r *CloudRepository) HardDeleteSoftDeletedExecutions(ctx context.Context, olderThan time.Time) error {
+	return errors.New("not supported")
+}

--- a/pkg/controlplane/scheduling/sqlc/execution_querier.sql
+++ b/pkg/controlplane/scheduling/sqlc/execution_querier.sql
@@ -7,6 +7,7 @@ FROM
         JOIN test_workflow_results r ON e.id = r.execution_id
 WHERE r.status = @status::text
   AND (COALESCE(@predicted_status::text, '') = '' OR predicted_status = @predicted_status::text)
+  AND e.deleted_at IS NULL
 ORDER BY e.scheduled_at;
 
 -- name: GetExecutionsByStatuses :many
@@ -17,4 +18,5 @@ FROM
     test_workflow_executions e
         JOIN test_workflow_results r ON e.id = r.execution_id
 WHERE r.status = ANY(@statuses::text[])
+  AND e.deleted_at IS NULL
 ORDER BY e.scheduled_at;

--- a/pkg/controlplane/scheduling/sqlc/execution_querier.sql.go
+++ b/pkg/controlplane/scheduling/sqlc/execution_querier.sql.go
@@ -18,6 +18,7 @@ FROM
         JOIN test_workflow_results r ON e.id = r.execution_id
 WHERE r.status = $1::text
   AND (COALESCE($2::text, '') = '' OR predicted_status = $2::text)
+  AND e.deleted_at IS NULL
 ORDER BY e.scheduled_at
 `
 
@@ -98,6 +99,7 @@ FROM
     test_workflow_executions e
         JOIN test_workflow_results r ON e.id = r.execution_id
 WHERE r.status = ANY($1::text[])
+  AND e.deleted_at IS NULL
 ORDER BY e.scheduled_at
 `
 

--- a/pkg/controlplane/scheduling/sqlc/execution_querier.sql.go
+++ b/pkg/controlplane/scheduling/sqlc/execution_querier.sql.go
@@ -11,7 +11,7 @@ import (
 
 const getExecutionsByStatus = `-- name: GetExecutionsByStatus :many
 SELECT
-    e.id, e.name, e.namespace, e.number, e.test_workflow_execution_name, e.group_id, e.runner_id, e.runner_target, e.runner_original_target, e.disable_webhooks, e.tags, e.running_context, e.config_params, e.scheduled_at, e.assigned_at, e.status_at, e.created_at, e.updated_at, e.organization_id, e.environment_id, e.runtime,
+    e.id, e.name, e.namespace, e.number, e.test_workflow_execution_name, e.group_id, e.runner_id, e.runner_target, e.runner_original_target, e.disable_webhooks, e.tags, e.running_context, e.config_params, e.scheduled_at, e.assigned_at, e.status_at, e.created_at, e.updated_at, e.organization_id, e.environment_id, e.runtime, e.deleted_at,
     r.execution_id, r.status, r.predicted_status, r.duration, r.total_duration, r.duration_ms, r.paused_ms, r.total_duration_ms, r.pauses, r.initialization, r.steps, r.queued_at, r.started_at, r.finished_at, r.created_at, r.updated_at
 FROM
     test_workflow_executions e
@@ -62,6 +62,7 @@ func (q *Queries) GetExecutionsByStatus(ctx context.Context, arg GetExecutionsBy
 			&i.TestWorkflowExecution.OrganizationID,
 			&i.TestWorkflowExecution.EnvironmentID,
 			&i.TestWorkflowExecution.Runtime,
+			&i.TestWorkflowExecution.DeletedAt,
 			&i.TestWorkflowResult.ExecutionID,
 			&i.TestWorkflowResult.Status,
 			&i.TestWorkflowResult.PredictedStatus,
@@ -91,7 +92,7 @@ func (q *Queries) GetExecutionsByStatus(ctx context.Context, arg GetExecutionsBy
 
 const getExecutionsByStatuses = `-- name: GetExecutionsByStatuses :many
 SELECT
-    e.id, e.name, e.namespace, e.number, e.test_workflow_execution_name, e.group_id, e.runner_id, e.runner_target, e.runner_original_target, e.disable_webhooks, e.tags, e.running_context, e.config_params, e.scheduled_at, e.assigned_at, e.status_at, e.created_at, e.updated_at, e.organization_id, e.environment_id, e.runtime,
+    e.id, e.name, e.namespace, e.number, e.test_workflow_execution_name, e.group_id, e.runner_id, e.runner_target, e.runner_original_target, e.disable_webhooks, e.tags, e.running_context, e.config_params, e.scheduled_at, e.assigned_at, e.status_at, e.created_at, e.updated_at, e.organization_id, e.environment_id, e.runtime, e.deleted_at,
     r.execution_id, r.status, r.predicted_status, r.duration, r.total_duration, r.duration_ms, r.paused_ms, r.total_duration_ms, r.pauses, r.initialization, r.steps, r.queued_at, r.started_at, r.finished_at, r.created_at, r.updated_at
 FROM
     test_workflow_executions e
@@ -136,6 +137,7 @@ func (q *Queries) GetExecutionsByStatuses(ctx context.Context, statuses []string
 			&i.TestWorkflowExecution.OrganizationID,
 			&i.TestWorkflowExecution.EnvironmentID,
 			&i.TestWorkflowExecution.Runtime,
+			&i.TestWorkflowExecution.DeletedAt,
 			&i.TestWorkflowResult.ExecutionID,
 			&i.TestWorkflowResult.Status,
 			&i.TestWorkflowResult.PredictedStatus,

--- a/pkg/controlplane/scheduling/sqlc/models.go
+++ b/pkg/controlplane/scheduling/sqlc/models.go
@@ -67,6 +67,7 @@ type TestWorkflowExecution struct {
 	OrganizationID            string                                               `db:"organization_id" json:"organization_id"`
 	EnvironmentID             string                                               `db:"environment_id" json:"environment_id"`
 	Runtime                   *testkube.TestWorkflowExecutionRuntime               `db:"runtime" json:"runtime"`
+	DeletedAt                 pgtype.Timestamptz                                   `db:"deleted_at" json:"deleted_at"`
 }
 
 type TestWorkflowOutput struct {

--- a/pkg/controlplane/scheduling/sqlc/scheduler.sql
+++ b/pkg/controlplane/scheduling/sqlc/scheduler.sql
@@ -6,8 +6,8 @@ FROM
     test_workflow_executions e
         JOIN test_workflow_results r ON e.id = r.execution_id
 WHERE
-    r.status IS NULL
-   OR r.status IN ('queued', 'assigned', 'starting')
+    (r.status IS NULL OR r.status IN ('queued', 'assigned', 'starting'))
+    AND e.deleted_at IS NULL
 ORDER BY
     e.scheduled_at
 LIMIT

--- a/pkg/controlplane/scheduling/sqlc/scheduler.sql.go
+++ b/pkg/controlplane/scheduling/sqlc/scheduler.sql.go
@@ -281,8 +281,8 @@ FROM
     test_workflow_executions e
         JOIN test_workflow_results r ON e.id = r.execution_id
 WHERE
-    r.status IS NULL
-   OR r.status IN ('queued', 'assigned', 'starting')
+    (r.status IS NULL OR r.status IN ('queued', 'assigned', 'starting'))
+    AND e.deleted_at IS NULL
 ORDER BY
     e.scheduled_at
 LIMIT

--- a/pkg/controlplane/scheduling/sqlc/scheduler.sql.go
+++ b/pkg/controlplane/scheduling/sqlc/scheduler.sql.go
@@ -55,7 +55,7 @@ SET
     status_at = $2::timestamptz,
     assigned_at = $2::timestamptz,
     updated_at = $2::timestamptz
-WHERE id = $3::text RETURNING id, name, namespace, number, test_workflow_execution_name, group_id, runner_id, runner_target, runner_original_target, disable_webhooks, tags, running_context, config_params, scheduled_at, assigned_at, status_at, created_at, updated_at, organization_id, environment_id, runtime
+WHERE id = $3::text RETURNING id, name, namespace, number, test_workflow_execution_name, group_id, runner_id, runner_target, runner_original_target, disable_webhooks, tags, running_context, config_params, scheduled_at, assigned_at, status_at, created_at, updated_at, organization_id, environment_id, runtime, deleted_at
 `
 
 type AssignExecutionRootParams struct {
@@ -89,6 +89,7 @@ func (q *Queries) AssignExecutionRoot(ctx context.Context, arg AssignExecutionRo
 		&i.OrganizationID,
 		&i.EnvironmentID,
 		&i.Runtime,
+		&i.DeletedAt,
 	)
 	return i, err
 }
@@ -274,7 +275,7 @@ func (q *Queries) GetExecutionWorkflow(ctx context.Context, executionID string) 
 
 const getNextExecution = `-- name: GetNextExecution :one
 SELECT
-    e.id, e.name, e.namespace, e.number, e.test_workflow_execution_name, e.group_id, e.runner_id, e.runner_target, e.runner_original_target, e.disable_webhooks, e.tags, e.running_context, e.config_params, e.scheduled_at, e.assigned_at, e.status_at, e.created_at, e.updated_at, e.organization_id, e.environment_id, e.runtime,
+    e.id, e.name, e.namespace, e.number, e.test_workflow_execution_name, e.group_id, e.runner_id, e.runner_target, e.runner_original_target, e.disable_webhooks, e.tags, e.running_context, e.config_params, e.scheduled_at, e.assigned_at, e.status_at, e.created_at, e.updated_at, e.organization_id, e.environment_id, e.runtime, e.deleted_at,
     r.execution_id, r.status, r.predicted_status, r.duration, r.total_duration, r.duration_ms, r.paused_ms, r.total_duration_ms, r.pauses, r.initialization, r.steps, r.queued_at, r.started_at, r.finished_at, r.created_at, r.updated_at
 FROM
     test_workflow_executions e
@@ -319,6 +320,7 @@ func (q *Queries) GetNextExecution(ctx context.Context) (GetNextExecutionRow, er
 		&i.TestWorkflowExecution.OrganizationID,
 		&i.TestWorkflowExecution.EnvironmentID,
 		&i.TestWorkflowExecution.Runtime,
+		&i.TestWorkflowExecution.DeletedAt,
 		&i.TestWorkflowResult.ExecutionID,
 		&i.TestWorkflowResult.Status,
 		&i.TestWorkflowResult.PredictedStatus,

--- a/pkg/database/postgres/migrations/20260223120000_soft_delete.sql
+++ b/pkg/database/postgres/migrations/20260223120000_soft_delete.sql
@@ -1,0 +1,16 @@
+-- +goose Up
+-- +goose StatementBegin
+-- Add soft-delete column to test_workflow_executions
+ALTER TABLE test_workflow_executions ADD COLUMN deleted_at TIMESTAMP WITH TIME ZONE;
+
+-- Partial index for efficient lookup of soft-deleted rows (reaper queries)
+CREATE INDEX idx_test_workflow_executions_deleted_at
+    ON test_workflow_executions(deleted_at)
+    WHERE deleted_at IS NOT NULL;
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+DROP INDEX IF EXISTS idx_test_workflow_executions_deleted_at;
+ALTER TABLE test_workflow_executions DROP COLUMN deleted_at;
+-- +goose StatementEnd

--- a/pkg/database/postgres/sqlc/models.go
+++ b/pkg/database/postgres/sqlc/models.go
@@ -66,6 +66,7 @@ type TestWorkflowExecution struct {
 	OrganizationID            string             `db:"organization_id" json:"organization_id"`
 	EnvironmentID             string             `db:"environment_id" json:"environment_id"`
 	Runtime                   []byte             `db:"runtime" json:"runtime"`
+	DeletedAt                 pgtype.Timestamptz `db:"deleted_at" json:"deleted_at"`
 }
 
 type TestWorkflowOutput struct {

--- a/pkg/database/postgres/sqlc/queries.go
+++ b/pkg/database/postgres/sqlc/queries.go
@@ -61,6 +61,10 @@ type TestWorkflowExecutionQueriesInterface interface {
 	GetPreviousFinishedState(ctx context.Context, arg GetPreviousFinishedStateParams) (pgtype.Text, error)
 	GetTestWorkflowExecutionTags(ctx context.Context, arg GetTestWorkflowExecutionTagsParams) ([]GetTestWorkflowExecutionTagsRow, error)
 
+	// Soft-delete reaper
+	GetSoftDeletedExecutionIDs(ctx context.Context, arg GetSoftDeletedExecutionIDsParams) ([]string, error)
+	HardDeleteSoftDeletedExecutions(ctx context.Context, arg HardDeleteSoftDeletedExecutionsParams) error
+
 	// Execution management
 	InitTestWorkflowExecution(ctx context.Context, arg InitTestWorkflowExecutionParams) error
 	AssignTestWorkflowExecution(ctx context.Context, arg AssignTestWorkflowExecutionParams) (string, error)

--- a/pkg/repository/testworkflow/interface.go
+++ b/pkg/repository/testworkflow/interface.go
@@ -155,6 +155,10 @@ type Repository interface {
 	Assign(ctx context.Context, id string, prevRunnerId string, newRunnerId string, assignedAt *time.Time) (bool, error)
 	// AbortIfQueued marks execution as aborted if it's queued
 	AbortIfQueued(ctx context.Context, id string) (bool, error)
+	// GetSoftDeletedExecutionIDs returns IDs of soft-deleted executions older than the given time (for background cleanup)
+	GetSoftDeletedExecutionIDs(ctx context.Context, olderThan time.Time, limit int32) ([]string, error)
+	// HardDeleteSoftDeletedExecutions permanently removes soft-deleted executions older than the given time
+	HardDeleteSoftDeletedExecutions(ctx context.Context, olderThan time.Time) error
 }
 
 type Sequences interface {

--- a/pkg/repository/testworkflow/mock_repository.go
+++ b/pkg/repository/testworkflow/mock_repository.go
@@ -486,3 +486,32 @@ func (mr *MockRepositoryMockRecorder) UpdateResultStrict(ctx, id, runnerId, resu
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateResultStrict", reflect.TypeOf((*MockRepository)(nil).UpdateResultStrict), ctx, id, runnerId, result)
 }
+
+// GetSoftDeletedExecutionIDs mocks base method.
+func (m *MockRepository) GetSoftDeletedExecutionIDs(ctx context.Context, olderThan time.Time, limit int32) ([]string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetSoftDeletedExecutionIDs", ctx, olderThan, limit)
+	ret0, _ := ret[0].([]string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetSoftDeletedExecutionIDs indicates an expected call of GetSoftDeletedExecutionIDs.
+func (mr *MockRepositoryMockRecorder) GetSoftDeletedExecutionIDs(ctx, olderThan, limit any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSoftDeletedExecutionIDs", reflect.TypeOf((*MockRepository)(nil).GetSoftDeletedExecutionIDs), ctx, olderThan, limit)
+}
+
+// HardDeleteSoftDeletedExecutions mocks base method.
+func (m *MockRepository) HardDeleteSoftDeletedExecutions(ctx context.Context, olderThan time.Time) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "HardDeleteSoftDeletedExecutions", ctx, olderThan)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// HardDeleteSoftDeletedExecutions indicates an expected call of HardDeleteSoftDeletedExecutions.
+func (mr *MockRepositoryMockRecorder) HardDeleteSoftDeletedExecutions(ctx, olderThan any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HardDeleteSoftDeletedExecutions", reflect.TypeOf((*MockRepository)(nil).HardDeleteSoftDeletedExecutions), ctx, olderThan)
+}

--- a/pkg/repository/testworkflow/mongo/mongo_integration_test.go
+++ b/pkg/repository/testworkflow/mongo/mongo_integration_test.go
@@ -7,6 +7,8 @@ import (
 	"github.com/kubeshop/testkube/pkg/utils/test"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/mongo"
 	"go.mongodb.org/mongo-driver/mongo/options"
 
@@ -650,4 +652,153 @@ func TestNewMongoRepository_Get_Integration(t *testing.T) {
 	assert.Equal(t, execution3.Id, result.Id)
 	assert.Equal(t, execution3.Name, result.Name)
 	assert.Equal(t, true, result.ConfigParams["param1"].Sensitive)
+}
+
+func TestNewMongoRepository_SoftDelete_Integration(t *testing.T) {
+	test.IntegrationTest(t)
+
+	ctx := context.Background()
+	client, err := mongo.Connect(ctx, options.Client().ApplyURI("mongodb://localhost:27017"))
+	if err != nil {
+		t.Fatalf("error connecting to mongo: %v", err)
+	}
+	db := client.Database("testworkflow-soft-delete-mongo-repository-test")
+	t.Cleanup(func() {
+		db.Drop(ctx)
+	})
+
+	repo := NewMongoRepository(db, false)
+
+	t.Run("DeleteByTestWorkflow sets deletedat and hides from queries", func(t *testing.T) {
+		execution := testkube.TestWorkflowExecution{
+			Id:   "sd-1",
+			Name: "sd-name-1",
+			Workflow: &testkube.TestWorkflow{
+				Name: "sd-workflow",
+				Spec: &testkube.TestWorkflowSpec{},
+			},
+		}
+		require.NoError(t, repo.Insert(ctx, execution))
+
+		// Verify visible before delete
+		_, err := repo.Get(ctx, "sd-1")
+		require.NoError(t, err)
+
+		// Soft-delete
+		err = repo.DeleteByTestWorkflow(ctx, "sd-workflow")
+		require.NoError(t, err)
+
+		// Verify hidden from Get
+		_, err = repo.Get(ctx, "sd-1")
+		assert.ErrorIs(t, err, mongo.ErrNoDocuments)
+
+		// Verify hidden from GetExecutions
+		results, err := repo.GetExecutions(ctx, testworkflow.NewExecutionsFilter().WithName("sd-workflow"))
+		require.NoError(t, err)
+		assert.Empty(t, results)
+
+		// Verify document still exists in collection with deletedat set
+		var raw bson.M
+		err = repo.Coll.FindOne(ctx, bson.M{"id": "sd-1"}).Decode(&raw)
+		require.NoError(t, err)
+		assert.NotNil(t, raw["deletedat"], "deletedat should be set on soft-deleted document")
+	})
+
+	t.Run("DeleteAll soft-deletes all documents", func(t *testing.T) {
+		execution := testkube.TestWorkflowExecution{
+			Id:   "sd-2",
+			Name: "sd-name-2",
+			Workflow: &testkube.TestWorkflow{
+				Name: "sd-workflow-2",
+				Spec: &testkube.TestWorkflowSpec{},
+			},
+		}
+		require.NoError(t, repo.Insert(ctx, execution))
+
+		err := repo.DeleteAll(ctx)
+		require.NoError(t, err)
+
+		// Verify hidden
+		_, err = repo.Get(ctx, "sd-2")
+		assert.ErrorIs(t, err, mongo.ErrNoDocuments)
+
+		// Verify document exists with deletedat
+		var raw bson.M
+		err = repo.Coll.FindOne(ctx, bson.M{"id": "sd-2"}).Decode(&raw)
+		require.NoError(t, err)
+		assert.NotNil(t, raw["deletedat"])
+	})
+
+	t.Run("DeleteByTestWorkflows soft-deletes matching workflows", func(t *testing.T) {
+		// Clean the collection for this sub-test
+		repo.Coll.Drop(ctx)
+
+		exec1 := testkube.TestWorkflowExecution{
+			Id:   "sd-3a",
+			Name: "sd-name-3a",
+			Workflow: &testkube.TestWorkflow{
+				Name: "wf-a",
+				Spec: &testkube.TestWorkflowSpec{},
+			},
+		}
+		exec2 := testkube.TestWorkflowExecution{
+			Id:   "sd-3b",
+			Name: "sd-name-3b",
+			Workflow: &testkube.TestWorkflow{
+				Name: "wf-b",
+				Spec: &testkube.TestWorkflowSpec{},
+			},
+		}
+		exec3 := testkube.TestWorkflowExecution{
+			Id:   "sd-3c",
+			Name: "sd-name-3c",
+			Workflow: &testkube.TestWorkflow{
+				Name: "wf-c",
+				Spec: &testkube.TestWorkflowSpec{},
+			},
+		}
+		require.NoError(t, repo.Insert(ctx, exec1))
+		require.NoError(t, repo.Insert(ctx, exec2))
+		require.NoError(t, repo.Insert(ctx, exec3))
+
+		// Soft-delete wf-a and wf-b
+		err := repo.DeleteByTestWorkflows(ctx, []string{"wf-a", "wf-b"})
+		require.NoError(t, err)
+
+		// wf-a and wf-b should be hidden
+		_, err = repo.Get(ctx, "sd-3a")
+		assert.ErrorIs(t, err, mongo.ErrNoDocuments)
+		_, err = repo.Get(ctx, "sd-3b")
+		assert.ErrorIs(t, err, mongo.ErrNoDocuments)
+
+		// wf-c should still be visible
+		result, err := repo.Get(ctx, "sd-3c")
+		require.NoError(t, err)
+		assert.Equal(t, "sd-3c", result.Id)
+	})
+
+	t.Run("soft-deleted documents are excluded from count and totals", func(t *testing.T) {
+		repo.Coll.Drop(ctx)
+
+		exec := testkube.TestWorkflowExecution{
+			Id:   "sd-4",
+			Name: "sd-name-4",
+			Workflow: &testkube.TestWorkflow{
+				Name: "wf-count",
+				Spec: &testkube.TestWorkflowSpec{},
+			},
+		}
+		require.NoError(t, repo.Insert(ctx, exec))
+
+		count, err := repo.Count(ctx, testworkflow.NewExecutionsFilter().WithName("wf-count"))
+		require.NoError(t, err)
+		assert.Equal(t, int64(1), count)
+
+		err = repo.DeleteByTestWorkflow(ctx, "wf-count")
+		require.NoError(t, err)
+
+		count, err = repo.Count(ctx, testworkflow.NewExecutionsFilter().WithName("wf-count"))
+		require.NoError(t, err)
+		assert.Equal(t, int64(0), count)
+	})
 }

--- a/pkg/repository/testworkflow/postgres/postgres.go
+++ b/pkg/repository/testworkflow/postgres/postgres.go
@@ -2342,6 +2342,25 @@ func (r *PostgresRepository) updateMainExecution(ctx context.Context, qtx sqlc.T
 	})
 }
 
+// GetSoftDeletedExecutionIDs returns IDs of soft-deleted executions older than olderThan
+func (r *PostgresRepository) GetSoftDeletedExecutionIDs(ctx context.Context, olderThan time.Time, limit int32) ([]string, error) {
+	return r.queries.GetSoftDeletedExecutionIDs(ctx, sqlc.GetSoftDeletedExecutionIDsParams{
+		OlderThan:      toPgTimestamp(olderThan),
+		OrganizationID: r.organizationID,
+		EnvironmentID:  r.environmentID,
+		Lmt:            limit,
+	})
+}
+
+// HardDeleteSoftDeletedExecutions permanently removes soft-deleted executions older than olderThan
+func (r *PostgresRepository) HardDeleteSoftDeletedExecutions(ctx context.Context, olderThan time.Time) error {
+	return r.queries.HardDeleteSoftDeletedExecutions(ctx, sqlc.HardDeleteSoftDeletedExecutionsParams{
+		OlderThan:      toPgTimestamp(olderThan),
+		OrganizationID: r.organizationID,
+		EnvironmentID:  r.environmentID,
+	})
+}
+
 // populateConfigParams - same as in mongo repository
 func populateConfigParams(resolvedWorkflow *testkube.TestWorkflow, configParams map[string]testkube.TestWorkflowExecutionConfigValue) map[string]testkube.TestWorkflowExecutionConfigValue {
 	if configParams == nil {

--- a/pkg/repository/testworkflow/postgres/postgres_test.go
+++ b/pkg/repository/testworkflow/postgres/postgres_test.go
@@ -238,6 +238,16 @@ func (m *MockTestWorkflowExecutionQueriesInterface) DeleteTestWorkflow(ctx conte
 	return args.Error(0)
 }
 
+func (m *MockTestWorkflowExecutionQueriesInterface) GetSoftDeletedExecutionIDs(ctx context.Context, arg sqlc.GetSoftDeletedExecutionIDsParams) ([]string, error) {
+	args := m.Called(ctx, arg)
+	return args.Get(0).([]string), args.Error(1)
+}
+
+func (m *MockTestWorkflowExecutionQueriesInterface) HardDeleteSoftDeletedExecutions(ctx context.Context, arg sqlc.HardDeleteSoftDeletedExecutionsParams) error {
+	args := m.Called(ctx, arg)
+	return args.Error(0)
+}
+
 // Mock DatabaseInterface
 type MockDatabaseInterface struct {
 	mock.Mock


### PR DESCRIPTION
## Summary
- Replace hard-deletes with soft-delete (`deleted_at` timestamp) for testworkflow execution records in both Postgres and MongoDB
- Eliminates cross-store consistency issues where a cancelled request could leave partially-deleted state across DB, MinIO, and K8s
- Soft-deleted records are automatically reaped: MongoDB via TTL index (7 days), Postgres via explicit reaper methods

## Changes

**Postgres:**
- Migration adds `deleted_at TIMESTAMPTZ` column to `test_workflow_executions` with partial index
- All 16 SELECT queries filter `deleted_at IS NULL`
- DELETE queries converted to `UPDATE SET deleted_at = NOW()`
- New reaper methods: `GetSoftDeletedExecutionIDs`, `HardDeleteSoftDeletedExecutions`
- Child tables use `ON DELETE CASCADE` so only the parent needs the column

**MongoDB:**
- Sparse TTL index on `deletedat` with 7-day expiry (automatic cleanup, no cron needed)
- All read queries filter `deletedat: nil`
- Delete methods converted to `UpdateMany` setting `deletedat`
- Bug fix: `DeleteByTestWorkflows` was using `ExecutionTypeTestSuite` instead of `ExecutionTypeTestWorkflow` for sequence cleanup

**Handlers:**
- Results repo calls now use request context (soft-delete is a fast SET, safe to cancel)
- MinIO output deletion runs first (while records are still visible), then soft-delete
- Compensating actions (create/update rollback) remain on `context.Background()`

**Scheduling:**
- Added `deleted_at IS NULL` filter to `GetExecutionsByStatus`, `GetExecutionsByStatuses`, `GetNextExecution`
- Fixed OR-clause precedence in `GetNextExecution` with proper parenthesisation

## Context
Addresses review feedback on #7025 — `context.Background()` on persistence operations was masking a deeper cross-store atomicity problem. Soft-delete makes the delete operation a single fast write, safe with request context, and self-healing via background reaping.

## Test plan
- [ ] Postgres: verify soft-deleted records are invisible to all read queries
- [ ] Postgres: verify reaper hard-deletes records older than retention period
- [ ] MongoDB: verify soft-deleted documents are invisible to all read queries
- [ ] MongoDB: verify TTL index reaps expired documents
- [ ] Handler: verify MinIO output is cleaned up before records are soft-deleted
- [ ] Scheduling: verify soft-deleted executions are not returned to the scheduler
- [ ] Integration: delete a workflow via API, confirm records are soft-deleted not removed