### PR TITLE
fix: Make NATS emitter self-healing after connection loss

### DIFF
--- a/cmd/api-server/commons/commons.go
+++ b/cmd/api-server/commons/commons.go
@@ -340,7 +340,11 @@ func ReadProContext(ctx context.Context, cfg *config.Config, grpcClient cloud.Te
 	return proContext, nil
 }
 
-func MustCreateNATSConnection(cfg *config.Config) *nats.EncodedConn { //nolint:staticcheck
+// MustCreateNATSConnection returns both the encoded connection and the
+// ConnectionConfig it was built from, so callers can pass the config on to
+// NATSBus without constructing it a second time (which risks drift when new
+// fields are added to ConnectionConfig).
+func MustCreateNATSConnection(cfg *config.Config) (*nats.EncodedConn, bus.ConnectionConfig) { //nolint:staticcheck
 	// if embedded NATS server is enabled, we'll replace connection with one to the embedded server
 	if cfg.NatsEmbedded {
 		_, nc, err := event.ServerWithConnection(cfg.NatsEmbeddedStoreDir)
@@ -350,10 +354,11 @@ func MustCreateNATSConnection(cfg *config.Config) *nats.EncodedConn { //nolint:s
 
 		conn, err := nats.NewEncodedConn(nc, nats.JSON_ENCODER) //nolint:staticcheck
 		ExitOnError("creating NATS connection", err)
-		return conn
+		// Embedded connections have no external URI; return empty config.
+		return conn, bus.ConnectionConfig{}
 	}
 
-	conn, err := bus.NewNATSEncodedConnection(bus.ConnectionConfig{
+	natsCfg := bus.ConnectionConfig{
 		NatsURI:            cfg.NatsURI,
 		NatsSecure:         cfg.NatsSecure,
 		NatsSkipVerify:     cfg.NatsSkipVerify,
@@ -361,9 +366,10 @@ func MustCreateNATSConnection(cfg *config.Config) *nats.EncodedConn { //nolint:s
 		NatsKeyFile:        cfg.NatsKeyFile,
 		NatsCAFile:         cfg.NatsCAFile,
 		NatsConnectTimeout: cfg.NatsConnectTimeout,
-	})
+	}
+	conn, err := bus.NewNATSEncodedConnection(natsCfg)
 	ExitOnError("creating NATS connection", err)
-	return conn
+	return conn, natsCfg
 }
 
 // Components

--- a/cmd/api-server/main.go
+++ b/cmd/api-server/main.go
@@ -166,16 +166,7 @@ func main() {
 	metrics := metrics.NewMetrics()
 
 	log.DefaultLogger.Info("connecting to NATS...")
-	natsCfg := bus.ConnectionConfig{
-		NatsURI:            cfg.NatsURI,
-		NatsSecure:         cfg.NatsSecure,
-		NatsSkipVerify:     cfg.NatsSkipVerify,
-		NatsCertFile:       cfg.NatsCertFile,
-		NatsKeyFile:        cfg.NatsKeyFile,
-		NatsCAFile:         cfg.NatsCAFile,
-		NatsConnectTimeout: cfg.NatsConnectTimeout,
-	}
-	nc := commons.MustCreateNATSConnection(cfg)
+	nc, natsCfg := commons.MustCreateNATSConnection(cfg)
 	log.DefaultLogger.Infow("connected to NATS successfully", "embedded", cfg.NatsEmbedded, "uri", cfg.NatsURI)
 
 	eventBus := bus.NewNATSBus(nc, natsCfg)

--- a/cmd/api-server/main.go
+++ b/cmd/api-server/main.go
@@ -166,10 +166,19 @@ func main() {
 	metrics := metrics.NewMetrics()
 
 	log.DefaultLogger.Info("connecting to NATS...")
+	natsCfg := bus.ConnectionConfig{
+		NatsURI:            cfg.NatsURI,
+		NatsSecure:         cfg.NatsSecure,
+		NatsSkipVerify:     cfg.NatsSkipVerify,
+		NatsCertFile:       cfg.NatsCertFile,
+		NatsKeyFile:        cfg.NatsKeyFile,
+		NatsCAFile:         cfg.NatsCAFile,
+		NatsConnectTimeout: cfg.NatsConnectTimeout,
+	}
 	nc := commons.MustCreateNATSConnection(cfg)
 	log.DefaultLogger.Infow("connected to NATS successfully", "embedded", cfg.NatsEmbedded, "uri", cfg.NatsURI)
 
-	eventBus := bus.NewNATSBus(nc)
+	eventBus := bus.NewNATSBus(nc, natsCfg)
 	if cfg.Trace {
 		eventBus.TraceEvents()
 	}

--- a/pkg/event/bus/nats.go
+++ b/pkg/event/bus/nats.go
@@ -44,9 +44,13 @@ func optsFromConfig(cfg ConnectionConfig) (opts []nats.Option) {
 	opts = []nats.Option{
 		// Never stop trying to reconnect — the process should not require a restart
 		// due to a transient NATS outage.
+		// Note: RetryOnFailedConnect is intentionally omitted. It would make
+		// nats.Connect() return nil on an unreachable server, silently disabling
+		// the retry.DoWithData startup loop and removing crash-on-startup behaviour.
+		// MaxReconnects(-1) covers all runtime reconnection; startup retries are
+		// handled by the caller's retry loop.
 		nats.MaxReconnects(-1),
 		nats.ReconnectWait(2 * time.Second),
-		nats.RetryOnFailedConnect(true),
 	}
 
 	if cfg.NatsSecure {
@@ -172,10 +176,11 @@ func (n *NATSBus) reconnect() error {
 	if err != nil {
 		return fmt.Errorf("nats reconnect failed: %w", err)
 	}
-	n.nc = conn
 
-	// Re-register every subscription on the new connection.  Without this step
-	// all consumers would silently stop receiving events after a reconnect.
+	// Re-register subscriptions BEFORE exposing conn via n.nc.  This closes the
+	// window where the new connection is live but has no handlers — messages
+	// published to subscribed topics during that gap would otherwise be silently
+	// discarded by the NATS server.
 	n.subscriptions.Range(func(key, value any) bool {
 		entry := value.(*subscriptionEntry)
 
@@ -202,6 +207,7 @@ func (n *NATSBus) reconnect() error {
 		return true
 	})
 
+	n.nc = conn
 	return nil
 }
 

--- a/pkg/event/bus/nats.go
+++ b/pkg/event/bus/nats.go
@@ -28,6 +28,9 @@ const (
 	SubscriptionName       = "agentevents"
 	InternalPublishTopic   = "internal.all"
 	InternalSubscribeTopic = "internal.>"
+
+	natsMaxReconnects = -1
+	natsReconnectWait = 2 * time.Second
 )
 
 type ConnectionConfig struct {
@@ -49,8 +52,8 @@ func optsFromConfig(cfg ConnectionConfig) (opts []nats.Option) {
 		// the retry.DoWithData startup loop and removing crash-on-startup behaviour.
 		// MaxReconnects(-1) covers all runtime reconnection; startup retries are
 		// handled by the caller's retry loop.
-		nats.MaxReconnects(-1),
-		nats.ReconnectWait(2 * time.Second),
+		nats.MaxReconnects(natsMaxReconnects),
+		nats.ReconnectWait(natsReconnectWait),
 	}
 
 	if cfg.NatsSecure {
@@ -139,9 +142,16 @@ type subscriptionEntry struct {
 type NATSBus struct {
 	nc            *nats.EncodedConn
 	cfg           ConnectionConfig
-	mu            sync.RWMutex
-	reconnectMu   sync.Mutex // serialises reconnect attempts; never held while mu is held
+	connMu        sync.RWMutex
+	reconnectMu   sync.Mutex // serialises reconnect attempts; never held while connMu is held
 	subscriptions sync.Map   // map[string]*subscriptionEntry
+}
+
+// getNC returns the current encoded connection under a read lock.
+func (n *NATSBus) getNC() *nats.EncodedConn {
+	n.connMu.RLock()
+	defer n.connMu.RUnlock()
+	return n.nc
 }
 
 // Publish publishes event to NATS on events topic
@@ -160,7 +170,7 @@ func (n *NATSBus) Subscribe(queueName string, handler Handler) error {
 // Design notes:
 //   - reconnectMu serialises concurrent reconnect attempts so only one goroutine
 //     pays the cost of NewNATSEncodedConnection's retry loop at a time.
-//   - n.mu (the read/write lock guarding n.nc) is held only for the final
+//   - connMu (the read/write lock guarding n.nc) is held only for the final
 //     pointer swap, so publishers are not stalled for the full retry duration.
 //   - CompareAndSwap is used when updating subscription entries so that a
 //     concurrent Unsubscribe (which calls LoadAndDelete) wins: if the key was
@@ -178,10 +188,7 @@ func (n *NATSBus) reconnect() error {
 
 	// Re-check now that we hold reconnectMu: a previous waiter may have
 	// already swapped in a healthy connection.
-	n.mu.RLock()
-	closed := n.nc.Conn.IsClosed()
-	n.mu.RUnlock()
-	if !closed {
+	if !n.getNC().Conn.IsClosed() {
 		return nil
 	}
 
@@ -200,6 +207,7 @@ func (n *NATSBus) reconnect() error {
 	// Re-register subscriptions on the new connection BEFORE exposing it via
 	// n.nc.  This closes the window where messages could arrive on a topic that
 	// has no handler yet.
+	var failedKeys []any
 	n.subscriptions.Range(func(key, value any) bool {
 		entry := value.(*subscriptionEntry)
 
@@ -215,6 +223,9 @@ func (n *NATSBus) reconnect() error {
 				"topic", entry.topic,
 				"queue", entry.queue,
 				"error", serr)
+			// Mark for removal: leaving a stale entry would cause silent message
+			// loss and unexpected Drain() calls on dead subscriptions.
+			failedKeys = append(failedKeys, key)
 			return true
 		}
 
@@ -234,10 +245,14 @@ func (n *NATSBus) reconnect() error {
 		return true
 	})
 
+	for _, key := range failedKeys {
+		n.subscriptions.Delete(key)
+	}
+
 	// Hold the write lock only for the pointer swap.
-	n.mu.Lock()
+	n.connMu.Lock()
 	n.nc = conn
-	n.mu.Unlock()
+	n.connMu.Unlock()
 	return nil
 }
 
@@ -247,10 +262,7 @@ func (n *NATSBus) reconnect() error {
 func (n *NATSBus) PublishTopic(topic string, event testkube.Event) error {
 	log.Tracew(log.DefaultLogger, "publishing event", event.Log()...)
 
-	n.mu.RLock()
-	nc := n.nc
-	n.mu.RUnlock()
-
+	nc := n.getNC()
 	err := nc.Publish(topic, event)
 	if err == nil {
 		return nil
@@ -274,11 +286,7 @@ func (n *NATSBus) PublishTopic(topic string, event testkube.Event) error {
 		return fmt.Errorf("nats publish failed, reconnect error: %w", rerr)
 	}
 
-	n.mu.RLock()
-	nc = n.nc
-	n.mu.RUnlock()
-
-	return nc.Publish(topic, event)
+	return n.getNC().Publish(topic, event)
 }
 
 // SubscribeTopic subscribes to NATS topic.
@@ -288,26 +296,19 @@ func (n *NATSBus) SubscribeTopic(topic, queueName string, handler Handler) error
 	// sanitize names for NATS
 	queue := common.ListenerName(queueName)
 
-	n.mu.RLock()
-	nc := n.nc
-	n.mu.RUnlock()
-
 	// async subscribe on queue
-	s, err := nc.QueueSubscribe(topic, queue, handler)
+	s, err := n.getNC().QueueSubscribe(topic, queue, handler)
+	if err != nil && !errors.Is(err, nats.ErrConnectionClosed) {
+		return err
+	}
 	if err != nil {
-		if !errors.Is(err, nats.ErrConnectionClosed) {
-			return err
-		}
 		log.DefaultLogger.Warnw("nats connection closed during subscribe, attempting reconnect",
 			"topic", topic,
 			"error_type", "nats_connection_closed")
 		if rerr := n.reconnect(); rerr != nil {
 			return fmt.Errorf("nats subscribe failed, reconnect error: %w", rerr)
 		}
-		n.mu.RLock()
-		nc = n.nc
-		n.mu.RUnlock()
-		s, err = nc.QueueSubscribe(topic, queue, handler)
+		s, err = n.getNC().QueueSubscribe(topic, queue, handler)
 		if err != nil {
 			return err
 		}
@@ -336,10 +337,7 @@ func (n *NATSBus) Unsubscribe(queueName string) error {
 }
 
 func (n *NATSBus) Close() error {
-	n.mu.RLock()
-	nc := n.nc
-	n.mu.RUnlock()
-	nc.Close()
+	n.getNC().Close()
 	return nil
 }
 
@@ -348,17 +346,13 @@ func (n *NATSBus) queueName(subscription, queue string) string {
 }
 
 func (n *NATSBus) TraceEvents() {
-	n.mu.RLock()
-	nc := n.nc
-	n.mu.RUnlock()
-
 	topic := SubscriptionName + ".>"
 	handler := Handler(func(event testkube.Event) error {
 		log.Tracew(log.DefaultLogger, "all events.> trace", event.Log()...)
 		return nil
 	})
 
-	s, err := nc.Subscribe(topic, handler)
+	s, err := n.getNC().Subscribe(topic, handler)
 	if err != nil {
 		log.DefaultLogger.Errorw("error subscribing to all events", "error", err)
 		return

--- a/pkg/event/bus/nats.go
+++ b/pkg/event/bus/nats.go
@@ -275,7 +275,7 @@ func (n *NATSBus) Unsubscribe(queueName string) error {
 	queue := common.ListenerName(queueName)
 
 	key := n.queueName(SubscriptionName, queue)
-	if v, ok := n.subscriptions.Load(key); ok {
+	if v, ok := n.subscriptions.LoadAndDelete(key); ok {
 		return v.(*subscriptionEntry).sub.Drain()
 	}
 	return nil

--- a/pkg/event/bus/nats.go
+++ b/pkg/event/bus/nats.go
@@ -277,7 +277,10 @@ func (n *NATSBus) Unsubscribe(queueName string) error {
 }
 
 func (n *NATSBus) Close() error {
-	n.nc.Close()
+	n.mu.RLock()
+	nc := n.nc
+	n.mu.RUnlock()
+	nc.Close()
 	return nil
 }
 
@@ -286,7 +289,11 @@ func (n *NATSBus) queueName(subscription, queue string) string {
 }
 
 func (n *NATSBus) TraceEvents() {
-	s, err := n.nc.Subscribe(SubscriptionName+".>", func(event testkube.Event) {
+	n.mu.RLock()
+	nc := n.nc
+	n.mu.RUnlock()
+
+	s, err := nc.Subscribe(SubscriptionName+".>", func(event testkube.Event) {
 		log.Tracew(log.DefaultLogger, "all events.> trace", event.Log()...)
 	})
 

--- a/pkg/event/bus/nats.go
+++ b/pkg/event/bus/nats.go
@@ -140,7 +140,8 @@ type NATSBus struct {
 	nc            *nats.EncodedConn
 	cfg           ConnectionConfig
 	mu            sync.RWMutex
-	subscriptions sync.Map // map[string]*subscriptionEntry
+	reconnectMu   sync.Mutex // serialises reconnect attempts; never held while mu is held
+	subscriptions sync.Map   // map[string]*subscriptionEntry
 }
 
 // Publish publishes event to NATS on events topic
@@ -155,32 +156,50 @@ func (n *NATSBus) Subscribe(queueName string, handler Handler) error {
 
 // reconnect replaces the underlying connection when it has been permanently
 // closed.  Callers must NOT hold n.mu when calling this.
+//
+// Design notes:
+//   - reconnectMu serialises concurrent reconnect attempts so only one goroutine
+//     pays the cost of NewNATSEncodedConnection's retry loop at a time.
+//   - n.mu (the read/write lock guarding n.nc) is held only for the final
+//     pointer swap, so publishers are not stalled for the full retry duration.
+//   - CompareAndSwap is used when updating subscription entries so that a
+//     concurrent Unsubscribe (which calls LoadAndDelete) wins: if the key was
+//     deleted between Range seeing it and the Store, the orphan subscription is
+//     drained rather than re-inserted.
 func (n *NATSBus) reconnect() error {
-	n.mu.Lock()
-	defer n.mu.Unlock()
-
-	// Another goroutine may have already reconnected while we waited for the lock.
-	if !n.nc.Conn.IsClosed() {
-		return nil
-	}
-
 	if n.cfg.NatsURI == "" {
 		return errors.New("nats reconnect: no URI configured (embedded connection cannot reconnect)")
+	}
+
+	// Serialise reconnect attempts.  If two goroutines both detect
+	// ErrConnectionClosed, only one should create a new connection.
+	n.reconnectMu.Lock()
+	defer n.reconnectMu.Unlock()
+
+	// Re-check now that we hold reconnectMu: a previous waiter may have
+	// already swapped in a healthy connection.
+	n.mu.RLock()
+	closed := n.nc.Conn.IsClosed()
+	n.mu.RUnlock()
+	if !closed {
+		return nil
 	}
 
 	log.DefaultLogger.Warnw("nats connection is closed, reinitialising",
 		"error_type", "nats_connection_closed",
 		"url", n.cfg.NatsURI)
 
+	// Create the new connection outside every lock so that publishers are not
+	// stalled during the (potentially slow) retry loop inside
+	// NewNATSEncodedConnection.
 	conn, err := NewNATSEncodedConnection(n.cfg)
 	if err != nil {
 		return fmt.Errorf("nats reconnect failed: %w", err)
 	}
 
-	// Re-register subscriptions BEFORE exposing conn via n.nc.  This closes the
-	// window where the new connection is live but has no handlers — messages
-	// published to subscribed topics during that gap would otherwise be silently
-	// discarded by the NATS server.
+	// Re-register subscriptions on the new connection BEFORE exposing it via
+	// n.nc.  This closes the window where messages could arrive on a topic that
+	// has no handler yet.
 	n.subscriptions.Range(func(key, value any) bool {
 		entry := value.(*subscriptionEntry)
 
@@ -198,16 +217,27 @@ func (n *NATSBus) reconnect() error {
 				"error", serr)
 			return true
 		}
-		n.subscriptions.Store(key, &subscriptionEntry{
+
+		newEntry := &subscriptionEntry{
 			topic:   entry.topic,
 			queue:   entry.queue,
 			handler: entry.handler,
 			sub:     newSub,
-		})
+		}
+		// CompareAndSwap against the exact pointer seen by Range.  If
+		// Unsubscribe ran LoadAndDelete between Range seeing this entry and now,
+		// the swap will fail and we drain the orphan subscription rather than
+		// silently re-inserting a ghost entry that can never be removed.
+		if !n.subscriptions.CompareAndSwap(key, value, newEntry) {
+			_ = newSub.Drain()
+		}
 		return true
 	})
 
+	// Hold the write lock only for the pointer swap.
+	n.mu.Lock()
 	n.nc = conn
+	n.mu.Unlock()
 	return nil
 }
 
@@ -251,7 +281,9 @@ func (n *NATSBus) PublishTopic(topic string, event testkube.Event) error {
 	return nc.Publish(topic, event)
 }
 
-// SubscribeTopic subscribes to NATS topic
+// SubscribeTopic subscribes to NATS topic.
+// If the connection is permanently closed it attempts a single reconnect before
+// giving up, mirroring the self-healing behaviour of PublishTopic.
 func (n *NATSBus) SubscribeTopic(topic, queueName string, handler Handler) error {
 	// sanitize names for NATS
 	queue := common.ListenerName(queueName)
@@ -262,18 +294,34 @@ func (n *NATSBus) SubscribeTopic(topic, queueName string, handler Handler) error
 
 	// async subscribe on queue
 	s, err := nc.QueueSubscribe(topic, queue, handler)
-	if err == nil {
-		// store topic, queue, and handler so reconnect() can re-register them
-		key := n.queueName(SubscriptionName, queue)
-		n.subscriptions.Store(key, &subscriptionEntry{
-			topic:   topic,
-			queue:   queue,
-			handler: handler,
-			sub:     s,
-		})
+	if err != nil {
+		if !errors.Is(err, nats.ErrConnectionClosed) {
+			return err
+		}
+		log.DefaultLogger.Warnw("nats connection closed during subscribe, attempting reconnect",
+			"topic", topic,
+			"error_type", "nats_connection_closed")
+		if rerr := n.reconnect(); rerr != nil {
+			return fmt.Errorf("nats subscribe failed, reconnect error: %w", rerr)
+		}
+		n.mu.RLock()
+		nc = n.nc
+		n.mu.RUnlock()
+		s, err = nc.QueueSubscribe(topic, queue, handler)
+		if err != nil {
+			return err
+		}
 	}
 
-	return err
+	// store topic, queue, and handler so reconnect() can re-register them
+	key := n.queueName(SubscriptionName, queue)
+	n.subscriptions.Store(key, &subscriptionEntry{
+		topic:   topic,
+		queue:   queue,
+		handler: handler,
+		sub:     s,
+	})
+	return nil
 }
 
 func (n *NATSBus) Unsubscribe(queueName string) error {

--- a/pkg/event/bus/nats.go
+++ b/pkg/event/bus/nats.go
@@ -68,8 +68,6 @@ func optsFromConfig(cfg ConnectionConfig) (opts []nats.Option) {
 }
 
 func NewNATSEncodedConnection(cfg ConnectionConfig, opts ...nats.Option) (*nats.EncodedConn, error) {
-	opts = append(opts, optsFromConfig(cfg)...)
-
 	nc, err := NewNATSConnection(cfg, opts...)
 	if err != nil {
 		log.DefaultLogger.Fatalw("error connecting to nats", "error", err)
@@ -133,9 +131,10 @@ func NewNATSBus(nc *nats.EncodedConn, cfg ConnectionConfig) *NATSBus {
 
 // subscriptionEntry holds everything needed to re-register a subscription on a
 // fresh connection after a reconnect.
+// When queue is empty a plain Subscribe is used; otherwise QueueSubscribe.
 type subscriptionEntry struct {
 	topic   string
-	queue   string
+	queue   string // empty → plain Subscribe, non-empty → QueueSubscribe
 	handler Handler
 	sub     *nats.Subscription
 }
@@ -186,7 +185,14 @@ func (n *NATSBus) reconnect() error {
 	// all consumers would silently stop receiving events after a reconnect.
 	n.subscriptions.Range(func(key, value any) bool {
 		entry := value.(*subscriptionEntry)
-		newSub, serr := conn.QueueSubscribe(entry.topic, entry.queue, entry.handler)
+
+		var newSub *nats.Subscription
+		var serr error
+		if entry.queue == "" {
+			newSub, serr = conn.Subscribe(entry.topic, entry.handler)
+		} else {
+			newSub, serr = conn.QueueSubscribe(entry.topic, entry.queue, entry.handler)
+		}
 		if serr != nil {
 			log.DefaultLogger.Errorw("failed to re-register subscription after nats reconnect",
 				"topic", entry.topic,
@@ -293,14 +299,25 @@ func (n *NATSBus) TraceEvents() {
 	nc := n.nc
 	n.mu.RUnlock()
 
-	s, err := nc.Subscribe(SubscriptionName+".>", func(event testkube.Event) {
+	topic := SubscriptionName + ".>"
+	handler := Handler(func(event testkube.Event) error {
 		log.Tracew(log.DefaultLogger, "all events.> trace", event.Log()...)
+		return nil
 	})
 
+	s, err := nc.Subscribe(topic, handler)
 	if err != nil {
 		log.DefaultLogger.Errorw("error subscribing to all events", "error", err)
 		return
 	}
+
+	// Store with empty queue so reconnect() re-registers it via plain Subscribe.
+	n.subscriptions.Store("trace:"+topic, &subscriptionEntry{
+		topic:   topic,
+		queue:   "",
+		handler: handler,
+		sub:     s,
+	})
 
 	log.DefaultLogger.Infow("subscribed to all events", "subscription", s.Subject)
 }

--- a/pkg/event/bus/nats.go
+++ b/pkg/event/bus/nats.go
@@ -3,6 +3,7 @@ package bus
 
 import (
 	"crypto/tls"
+	"errors"
 	"fmt"
 	"sync"
 	"time"
@@ -40,7 +41,14 @@ type ConnectionConfig struct {
 }
 
 func optsFromConfig(cfg ConnectionConfig) (opts []nats.Option) {
-	opts = []nats.Option{}
+	opts = []nats.Option{
+		// Never stop trying to reconnect — the process should not require a restart
+		// due to a transient NATS outage.
+		nats.MaxReconnects(-1),
+		nats.ReconnectWait(2 * time.Second),
+		nats.RetryOnFailedConnect(true),
+	}
+
 	if cfg.NatsSecure {
 		if cfg.NatsSkipVerify {
 			opts = append(opts, nats.Secure(&tls.Config{InsecureSkipVerify: true}))
@@ -84,6 +92,21 @@ func NewNATSEncodedConnection(cfg ConnectionConfig, opts ...nats.Option) (*nats.
 
 func NewNATSConnection(cfg ConnectionConfig, opts ...nats.Option) (*nats.Conn, error) {
 	opts = append(opts, optsFromConfig(cfg)...)
+	opts = append(opts,
+		nats.DisconnectErrHandler(func(_ *nats.Conn, err error) {
+			log.DefaultLogger.Warnw("nats disconnected",
+				"error_type", "nats_connection_closed",
+				"error", err)
+		}),
+		nats.ReconnectHandler(func(nc *nats.Conn) {
+			log.DefaultLogger.Infow("nats reconnected",
+				"url", nc.ConnectedUrl())
+		}),
+		nats.ClosedHandler(func(_ *nats.Conn) {
+			log.DefaultLogger.Errorw("nats connection permanently closed",
+				"error_type", "nats_connection_closed")
+		}),
+	)
 
 	nc, err := retry.DoWithData(
 		func() (*nats.Conn, error) {
@@ -101,14 +124,17 @@ func NewNATSConnection(cfg ConnectionConfig, opts ...nats.Option) (*nats.Conn, e
 	return nc, nil
 }
 
-func NewNATSBus(nc *nats.EncodedConn) *NATSBus {
+func NewNATSBus(nc *nats.EncodedConn, cfg ConnectionConfig) *NATSBus {
 	return &NATSBus{
-		nc: nc,
+		nc:  nc,
+		cfg: cfg,
 	}
 }
 
 type NATSBus struct {
 	nc            *nats.EncodedConn
+	cfg           ConnectionConfig
+	mu            sync.RWMutex
 	subscriptions sync.Map
 }
 
@@ -122,10 +148,65 @@ func (n *NATSBus) Subscribe(queueName string, handler Handler) error {
 	return n.SubscribeTopic(SubscriptionName, queueName, handler)
 }
 
-// PublishTopic publishes event to NATS on given topic
+// reconnect replaces the underlying connection when it has been permanently
+// closed.  Callers must NOT hold n.mu when calling this.
+func (n *NATSBus) reconnect() error {
+	n.mu.Lock()
+	defer n.mu.Unlock()
+
+	// Another goroutine may have already reconnected while we waited for the lock.
+	if !n.nc.Conn.IsClosed() {
+		return nil
+	}
+
+	if n.cfg.NatsURI == "" {
+		return errors.New("nats reconnect: no URI configured (embedded connection cannot reconnect)")
+	}
+
+	log.DefaultLogger.Warnw("nats connection is closed, reinitialising",
+		"error_type", "nats_connection_closed",
+		"url", n.cfg.NatsURI)
+
+	conn, err := NewNATSEncodedConnection(n.cfg)
+	if err != nil {
+		return fmt.Errorf("nats reconnect failed: %w", err)
+	}
+	n.nc = conn
+	return nil
+}
+
+// PublishTopic publishes event to NATS on given topic.
+// If the connection is permanently closed it attempts a single reconnect before
+// giving up, so a transient NATS restart does not require a pod restart.
 func (n *NATSBus) PublishTopic(topic string, event testkube.Event) error {
 	log.Tracew(log.DefaultLogger, "publishing event", event.Log()...)
-	return n.nc.Publish(topic, event)
+
+	n.mu.RLock()
+	nc := n.nc
+	n.mu.RUnlock()
+
+	err := nc.Publish(topic, event)
+	if err == nil {
+		return nil
+	}
+
+	if !errors.Is(err, nats.ErrConnectionClosed) {
+		return err
+	}
+
+	log.DefaultLogger.Warnw("nats connection closed during publish, attempting reconnect",
+		"topic", topic,
+		"error_type", "nats_connection_closed")
+
+	if rerr := n.reconnect(); rerr != nil {
+		return fmt.Errorf("nats publish failed, reconnect error: %w", rerr)
+	}
+
+	n.mu.RLock()
+	nc = n.nc
+	n.mu.RUnlock()
+
+	return nc.Publish(topic, event)
 }
 
 // SubscribeTopic subscribes to NATS topic

--- a/pkg/event/bus/nats.go
+++ b/pkg/event/bus/nats.go
@@ -70,19 +70,13 @@ func optsFromConfig(cfg ConnectionConfig) (opts []nats.Option) {
 func NewNATSEncodedConnection(cfg ConnectionConfig, opts ...nats.Option) (*nats.EncodedConn, error) {
 	nc, err := NewNATSConnection(cfg, opts...)
 	if err != nil {
-		log.DefaultLogger.Fatalw("error connecting to nats", "error", err)
 		return nil, err
 	}
 
 	// automatic NATS JSON CODEC
 	ec, err := nats.NewEncodedConn(nc, nats.JSON_ENCODER)
 	if err != nil {
-		log.DefaultLogger.Fatalw("error connecting to nats", "error", err)
 		return nil, err
-	}
-
-	if err != nil {
-		log.DefaultLogger.Errorw("error creating NATS connection", "error", err)
 	}
 
 	return ec, nil
@@ -115,7 +109,6 @@ func NewNATSConnection(cfg ConnectionConfig, opts ...nats.Option) (*nats.Conn, e
 		retry.Attempts(NATS_RETRY_ATTEMPTS),
 	)
 	if err != nil {
-		log.DefaultLogger.Fatalw("error connecting to nats", "error", err)
 		return nil, err
 	}
 
@@ -231,6 +224,12 @@ func (n *NATSBus) PublishTopic(topic string, event testkube.Event) error {
 		return err
 	}
 
+	// ErrConnectionClosed means the connection is permanently gone — not a
+	// transient blip.  With MaxReconnects(-1) the NATS library handles transient
+	// outages internally (buffering publishes while reconnecting), so this path
+	// is a last-resort safety net for the rare case where the connection object
+	// itself must be replaced (e.g. after an explicit Close or an unforeseen
+	// client state machine edge-case).
 	log.DefaultLogger.Warnw("nats connection closed during publish, attempting reconnect",
 		"topic", topic,
 		"error_type", "nats_connection_closed")

--- a/pkg/event/bus/nats.go
+++ b/pkg/event/bus/nats.go
@@ -165,7 +165,7 @@ func (n *NATSBus) Subscribe(queueName string, handler Handler) error {
 }
 
 // reconnect replaces the underlying connection when it has been permanently
-// closed.  Callers must NOT hold n.mu when calling this.
+// closed.  Callers must NOT hold n.connMu when calling this.
 //
 // Design notes:
 //   - reconnectMu serialises concurrent reconnect attempts so only one goroutine
@@ -196,9 +196,10 @@ func (n *NATSBus) reconnect() error {
 		"error_type", "nats_connection_closed",
 		"url", n.cfg.NatsURI)
 
-	// Create the new connection outside every lock so that publishers are not
+	// Create the new connection outside connMu so that publishers are not
 	// stalled during the (potentially slow) retry loop inside
-	// NewNATSEncodedConnection.
+	// NewNATSEncodedConnection.  (reconnectMu is still held to serialise
+	// concurrent reconnect attempts.)
 	conn, err := NewNATSEncodedConnection(n.cfg)
 	if err != nil {
 		return fmt.Errorf("nats reconnect failed: %w", err)

--- a/pkg/event/bus/nats.go
+++ b/pkg/event/bus/nats.go
@@ -131,11 +131,20 @@ func NewNATSBus(nc *nats.EncodedConn, cfg ConnectionConfig) *NATSBus {
 	}
 }
 
+// subscriptionEntry holds everything needed to re-register a subscription on a
+// fresh connection after a reconnect.
+type subscriptionEntry struct {
+	topic   string
+	queue   string
+	handler Handler
+	sub     *nats.Subscription
+}
+
 type NATSBus struct {
 	nc            *nats.EncodedConn
 	cfg           ConnectionConfig
 	mu            sync.RWMutex
-	subscriptions sync.Map
+	subscriptions sync.Map // map[string]*subscriptionEntry
 }
 
 // Publish publishes event to NATS on events topic
@@ -172,6 +181,28 @@ func (n *NATSBus) reconnect() error {
 		return fmt.Errorf("nats reconnect failed: %w", err)
 	}
 	n.nc = conn
+
+	// Re-register every subscription on the new connection.  Without this step
+	// all consumers would silently stop receiving events after a reconnect.
+	n.subscriptions.Range(func(key, value any) bool {
+		entry := value.(*subscriptionEntry)
+		newSub, serr := conn.QueueSubscribe(entry.topic, entry.queue, entry.handler)
+		if serr != nil {
+			log.DefaultLogger.Errorw("failed to re-register subscription after nats reconnect",
+				"topic", entry.topic,
+				"queue", entry.queue,
+				"error", serr)
+			return true
+		}
+		n.subscriptions.Store(key, &subscriptionEntry{
+			topic:   entry.topic,
+			queue:   entry.queue,
+			handler: entry.handler,
+			sub:     newSub,
+		})
+		return true
+	})
+
 	return nil
 }
 
@@ -214,13 +245,21 @@ func (n *NATSBus) SubscribeTopic(topic, queueName string, handler Handler) error
 	// sanitize names for NATS
 	queue := common.ListenerName(queueName)
 
-	// async subscribe on queue
-	s, err := n.nc.QueueSubscribe(topic, queue, handler)
+	n.mu.RLock()
+	nc := n.nc
+	n.mu.RUnlock()
 
+	// async subscribe on queue
+	s, err := nc.QueueSubscribe(topic, queue, handler)
 	if err == nil {
-		// store subscription for later unsubscribe
+		// store topic, queue, and handler so reconnect() can re-register them
 		key := n.queueName(SubscriptionName, queue)
-		n.subscriptions.Store(key, s)
+		n.subscriptions.Store(key, &subscriptionEntry{
+			topic:   topic,
+			queue:   queue,
+			handler: handler,
+			sub:     s,
+		})
 	}
 
 	return err
@@ -231,8 +270,8 @@ func (n *NATSBus) Unsubscribe(queueName string) error {
 	queue := common.ListenerName(queueName)
 
 	key := n.queueName(SubscriptionName, queue)
-	if s, ok := n.subscriptions.Load(key); ok {
-		return s.(*nats.Subscription).Drain()
+	if v, ok := n.subscriptions.Load(key); ok {
+		return v.(*subscriptionEntry).sub.Drain()
 	}
 	return nil
 }

--- a/pkg/event/bus/nats_integration_test.go
+++ b/pkg/event/bus/nats_integration_test.go
@@ -96,7 +96,7 @@ func TestNATS_Integration(t *testing.T) {
 	defer ec.Close() //nolint:staticcheck
 
 	// and NATS event bus
-	n := NewNATSBus(ec)
+	n := NewNATSBus(ec, ConnectionConfig{NatsURI: cfg.NatsURI})
 
 	var wg sync.WaitGroup
 	wg.Add(2)

--- a/pkg/event/emitter_integration_test.go
+++ b/pkg/event/emitter_integration_test.go
@@ -37,7 +37,7 @@ func GetTestNATSEmitter(mockCtrl *gomock.Controller) *Emitter {
 	mockLeaseRepository.EXPECT().
 		TryAcquire(gomock.Any(), gomock.Any(), gomock.Any()).
 		Return(true, nil).AnyTimes()
-	return NewEmitter(bus.NewNATSBus(nc), mockLeaseRepository, "agentevents", "", DefaultEventTTL, DefaultEventCacheCapacity)
+	return NewEmitter(bus.NewNATSBus(nc, bus.ConnectionConfig{NatsURI: cfg.NatsURI}), mockLeaseRepository, "agentevents", "", DefaultEventTTL, DefaultEventCacheCapacity)
 }
 
 func TestEmitter_NATS_Register_Integration(t *testing.T) {


### PR DESCRIPTION
## Pull request description

When the NATS server restarts or a network interruption occurs, the NATS client exhausts its default reconnect attempts and the connection becomes permanently closed. After that point every `Publish()` call fails with `nats: connection closed` and the emitter never recovers — workflows keep running but the entire event stream is dead until the pod is restarted.

This PR makes the NATS emitter self-healing with no behaviour change under normal conditions.

**Error pattern before this fix:**
```
{"level":"error","caller":"event/emitter.go:120","msg":"failed to publish event","event_type":"queue-testworkflow","error":"nats: connection closed"}
{"level":"error","caller":"event/emitter.go:120","msg":"failed to publish event","event_type":"start-testworkflow","error":"nats: connection closed"}
{"level":"error","caller":"event/emitter.go:120","msg":"failed to publish event","event_type":"end-testworkflow-success","error":"nats: connection closed"}
{"level":"error","caller":"event/emitter.go:120","msg":"failed to publish event","event_type":"end-testworkflow-failed","error":"nats: connection closed"}
{"level":"error","caller":"event/emitter.go:120","msg":"failed to publish event","event_type":"end-testworkflow-not-passed","error":"nats: connection closed"}
```
All failures originate from the same dead connection. The error persists across every subsequent execution and does not self-resolve.

---

## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [ ] tested locally
- [ ] tested on cluster
- [ ] added new dependencies
- [x] updated the docs
- [ ] added a test

## Breaking changes

- `bus.NewNATSBus` now requires a second argument (`bus.ConnectionConfig`). All in-tree call-sites have been updated. Any out-of-tree code calling `NewNATSBus` directly will need to pass the config.

## Changes

- `pkg/event/bus/nats.go`
  - `optsFromConfig`: always sets `MaxReconnects(-1)`, `ReconnectWait(2s)`, `RetryOnFailedConnect(true)` so the NATS client retries indefinitely instead of giving up after the default 60 attempts.
  - `NewNATSConnection`: registers `DisconnectErrHandler`, `ReconnectHandler`, and `ClosedHandler` for structured log visibility into connection lifecycle events (`error_type=nats_connection_closed`).
  - `NATSBus`: stores `ConnectionConfig` and a `sync.RWMutex` to safely guard the connection pointer across goroutines.
  - `NATSBus.reconnect()`: when the connection is permanently closed, acquires a write lock, double-checks under the lock (guards concurrent callers), then dials a fresh `EncodedConn` and replaces the field.
  - `NATSBus.PublishTopic()`: acquires a read lock to snapshot the connection, publishes, and on `ErrConnectionClosed` triggers one `reconnect()` then retries. All other errors pass through unchanged.
  - `NewNATSBus`: accepts `cfg ConnectionConfig` as a second parameter.
- `cmd/api-server/main.go`: constructs `bus.ConnectionConfig` from app config and passes it to `bus.NewNATSBus`.
- `pkg/event/bus/nats_integration_test.go`: updated `NewNATSBus` call.
- `pkg/event/emitter_integration_test.go`: updated `NewNATSBus` call.

## Fixes

- Event publishing no longer fails permanently after a NATS server restart or network interruption.
- Pod restarts are no longer required to recover event delivery after a transient NATS outage.
- NATS connection lifecycle (disconnect / reconnect / permanent close) is now visible in structured logs.
