### PR TITLE
feat: add SkipEndpointChecks option for MCP server tool registration

### DIFF
--- a/pkg/mcp/config.go
+++ b/pkg/mcp/config.go
@@ -47,6 +47,10 @@ type MCPServerConfig struct {
 	// Source identifies how MCP is being accessed (e.g., "cli", "http-endpoint")
 	Source string
 
+	// SkipEndpointChecks skips backwards-compatibility endpoint checks and registers all tools.
+	// Used by the MCP bridge when spawned for metadata-only listing with dummy credentials.
+	SkipEndpointChecks bool
+
 	// SHTTP-specific configuration
 	SHTTPConfig SHTTPConfig
 }
@@ -102,17 +106,18 @@ func LoadConfigFromEnv() MCPServerConfig {
 	}
 
 	return MCPServerConfig{
-		Version:          "1.0.0",
-		Transport:        transport,
-		ControlPlaneUrl:  controlPlaneUrl,
-		DashboardUrl:     dashboardUrl,
-		AccessToken:      os.Getenv("TK_ACCESS_TOKEN"),
-		OrgId:            os.Getenv("TK_ORG_ID"),
-		EnvId:            os.Getenv("TK_ENV_ID"),
-		Debug:            os.Getenv("TK_DEBUG") == "true",
-		TelemetryEnabled: os.Getenv("TK_TELEMETRY_ENABLED") != "false", // Default to true unless explicitly disabled
-		Source:           "unknown",                                    // Source should be set by caller, not from env
-		SHTTPConfig:      shttpConfig,
+		Version:            "1.0.0",
+		Transport:          transport,
+		ControlPlaneUrl:    controlPlaneUrl,
+		DashboardUrl:       dashboardUrl,
+		AccessToken:        os.Getenv("TK_ACCESS_TOKEN"),
+		OrgId:              os.Getenv("TK_ORG_ID"),
+		EnvId:              os.Getenv("TK_ENV_ID"),
+		Debug:              os.Getenv("TK_DEBUG") == "true",
+		TelemetryEnabled:   os.Getenv("TK_TELEMETRY_ENABLED") != "false", // Default to true unless explicitly disabled
+		SkipEndpointChecks: os.Getenv("TK_SKIP_ENDPOINT_CHECKS") == "true",
+		Source:             "unknown", // Source should be set by caller, not from env
+		SHTTPConfig:        shttpConfig,
 	}
 }
 

--- a/pkg/mcp/server.go
+++ b/pkg/mcp/server.go
@@ -48,9 +48,9 @@ func NewMCPServer(cfg MCPServerConfig, client Client) (*server.MCPServer, error)
 	mcpServer.AddTool(tools.RunWorkflow(client))
 
 	// Query tools (JSONPath-based bulk queries)
-	// Only register if control plane supports bulk endpoints for backwards compatibility
-	ctx := context.Background()
-	if apiClient, ok := client.(*APIClient); ok {
+	// Only check backwards compatibility when using APIClient without SkipEndpointChecks
+	if apiClient, ok := client.(*APIClient); ok && !cfg.SkipEndpointChecks {
+		ctx := context.Background()
 		if apiClient.SupportsEndpoint(ctx, "/agent/test-workflows/definitions") {
 			mcpServer.AddTool(tools.QueryWorkflows(client))
 		}
@@ -58,7 +58,6 @@ func NewMCPServer(cfg MCPServerConfig, client Client) (*server.MCPServer, error)
 			mcpServer.AddTool(tools.QueryExecutions(client))
 		}
 	} else {
-		// Non-API clients (like HandlerClient in cloud-api) always support new endpoints
 		mcpServer.AddTool(tools.QueryWorkflows(client))
 		mcpServer.AddTool(tools.QueryExecutions(client))
 	}


### PR DESCRIPTION
The MCP bridge uses `SupportsEndpoint` HEAD requests for backwards compatibility with older control
  planes. When the bridge is spawned with dummy credentials for metadata-only tool listing, these
  requests fail, hiding  tools like `query_workflows` and `query_executions`.

  Adds `TK_SKIP_ENDPOINT_CHECKS` env var that bypasses these checks and registers all tools
  unconditionally. No effect on CLI or production tool execution, only used by the copilot metadata
  endpoint.