### PR TITLE
fix: [TKC-5104] add gitops watcher RBAC for workflow templates

### DIFF
--- a/k8s/helm/testkube-runner/templates/_helpers.tpl
+++ b/k8s/helm/testkube-runner/templates/_helpers.tpl
@@ -184,6 +184,7 @@ rules:
       - "testworkflows.testkube.io"
     resources:
       - testworkflows
+      - testworkflowtemplates
     verbs:
       - get
       - list


### PR DESCRIPTION
## Summary
- add missing watcher RBAC permission for `testworkflowtemplates` in runner Helm helpers
- keep watcher role aligned with GitOps-synced resources

## Context
GitOps-enabled runner failed to watch/list `testworkflowtemplates.testworkflows.testkube.io` due to missing RBAC.

## Linear
- TKC-5104
