### PR TITLE
chore: remove broad testkube group from test owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,6 +1,6 @@
 * @kubeshop/testkube-backend
 
-/test/ @kubeshop/testkube-qa @kubeshop/testkube
+/test/ @kubeshop/testkube-qa
 
 /.github/ @kubeshop/testkube-devops
 /goreleaser_files/ @kubeshop/testkube-devops


### PR DESCRIPTION
`@kubeshop/testkube` has too many people in it, `@kubeshop/testkube-qa` is the appropriate group.