### PR TITLE
fix: use ephemeral port for control server in tests

### DIFF
--- a/cmd/testworkflow-init/constants/addr.go
+++ b/cmd/testworkflow-init/constants/addr.go
@@ -1,5 +1,3 @@
 package constants
 
-const (
-	ControlServerPort = 60434
-)
+var ControlServerPort = 60434

--- a/cmd/testworkflow-init/control/server.go
+++ b/cmd/testworkflow-init/control/server.go
@@ -76,10 +76,9 @@ func (s *server) Listen() (func(), error) {
 	}
 	go func() {
 		for {
-			// Accept incoming connections
 			conn, err := listener.Accept()
 			if err != nil {
-				continue
+				return
 			}
 			go s.handler(conn)
 		}

--- a/internal/test/framework/init.go
+++ b/internal/test/framework/init.go
@@ -254,6 +254,8 @@ func (f *InitTestFramework) configureEnvironment() error {
 }
 
 func (f *InitTestFramework) updateGlobalConstants() {
+	constants.ControlServerPort = 0
+
 	constants.InternalPath = os.Getenv("TESTKUBE_TW_INTERNAL_PATH")
 	if constants.InternalPath == "" {
 		constants.InternalPath = "/.tktw"


### PR DESCRIPTION
## Summary
- Fix flaky `TestInitProcess` / `TestInitStateContent` / `TestInitMetrics` tests in `cmd/testworkflow-init/runner/runner_test.go`
- Tests failed intermittently with `listen tcp :60434: bind: address already in use` because the control server bound to a hardcoded port
- Change `ControlServerPort` from `const` to `var` and override to `0` (OS-assigned ephemeral port) in the test framework
- Fix goroutine leak in `control/server.go` where the `Accept` loop spun forever after `listener.Close()`

Related: #7084 (CI was failing due to this flaky test)

## Test plan
- [x] `go test -count=3 ./cmd/testworkflow-init/runner/...` passes all 3 iterations with no port conflicts
- [x] `go build ./pkg/testworkflows/executionworker/...` compiles (callers of `ControlServerPort` unaffected)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)