### PR TITLE
fix: [TKC-4934] remove hardcoded cloud workflow list limit

### DIFF
--- a/pkg/controlplaneclient/testworkflows.go
+++ b/pkg/controlplaneclient/testworkflows.go
@@ -56,7 +56,7 @@ func (c *client) GetTestWorkflow(ctx context.Context, environmentId, name string
 func (c *client) ListTestWorkflows(ctx context.Context, environmentId string, options ListTestWorkflowOptions) TestWorkflowsReader {
 	req := &cloud.ListTestWorkflowsRequest{
 		Offset:     options.Offset,
-		Limit:      100,
+		Limit:      options.Limit,
 		Labels:     options.Labels,
 		TextSearch: options.TextSearch,
 	}

--- a/pkg/controlplaneclient/testworkflows_test.go
+++ b/pkg/controlplaneclient/testworkflows_test.go
@@ -1,0 +1,69 @@
+package controlplaneclient
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	gomock "go.uber.org/mock/gomock"
+	"google.golang.org/grpc"
+
+	"github.com/kubeshop/testkube/internal/config"
+	"github.com/kubeshop/testkube/pkg/cloud"
+)
+
+func TestListTestWorkflows_ForwardsOptionsLimit(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	t.Cleanup(ctrl.Finish)
+
+	mockCloudClient := cloud.NewMockTestKubeCloudAPIClient(ctrl)
+	client := &client{
+		client:     mockCloudClient,
+		proContext: config.ProContext{},
+	}
+
+	expectedErr := errors.New("list failed")
+	mockCloudClient.EXPECT().
+		ListTestWorkflows(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ context.Context, req *cloud.ListTestWorkflowsRequest, _ ...grpc.CallOption) (cloud.TestKubeCloudAPI_ListTestWorkflowsClient, error) {
+			require.Equal(t, uint32(25), req.Offset)
+			require.Equal(t, uint32(250), req.Limit)
+			require.Equal(t, map[string]string{"team": "qa"}, req.Labels)
+			require.Equal(t, "smoke", req.TextSearch)
+			return nil, expectedErr
+		})
+
+	items, err := client.ListTestWorkflows(context.Background(), "env-1", ListTestWorkflowOptions{
+		Offset:     25,
+		Limit:      250,
+		Labels:     map[string]string{"team": "qa"},
+		TextSearch: "smoke",
+	}).All()
+
+	require.ErrorIs(t, err, expectedErr)
+	require.Empty(t, items)
+}
+
+func TestListTestWorkflows_LeavesLimitUnsetWhenOptionIsZero(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	t.Cleanup(ctrl.Finish)
+
+	mockCloudClient := cloud.NewMockTestKubeCloudAPIClient(ctrl)
+	client := &client{
+		client:     mockCloudClient,
+		proContext: config.ProContext{},
+	}
+
+	expectedErr := errors.New("list failed")
+	mockCloudClient.EXPECT().
+		ListTestWorkflows(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ context.Context, req *cloud.ListTestWorkflowsRequest, _ ...grpc.CallOption) (cloud.TestKubeCloudAPI_ListTestWorkflowsClient, error) {
+			require.Equal(t, uint32(0), req.Limit)
+			return nil, expectedErr
+		})
+
+	_, err := client.ListTestWorkflows(context.Background(), "env-1", ListTestWorkflowOptions{}).All()
+
+	require.ErrorIs(t, err, expectedErr)
+}


### PR DESCRIPTION
## Summary
- remove hardcoded `Limit: 100` in cloud `ListTestWorkflows` request
- forward `options.Limit` so cloud listing is not capped at 100 by default
- add regression tests for limit forwarding and zero-limit behavior

## Validation
- `go test ./pkg/controlplaneclient` passed
- `go test ./...` fails due to pre-existing unrelated issue in `api/testtriggers/v1` (Ginkgo decorator)
- `make lint-go` / `make lint-openapi` targets are not available in this repository

## Context
Customer reported `testkube get tw -o json` in cloud mode returns only 100 workflows while Kubernetes context returns the full count. This change removes the cloud client-side cap.
