### PR TITLE
feat: add id field to step spec and propagate to runtime

### DIFF
--- a/api/testworkflows/v1/step_types.go
+++ b/api/testworkflows/v1/step_types.go
@@ -20,6 +20,11 @@ type RetryPolicy struct {
 }
 
 type StepMeta struct {
+	// stable identifier for referencing this step in expressions (e.g., step.<id>.outputs)
+	// if not provided, auto-derived from name by lowercasing and replacing non-alphanumeric characters with underscores
+	// must contain only lowercase alphanumeric characters and underscores
+	Id string `json:"id,omitempty"`
+
 	// readable name for the step
 	Name string `json:"name,omitempty" expr:"template"`
 

--- a/api/v1/testkube.yaml
+++ b/api/v1/testkube.yaml
@@ -9244,6 +9244,9 @@ components:
         ref:
           type: string
           description: step reference
+        id:
+          type: string
+          description: stable step identifier for expressions
         name:
           type: string
           description: step name
@@ -9630,6 +9633,9 @@ components:
     TestWorkflowIndependentStep:
       type: object
       properties:
+        id:
+          type: string
+          description: stable identifier for referencing this step in expressions
         name:
           type: string
           description: readable name for the step
@@ -9691,6 +9697,9 @@ components:
     TestWorkflowStep:
       type: object
       properties:
+        id:
+          type: string
+          description: stable identifier for referencing this step in expressions
         name:
           type: string
           description: readable name for the step

--- a/k8s/crd/testworkflows.testkube.io_testworkflows.yaml
+++ b/k8s/crd/testworkflows.testkube.io_testworkflows.yaml
@@ -1121,6 +1121,12 @@ spec:
                               type: object
                             type: array
                         type: object
+                      id:
+                        description: |-
+                          stable identifier for referencing this step in expressions (e.g., step.<id>.outputs)
+                          if not provided, auto-derived from name by lowercasing and replacing non-alphanumeric characters with underscores
+                          must contain only lowercase alphanumeric characters and underscores
+                        type: string
                       name:
                         description: readable name for the step
                         type: string
@@ -6659,6 +6665,12 @@ spec:
                               type: object
                             type: array
                         type: object
+                      id:
+                        description: |-
+                          stable identifier for referencing this step in expressions (e.g., step.<id>.outputs)
+                          if not provided, auto-derived from name by lowercasing and replacing non-alphanumeric characters with underscores
+                          must contain only lowercase alphanumeric characters and underscores
+                        type: string
                       name:
                         description: readable name for the step
                         type: string
@@ -9991,6 +10003,12 @@ spec:
                               type: object
                             type: array
                         type: object
+                      id:
+                        description: |-
+                          stable identifier for referencing this step in expressions (e.g., step.<id>.outputs)
+                          if not provided, auto-derived from name by lowercasing and replacing non-alphanumeric characters with underscores
+                          must contain only lowercase alphanumeric characters and underscores
+                        type: string
                       name:
                         description: readable name for the step
                         type: string

--- a/k8s/crd/testworkflows.testkube.io_testworkflowtemplates.yaml
+++ b/k8s/crd/testworkflows.testkube.io_testworkflowtemplates.yaml
@@ -1121,6 +1121,12 @@ spec:
                               type: object
                             type: array
                         type: object
+                      id:
+                        description: |-
+                          stable identifier for referencing this step in expressions (e.g., step.<id>.outputs)
+                          if not provided, auto-derived from name by lowercasing and replacing non-alphanumeric characters with underscores
+                          must contain only lowercase alphanumeric characters and underscores
+                        type: string
                       name:
                         description: readable name for the step
                         type: string
@@ -6520,6 +6526,12 @@ spec:
                               type: object
                             type: array
                         type: object
+                      id:
+                        description: |-
+                          stable identifier for referencing this step in expressions (e.g., step.<id>.outputs)
+                          if not provided, auto-derived from name by lowercasing and replacing non-alphanumeric characters with underscores
+                          must contain only lowercase alphanumeric characters and underscores
+                        type: string
                       name:
                         description: readable name for the step
                         type: string
@@ -9733,6 +9745,12 @@ spec:
                               type: object
                             type: array
                         type: object
+                      id:
+                        description: |-
+                          stable identifier for referencing this step in expressions (e.g., step.<id>.outputs)
+                          if not provided, auto-derived from name by lowercasing and replacing non-alphanumeric characters with underscores
+                          must contain only lowercase alphanumeric characters and underscores
+                        type: string
                       name:
                         description: readable name for the step
                         type: string

--- a/k8s/helm/testkube-crds/templates/_generated_crds.tpl
+++ b/k8s/helm/testkube-crds/templates/_generated_crds.tpl
@@ -8505,6 +8505,12 @@ spec:
                               type: object
                             type: array
                         type: object
+                      id:
+                        description: |-
+                          stable identifier for referencing this step in expressions (e.g., step.<id>.outputs)
+                          if not provided, auto-derived from name by lowercasing and replacing non-alphanumeric characters with underscores
+                          must contain only lowercase alphanumeric characters and underscores
+                        type: string
                       name:
                         description: readable name for the step
                         type: string
@@ -14043,6 +14049,12 @@ spec:
                               type: object
                             type: array
                         type: object
+                      id:
+                        description: |-
+                          stable identifier for referencing this step in expressions (e.g., step.<id>.outputs)
+                          if not provided, auto-derived from name by lowercasing and replacing non-alphanumeric characters with underscores
+                          must contain only lowercase alphanumeric characters and underscores
+                        type: string
                       name:
                         description: readable name for the step
                         type: string
@@ -17375,6 +17387,12 @@ spec:
                               type: object
                             type: array
                         type: object
+                      id:
+                        description: |-
+                          stable identifier for referencing this step in expressions (e.g., step.<id>.outputs)
+                          if not provided, auto-derived from name by lowercasing and replacing non-alphanumeric characters with underscores
+                          must contain only lowercase alphanumeric characters and underscores
+                        type: string
                       name:
                         description: readable name for the step
                         type: string
@@ -20978,6 +20996,12 @@ spec:
                               type: object
                             type: array
                         type: object
+                      id:
+                        description: |-
+                          stable identifier for referencing this step in expressions (e.g., step.<id>.outputs)
+                          if not provided, auto-derived from name by lowercasing and replacing non-alphanumeric characters with underscores
+                          must contain only lowercase alphanumeric characters and underscores
+                        type: string
                       name:
                         description: readable name for the step
                         type: string
@@ -26377,6 +26401,12 @@ spec:
                               type: object
                             type: array
                         type: object
+                      id:
+                        description: |-
+                          stable identifier for referencing this step in expressions (e.g., step.<id>.outputs)
+                          if not provided, auto-derived from name by lowercasing and replacing non-alphanumeric characters with underscores
+                          must contain only lowercase alphanumeric characters and underscores
+                        type: string
                       name:
                         description: readable name for the step
                         type: string
@@ -29590,6 +29620,12 @@ spec:
                               type: object
                             type: array
                         type: object
+                      id:
+                        description: |-
+                          stable identifier for referencing this step in expressions (e.g., step.<id>.outputs)
+                          if not provided, auto-derived from name by lowercasing and replacing non-alphanumeric characters with underscores
+                          must contain only lowercase alphanumeric characters and underscores
+                        type: string
                       name:
                         description: readable name for the step
                         type: string

--- a/pkg/api/v1/testkube/model_test_workflow_independent_step.go
+++ b/pkg/api/v1/testkube/model_test_workflow_independent_step.go
@@ -10,6 +10,8 @@
 package testkube
 
 type TestWorkflowIndependentStep struct {
+	// stable identifier for referencing this step in expressions
+	Id string `json:"id,omitempty"`
 	// readable name for the step
 	Name string `json:"name,omitempty"`
 	// expression to declare under which conditions the step should be run; defaults to \"passed\", except artifacts where it defaults to \"always\"

--- a/pkg/api/v1/testkube/model_test_workflow_signature.go
+++ b/pkg/api/v1/testkube/model_test_workflow_signature.go
@@ -12,6 +12,8 @@ package testkube
 type TestWorkflowSignature struct {
 	// step reference
 	Ref string `json:"ref,omitempty"`
+	// stable step identifier for expressions
+	Id string `json:"id,omitempty"`
 	// step name
 	Name string `json:"name,omitempty"`
 	// step category, that may be used as name fallback

--- a/pkg/api/v1/testkube/model_test_workflow_step.go
+++ b/pkg/api/v1/testkube/model_test_workflow_step.go
@@ -10,6 +10,8 @@
 package testkube
 
 type TestWorkflowStep struct {
+	// stable identifier for referencing this step in expressions
+	Id string `json:"id,omitempty"`
 	// readable name for the step
 	Name string `json:"name,omitempty"`
 	// expression to declare under which conditions the step should be run; defaults to \"passed\", except artifacts where it defaults to \"always\"

--- a/pkg/mapper/testworkflows/kube_openapi.go
+++ b/pkg/mapper/testworkflows/kube_openapi.go
@@ -1199,6 +1199,7 @@ func MapServiceSpecKubeToAPI(v testworkflowsv1.ServiceSpec) testkube.TestWorkflo
 
 func MapStepKubeToAPI(v testworkflowsv1.Step) testkube.TestWorkflowStep {
 	return testkube.TestWorkflowStep{
+		Id:         v.Id,
 		Name:       v.Name,
 		Condition:  v.Condition,
 		Paused:     v.Paused,
@@ -1226,6 +1227,7 @@ func MapStepKubeToAPI(v testworkflowsv1.Step) testkube.TestWorkflowStep {
 
 func MapIndependentStepKubeToAPI(v testworkflowsv1.IndependentStep) testkube.TestWorkflowIndependentStep {
 	return testkube.TestWorkflowIndependentStep{
+		Id:         v.Id,
 		Name:       v.Name,
 		Condition:  v.Condition,
 		Paused:     v.Paused,

--- a/pkg/mapper/testworkflows/openapi_kube.go
+++ b/pkg/mapper/testworkflows/openapi_kube.go
@@ -1278,6 +1278,7 @@ func MapServiceSpecAPIToKube(v testkube.TestWorkflowServiceSpec) testworkflowsv1
 func MapStepAPIToKube(v testkube.TestWorkflowStep) testworkflowsv1.Step {
 	return testworkflowsv1.Step{
 		StepMeta: testworkflowsv1.StepMeta{
+			Id:        v.Id,
 			Name:      v.Name,
 			Condition: v.Condition,
 			Pure:      MapBoxedBooleanToBool(v.Pure),
@@ -1315,6 +1316,7 @@ func MapStepAPIToKube(v testkube.TestWorkflowStep) testworkflowsv1.Step {
 func MapIndependentStepAPIToKube(v testkube.TestWorkflowIndependentStep) testworkflowsv1.IndependentStep {
 	return testworkflowsv1.IndependentStep{
 		StepMeta: testworkflowsv1.StepMeta{
+			Id:        v.Id,
 			Name:      v.Name,
 			Condition: v.Condition,
 			Pure:      MapBoxedBooleanToBool(v.Pure),

--- a/pkg/testworkflows/testworkflowprocessor/action/actiontypes/lite/action.go
+++ b/pkg/testworkflows/testworkflowprocessor/action/actiontypes/lite/action.go
@@ -13,6 +13,7 @@ type ActionResult struct {
 type ActionDeclare struct {
 	Condition string   `json:"c"`
 	Ref       string   `json:"r"`
+	Id        string   `json:"i,omitempty"`
 	Parents   []string `json:"p,omitempty"`
 }
 

--- a/pkg/testworkflows/testworkflowprocessor/action/actiontypes/lite/utils.go
+++ b/pkg/testworkflows/testworkflowprocessor/action/actiontypes/lite/utils.go
@@ -10,8 +10,8 @@ func (a LiteActionList) Setup(copyInit, copyToolkit, copyBinaries bool) LiteActi
 	return append(a, LiteAction{Setup: &ActionSetup{CopyInit: copyInit, CopyToolkit: copyToolkit, CopyBinaries: copyBinaries}})
 }
 
-func (a LiteActionList) Declare(ref string, condition string, parents ...string) LiteActionList {
-	return append(a, LiteAction{Declare: &ActionDeclare{Ref: ref, Condition: condition, Parents: parents}})
+func (a LiteActionList) Declare(ref string, id string, condition string, parents ...string) LiteActionList {
+	return append(a, LiteAction{Declare: &ActionDeclare{Ref: ref, Id: id, Condition: condition, Parents: parents}})
 }
 
 func (a LiteActionList) Start(ref string) LiteActionList {

--- a/pkg/testworkflows/testworkflowprocessor/action/actiontypes/utils.go
+++ b/pkg/testworkflows/testworkflowprocessor/action/actiontypes/utils.go
@@ -44,8 +44,8 @@ func (a ActionList) Setup(copyInit, copyToolkit, copyBinaries bool) ActionList {
 	return append(a, Action{Setup: &lite.ActionSetup{CopyInit: copyInit, CopyToolkit: copyToolkit, CopyBinaries: copyBinaries}})
 }
 
-func (a ActionList) Declare(ref string, condition string, parents ...string) ActionList {
-	return append(a, Action{Declare: &lite.ActionDeclare{Ref: ref, Condition: condition, Parents: parents}})
+func (a ActionList) Declare(ref string, id string, condition string, parents ...string) ActionList {
+	return append(a, Action{Declare: &lite.ActionDeclare{Ref: ref, Id: id, Condition: condition, Parents: parents}})
 }
 
 func (a ActionList) Start(ref string) ActionList {

--- a/pkg/testworkflows/testworkflowprocessor/action/group_test.go
+++ b/pkg/testworkflows/testworkflowprocessor/action/group_test.go
@@ -13,10 +13,10 @@ import (
 func TestGroup_Basic(t *testing.T) {
 	input := actiontypes.NewActionList().
 		// Configure
-		Declare("init", "true").
-		Declare("step1", "false").
-		Declare("step2", "true", "init").
-		Declare("step3", "true", "init").
+		Declare("init", "", "true").
+		Declare("step1", "", "false").
+		Declare("step2", "", "true", "init").
+		Declare("step3", "", "true", "init").
 		Result("init", "step2 && step3").
 		Result("", "init").
 		Start("").

--- a/pkg/testworkflows/testworkflowprocessor/action/process.go
+++ b/pkg/testworkflows/testworkflowprocessor/action/process.go
@@ -30,7 +30,7 @@ func process(currentStatus string, parents []string, stage stage2.Stage, parentC
 	}
 
 	actions = append(actions, actiontypes.Action{
-		Declare: &lite.ActionDeclare{Ref: stage.Ref(), Condition: condition, Parents: parents},
+		Declare: &lite.ActionDeclare{Ref: stage.Ref(), Id: stage.Id(), Condition: condition, Parents: parents},
 	})
 
 	// Configure the container for action

--- a/pkg/testworkflows/testworkflowprocessor/action/process_test.go
+++ b/pkg/testworkflows/testworkflowprocessor/action/process_test.go
@@ -21,9 +21,9 @@ func TestProcess_BasicSteps(t *testing.T) {
 	// Build the expectations
 	want := actiontypes.NewActionList().
 		// Declare stage conditions
-		Declare("init", "true").
-		Declare("step1", "true", "init").
-		Declare("step2", "step1", "init").
+		Declare("init", "", "true").
+		Declare("step1", "", "true", "init").
+		Declare("step2", "", "step1", "init").
 
 		// Declare group resolutions
 		Result("init", "step1&&step2").
@@ -77,12 +77,12 @@ func TestProcess_Grouping(t *testing.T) {
 	// Build the expectations
 	want := actiontypes.NewActionList().
 		// Declare stage conditions
-		Declare("init", "true").
-		Declare("step1", "true", "init").
-		Declare("group1", "step1", "init").
-		Declare("step2", "step1", "init", "group1").
-		Declare("step3", "step2&&step1", "init", "group1").
-		Declare("step4", "group1&&step1", "init").
+		Declare("init", "", "true").
+		Declare("step1", "", "true", "init").
+		Declare("group1", "", "step1", "init").
+		Declare("step2", "", "step1", "init", "group1").
+		Declare("step3", "", "step2&&step1", "init", "group1").
+		Declare("step4", "", "group1&&step1", "init").
 
 		// Declare group resolutions
 		Result("group1", "step2&&step3").
@@ -162,9 +162,9 @@ func TestProcess_Pause(t *testing.T) {
 	// Build the expectations
 	want := actiontypes.NewActionList().
 		// Declare stage conditions
-		Declare("init", "true").
-		Declare("step1", "true", "init").
-		Declare("step2", "step1", "init").
+		Declare("init", "", "true").
+		Declare("step1", "", "true", "init").
+		Declare("step2", "", "step1", "init").
 
 		// Declare information about potential pauses
 		Pause("step1").
@@ -219,9 +219,9 @@ func TestProcess_NegativeStep(t *testing.T) {
 	// Build the expectations
 	want := actiontypes.NewActionList().
 		// Declare stage conditions
-		Declare("init", "true").
-		Declare("step1", "true", "init").
-		Declare("step2", "step1", "init").
+		Declare("init", "", "true").
+		Declare("step1", "", "true", "init").
+		Declare("step2", "", "step1", "init").
 
 		// Declare group resolutions
 		Result("init", "step1&&step2").
@@ -272,9 +272,9 @@ func TestProcess_NegativeGroup(t *testing.T) {
 	// Build the expectations
 	want := actiontypes.NewActionList().
 		// Declare stage conditions
-		Declare("init", "true").
-		Declare("step1", "true", "init").
-		Declare("step2", "step1", "init").
+		Declare("init", "", "true").
+		Declare("step1", "", "true", "init").
+		Declare("step2", "", "step1", "init").
 
 		// Declare group resolutions
 		Result("init", "!step1||!step2").
@@ -326,9 +326,9 @@ func TestProcess_OptionalStep(t *testing.T) {
 	// Build the expectations
 	want := actiontypes.NewActionList().
 		// Declare stage conditions
-		Declare("init", "true").
-		Declare("step1", "true", "init").
-		Declare("step2", "true", "init"). // because step1 is optional
+		Declare("init", "", "true").
+		Declare("step1", "", "true", "init").
+		Declare("step2", "", "true", "init"). // because step1 is optional
 
 		// Declare group resolutions
 		Result("init", "step2").
@@ -381,10 +381,10 @@ func TestProcess_OptionalGroup(t *testing.T) {
 	// Build the expectations
 	want := actiontypes.NewActionList().
 		// Declare stage conditions
-		Declare("init", "true").
-		Declare("inner", "true", "init").
-		Declare("step1", "true", "init", "inner").
-		Declare("step2", "step1", "init", "inner").
+		Declare("init", "", "true").
+		Declare("inner", "", "true", "init").
+		Declare("step1", "", "true", "init", "inner").
+		Declare("step2", "", "step1", "init", "inner").
 
 		// Declare group resolutions
 		Result("inner", "step1&&step2").
@@ -440,9 +440,9 @@ func TestProcess_IgnoreExecutionOfStaticSkip(t *testing.T) {
 	// Build the expectations
 	want := actiontypes.NewActionList().
 		// Declare stage conditions
-		Declare("init", "true").
-		Declare("step1", "false").
-		Declare("step2", "true", "init"). // because step1 is skipped
+		Declare("init", "", "true").
+		Declare("step1", "", "false").
+		Declare("step2", "", "true", "init"). // because step1 is skipped
 
 		// Declare group resolutions
 		Result("init", "step2").
@@ -488,9 +488,9 @@ func TestProcess_IgnoreExecutionOfStaticSkipGroup(t *testing.T) {
 	// Build the expectations
 	want := actiontypes.NewActionList().
 		// Declare stage conditions
-		Declare("init", "false").
-		Declare("step1", "false").
-		Declare("step2", "false").
+		Declare("init", "", "false").
+		Declare("step1", "", "false").
+		Declare("step2", "", "false").
 
 		// Declare group resolutions
 		Result("", "true").
@@ -531,9 +531,9 @@ func TestProcess_IgnoreExecutionOfStaticSkipGroup_Pause(t *testing.T) {
 	// Build the expectations
 	want := actiontypes.NewActionList().
 		// Declare stage conditions
-		Declare("init", "false").
-		Declare("step1", "false").
-		Declare("step2", "false").
+		Declare("init", "", "false").
+		Declare("step1", "", "false").
+		Declare("step2", "", "false").
 
 		//Pause("init"). // ignored as it's not executed
 
@@ -577,9 +577,9 @@ func TestProcess_IgnoreExecutionOfStaticSkip_PauseGroup(t *testing.T) {
 	// Build the expectations
 	want := actiontypes.NewActionList().
 		// Declare stage conditions
-		Declare("init", "true").
-		Declare("step1", "false").
-		Declare("step2", "true", "init"). // because step1 is skipped
+		Declare("init", "", "true").
+		Declare("step1", "", "false").
+		Declare("step2", "", "true", "init"). // because step1 is skipped
 
 		// Declare information about potential pauses
 		Pause("init").
@@ -631,9 +631,9 @@ func TestProcess_ConsecutiveAlways(t *testing.T) {
 	// Build the expectations
 	want := actiontypes.NewActionList().
 		// Declare stage conditions
-		Declare("init", "true").
-		Declare("step1", "true", "init").
-		Declare("step2", "true", "init").
+		Declare("init", "", "true").
+		Declare("step1", "", "true", "init").
+		Declare("step2", "", "true", "init").
 
 		// Declare group resolutions
 		Result("init", "step1&&step2").
@@ -689,9 +689,9 @@ func TestProcess_PureShellAtTheEnd(t *testing.T) {
 	// Build the expectations
 	want := actiontypes.NewActionList().
 		// Declare stage conditions
-		Declare("init", "true").
-		Declare("step1", "true", "init").
-		Declare("step2", "true", "init").
+		Declare("init", "", "true").
+		Declare("step1", "", "true", "init").
+		Declare("step2", "", "true", "init").
 
 		// Declare group resolutions
 		Result("init", "step1&&step2").

--- a/pkg/testworkflows/testworkflowprocessor/presets/processor_test.go
+++ b/pkg/testworkflows/testworkflowprocessor/presets/processor_test.go
@@ -161,8 +161,8 @@ func TestProcessBasic(t *testing.T) {
 		Append(func(list actiontypes.ActionList) actiontypes.ActionList {
 			return list.
 				Setup(false, false, false).
-				Declare(constants.RootOperationName, "true").
-				Declare(sig[0].Ref(), "true", constants.RootOperationName).
+				Declare(constants.RootOperationName, "", "true").
+				Declare(sig[0].Ref(), "", "true", constants.RootOperationName).
 				Result(constants.RootOperationName, sig[0].Ref()).
 				Result("", constants.RootOperationName).
 				Start("").
@@ -283,8 +283,8 @@ func TestProcessShellWithNonStandardImage(t *testing.T) {
 		Append(func(list actiontypes.ActionList) actiontypes.ActionList {
 			return list.
 				Setup(true, false, true).
-				Declare(constants.RootOperationName, "true").
-				Declare(sig[0].Ref(), "true", constants.RootOperationName).
+				Declare(constants.RootOperationName, "", "true").
+				Declare(sig[0].Ref(), "", "true", constants.RootOperationName).
 				Result(constants.RootOperationName, sig[0].Ref()).
 				Result("", constants.RootOperationName).
 				Start("").
@@ -425,8 +425,8 @@ func TestProcessBasicEnvReference(t *testing.T) {
 		Append(func(list lite.LiteActionList) lite.LiteActionList {
 			return list.
 				Setup(false, false, false).
-				Declare(constants.RootOperationName, "true").
-				Declare(sig[0].Ref(), "true", constants.RootOperationName).
+				Declare(constants.RootOperationName, "", "true").
+				Declare(sig[0].Ref(), "", "true", constants.RootOperationName).
 				Result(constants.RootOperationName, sig[0].Ref()).
 				Result("", constants.RootOperationName).
 				Start("").
@@ -508,9 +508,9 @@ func TestProcessMultipleSteps(t *testing.T) {
 		Append(func(list lite.LiteActionList) lite.LiteActionList {
 			return list.
 				Setup(false, false, false).
-				Declare(constants.RootOperationName, "true").
-				Declare(sig[0].Ref(), "true", constants.RootOperationName).
-				Declare(sig[1].Ref(), sig[0].Ref(), constants.RootOperationName).
+				Declare(constants.RootOperationName, "", "true").
+				Declare(sig[0].Ref(), "", "true", constants.RootOperationName).
+				Declare(sig[1].Ref(), "", sig[0].Ref(), constants.RootOperationName).
 				Result(constants.RootOperationName, and(sig[0].Ref(), sig[1].Ref())).
 				Result("", constants.RootOperationName).
 				Start("").
@@ -623,12 +623,12 @@ func TestProcessNestedSteps(t *testing.T) {
 		Append(func(list lite.LiteActionList) lite.LiteActionList {
 			return list.
 				Setup(false, false, false).
-				Declare(constants.RootOperationName, "true").
-				Declare(sig[0].Ref(), "true", constants.RootOperationName).
-				Declare(sig[1].Ref(), sig[0].Ref(), constants.RootOperationName).
-				Declare(sig[1].Children()[0].Ref(), sig[0].Ref(), constants.RootOperationName, sig[1].Ref()).
-				Declare(sig[1].Children()[1].Ref(), and(sig[1].Children()[0].Ref(), sig[0].Ref()), constants.RootOperationName, sig[1].Ref()).
-				Declare(sig[2].Ref(), and(sig[1].Ref(), sig[0].Ref()), constants.RootOperationName).
+				Declare(constants.RootOperationName, "", "true").
+				Declare(sig[0].Ref(), sig[0].Id(), "true", constants.RootOperationName).
+				Declare(sig[1].Ref(), sig[1].Id(), sig[0].Ref(), constants.RootOperationName).
+				Declare(sig[1].Children()[0].Ref(), sig[1].Children()[0].Id(), sig[0].Ref(), constants.RootOperationName, sig[1].Ref()).
+				Declare(sig[1].Children()[1].Ref(), sig[1].Children()[1].Id(), and(sig[1].Children()[0].Ref(), sig[0].Ref()), constants.RootOperationName, sig[1].Ref()).
+				Declare(sig[2].Ref(), sig[2].Id(), and(sig[1].Ref(), sig[0].Ref()), constants.RootOperationName).
 				Result(sig[1].Ref(), and(sig[1].Children()[0].Ref(), sig[1].Children()[1].Ref())).
 				Result(constants.RootOperationName, and(sig[0].Ref(), sig[1].Ref(), sig[2].Ref())).
 				Result("", constants.RootOperationName).
@@ -980,8 +980,8 @@ func TestProcessShell(t *testing.T) {
 		Append(func(list lite.LiteActionList) lite.LiteActionList {
 			return list.
 				Setup(false, false, false).
-				Declare(constants.RootOperationName, "true").
-				Declare(sig[0].Ref(), "true", constants.RootOperationName).
+				Declare(constants.RootOperationName, "", "true").
+				Declare(sig[0].Ref(), "", "true", constants.RootOperationName).
 				Result(constants.RootOperationName, sig[0].Ref()).
 				Result("", constants.RootOperationName).
 				Start("").
@@ -1027,9 +1027,9 @@ func TestProcessConsecutiveAlways(t *testing.T) {
 		Append(func(list lite.LiteActionList) lite.LiteActionList {
 			return list.
 				Setup(false, false, false).
-				Declare(constants.RootOperationName, "true").
-				Declare(sig[0].Ref(), "true", constants.RootOperationName).
-				Declare(sig[1].Ref(), "true", constants.RootOperationName).
+				Declare(constants.RootOperationName, "", "true").
+				Declare(sig[0].Ref(), "", "true", constants.RootOperationName).
+				Declare(sig[1].Ref(), "", "true", constants.RootOperationName).
 				Result(constants.RootOperationName, and(sig[0].Ref(), sig[1].Ref())).
 				Result("", constants.RootOperationName).
 				Start("").
@@ -1087,9 +1087,9 @@ func TestProcessNestedCondition(t *testing.T) {
 		Append(func(list lite.LiteActionList) lite.LiteActionList {
 			return list.
 				Setup(false, false, false).
-				Declare(constants.RootOperationName, "true").
-				Declare(sig[0].Ref(), "true", constants.RootOperationName).
-				Declare(sig[1].Ref(), sig[0].Ref(), constants.RootOperationName).
+				Declare(constants.RootOperationName, "", "true").
+				Declare(sig[0].Ref(), "", "true", constants.RootOperationName).
+				Declare(sig[1].Ref(), "", sig[0].Ref(), constants.RootOperationName).
 				Result(constants.RootOperationName, and(sig[0].Ref(), sig[1].Ref())).
 				Result("", constants.RootOperationName).
 				Start("").
@@ -1149,11 +1149,11 @@ func TestProcessConditionWithMultipleOperations(t *testing.T) {
 		Append(func(list lite.LiteActionList) lite.LiteActionList {
 			return list.
 				Setup(false, false, false).
-				Declare(constants.RootOperationName, "true").
-				Declare(sig[0].Ref(), "true", constants.RootOperationName).
-				Declare(virtual.Ref(), "true", constants.RootOperationName).
-				Declare(sig[1].Ref(), "true", constants.RootOperationName, virtual.Ref()).
-				Declare(sig[2].Ref(), "true", constants.RootOperationName, virtual.Ref()).
+				Declare(constants.RootOperationName, "", "true").
+				Declare(sig[0].Ref(), "", "true", constants.RootOperationName).
+				Declare(virtual.Ref(), "", "true", constants.RootOperationName).
+				Declare(sig[1].Ref(), "", "true", constants.RootOperationName, virtual.Ref()).
+				Declare(sig[2].Ref(), "", "true", constants.RootOperationName, virtual.Ref()).
 				Result(virtual.Ref(), and(sig[1].Ref(), sig[2].Ref())).
 				Result(constants.RootOperationName, and(sig[0].Ref(), virtual.Ref())).
 				Result("", constants.RootOperationName).
@@ -1227,10 +1227,10 @@ func TestProcessNamedGroupWithSkippedSteps(t *testing.T) {
 			return list.
 				// configure
 				Setup(false, false, false).
-				Declare(constants.RootOperationName, "true").
-				Declare(sig[0].Ref(), "true", constants.RootOperationName).
-				Declare(sig[0].Children()[0].Ref(), "false").
-				Declare(sig[0].Children()[1].Ref(), "false").
+				Declare(constants.RootOperationName, "", "true").
+				Declare(sig[0].Ref(), sig[0].Id(), "true", constants.RootOperationName).
+				Declare(sig[0].Children()[0].Ref(), sig[0].Children()[0].Id(), "false").
+				Declare(sig[0].Children()[1].Ref(), sig[0].Children()[1].Id(), "false").
 				Result(sig[0].Ref(), "true").
 				Result(constants.RootOperationName, sig[0].Ref()).
 				Result("", constants.RootOperationName).
@@ -1290,9 +1290,9 @@ func TestProcess_ConditionAlways(t *testing.T) {
 			return list.
 				// configure
 				Setup(false, false, false).
-				Declare(constants.RootOperationName, "true").
-				Declare(sig[0].Ref(), "true", constants.RootOperationName).
-				Declare(sig[1].Ref(), "true", constants.RootOperationName).
+				Declare(constants.RootOperationName, "", "true").
+				Declare(sig[0].Ref(), "", "true", constants.RootOperationName).
+				Declare(sig[1].Ref(), "", "true", constants.RootOperationName).
 				Result(constants.RootOperationName, and(sig[0].Ref(), sig[1].Ref())).
 				Result("", constants.RootOperationName).
 
@@ -1356,9 +1356,9 @@ func TestProcess_PureShellAtTheEnd(t *testing.T) {
 			return list.
 				// configure
 				Setup(true, false, true).
-				Declare(constants.RootOperationName, "true").
-				Declare(sig[0].Ref(), "true", constants.RootOperationName).
-				Declare(sig[1].Ref(), sig[0].Ref(), constants.RootOperationName).
+				Declare(constants.RootOperationName, "", "true").
+				Declare(sig[0].Ref(), "", "true", constants.RootOperationName).
+				Declare(sig[1].Ref(), "", sig[0].Ref(), constants.RootOperationName).
 				Result(constants.RootOperationName, and(sig[0].Ref(), sig[1].Ref())).
 				Result("", constants.RootOperationName).
 
@@ -1419,9 +1419,9 @@ func TestProcess_MergingActions(t *testing.T) {
 			return list.
 				// configure
 				Setup(true, false, true).
-				Declare(constants.RootOperationName, "true").
-				Declare(sig[0].Ref(), "true", constants.RootOperationName).
-				Declare(sig[1].Ref(), sig[0].Ref(), constants.RootOperationName).
+				Declare(constants.RootOperationName, "", "true").
+				Declare(sig[0].Ref(), "", "true", constants.RootOperationName).
+				Declare(sig[1].Ref(), "", sig[0].Ref(), constants.RootOperationName).
 				Result(constants.RootOperationName, and(sig[0].Ref(), sig[1].Ref())).
 				Result("", constants.RootOperationName).
 

--- a/pkg/testworkflows/testworkflowprocessor/processor.go
+++ b/pkg/testworkflows/testworkflowprocessor/processor.go
@@ -65,6 +65,7 @@ func (p *processor) process(layer Intermediate, container stage.Container, step 
 	// Build an initial group for the inner items
 	self := stage.NewGroupStage(ref, false)
 	self.SetPure(step.Pure)
+	self.SetId(step.Id)
 	self.SetName(step.Name)
 	self.SetOptional(step.Optional).SetNegative(step.Negative).SetTimeout(step.Timeout).SetPaused(step.Paused)
 	if step.Condition == "" {
@@ -143,7 +144,19 @@ func (p *processor) Bundle(ctx context.Context, workflow *testworkflowsv1.TestWo
 		return nil, errors.New("could not resolve resource.root")
 	}
 
-	// Process steps
+	err = expressions.Simplify(&workflow, machines...)
+	if err != nil {
+		return nil, errors.Wrap(err, "error while simplifying workflow instructions")
+	}
+
+	// Resolve and validate step IDs after expression simplification,
+	// so auto-derivation works on resolved names rather than raw templates.
+	if err := ResolveAndValidateStepIds(&workflow.Spec); err != nil {
+		return nil, errors.Wrap(err, "step id validation")
+	}
+
+	// Process steps - must be after ResolveAndValidateStepIds so rootStep
+	// picks up the resolved IDs from the spec.
 	rootStep := testworkflowsv1.Step{
 		StepSource: testworkflowsv1.StepSource{
 			Content: workflow.Spec.Content,
@@ -155,10 +168,6 @@ func (p *processor) Bundle(ctx context.Context, workflow *testworkflowsv1.TestWo
 		Steps: append(workflow.Spec.Setup, append(workflow.Spec.Steps, workflow.Spec.After...)...),
 	}
 
-	err = expressions.Simplify(&workflow, machines...)
-	if err != nil {
-		return nil, errors.Wrap(err, "error while simplifying workflow instructions")
-	}
 	root, err := p.process(layer, layer.ContainerDefaults(), rootStep, constants.RootOperationName)
 	if err != nil {
 		return nil, errors.Wrap(err, "processing error")

--- a/pkg/testworkflows/testworkflowprocessor/stage/containerstage.go
+++ b/pkg/testworkflows/testworkflowprocessor/stage/containerstage.go
@@ -56,6 +56,7 @@ func (s *containerStage) Len() int {
 func (s *containerStage) Signature() Signature {
 	return &signature{
 		RefValue:      s.ref,
+		IdValue:       s.id,
 		NameValue:     s.name,
 		CategoryValue: s.category,
 		OptionalValue: s.optional,

--- a/pkg/testworkflows/testworkflowprocessor/stage/groupstage.go
+++ b/pkg/testworkflows/testworkflowprocessor/stage/groupstage.go
@@ -74,6 +74,7 @@ func (s *groupStage) signature(full bool) Signature {
 
 	return &signature{
 		RefValue:      s.ref,
+		IdValue:       s.id,
 		NameValue:     s.name,
 		CategoryValue: s.category,
 		OptionalValue: s.optional,
@@ -147,6 +148,9 @@ func (s *groupStage) Flatten() []Stage {
 	if len(s.children) == 1 && (s.name == "" || first.Name() == "") && (s.timeout == "" || first.Timeout() == "") && (!s.paused || !first.Paused()) {
 		if first.Name() == "" {
 			first.SetName(s.name)
+		}
+		if first.Id() == "" {
+			first.SetId(s.id)
 		}
 		if first.Condition() == "" {
 			// Virtualize with the default condition

--- a/pkg/testworkflows/testworkflowprocessor/stage/mock_stage.go
+++ b/pkg/testworkflows/testworkflowprocessor/stage/mock_stage.go
@@ -158,6 +158,20 @@ func (mr *MockStageMockRecorder) GetImages(isGroupNeeded any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetImages", reflect.TypeOf((*MockStage)(nil).GetImages), isGroupNeeded)
 }
 
+// Id mocks base method.
+func (m *MockStage) Id() string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Id")
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+// Id indicates an expected call of Id.
+func (mr *MockStageMockRecorder) Id() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Id", reflect.TypeOf((*MockStage)(nil).Id))
+}
+
 // HasPause mocks base method.
 func (m *MockStage) HasPause() bool {
 	m.ctrl.T.Helper()
@@ -286,6 +300,20 @@ func (m *MockStage) RetryPolicy() v1.RetryPolicy {
 func (mr *MockStageMockRecorder) RetryPolicy() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RetryPolicy", reflect.TypeOf((*MockStage)(nil).RetryPolicy))
+}
+
+// SetId mocks base method.
+func (m *MockStage) SetId(id string) StageMetadata {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SetId", id)
+	ret0, _ := ret[0].(StageMetadata)
+	return ret0
+}
+
+// SetId indicates an expected call of SetId.
+func (mr *MockStageMockRecorder) SetId(id any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetId", reflect.TypeOf((*MockStage)(nil).SetId), id)
 }
 
 // SetCategory mocks base method.

--- a/pkg/testworkflows/testworkflowprocessor/stage/signature.go
+++ b/pkg/testworkflows/testworkflowprocessor/stage/signature.go
@@ -10,6 +10,7 @@ import (
 
 type Signature interface {
 	Ref() string
+	Id() string
 	Name() string
 	Category() string
 	Optional() bool
@@ -21,6 +22,7 @@ type Signature interface {
 
 type signature struct {
 	RefValue      string      `json:"ref"`
+	IdValue       string      `json:"id,omitempty"`
 	NameValue     string      `json:"name,omitempty"`
 	CategoryValue string      `json:"category,omitempty"`
 	OptionalValue bool        `json:"optional,omitempty"`
@@ -30,6 +32,10 @@ type signature struct {
 
 func (s *signature) Ref() string {
 	return s.RefValue
+}
+
+func (s *signature) Id() string {
+	return s.IdValue
 }
 
 func (s *signature) Name() string {
@@ -55,6 +61,7 @@ func (s *signature) Children() []Signature {
 func (s *signature) ToInternal() testkube.TestWorkflowSignature {
 	return testkube.TestWorkflowSignature{
 		Ref:      s.RefValue,
+		Id:       s.IdValue,
 		Name:     s.NameValue,
 		Category: s.CategoryValue,
 		Optional: s.OptionalValue,
@@ -91,6 +98,7 @@ func MapSignatureList(v []testkube.TestWorkflowSignature) []Signature {
 	for i := range v {
 		r[i] = Signature(&signature{
 			RefValue:      v[i].Ref,
+			IdValue:       v[i].Id,
 			NameValue:     v[i].Name,
 			CategoryValue: v[i].Category,
 			OptionalValue: v[i].Optional,
@@ -114,6 +122,7 @@ func MapSignatureListToStepResults(v []Signature) map[string]testkube.TestWorkfl
 
 type rawSignature struct {
 	RefValue      string         `json:"ref"`
+	IdValue       string         `json:"id,omitempty"`
 	NameValue     string         `json:"name,omitempty"`
 	CategoryValue string         `json:"category,omitempty"`
 	OptionalValue bool           `json:"optional,omitempty"`
@@ -128,6 +137,7 @@ func rawSignatureToSignature(sig rawSignature) Signature {
 	}
 	return &signature{
 		RefValue:      sig.RefValue,
+		IdValue:       sig.IdValue,
 		NameValue:     sig.NameValue,
 		CategoryValue: sig.CategoryValue,
 		OptionalValue: sig.OptionalValue,

--- a/pkg/testworkflows/testworkflowprocessor/stage/stagemetadata.go
+++ b/pkg/testworkflows/testworkflowprocessor/stage/stagemetadata.go
@@ -2,15 +2,18 @@ package stage
 
 type StageMetadata interface {
 	Ref() string
+	Id() string
 	Name() string
 	Category() string
 
+	SetId(id string) StageMetadata
 	SetName(name string) StageMetadata
 	SetCategory(category string) StageMetadata
 }
 
 type stageMetadata struct {
 	ref      string
+	id       string
 	name     string
 	category string
 }
@@ -23,12 +26,21 @@ func (s *stageMetadata) Ref() string {
 	return s.ref
 }
 
+func (s *stageMetadata) Id() string {
+	return s.id
+}
+
 func (s *stageMetadata) Name() string {
 	return s.name
 }
 
 func (s *stageMetadata) Category() string {
 	return s.category
+}
+
+func (s *stageMetadata) SetId(id string) StageMetadata {
+	s.id = id
+	return s
 }
 
 func (s *stageMetadata) SetName(name string) StageMetadata {

--- a/pkg/testworkflows/testworkflowprocessor/stepid.go
+++ b/pkg/testworkflows/testworkflowprocessor/stepid.go
@@ -1,0 +1,155 @@
+package testworkflowprocessor
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+	"unicode"
+
+	testworkflowsv1 "github.com/kubeshop/testkube/api/testworkflows/v1"
+)
+
+// stepIdPattern allows lowercase alphanumeric and underscores.
+var stepIdPattern = regexp.MustCompile(`^[a-z0-9][a-z0-9_]*$`)
+
+// ValidateStepId checks that a step ID contains only lowercase alphanumeric
+// characters and underscores.
+func ValidateStepId(id string) error {
+	if !stepIdPattern.MatchString(id) {
+		return fmt.Errorf("step id %q must contain only lowercase alphanumeric characters and underscores", id)
+	}
+	return nil
+}
+
+// DeriveStepId converts a step name to an identifier candidate by lowercasing
+// and replacing all non-alphanumeric characters with underscores.
+// The result may not pass ValidateStepId (e.g., non-ASCII names); callers must validate.
+func DeriveStepId(name string) string {
+	if name == "" {
+		return ""
+	}
+	var b strings.Builder
+	prevUnderscore := false
+	for _, r := range name {
+		if unicode.IsLetter(r) || unicode.IsDigit(r) {
+			b.WriteRune(unicode.ToLower(r))
+			prevUnderscore = false
+		} else if !prevUnderscore {
+			b.WriteByte('_')
+			prevUnderscore = true
+		}
+	}
+	result := strings.Trim(b.String(), "_")
+	if result == "" {
+		return ""
+	}
+	return result
+}
+
+// ResolveStepId returns the step's effective ID: explicit id > derived from name > empty.
+func ResolveStepId(step testworkflowsv1.StepMeta) string {
+	if step.Id != "" {
+		return step.Id
+	}
+	return DeriveStepId(step.Name)
+}
+
+// ValidateExplicitStepIds checks that all explicitly set step IDs have a valid format
+// and are unique within their scope. Parallel blocks are validated independently
+// since they run as separate workflows. This is intended for API-time validation
+// before the workflow is stored.
+func ValidateExplicitStepIds(spec *testworkflowsv1.TestWorkflowSpec) error {
+	seen := make(map[string]bool)
+	for _, steps := range [][]testworkflowsv1.Step{spec.Setup, spec.Steps, spec.After} {
+		for i := range steps {
+			if err := validateExplicitStepId(&steps[i], seen); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func validateExplicitStepId(step *testworkflowsv1.Step, seen map[string]bool) error {
+	if step.Id != "" {
+		if err := ValidateStepId(step.Id); err != nil {
+			return err
+		}
+		if seen[step.Id] {
+			return fmt.Errorf("duplicate step id %q", step.Id)
+		}
+		seen[step.Id] = true
+	}
+
+	// Recurse into nested steps (same ID namespace)
+	for _, steps := range [][]testworkflowsv1.Step{step.Setup, step.Steps} {
+		for i := range steps {
+			if err := validateExplicitStepId(&steps[i], seen); err != nil {
+				return err
+			}
+		}
+	}
+
+	// Parallel blocks have their own ID namespace (separate pods)
+	if step.Parallel != nil {
+		parallelSeen := make(map[string]bool)
+		for _, steps := range [][]testworkflowsv1.Step{step.Parallel.Setup, step.Parallel.Steps, step.Parallel.After} {
+			for i := range steps {
+				if err := validateExplicitStepId(&steps[i], parallelSeen); err != nil {
+					return err
+				}
+			}
+		}
+	}
+
+	return nil
+}
+
+// ResolveAndValidateStepIds walks all steps in a workflow, auto-derives IDs
+// from names where not explicitly set, and validates all IDs (format and uniqueness).
+// Auto-derived IDs that conflict get an index suffix (e.g., build, build_1, build_2).
+func ResolveAndValidateStepIds(spec *testworkflowsv1.TestWorkflowSpec) error {
+	seen := make(map[string]bool)
+	for _, steps := range [][]testworkflowsv1.Step{spec.Setup, spec.Steps, spec.After} {
+		for i := range steps {
+			if err := resolveAndValidateStep(&steps[i], seen); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func resolveAndValidateStep(step *testworkflowsv1.Step, seen map[string]bool) error {
+	if step.Id != "" {
+		// Explicit ID: strict validation
+		if err := ValidateStepId(step.Id); err != nil {
+			return err
+		}
+		if seen[step.Id] {
+			return fmt.Errorf("duplicate step id %q", step.Id)
+		}
+		seen[step.Id] = true
+	} else if step.Name != "" {
+		// Auto-derive from name, appending _1, _2, etc. on conflict
+		derived := DeriveStepId(step.Name)
+		if derived != "" && ValidateStepId(derived) == nil {
+			candidate := derived
+			for n := 1; seen[candidate]; n++ {
+				candidate = fmt.Sprintf("%s_%d", derived, n)
+			}
+			step.Id = candidate
+			seen[candidate] = true
+		}
+	}
+
+	// Recurse into nested steps
+	for _, steps := range [][]testworkflowsv1.Step{step.Setup, step.Steps} {
+		for i := range steps {
+			if err := resolveAndValidateStep(&steps[i], seen); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}

--- a/pkg/testworkflows/testworkflowprocessor/stepid_test.go
+++ b/pkg/testworkflows/testworkflowprocessor/stepid_test.go
@@ -1,0 +1,266 @@
+package testworkflowprocessor
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	testworkflowsv1 "github.com/kubeshop/testkube/api/testworkflows/v1"
+)
+
+func TestValidateStepId(t *testing.T) {
+	tests := map[string]struct {
+		id      string
+		wantErr bool
+	}{
+		"valid simple":              {id: "auth", wantErr: false},
+		"valid with number":         {id: "step1", wantErr: false},
+		"valid snake_case":          {id: "get_auth_token", wantErr: false},
+		"valid with underscores":    {id: "my__id", wantErr: false},
+		"valid trailing underscore": {id: "my_id_", wantErr: false},
+		"valid former reserved":     {id: "config", wantErr: false},
+		"invalid uppercase":         {id: "Auth", wantErr: true},
+		"invalid hyphen":            {id: "get-auth", wantErr: true},
+		"valid starts with digit":   {id: "1step", wantErr: false},
+		"invalid empty":             {id: "", wantErr: true},
+		"invalid spaces":            {id: "my step", wantErr: true},
+	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			err := ValidateStepId(tc.id)
+			if tc.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestDeriveStepId(t *testing.T) {
+	tests := map[string]struct {
+		name string
+		want string
+	}{
+		"simple":             {name: "Build", want: "build"},
+		"multi word":         {name: "Run Load Test", want: "run_load_test"},
+		"with parens":        {name: "Get Auth Token (v2)", want: "get_auth_token_v2"},
+		"camelCase":          {name: "getNodeCount", want: "getnodecount"},
+		"already snake_case": {name: "run_tests", want: "run_tests"},
+		"empty":              {name: "", want: ""},
+		"special chars only": {name: "---", want: ""},
+		"starts with number": {name: "1st step", want: "1st_step"},
+		"trailing space":     {name: "test ", want: "test"},
+		"multiple spaces":    {name: "run  load  test", want: "run_load_test"},
+		"hyphens replaced":   {name: "get-auth-token", want: "get_auth_token"},
+		"unicode name":       {name: "Résumé", want: "résumé"},
+	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			got := DeriveStepId(tc.name)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
+func TestResolveAndValidateStepIds(t *testing.T) {
+	t.Run("valid explicit ids", func(t *testing.T) {
+		spec := &testworkflowsv1.TestWorkflowSpec{
+			Steps: []testworkflowsv1.Step{
+				{StepMeta: testworkflowsv1.StepMeta{Id: "build", Name: "Build"}},
+				{StepMeta: testworkflowsv1.StepMeta{Id: "test", Name: "Test"}},
+			},
+		}
+		assert.NoError(t, ResolveAndValidateStepIds(spec))
+	})
+
+	t.Run("duplicate explicit ids rejected", func(t *testing.T) {
+		spec := &testworkflowsv1.TestWorkflowSpec{
+			Steps: []testworkflowsv1.Step{
+				{StepMeta: testworkflowsv1.StepMeta{Id: "build", Name: "Build"}},
+				{StepMeta: testworkflowsv1.StepMeta{Id: "build", Name: "Build 2"}},
+			},
+		}
+		assert.Error(t, ResolveAndValidateStepIds(spec))
+	})
+
+	t.Run("invalid format rejected", func(t *testing.T) {
+		spec := &testworkflowsv1.TestWorkflowSpec{
+			Steps: []testworkflowsv1.Step{
+				{StepMeta: testworkflowsv1.StepMeta{Id: "My-Step"}},
+			},
+		}
+		assert.Error(t, ResolveAndValidateStepIds(spec))
+	})
+
+	t.Run("auto-derived ids set on steps", func(t *testing.T) {
+		spec := &testworkflowsv1.TestWorkflowSpec{
+			Steps: []testworkflowsv1.Step{
+				{StepMeta: testworkflowsv1.StepMeta{Name: "Build Binary"}},
+				{StepMeta: testworkflowsv1.StepMeta{Name: "Run Tests"}},
+			},
+		}
+		assert.NoError(t, ResolveAndValidateStepIds(spec))
+		assert.Equal(t, "build_binary", spec.Steps[0].Id)
+		assert.Equal(t, "run_tests", spec.Steps[1].Id)
+	})
+
+	t.Run("auto-derived conflict gets index suffix", func(t *testing.T) {
+		spec := &testworkflowsv1.TestWorkflowSpec{
+			Steps: []testworkflowsv1.Step{
+				{StepMeta: testworkflowsv1.StepMeta{Name: "Build"}},
+				{StepMeta: testworkflowsv1.StepMeta{Name: "Build"}},
+				{StepMeta: testworkflowsv1.StepMeta{Name: "Build"}},
+			},
+		}
+		assert.NoError(t, ResolveAndValidateStepIds(spec))
+		assert.Equal(t, "build", spec.Steps[0].Id)
+		assert.Equal(t, "build_1", spec.Steps[1].Id)
+		assert.Equal(t, "build_2", spec.Steps[2].Id)
+	})
+
+	t.Run("auto-derived conflict with explicit id gets suffix", func(t *testing.T) {
+		spec := &testworkflowsv1.TestWorkflowSpec{
+			Steps: []testworkflowsv1.Step{
+				{StepMeta: testworkflowsv1.StepMeta{Id: "build", Name: "Build"}},
+				{StepMeta: testworkflowsv1.StepMeta{Name: "Build"}},
+			},
+		}
+		assert.NoError(t, ResolveAndValidateStepIds(spec))
+		assert.Equal(t, "build", spec.Steps[0].Id)
+		assert.Equal(t, "build_1", spec.Steps[1].Id)
+	})
+
+	t.Run("no ids or names is valid", func(t *testing.T) {
+		spec := &testworkflowsv1.TestWorkflowSpec{
+			Steps: []testworkflowsv1.Step{
+				{StepOperations: testworkflowsv1.StepOperations{Shell: "echo hello"}},
+			},
+		}
+		assert.NoError(t, ResolveAndValidateStepIds(spec))
+	})
+
+	t.Run("nested duplicate ids rejected", func(t *testing.T) {
+		spec := &testworkflowsv1.TestWorkflowSpec{
+			Steps: []testworkflowsv1.Step{
+				{
+					StepMeta: testworkflowsv1.StepMeta{Id: "parent", Name: "Parent"},
+					Steps: []testworkflowsv1.Step{
+						{StepMeta: testworkflowsv1.StepMeta{Id: "parent"}},
+					},
+				},
+			},
+		}
+		assert.Error(t, ResolveAndValidateStepIds(spec))
+	})
+
+	t.Run("unicode name not auto-derived", func(t *testing.T) {
+		spec := &testworkflowsv1.TestWorkflowSpec{
+			Steps: []testworkflowsv1.Step{
+				{StepMeta: testworkflowsv1.StepMeta{Name: "Résumé"}},
+			},
+		}
+		assert.NoError(t, ResolveAndValidateStepIds(spec))
+		assert.Equal(t, "", spec.Steps[0].Id)
+	})
+
+	t.Run("cross-section uniqueness enforced", func(t *testing.T) {
+		spec := &testworkflowsv1.TestWorkflowSpec{
+			Setup: []testworkflowsv1.Step{
+				{StepMeta: testworkflowsv1.StepMeta{Id: "init", Name: "Init"}},
+			},
+			Steps: []testworkflowsv1.Step{
+				{StepMeta: testworkflowsv1.StepMeta{Id: "init", Name: "Init 2"}},
+			},
+		}
+		assert.Error(t, ResolveAndValidateStepIds(spec))
+	})
+}
+
+func TestValidateExplicitStepIds(t *testing.T) {
+	t.Run("valid unique ids", func(t *testing.T) {
+		spec := &testworkflowsv1.TestWorkflowSpec{
+			Steps: []testworkflowsv1.Step{
+				{StepMeta: testworkflowsv1.StepMeta{Id: "build"}},
+				{StepMeta: testworkflowsv1.StepMeta{Id: "test"}},
+			},
+		}
+		assert.NoError(t, ValidateExplicitStepIds(spec))
+	})
+
+	t.Run("duplicate ids rejected", func(t *testing.T) {
+		spec := &testworkflowsv1.TestWorkflowSpec{
+			Steps: []testworkflowsv1.Step{
+				{StepMeta: testworkflowsv1.StepMeta{Id: "build"}},
+				{StepMeta: testworkflowsv1.StepMeta{Id: "build"}},
+			},
+		}
+		assert.Error(t, ValidateExplicitStepIds(spec))
+	})
+
+	t.Run("invalid format rejected", func(t *testing.T) {
+		spec := &testworkflowsv1.TestWorkflowSpec{
+			Steps: []testworkflowsv1.Step{
+				{StepMeta: testworkflowsv1.StepMeta{Id: "My-Step"}},
+			},
+		}
+		assert.Error(t, ValidateExplicitStepIds(spec))
+	})
+
+	t.Run("steps without id are skipped", func(t *testing.T) {
+		spec := &testworkflowsv1.TestWorkflowSpec{
+			Steps: []testworkflowsv1.Step{
+				{StepMeta: testworkflowsv1.StepMeta{Name: "Build"}},
+				{StepMeta: testworkflowsv1.StepMeta{Name: "Build"}},
+			},
+		}
+		assert.NoError(t, ValidateExplicitStepIds(spec))
+	})
+
+	t.Run("nested duplicate rejected", func(t *testing.T) {
+		spec := &testworkflowsv1.TestWorkflowSpec{
+			Steps: []testworkflowsv1.Step{
+				{
+					StepMeta: testworkflowsv1.StepMeta{Id: "parent"},
+					Steps: []testworkflowsv1.Step{
+						{StepMeta: testworkflowsv1.StepMeta{Id: "parent"}},
+					},
+				},
+			},
+		}
+		assert.Error(t, ValidateExplicitStepIds(spec))
+	})
+
+	t.Run("parallel ids are independent from parent", func(t *testing.T) {
+		spec := &testworkflowsv1.TestWorkflowSpec{
+			Steps: []testworkflowsv1.Step{
+				{StepMeta: testworkflowsv1.StepMeta{Id: "build"}},
+				{
+					StepMeta: testworkflowsv1.StepMeta{Id: "run_parallel"},
+					Parallel: &testworkflowsv1.StepParallel{
+						Steps: []testworkflowsv1.Step{
+							{StepMeta: testworkflowsv1.StepMeta{Id: "build"}},
+						},
+					},
+				},
+			},
+		}
+		assert.NoError(t, ValidateExplicitStepIds(spec))
+	})
+
+	t.Run("duplicate ids within parallel rejected", func(t *testing.T) {
+		spec := &testworkflowsv1.TestWorkflowSpec{
+			Steps: []testworkflowsv1.Step{
+				{
+					Parallel: &testworkflowsv1.StepParallel{
+						Steps: []testworkflowsv1.Step{
+							{StepMeta: testworkflowsv1.StepMeta{Id: "build"}},
+							{StepMeta: testworkflowsv1.StepMeta{Id: "build"}},
+						},
+					},
+				},
+			},
+		}
+		assert.Error(t, ValidateExplicitStepIds(spec))
+	})
+}


### PR DESCRIPTION
## Summary

- Add `id` field to `StepMeta` CRD type, OpenAPI spec, and API models
- Auto-derive id from step name when not explicitly set (lowercase, non-alphanumeric chars become underscores)
- Duplicate auto-derived IDs get an index suffix: `build`, `build_1`, `build_2`
- Validate explicit IDs: lowercase alphanumeric + underscores, unique within workflow
- Propagate id through stage metadata, signature, action declaration, and serialization layers
- Update all mappers (Kube <-> OpenAPI)
- Add `ValidateExplicitStepIds` for API-time validation (wired in cloud-api via TKC-5249)

## Test plan

- [x] Explicit id preserved in signature
- [x] Name auto-derives to valid id (including digit-starting names like "1st step")
- [x] Duplicate auto-derived IDs get index suffixes
- [x] Auto-derived conflict with explicit ID gets suffix
- [x] Invalid format rejected for explicit IDs
- [x] Unicode names skipped (non-ASCII fails regex)
- [x] Cross-section uniqueness enforced (setup vs steps)
- [x] ValidateExplicitStepIds: parallel blocks validated independently
- [x] ValidateExplicitStepIds: steps without id skipped
- [x] Existing processor and preset tests pass

Closes TKC-5165