### PR TITLE
feat: trigger FIPS OSS images build on stable release tags and branches

### DIFF
--- a/.github/workflows/fips-oss.yaml
+++ b/.github/workflows/fips-oss.yaml
@@ -10,6 +10,8 @@ on:
 jobs:
   trigger-fips-build:
     name: Trigger FIPS OSS build
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     if: ${{ !contains(github.ref, '-dev') && !contains(github.ref, '-rc') }}
     steps:
@@ -22,7 +24,6 @@ jobs:
             VERSION="${REF#refs/tags/}"
             MAJOR="${VERSION%%.*}"
             MINOR="${VERSION#*.}"; MINOR="${MINOR%%.*}"
-            # Use release/X-Y branch (more reliable than vX.Y.Z tag)
             OSS_REF="release/${MAJOR}-${MINOR}"
             echo "Triggered by tag: $VERSION -> oss_ref=$OSS_REF"
           elif [[ "$REF" == refs/heads/release/* ]]; then
@@ -41,17 +42,25 @@ jobs:
             echo "Triggered by branch: $VERSION -> oss_ref=$OSS_REF"
           fi
 
+          if [[ -z "$VERSION" || -z "$OSS_REF" ]]; then
+            echo "::error::Could not determine VERSION or OSS_REF from GITHUB_REF=$GITHUB_REF"
+            exit 1
+          fi
+
           echo "version=$VERSION" >> $GITHUB_OUTPUT
           echo "oss_ref=$OSS_REF" >> $GITHUB_OUTPUT
 
       - name: Trigger FIPS OSS build in testkube-fips-enable-images
         continue-on-error: true
-        uses: actions/github-script@v6
+        uses: actions/github-script@v8
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+          OSS_REF: ${{ steps.version.outputs.oss_ref }}
         with:
           github-token: ${{ secrets.CI_BOT_TOKEN }}
           script: |
-            const version = '${{ steps.version.outputs.version }}';
-            const ossRef = '${{ steps.version.outputs.oss_ref }}';
+            const version = process.env.VERSION;
+            const ossRef = process.env.OSS_REF;
             console.log(`Triggering FIPS OSS build: version=${version}, oss_ref=${ossRef}`);
             await github.rest.repos.createDispatchEvent({
               owner: 'kubeshop',


### PR DESCRIPTION
## Summary

- Adds `fips-oss.yaml` workflow that triggers FIPS OSS image builds in [testkube-fips-enable-images](https://github.com/kubeshop/testkube-fips-enable-images) when a stable release tag (`X.Y.Z`) is pushed or a release branch is updated
- Uses `CI_BOT_TOKEN` with `actions/github-script` (same convention as `new-build.yaml`)
- `continue-on-error: true` ensures the FIPS trigger never breaks the release pipeline
- Skips `-dev` and `-rc` tags

## How it works

| Trigger | `oss_ref` sent |
|---------|---------------|
| Tag `2.7.0` | `release/2-7` |
| Branch `release/2-7` | `release/2-7` |
| Branch `release/2.7.0` | `release/2-7` |

1. Stable tag or release branch push → this workflow runs
2. Dispatches `build-fips-oss` event to `testkube-fips-enable-images`
3. FIPS OSS images are built in that repo (api-server, tw-init, tw-toolkit)

## Test plan

- [x] Tested dispatch mechanism in [trigger-deployment-test](https://github.com/kubeshop/trigger-deployment-test) using same `CI_BOT_TOKEN` + `actions/github-script` approach
- [x] Verified FIPS OSS build runs successfully in [testkube-fips-enable-images](https://github.com/kubeshop/testkube-fips-enable-images/actions)
- [x] Confirmed `continue-on-error` prevents caller workflow failure

## Related

- Enterprise counterpart: https://github.com/kubeshop/testkube-cloud-api/pull/3235

Made with [Cursor](https://cursor.com)