### PR TITLE
fix: [TKC-5040] avoid idle timeout errors after log stream completion

### DIFF
--- a/pkg/testworkflows/executionworker/controller/logs.go
+++ b/pkg/testworkflows/executionworker/controller/logs.go
@@ -4,7 +4,6 @@ import (
 	"bufio"
 	"bytes"
 	"context"
-	"fmt"
 	"io"
 	"strings"
 	"sync"
@@ -172,7 +171,6 @@ func watchContainerLogsWithStream(parentCtx context.Context, opener logStreamOpe
 					}
 					last := time.Unix(0, atomic.LoadInt64(&lastActivity))
 					if time.Since(last) >= idleTimeout {
-						sendError(fmt.Errorf("log stream idle timeout after %s", idleTimeout))
 						ctxCancel()
 						return
 					}


### PR DESCRIPTION
## Pull request description 



## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [ ] tested locally
- [ ] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Breaking changes

-

## Changes

-

## Fixes

-