### PR TITLE
chore: update Chart.lock for mongodb and postgresql

### DIFF
--- a/k8s/helm/testkube/Chart.lock
+++ b/k8s/helm/testkube/Chart.lock
@@ -4,10 +4,10 @@ dependencies:
   version: 2.5.0-rc.0
 - name: mongodb
   repository: oci://us-east1-docker.pkg.dev/testkube-cloud-372110/testkube
-  version: 8.2.3-1
+  version: 8.2.5-0
 - name: postgresql
   repository: oci://us-east1-docker.pkg.dev/testkube-cloud-372110/testkube
-  version: 0.1.0
+  version: 18.2-0
 - name: nats
   repository: file://./charts/nats
   version: 1.2.6-4
@@ -17,5 +17,5 @@ dependencies:
 - name: global
   repository: file://../global
   version: 0.1.3
-digest: sha256:427f7570c6e49b2dc46a660597fe3dc697da13e8d587ab7baafa2d677d5bb4ab
-generated: "2026-02-25T13:07:06.628126442Z"
+digest: sha256:ece57ce94d67bb1e39668ffd3627a650b823ec13d2cd2df77a318eb019f7ee97
+generated: "2026-02-27T09:46:06.83209-03:00"


### PR DESCRIPTION
- mongodb: 8.2.3-1 → 8.2.5-0
- postgresql: 0.1.0 → 18.2-0

Made-with: Cursor

## Pull request description 



## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [ ] tested locally
- [ ] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Breaking changes

-

## Changes

-

## Fixes

-