### PR TITLE
fix: [TKC-5081] sync templates before workflows during SuperAgent migration

### DIFF
--- a/cmd/api-server/superagentmigration.go
+++ b/cmd/api-server/superagentmigration.go
@@ -177,12 +177,14 @@ func migrateSuperAgent(ctx context.Context, log superAgentMigrationLogger, cfg s
 				}
 			}
 			b.Reset()
-			for _, t := range testWorkflowList.Items {
+			// Sync templates before workflows so that template-inherited cron schedules
+			// can be resolved when the Control Plane processes workflow inserts.
+			for _, t := range testWorkflowTemplateList.Items {
 				for {
-					if err := syncStore.UpdateOrCreateTestWorkflow(ctx, t); err != nil {
+					if err := syncStore.UpdateOrCreateTestWorkflowTemplate(ctx, t); err != nil {
 						retryAfter := b.Duration()
-						log.Errorw("error updating or creating TestWorkflow, unable to migrate SuperAgent, will retry after backoff.",
-							"TestWorkflow", t.Name,
+						log.Errorw("error updating or creating TestWorkflowTemplate, unable to migrate SuperAgent, will retry after backoff.",
+							"TestWorkflowTemplate", t.Name,
 							"backoff", retryAfter,
 							"error", err.Error())
 						time.Sleep(retryAfter)
@@ -192,12 +194,12 @@ func migrateSuperAgent(ctx context.Context, log superAgentMigrationLogger, cfg s
 				}
 			}
 			b.Reset()
-			for _, t := range testWorkflowTemplateList.Items {
+			for _, t := range testWorkflowList.Items {
 				for {
-					if err := syncStore.UpdateOrCreateTestWorkflowTemplate(ctx, t); err != nil {
+					if err := syncStore.UpdateOrCreateTestWorkflow(ctx, t); err != nil {
 						retryAfter := b.Duration()
-						log.Errorw("error updating or creating TestWorkflowTemplate, unable to migrate SuperAgent, will retry after backoff.",
-							"TestWorkflowTemplate", t.Name,
+						log.Errorw("error updating or creating TestWorkflow, unable to migrate SuperAgent, will retry after backoff.",
+							"TestWorkflow", t.Name,
 							"backoff", retryAfter,
 							"error", err.Error())
 						time.Sleep(retryAfter)


### PR DESCRIPTION
## Pull request description 

### Problem

During SuperAgent migration, workflows are synced at line 180 before templates at line 195. When a workflow is inserted on the CP, `extractSchedules` resolves template references (`spec.use`) to find cron events defined in templates. If the template hasn't been synced yet, the lookup fails silently and cron schedules from that template are lost.

### Fix

Move the `testWorkflowTemplateList` sync loop before the `testWorkflowList` sync loop. This ensures templates are available in the CP database when workflows are synced and their cron schedules are extracted.

## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [ ] tested locally
- [ ] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Breaking changes

-

## Changes

-

## Fixes

-