### PR TITLE
chore: change backend team to /test CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,6 +1,6 @@
 * @kubeshop/testkube-backend
 
-/test/ @kubeshop/testkube-qa
+/test/ @kubeshop/testkube-qa @kubeshop/testkube-backend
 
 /.github/ @kubeshop/testkube-devops
 /goreleaser_files/ @kubeshop/testkube-devops


### PR DESCRIPTION
## Summary
- update .github/CODEOWNERS
- change /test/ ownership from @kubeshop/testkube-qa @kubeshop/testkube to @kubeshop/testkube-qa

## Validation
- reviewed diff