### PR TITLE
fix: [TKC-5040] handle idle log stream timeout without aborting workflow

### DIFF
--- a/pkg/testworkflows/executionworker/controller/logs_test.go
+++ b/pkg/testworkflows/executionworker/controller/logs_test.go
@@ -4,7 +4,9 @@ import (
 	"bufio"
 	"bytes"
 	"context"
+	"errors"
 	"io"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -80,6 +82,71 @@ func (r *blockingReader) Read(p []byte) (int, error) {
 	return 0, r.ctx.Err()
 }
 
+type lateReadAfterTimeoutReader struct {
+	ctx      context.Context
+	release  <-chan struct{}
+	mu       sync.Mutex
+	stage    int
+	released bool
+	first    *bytes.Reader
+	second   *bytes.Reader
+}
+
+func newLateReadAfterTimeoutReader(ctx context.Context, release <-chan struct{}) *lateReadAfterTimeoutReader {
+	return &lateReadAfterTimeoutReader{
+		ctx:     ctx,
+		release: release,
+		first:   bytes.NewReader([]byte("2024-06-07T12:41:49.037275300Z first\n")),
+		second:  bytes.NewReader([]byte("2024-06-07T12:41:50.037275300Z second\n")),
+	}
+}
+
+func (r *lateReadAfterTimeoutReader) Read(p []byte) (int, error) {
+	for {
+		r.mu.Lock()
+		switch r.stage {
+		case 0:
+			n, err := r.first.Read(p)
+			if err == io.EOF {
+				r.stage = 1
+				r.mu.Unlock()
+				if n > 0 {
+					return n, nil
+				}
+				continue
+			}
+			r.mu.Unlock()
+			return n, err
+		case 1:
+			if !r.released {
+				r.mu.Unlock()
+				<-r.release
+				r.mu.Lock()
+				r.released = true
+			}
+			r.stage = 2
+			r.mu.Unlock()
+			continue
+		case 2:
+			n, err := r.second.Read(p)
+			if err == io.EOF {
+				r.stage = 3
+				r.mu.Unlock()
+				if n > 0 {
+					return n, nil
+				}
+				continue
+			}
+			r.mu.Unlock()
+			return n, err
+		default:
+			r.mu.Unlock()
+			<-r.ctx.Done()
+			return 0, r.ctx.Err()
+		}
+	}
+}
+
 func TestWatchContainerLogsIdleTimeoutCancelsWhenDone(t *testing.T) {
 	t.Parallel()
 
@@ -116,9 +183,109 @@ func TestWatchContainerLogsIdleTimeoutCancelsWhenDone(t *testing.T) {
 			if msg.Error != nil {
 				gotErr = true
 				assert.Contains(t, msg.Error.Error(), "idle timeout")
+				assert.True(t, errors.Is(msg.Error, ErrLogStreamIdleTimeout))
 			}
 		case <-deadline.C:
 			t.Fatal("timed out waiting for idle timeout to close the channel")
+		}
+	}
+}
+
+func TestWatchContainerLogsIdleTimeoutRetriesBeforeClose(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	var calls int32
+	idleTimeout := 30 * time.Millisecond
+	ch := watchContainerLogsWithStream(
+		ctx,
+		func(ctx context.Context, _ kubernetes.Interface, _, _, _ string, _ func() bool, _ *time.Time) (io.Reader, error) {
+			atomic.AddInt32(&calls, 1)
+			return &blockingReader{ctx: ctx}, nil
+		},
+		nil,
+		"default",
+		"pod",
+		"container",
+		1,
+		func() bool { return true },
+		func(*instructions.Instruction) bool { return false },
+		idleTimeout,
+	)
+
+	deadline := time.NewTimer(1500 * time.Millisecond)
+	defer deadline.Stop()
+
+	idleErrors := 0
+	for {
+		select {
+		case msg, ok := <-ch:
+			if !ok {
+				assert.Equal(t, int32(LogStreamIdleMaxRetries+1), atomic.LoadInt32(&calls))
+				assert.GreaterOrEqual(t, idleErrors, 1)
+				return
+			}
+			if msg.Error != nil && errors.Is(msg.Error, ErrLogStreamIdleTimeout) {
+				idleErrors++
+			}
+		case <-deadline.C:
+			t.Fatalf("timed out waiting for retries, calls=%d idleErrors=%d", atomic.LoadInt32(&calls), idleErrors)
+		}
+	}
+}
+
+func TestWatchContainerLogsIdleTimeoutRetriesAfterLateRead(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	var calls int32
+	var releaseOnce sync.Once
+	release := make(chan struct{})
+
+	idleTimeout := 30 * time.Millisecond
+	ch := watchContainerLogsWithStream(
+		ctx,
+		func(ctx context.Context, _ kubernetes.Interface, _, _, _ string, _ func() bool, _ *time.Time) (io.Reader, error) {
+			call := atomic.AddInt32(&calls, 1)
+			if call == 1 {
+				return newLateReadAfterTimeoutReader(ctx, release), nil
+			}
+			return bytes.NewBuffer(nil), nil
+		},
+		nil,
+		"default",
+		"pod",
+		"container",
+		1,
+		func() bool { return true },
+		func(*instructions.Instruction) bool { return false },
+		idleTimeout,
+	)
+
+	deadline := time.NewTimer(2 * time.Second)
+	defer deadline.Stop()
+
+	sawIdleError := false
+	for {
+		select {
+		case msg, ok := <-ch:
+			if !ok {
+				assert.True(t, sawIdleError, "expected idle timeout error before channel close")
+				assert.GreaterOrEqual(t, atomic.LoadInt32(&calls), int32(2), "expected stream reopen after timeout-triggered cancellation")
+				return
+			}
+			if msg.Error != nil && errors.Is(msg.Error, ErrLogStreamIdleTimeout) {
+				sawIdleError = true
+				releaseOnce.Do(func() {
+					close(release)
+				})
+			}
+		case <-deadline.C:
+			t.Fatalf("timed out waiting for retry after late read, calls=%d sawIdleError=%t", atomic.LoadInt32(&calls), sawIdleError)
 		}
 	}
 }

--- a/pkg/testworkflows/executionworker/controller/notifier_test.go
+++ b/pkg/testworkflows/executionworker/controller/notifier_test.go
@@ -1,0 +1,110 @@
+package controller
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	batchv1 "k8s.io/api/batch/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	initconstants "github.com/kubeshop/testkube/cmd/testworkflow-init/constants"
+	"github.com/kubeshop/testkube/internal/common"
+	"github.com/kubeshop/testkube/pkg/api/v1/testkube"
+	watchers2 "github.com/kubeshop/testkube/pkg/testworkflows/executionworker/controller/watchers"
+	constants2 "github.com/kubeshop/testkube/pkg/testworkflows/testworkflowprocessor/constants"
+)
+
+func TestNotifierEndWithoutTerminationCodeDefaultsToAbort(t *testing.T) {
+	t.Parallel()
+
+	now := time.Now().UTC()
+	n := newTestNotifierWithJobTerminationCode("", now)
+	if got := watchers2.GetTerminationCode(n.state.Job().Original()); got != string(testkube.ABORTED_TestWorkflowStatus) {
+		t.Fatalf("expected missing termination code to default to aborted, got: %q", got)
+	}
+
+	n.End()
+
+	if status := n.result.Steps["step-1"].Status; status == nil || (*status != testkube.ABORTED_TestWorkflowStepStatus && *status != testkube.SKIPPED_TestWorkflowStepStatus) {
+		if status == nil {
+			t.Fatalf("expected step-1 to be aborted/skipped, got nil status")
+		}
+		t.Fatalf("expected step-1 to be aborted/skipped, got: %s", *status)
+	}
+	if n.result.Initialization == nil || n.result.Initialization.Status == nil || *n.result.Initialization.Status != testkube.ABORTED_TestWorkflowStepStatus {
+		t.Fatalf("expected initialization to be aborted, got: %v", n.result.Initialization)
+	}
+}
+
+func TestNotifierEndWithExplicitAbortTerminationCodeAborts(t *testing.T) {
+	t.Parallel()
+
+	now := time.Now().UTC()
+	n := newTestNotifierWithJobTerminationCode(string(testkube.ABORTED_TestWorkflowStatus), now)
+	if got := watchers2.GetTerminationCode(n.state.Job().Original()); got != string(testkube.ABORTED_TestWorkflowStatus) {
+		t.Fatalf("expected termination code to be propagated, got: %q", got)
+	}
+
+	n.End()
+
+	if status := n.result.Steps["step-1"].Status; status == nil || (*status != testkube.ABORTED_TestWorkflowStepStatus && *status != testkube.SKIPPED_TestWorkflowStepStatus) {
+		if status == nil {
+			t.Fatalf("expected step-1 to be aborted/skipped, got nil status")
+		}
+		t.Fatalf("expected step-1 to be aborted/skipped, got: %s", *status)
+	}
+	if n.result.Initialization == nil || n.result.Initialization.Status == nil || *n.result.Initialization.Status != testkube.ABORTED_TestWorkflowStepStatus {
+		t.Fatalf("expected initialization to be aborted, got: %v", n.result.Initialization)
+	}
+}
+
+func newTestNotifierWithJobTerminationCode(terminationCode string, now time.Time) *notifier {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // avoid blocking send() in notifier during unit tests
+
+	initial := testkube.TestWorkflowResult{
+		QueuedAt:  now.Add(-3 * time.Minute),
+		StartedAt: now.Add(-2 * time.Minute),
+		Initialization: &testkube.TestWorkflowStepResult{
+			Status:    common.Ptr(testkube.RUNNING_TestWorkflowStepStatus),
+			QueuedAt:  now.Add(-2 * time.Minute),
+			StartedAt: now.Add(-2 * time.Minute),
+		},
+		Steps: map[string]testkube.TestWorkflowStepResult{
+			"step-1": {
+				Status:    common.Ptr(testkube.RUNNING_TestWorkflowStepStatus),
+				QueuedAt:  now.Add(-90 * time.Second),
+				StartedAt: now.Add(-90 * time.Second),
+			},
+		},
+	}
+	n := newNotifier(ctx, initial, now.Add(-3*time.Minute))
+
+	annotations := map[string]string{}
+	if terminationCode != "" {
+		annotations[constants2.AnnotationTerminationCode] = terminationCode
+	}
+
+	job := watchers2.NewJob(&batchv1.Job{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        "exec-id",
+			Namespace:   "testkube",
+			Annotations: annotations,
+		},
+	})
+
+	n.state = watchers2.NewExecutionState(
+		job,
+		nil,
+		watchers2.NewJobEvents(nil),
+		watchers2.NewPodEvents(nil),
+		&watchers2.ExecutionStateOptions{ScheduledAt: now.Add(-3 * time.Minute)},
+	)
+	n.sigSequence = []testkube.TestWorkflowSignature{
+		{Ref: initconstants.InitStepName, Name: "Initializing"},
+		{Ref: "step-1", Name: "Step 1"},
+	}
+
+	return n
+}

--- a/pkg/testworkflows/executionworker/controller/watchers/commons_test.go
+++ b/pkg/testworkflows/executionworker/controller/watchers/commons_test.go
@@ -1,0 +1,34 @@
+package watchers
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	batchv1 "k8s.io/api/batch/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/kubeshop/testkube/pkg/api/v1/testkube"
+	constants2 "github.com/kubeshop/testkube/pkg/testworkflows/testworkflowprocessor/constants"
+)
+
+func TestGetTerminationCode_DefaultAbortedWhenMissing(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t, string(testkube.ABORTED_TestWorkflowStatus), GetTerminationCode(nil))
+	assert.Equal(t, string(testkube.ABORTED_TestWorkflowStatus), GetTerminationCode(&batchv1.Job{}))
+	assert.Equal(t, string(testkube.ABORTED_TestWorkflowStatus), GetTerminationCode(&batchv1.Job{ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{}}}))
+}
+
+func TestGetTerminationCode_FromAnnotation(t *testing.T) {
+	t.Parallel()
+
+	job := &batchv1.Job{
+		ObjectMeta: metav1.ObjectMeta{
+			Annotations: map[string]string{
+				constants2.AnnotationTerminationCode: string(testkube.CANCELED_TestWorkflowStatus),
+			},
+		},
+	}
+
+	assert.Equal(t, string(testkube.CANCELED_TestWorkflowStatus), GetTerminationCode(job))
+}


### PR DESCRIPTION
## Pull request description 

Two fixes:
- Don't return on idleTimeout, 
- retry 3 times on idleTimeout


## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [ ] tested locally
- [ ] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Breaking changes

-

## Changes

-

## Fixes

-