### PR TITLE
feat: per-step results directories for file sharing between steps

### DIFF
--- a/cmd/testworkflow-init/data/global.go
+++ b/cmd/testworkflow-init/data/global.go
@@ -17,7 +17,7 @@ func GetBaseTestWorkflowMachine() expressions.Machine {
 	}
 	fileMachine := libs.NewFsMachine(os.DirFS("/"), wd)
 	GetState() // load state
-	return expressions.CombinedMachines(EnvMachine, StateMachine, fileMachine)
+	return expressions.CombinedMachines(EnvMachine, StepMachine, StateMachine, fileMachine)
 }
 
 func ExecutionMachine() expressions.Machine {

--- a/cmd/testworkflow-init/data/state.go
+++ b/cmd/testworkflow-init/data/state.go
@@ -98,6 +98,18 @@ func (s *state) getSubSteps(ref string, visited *map[*StepData]struct{}) {
 	}
 }
 
+func (s *state) GetStepByID(id string) *StepData {
+	stateMu.RLock()
+	defer stateMu.RUnlock()
+
+	for _, step := range s.Steps {
+		if step.Id == id {
+			return step
+		}
+	}
+	return nil
+}
+
 func (s *state) GetSubSteps(ref string) []*StepData {
 	stateMu.RLock()
 	defer stateMu.RUnlock()
@@ -161,9 +173,7 @@ func persistState(filePath string) error {
 	return nil
 }
 
-var (
-	prevTerminationLog []string
-)
+var prevTerminationLog []string
 
 func persistTerminationLog() {
 	// Read the state

--- a/cmd/testworkflow-init/data/stepData.go
+++ b/cmd/testworkflow-init/data/stepData.go
@@ -17,6 +17,7 @@ type RetryPolicy struct {
 
 type StepData struct {
 	Ref           string                `json:"_,omitempty"`
+	Id            string                `json:"I,omitempty"`
 	ExitCode      uint8                 `json:"e,omitempty"`
 	Status        *constants.StepStatus `json:"s,omitempty"`
 	StartedAt     *time.Time            `json:"S,omitempty"`
@@ -77,6 +78,11 @@ func (s *StepData) SetExitCode(exitCode uint8) *StepData {
 	return s
 }
 
+func (s *StepData) SetId(id string) *StepData {
+	s.Id = id
+	return s
+}
+
 func (s *StepData) SetCondition(expression string) *StepData {
 	s.Condition = expression
 	return s
@@ -97,6 +103,7 @@ func (s *StepData) SetPausedOnStart(pause bool) *StepData {
 func (s *StepData) SetTimeout(timeout string) *StepData {
 	if timeout == "" {
 		s.Timeout = nil
+		return s
 	}
 	duration, err := time.ParseDuration(timeout)
 	if err != nil {
@@ -129,8 +136,7 @@ func (s *StepData) RegisterPauseStart(ts time.Time) bool {
 		return false
 	}
 	s.paused = true
-	start := ts
-	s.PausedStart = &start
+	s.PausedStart = &ts
 	return true
 }
 

--- a/cmd/testworkflow-init/data/stepmachine.go
+++ b/cmd/testworkflow-init/data/stepmachine.go
@@ -1,0 +1,55 @@
+package data
+
+import (
+	"path/filepath"
+	"strings"
+
+	"github.com/kubeshop/testkube/pkg/expressions"
+)
+
+const (
+	stepPrefix      = "step."
+	stepResultsBase = "/data/.steps/"
+)
+
+// StepResultsDir returns the results directory path for a step.
+// Step IDs are validated by ValidateStepId (alphanumeric + underscores only),
+// so path traversal is not possible.
+func StepResultsDir(id string) string {
+	return filepath.Join(stepResultsBase, id)
+}
+
+// StepMachine resolves step-scoped expressions:
+//   - step.results -> current step's results directory
+//   - step.<id>.results -> named step's results directory
+var StepMachine = expressions.NewMachine().
+	RegisterAccessor(func(name string) (interface{}, bool) {
+		if !strings.HasPrefix(name, stepPrefix) {
+			return nil, false
+		}
+		suffix := name[len(stepPrefix):]
+		state := GetState()
+
+		if suffix == "results" {
+			currentStep := state.GetStep(state.CurrentRef)
+			if currentStep.Id == "" {
+				return nil, false
+			}
+			return StepResultsDir(currentStep.Id), true
+		}
+
+		parts := strings.SplitN(suffix, ".", 2)
+		if len(parts) != 2 {
+			return nil, false
+		}
+		stepId, property := parts[0], parts[1]
+
+		if property == "results" {
+			if state.GetStepByID(stepId) == nil {
+				return nil, false
+			}
+			return StepResultsDir(stepId), true
+		}
+
+		return nil, false
+	})

--- a/cmd/testworkflow-init/data/stepmachine_test.go
+++ b/cmd/testworkflow-init/data/stepmachine_test.go
@@ -1,0 +1,110 @@
+package data
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/kubeshop/testkube/cmd/testworkflow-init/constants"
+	"github.com/kubeshop/testkube/pkg/expressions"
+)
+
+func setupTestState(steps map[string]*StepData, currentRef string) {
+	ClearState()
+	state := GetState()
+	state.CurrentRef = currentRef
+	for ref, step := range steps {
+		step.Ref = ref
+		state.Steps[ref] = step
+	}
+}
+
+func resolveStepExpr(t *testing.T, expr string) (string, bool) {
+	t.Helper()
+	compiled, err := expressions.CompileAndResolve(expr, StepMachine)
+	if err != nil {
+		return "", false
+	}
+	if compiled.Static() == nil {
+		return "", false
+	}
+	val, _ := compiled.Static().StringValue()
+	return val, true
+}
+
+func TestStepMachine(t *testing.T) {
+	tests := map[string]struct {
+		steps      map[string]*StepData
+		currentRef string
+		expr       string
+		wantVal    string
+		wantOk     bool
+	}{
+		"step.results resolves to current step dir": {
+			steps:      map[string]*StepData{"ref1": {Id: "build"}},
+			currentRef: "ref1",
+			expr:       "step.results",
+			wantVal:    "/data/.steps/build",
+			wantOk:     true,
+		},
+		"step.results returns nothing without id": {
+			steps:      map[string]*StepData{"ref1": {}},
+			currentRef: "ref1",
+			expr:       "step.results",
+			wantOk:     false,
+		},
+		"step.<id>.results resolves to named step dir": {
+			steps:      map[string]*StepData{"ref1": {Id: "build"}, "ref2": {Id: "test"}},
+			currentRef: "ref2",
+			expr:       "step.build.results",
+			wantVal:    "/data/.steps/build",
+			wantOk:     true,
+		},
+		"step.<id>.results returns nothing for unknown id": {
+			steps:      map[string]*StepData{"ref1": {Id: "build"}},
+			currentRef: "ref1",
+			expr:       "step.unknown.results",
+			wantOk:     false,
+		},
+		"unrelated expression not handled": {
+			steps:      map[string]*StepData{"ref1": {Id: "build"}},
+			currentRef: "ref1",
+			expr:       "other.thing",
+			wantOk:     false,
+		},
+	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			setupTestState(tc.steps, tc.currentRef)
+			val, ok := resolveStepExpr(t, tc.expr)
+			assert.Equal(t, tc.wantOk, ok)
+			if tc.wantOk {
+				assert.Equal(t, tc.wantVal, val)
+			}
+		})
+	}
+
+}
+
+func TestStepMachine_TemplateExpression(t *testing.T) {
+	setupTestState(map[string]*StepData{"ref1": {Id: "build"}}, "ref1")
+	compiled, err := expressions.CompileAndResolveTemplate("go build -o {{ step.results }}/binary", StepMachine)
+	assert.NoError(t, err)
+	val, _ := compiled.Static().StringValue()
+	assert.Equal(t, "go build -o /data/.steps/build/binary", val)
+}
+
+func TestStepResultsDir(t *testing.T) {
+	assert.Equal(t, "/data/.steps/build", StepResultsDir("build"))
+	assert.Equal(t, "/data/.steps/run_tests", StepResultsDir("run_tests"))
+}
+
+func TestStepData_SetId(t *testing.T) {
+	step := &StepData{Ref: "ref1"}
+	step.SetId("build")
+	assert.Equal(t, "build", step.Id)
+
+	status := constants.StepStatusPassed
+	step.Status = &status
+	assert.True(t, step.IsFinished())
+}

--- a/cmd/testworkflow-init/runner/action_dispatcher.go
+++ b/cmd/testworkflow-init/runner/action_dispatcher.go
@@ -2,9 +2,11 @@ package runner
 
 import (
 	"fmt"
+	"os"
 	"slices"
 
 	"github.com/kubeshop/testkube/cmd/testworkflow-init/constants"
+	"github.com/kubeshop/testkube/cmd/testworkflow-init/data"
 	"github.com/kubeshop/testkube/cmd/testworkflow-init/orchestration"
 	"github.com/kubeshop/testkube/pkg/testworkflows/testworkflowprocessor/action/actiontypes/lite"
 )
@@ -145,6 +147,17 @@ func (d *ActionDispatcher) handleStart(action *lite.LiteAction, ctx *ExecutionCo
 		for _, v := range ctx.State.GetSteps() {
 			if slices.Contains(v.Parents, step.Ref) {
 				v.SetStatus(constants.StepStatusSkipped)
+			}
+		}
+	}
+
+	// Create per-step results directory if the step has an ID and will execute
+	if !step.IsFinished() && step.Id != "" {
+		resultsDir := data.StepResultsDir(step.Id)
+		if err := os.MkdirAll(resultsDir, 0777); err != nil {
+			return ActionResult{
+				ContinueExecution: false,
+				Error:             fmt.Errorf("failed to create step results directory %s: %w", resultsDir, err),
 			}
 		}
 	}

--- a/cmd/testworkflow-init/runner/action_handlers.go
+++ b/cmd/testworkflow-init/runner/action_handlers.go
@@ -25,7 +25,7 @@ import (
 
 // handleDeclareAction processes declare actions
 func handleDeclareAction(step *data.StepData, action *lite.ActionDeclare) {
-	step.SetCondition(action.Condition).SetParents(action.Parents)
+	step.SetId(action.Id).SetCondition(action.Condition).SetParents(action.Parents)
 }
 
 // handlePauseAction processes pause actions
@@ -51,7 +51,6 @@ func handleRetryAction(step *data.StepData, action *lite.ActionRetry) {
 	})
 }
 
-// handleContainerTransition processes container transition actions
 func handleContainerTransition(container *lite.LiteActionContainer, actions []lite.LiteAction, currentIndex int, state interface{ GetStep(string) *data.StepData }, stdout interface{ SetSensitiveWords([]string) }) (*lite.LiteActionContainer, error) {
 	orchestration.Setup.SetConfig(container.Config)
 	err := orchestration.Setup.AdvanceEnv()
@@ -240,7 +239,6 @@ func handleExecuteAction(action *lite.ActionExecute, ctx *ExecutionContext) Acti
 	return ActionResult{ContinueExecution: true}
 }
 
-// handlePause handles pausing of a step and its parents
 func handlePause(ts time.Time, step *data.StepData, ctx *ExecutionContext) error {
 	if step.PausedStart != nil {
 		return nil
@@ -257,7 +255,6 @@ func handlePause(ts time.Time, step *data.StepData, ctx *ExecutionContext) error
 	return err
 }
 
-// newMetricsRecorderConfig creates configuration for metrics recording
 func newMetricsRecorderConfig(stepRef string, skip bool, containerResources testworkflowconfig.ContainerResourceConfig) utilization.Config {
 	s := data.GetState()
 	metricsDir := filepath.Join(constants.InternalPath, "metrics", stepRef)
@@ -294,7 +291,6 @@ func appendSuffixIfNeeded(s, suffix string) string {
 	return s + suffix
 }
 
-// scrapeMetricsPostProcessor returns a function that processes scraped metrics
 func scrapeMetricsPostProcessor(path, step string, config testworkflowconfig.InternalConfig) func() error {
 	return func() error {
 		err := orchestration.Setup.UseCurrentEnv()
@@ -335,7 +331,6 @@ func scrapeMetricsPostProcessor(path, step string, config testworkflowconfig.Int
 	}
 }
 
-// shouldRetry determines if a step should be retried based on conditions
 func shouldRetry(step *data.StepData, hasTimeout bool, hasOwnTimeout bool, stdout interface {
 	Printf(format string, args ...interface{})
 }) bool {


### PR DESCRIPTION
## Summary

- Add `step.results` and `step.<id>.results` expression accessors that resolve to per-step directories (`/data/.steps/<id>/`)
- Directories created at runtime by the init process when a step starts
- Store step ID on `StepData` from `ActionDeclare.Id` so the init process knows the ref-to-id mapping

Example:
```yaml
steps:
- name: Build
  id: build
  shell: go build -o ${{ step.results }}/binary ./cmd/...
- name: Test
  id: test
  shell: ${{ step.build.results }}/binary --self-test
```

## Test plan

- [x] `step.results` resolves to current step directory
- [x] `step.<id>.results` resolves to named step directory
- [x] Returns nothing for unknown step ID or missing ID
- [x] Works in template expressions (shell commands)
- [x] All existing init process tests pass

Depends on #7358

Closes TKC-5167