### PR TITLE
fix: API server panic caused by concurrent websocket writes 

### DIFF
--- a/pkg/event/kind/websocket/listener.go
+++ b/pkg/event/kind/websocket/listener.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"sync"
 
 	"go.uber.org/zap"
 
@@ -18,7 +19,7 @@ func NewWebsocketListener() *WebsocketListener {
 	return &WebsocketListener{
 		Log:        log.DefaultLogger,
 		selector:   "",
-		Websockets: []Websocket{},
+		Websockets: []*Websocket{},
 		events:     testkube.AllEventTypes,
 	}
 }
@@ -26,8 +27,9 @@ func NewWebsocketListener() *WebsocketListener {
 type WebsocketListener struct {
 	Log        *zap.SugaredLogger
 	events     []testkube.EventType
-	Websockets []Websocket
+	Websockets []*Websocket
 	selector   string
+	mu         sync.RWMutex
 }
 
 func (l *WebsocketListener) Name() string {
@@ -43,8 +45,9 @@ func (l *WebsocketListener) Events() []testkube.EventType {
 }
 
 func (l *WebsocketListener) Metadata() map[string]string {
+	websockets := l.SnapshotWebsockets()
 	ids := "["
-	for _, w := range l.Websockets {
+	for _, w := range websockets {
 		ids += w.Id + " "
 	}
 	ids += "]"
@@ -64,9 +67,9 @@ func (l *WebsocketListener) Match(event testkube.Event) bool {
 func (l *WebsocketListener) Notify(event testkube.Event) (result testkube.EventResult) {
 	var success, failed []string
 
-	for _, w := range l.Websockets {
+	for _, w := range l.SnapshotWebsockets() {
 		l.Log.Debugw("notifying websocket", "id", w.Id, "event", event.Type(), "resourceId", event.ResourceId)
-		err := w.Conn.WriteJSON(event)
+		err := w.SendJSON(event)
 		if err != nil {
 			failed = append(failed, w.Id)
 		} else {
@@ -90,4 +93,30 @@ func (l *WebsocketListener) Kind() string {
 
 func (l *WebsocketListener) Group() string {
 	return ""
+}
+
+func (l *WebsocketListener) AddWebsocket(ws *Websocket) {
+	l.mu.Lock()
+	l.Websockets = append(l.Websockets, ws)
+	l.mu.Unlock()
+}
+
+func (l *WebsocketListener) RemoveWebsocket(id string) {
+	l.mu.Lock()
+	for i, ws := range l.Websockets {
+		if ws.Id == id {
+			l.Websockets = append(l.Websockets[:i], l.Websockets[i+1:]...)
+			break
+		}
+	}
+	l.mu.Unlock()
+}
+
+func (l *WebsocketListener) SnapshotWebsockets() []*Websocket {
+	l.mu.RLock()
+	defer l.mu.RUnlock()
+
+	websockets := make([]*Websocket, len(l.Websockets))
+	copy(websockets, l.Websockets)
+	return websockets
 }

--- a/pkg/event/kind/websocket/listener_test.go
+++ b/pkg/event/kind/websocket/listener_test.go
@@ -14,7 +14,7 @@ func TestWebsocketListener(t *testing.T) {
 
 	// given
 	l := NewWebsocketListener()
-	l.Websockets = []Websocket{{
+	l.Websockets = []*Websocket{{
 		Id:   "1",
 		Conn: &websocket.Conn{},
 	}}

--- a/pkg/event/kind/websocket/websocket.go
+++ b/pkg/event/kind/websocket/websocket.go
@@ -1,6 +1,8 @@
 package websocket
 
 import (
+	"sync"
+
 	"github.com/gofiber/websocket/v2"
 
 	"github.com/kubeshop/testkube/pkg/api/v1/testkube"
@@ -11,4 +13,11 @@ type Websocket struct {
 	Conn     *websocket.Conn
 	Selector string
 	Events   []testkube.EventType
+	mu       sync.Mutex
+}
+
+func (w *Websocket) SendJSON(v any) error {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return w.Conn.WriteJSON(v)
 }


### PR DESCRIPTION
## Pull request description

Fix API server panic caused by concurrent websocket writes by serializing per-connection writes and making websocket listener bookkeeping concurrency-safe.

## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [x] tested locally
- [x] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Breaking changes

- None.

## Changes

- Add per-connection mutex to serialize websocket writes.
- Protect websocket list with RW mutex and iterate via snapshot.
- Use a buffered close channel and listener helper methods in the websocket loader.

## Fixes

- Prevents `panic: concurrent write to websocket connection` when multiple goroutines notify the same websocket.
