### PR TITLE
fix(mcp): dataPoint unmarshal for InfluxDB string-encoded values

### DIFF
--- a/pkg/mcp/formatters/workflows.go
+++ b/pkg/mcp/formatters/workflows.go
@@ -2,7 +2,9 @@ package formatters
 
 import (
 	"encoding/json"
+	"fmt"
 	"math"
+	"strconv"
 	"time"
 
 	"github.com/kubeshop/testkube/pkg/api/v1/testkube"
@@ -314,10 +316,10 @@ type formattedStepData struct {
 }
 
 type formattedMetricSeries struct {
-	Metric      string       `json:"metric"` // e.g. "cpu.millicores", "memory.used"
-	SampleCount int          `json:"sampleCount"`
-	Summary     metricStats  `json:"summary"`
-	Samples     [][2]float64 `json:"samples"` // [timestamp_ms, value]
+	Metric      string      `json:"metric"` // e.g. "cpu.millicores", "memory.used"
+	SampleCount int         `json:"sampleCount"`
+	Summary     metricStats `json:"summary"`
+	Samples     []dataPoint `json:"samples"` // [timestamp_ms, value]
 }
 
 type metricStats struct {
@@ -343,9 +345,44 @@ type linkedMetricInput struct {
 }
 
 type dataPointInput struct {
-	Measurement string       `json:"measurement"`
-	Field       string       `json:"fields"` // note: JSON key is "fields" (singular value despite plural name)
-	Values      [][2]float64 `json:"values"` // [timestamp_ms, value]
+	Measurement string      `json:"measurement"`
+	Field       string      `json:"fields"` // note: JSON key is "fields" (singular value despite plural name)
+	Values      []dataPoint `json:"values"` // [timestamp_ms, value]
+}
+
+// dataPoint is a [timestamp_ms, value] pair. Values are string-encoded in the
+// wire format (InfluxDB line protocol parses all field values as strings), so we
+// accept both JSON numbers and quoted strings.
+type dataPoint [2]float64
+
+func (dp *dataPoint) UnmarshalJSON(b []byte) error {
+	var raw [2]json.RawMessage
+	if err := json.Unmarshal(b, &raw); err != nil {
+		return err
+	}
+	ts, err := rawToFloat64(raw[0])
+	if err != nil {
+		return fmt.Errorf("dataPoint timestamp: %w", err)
+	}
+	v, err := rawToFloat64(raw[1])
+	if err != nil {
+		return fmt.Errorf("dataPoint value: %w", err)
+	}
+	dp[0] = ts
+	dp[1] = v
+	return nil
+}
+
+func rawToFloat64(raw json.RawMessage) (float64, error) {
+	var n json.Number
+	if err := json.Unmarshal(raw, &n); err == nil {
+		return n.Float64()
+	}
+	var s string
+	if err := json.Unmarshal(raw, &s); err != nil {
+		return 0, fmt.Errorf("expected number or string, got: %s", string(raw))
+	}
+	return strconv.ParseFloat(s, 64)
 }
 
 // FormatGetWorkflowExecutionMetrics formats raw /metrics API output for the AI agent.
@@ -417,7 +454,7 @@ func FormatGetWorkflowExecutionMetrics(raw string, maxSamples int) (string, erro
 }
 
 // computeStats calculates min/max/avg from a time-series of [timestamp, value] pairs.
-func computeStats(values [][2]float64) metricStats {
+func computeStats(values []dataPoint) metricStats {
 	if len(values) == 0 {
 		return metricStats{}
 	}
@@ -446,12 +483,12 @@ func computeStats(values [][2]float64) metricStats {
 
 // downsample reduces a time-series to at most maxPoints, evenly spaced.
 // Always preserves the first and last data points.
-func downsample(values [][2]float64, maxPoints int) [][2]float64 {
+func downsample(values []dataPoint, maxPoints int) []dataPoint {
 	if len(values) <= maxPoints {
 		return values
 	}
 
-	result := make([][2]float64, 0, maxPoints)
+	result := make([]dataPoint, 0, maxPoints)
 	result = append(result, values[0])
 
 	// Evenly pick interior points

--- a/pkg/mcp/formatters/workflows_test.go
+++ b/pkg/mcp/formatters/workflows_test.go
@@ -675,9 +675,9 @@ func TestFormatGetWorkflowExecutionMetrics(t *testing.T) {
 
 	t.Run("downsamples large time-series with default", func(t *testing.T) {
 		// Build a series with 200 data points (more than defaultMaxSamplesPerSeries)
-		values := make([][2]float64, 200)
+		values := make([]dataPoint, 200)
 		for i := 0; i < 200; i++ {
-			values[i] = [2]float64{float64(1000 + i*1000), float64(i)}
+			values[i] = dataPoint{float64(1000 + i*1000), float64(i)}
 		}
 		valuesJSON, _ := json.Marshal(values)
 
@@ -710,9 +710,9 @@ func TestFormatGetWorkflowExecutionMetrics(t *testing.T) {
 
 	t.Run("respects custom maxSamples parameter", func(t *testing.T) {
 		// Build a series with 100 data points
-		values := make([][2]float64, 100)
+		values := make([]dataPoint, 100)
 		for i := 0; i < 100; i++ {
-			values[i] = [2]float64{float64(1000 + i*1000), float64(i)}
+			values[i] = dataPoint{float64(1000 + i*1000), float64(i)}
 		}
 		valuesJSON, _ := json.Marshal(values)
 
@@ -784,6 +784,39 @@ func TestFormatGetWorkflowExecutionMetrics(t *testing.T) {
 		assert.Equal(t, "nunit-workflow-smoke", output.Workflow)
 		assert.Equal(t, "69a5856290fc8ddbee159e78", output.Execution)
 		assert.Empty(t, output.Steps)
+	})
+
+	t.Run("parses real wire format with string-encoded values (InfluxDB line protocol)", func(t *testing.T) {
+		// The API serializes values as [int64_timestamp, "string_float"] because
+		// InfluxDB line protocol field values are parsed as strings. This is the
+		// root cause of the original ToolException.
+		input := `{
+			"workflow": "my-workflow",
+			"execution": "exec-real",
+			"metrics": [
+				{
+					"step": "step1",
+					"data": [
+						{
+							"measurement": "cpu",
+							"fields": "millicores",
+							"values": [[1739525804000, "44.0"], [1739525805000, "46.5"], [1739525806000, "43.2"]]
+						}
+					]
+				}
+			]
+		}`
+		result, err := FormatGetWorkflowExecutionMetrics(input, 0)
+		require.NoError(t, err)
+
+		var output formattedExecutionMetrics
+		err = json.Unmarshal([]byte(result), &output)
+		require.NoError(t, err)
+		require.Len(t, output.Steps, 1)
+		series := output.Steps[0].Series[0]
+		assert.Equal(t, 3, series.SampleCount)
+		assert.Equal(t, 43.2, series.Summary.Min)
+		assert.Equal(t, 46.5, series.Summary.Max)
 	})
 
 	t.Run("returns error for invalid JSON", func(t *testing.T) {


### PR DESCRIPTION
### What 

`get_workflow_execution_metrics` was throwing a `ToolException` when executions had real telemetry data:

```
json: cannot unmarshal string into Go struct field
dataPointInput.metrics.data.values of type float64
```

The metrics endpoint serializes values as `[timestamp_int, "value_string"]` — InfluxDB line protocol parses all field values as plain strings, so they arrive JSON-encoded as quoted strings, not numbers. The formatter expected `[][2]float64` and failed on any real data.

### Changes

- Replaced `[][2]float64` with a `dataPoint` type that has a custom `UnmarshalJSON` accepting both JSON numbers and quoted strings (number-first, string fallback via `strconv.ParseFloat`)
- Updated `computeStats` and `downsample` signatures accordingly
- Added a test using the actual wire format `[[timestamp, "value_string"]]` that would have caught the original regression

### Why
The formatter had never been tested against real API output — only against Go-constructed float64 slices. Any execution with actual resource metrics collected would have failed with the `ToolException`. This was a silent data layer bug: the feature appeared to work in unit tests but was broken end-to-end.