### PR TITLE
feat: per-step output values for parameter sharing between steps

### DIFF
--- a/cmd/testworkflow-init/data/outputscan.go
+++ b/cmd/testworkflow-init/data/outputscan.go
@@ -1,0 +1,70 @@
+package data
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+const (
+	OutputsDir    = "/testkube/outputs"
+	MaxOutputSize = 4096
+)
+
+// ScanStepOutputs reads files from OutputsDir and stores their contents
+// as per-step outputs. Files exceeding MaxOutputSize are skipped.
+func ScanStepOutputs(stepId string) error {
+	return scanStepOutputsFrom(OutputsDir, stepId)
+}
+
+func scanStepOutputsFrom(dir, stepId string) error {
+	if stepId == "" {
+		return nil
+	}
+
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return fmt.Errorf("failed to read outputs directory: %w", err)
+	}
+
+	state := GetState()
+	for _, entry := range entries {
+		if entry.IsDir() || strings.HasPrefix(entry.Name(), ".") || !entry.Type().IsRegular() {
+			continue
+		}
+
+		name := entry.Name()
+		path := filepath.Join(dir, name)
+		info, err := entry.Info()
+		if err != nil {
+			continue
+		}
+		if info.Size() > MaxOutputSize {
+			fmt.Fprintf(os.Stderr, "warn: step output %q exceeds %d byte limit, skipping (use step.results for large files)\n", name, MaxOutputSize)
+			continue
+		}
+
+		content, err := os.ReadFile(path)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "warn: failed to read step output %q: %s\n", name, err.Error())
+			continue
+		}
+
+		state.SetStepOutput(stepId, name, strings.TrimSpace(string(content)))
+	}
+	return nil
+}
+
+func PrepareOutputsDir() error {
+	if err := os.RemoveAll(OutputsDir); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("failed to clear outputs directory: %w", err)
+	}
+	if err := os.MkdirAll(OutputsDir, 0777); err != nil {
+		return fmt.Errorf("failed to create outputs directory: %w", err)
+	}
+	return nil
+}

--- a/cmd/testworkflow-init/data/state.go
+++ b/cmd/testworkflow-init/data/state.go
@@ -110,6 +110,48 @@ func (s *state) GetStepByID(id string) *StepData {
 	return nil
 }
 
+func stepOutputKey(stepId, name string) string {
+	return "step." + stepId + "." + name
+}
+
+func stepOutputPrefix(stepId string) string {
+	return "step." + stepId + "."
+}
+
+func (s *state) SetStepOutput(stepId, name, value string) {
+	stateMu.Lock()
+	defer stateMu.Unlock()
+
+	if s.Output == nil {
+		s.Output = make(map[string]string)
+	}
+	s.Output[stepOutputKey(stepId, name)] = value
+}
+
+func (s *state) ClearStepOutputs(stepId string) {
+	stateMu.Lock()
+	defer stateMu.Unlock()
+
+	prefix := stepOutputPrefix(stepId)
+	for k := range s.Output {
+		if strings.HasPrefix(k, prefix) {
+			delete(s.Output, k)
+		}
+	}
+}
+
+func (s *state) GetStepOutput(stepId, name string) (interface{}, bool, error) {
+	key := stepOutputKey(stepId, name)
+	stateMu.RLock()
+	v, ok := s.Output[key]
+	stateMu.RUnlock()
+
+	if !ok {
+		return nil, false, nil
+	}
+	return v, true, nil
+}
+
 func (s *state) GetSubSteps(ref string) []*StepData {
 	stateMu.RLock()
 	defer stateMu.RUnlock()

--- a/cmd/testworkflow-init/data/stepmachine.go
+++ b/cmd/testworkflow-init/data/stepmachine.go
@@ -9,7 +9,7 @@ import (
 
 const (
 	stepPrefix      = "step."
-	stepResultsBase = "/data/.steps/"
+	stepResultsBase = "/data/.steps"
 )
 
 // StepResultsDir returns the results directory path for a step.
@@ -19,13 +19,12 @@ func StepResultsDir(id string) string {
 	return filepath.Join(stepResultsBase, id)
 }
 
-// StepMachine resolves step-scoped expressions:
-//   - step.results -> current step's results directory
-//   - step.<id>.results -> named step's results directory
+// StepMachine resolves step-scoped expressions like step.results,
+// step.<id>.results, and step.<id>.outputs.<key>.
 var StepMachine = expressions.NewMachine().
-	RegisterAccessor(func(name string) (interface{}, bool) {
+	RegisterAccessorExt(func(name string) (interface{}, bool, error) {
 		if !strings.HasPrefix(name, stepPrefix) {
-			return nil, false
+			return nil, false, nil
 		}
 		suffix := name[len(stepPrefix):]
 		state := GetState()
@@ -33,23 +32,31 @@ var StepMachine = expressions.NewMachine().
 		if suffix == "results" {
 			currentStep := state.GetStep(state.CurrentRef)
 			if currentStep.Id == "" {
-				return nil, false
+				return nil, false, nil
 			}
-			return StepResultsDir(currentStep.Id), true
+			return StepResultsDir(currentStep.Id), true, nil
 		}
 
 		parts := strings.SplitN(suffix, ".", 2)
 		if len(parts) != 2 {
-			return nil, false
+			return nil, false, nil
 		}
-		stepId, property := parts[0], parts[1]
+		stepId, rest := parts[0], parts[1]
 
-		if property == "results" {
+		switch {
+		case rest == "results":
 			if state.GetStepByID(stepId) == nil {
-				return nil, false
+				return nil, false, nil
 			}
-			return StepResultsDir(stepId), true
+			return StepResultsDir(stepId), true, nil
+
+		case strings.HasPrefix(rest, "outputs."):
+			key := rest[len("outputs."):]
+			if key == "" {
+				return nil, false, nil
+			}
+			return state.GetStepOutput(stepId, key)
 		}
 
-		return nil, false
+		return nil, false, nil
 	})

--- a/cmd/testworkflow-init/data/stepmachine_test.go
+++ b/cmd/testworkflow-init/data/stepmachine_test.go
@@ -1,11 +1,14 @@
 package data
 
 import (
+	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
-	"github.com/kubeshop/testkube/cmd/testworkflow-init/constants"
 	"github.com/kubeshop/testkube/pkg/expressions"
 )
 
@@ -22,9 +25,7 @@ func setupTestState(steps map[string]*StepData, currentRef string) {
 func resolveStepExpr(t *testing.T, expr string) (string, bool) {
 	t.Helper()
 	compiled, err := expressions.CompileAndResolve(expr, StepMachine)
-	if err != nil {
-		return "", false
-	}
+	require.NoError(t, err)
 	if compiled.Static() == nil {
 		return "", false
 	}
@@ -32,7 +33,7 @@ func resolveStepExpr(t *testing.T, expr string) (string, bool) {
 	return val, true
 }
 
-func TestStepMachine(t *testing.T) {
+func TestStepMachine_Results(t *testing.T) {
 	tests := map[string]struct {
 		steps      map[string]*StepData
 		currentRef string
@@ -83,28 +84,119 @@ func TestStepMachine(t *testing.T) {
 			}
 		})
 	}
+}
 
+func TestStepMachine_Outputs(t *testing.T) {
+	tests := map[string]struct {
+		outputs map[string]map[string]string // stepId -> key -> value
+		expr    string
+		wantVal string
+		wantOk  bool
+	}{
+		"resolves stored output": {
+			outputs: map[string]map[string]string{"auth": {"token": "abc123"}},
+			expr:    "step.auth.outputs.token",
+			wantVal: "abc123",
+			wantOk:  true,
+		},
+		"returns nothing for missing output": {
+			outputs: nil,
+			expr:    "step.auth.outputs.token",
+			wantOk:  false,
+		},
+		"isolated between steps": {
+			outputs: map[string]map[string]string{"step_a": {"token": "aaa"}, "step_b": {"token": "bbb"}},
+			expr:    "step.step_a.outputs.token",
+			wantVal: "aaa",
+			wantOk:  true,
+		},
+	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			setupTestState(map[string]*StepData{
+				"ref1": {Id: "auth"},
+				"ref2": {Id: "step_a"},
+				"ref3": {Id: "step_b"},
+			}, "ref1")
+			for stepId, outputs := range tc.outputs {
+				for k, v := range outputs {
+					GetState().SetStepOutput(stepId, k, v)
+				}
+			}
+			val, ok := resolveStepExpr(t, tc.expr)
+			assert.Equal(t, tc.wantOk, ok)
+			if tc.wantOk {
+				assert.Equal(t, tc.wantVal, val)
+			}
+		})
+	}
 }
 
 func TestStepMachine_TemplateExpression(t *testing.T) {
-	setupTestState(map[string]*StepData{"ref1": {Id: "build"}}, "ref1")
-	compiled, err := expressions.CompileAndResolveTemplate("go build -o {{ step.results }}/binary", StepMachine)
+	setupTestState(map[string]*StepData{"ref1": {Id: "auth"}}, "ref1")
+	GetState().SetStepOutput("auth", "token", "mytoken")
+
+	compiled, err := expressions.CompileAndResolveTemplate(
+		"curl -H \"Auth: {{ step.auth.outputs.token }}\" https://api",
+		StepMachine,
+	)
 	assert.NoError(t, err)
 	val, _ := compiled.Static().StringValue()
-	assert.Equal(t, "go build -o /data/.steps/build/binary", val)
+	assert.Equal(t, "curl -H \"Auth: mytoken\" https://api", val)
+}
+
+func TestScanStepOutputs(t *testing.T) {
+	t.Run("scans files and trims whitespace", func(t *testing.T) {
+		dir := t.TempDir()
+		setupTestState(map[string]*StepData{"ref1": {Id: "auth"}}, "ref1")
+
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "token"), []byte("abc123\n"), 0644))
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "count"), []byte("42"), 0644))
+
+		require.NoError(t, scanStepOutputsFrom(dir, "auth"))
+
+		val, ok := resolveStepExpr(t, "step.auth.outputs.token")
+		assert.True(t, ok)
+		assert.Equal(t, "abc123", val)
+
+		val, ok = resolveStepExpr(t, "step.auth.outputs.count")
+		assert.True(t, ok)
+		assert.Equal(t, "42", val)
+	})
+
+	t.Run("skips hidden files", func(t *testing.T) {
+		dir := t.TempDir()
+		setupTestState(map[string]*StepData{"ref1": {Id: "auth"}}, "ref1")
+
+		require.NoError(t, os.WriteFile(filepath.Join(dir, ".hidden"), []byte("secret"), 0644))
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "visible"), []byte("ok"), 0644))
+
+		require.NoError(t, scanStepOutputsFrom(dir, "auth"))
+
+		val, ok := resolveStepExpr(t, "step.auth.outputs.visible")
+		assert.True(t, ok)
+		assert.Equal(t, "ok", val)
+	})
+
+	t.Run("skips oversized files", func(t *testing.T) {
+		dir := t.TempDir()
+		setupTestState(map[string]*StepData{"ref1": {Id: "auth"}}, "ref1")
+
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "big"), []byte(strings.Repeat("x", MaxOutputSize+1)), 0644))
+
+		require.NoError(t, scanStepOutputsFrom(dir, "auth"))
+
+		_, ok := resolveStepExpr(t, "step.auth.outputs.big")
+		assert.False(t, ok)
+	})
+
+	t.Run("noop for empty id or missing dir", func(t *testing.T) {
+		assert.NoError(t, scanStepOutputsFrom("/nonexistent", ""))
+		assert.NoError(t, scanStepOutputsFrom("/nonexistent", "build"))
+	})
 }
 
 func TestStepResultsDir(t *testing.T) {
 	assert.Equal(t, "/data/.steps/build", StepResultsDir("build"))
 	assert.Equal(t, "/data/.steps/run_tests", StepResultsDir("run_tests"))
-}
-
-func TestStepData_SetId(t *testing.T) {
-	step := &StepData{Ref: "ref1"}
-	step.SetId("build")
-	assert.Equal(t, "build", step.Id)
-
-	status := constants.StepStatusPassed
-	step.Status = &status
-	assert.True(t, step.IsFinished())
 }

--- a/cmd/testworkflow-init/runner/action_handlers.go
+++ b/cmd/testworkflow-init/runner/action_handlers.go
@@ -23,27 +23,22 @@ import (
 	"github.com/kubeshop/testkube/pkg/utilization/core"
 )
 
-// handleDeclareAction processes declare actions
 func handleDeclareAction(step *data.StepData, action *lite.ActionDeclare) {
 	step.SetId(action.Id).SetCondition(action.Condition).SetParents(action.Parents)
 }
 
-// handlePauseAction processes pause actions
 func handlePauseAction(step *data.StepData, action *lite.ActionPause) {
 	step.SetPausedOnStart(true)
 }
 
-// handleResultAction processes result actions
 func handleResultAction(step *data.StepData, action *lite.ActionResult) {
 	step.SetResult(action.Value)
 }
 
-// handleTimeoutAction processes timeout actions
 func handleTimeoutAction(step *data.StepData, action *lite.ActionTimeout) {
 	step.SetTimeout(action.Timeout)
 }
 
-// handleRetryAction processes retry actions
 func handleRetryAction(step *data.StepData, action *lite.ActionRetry) {
 	step.SetRetryPolicy(data.RetryPolicy{
 		Count: action.Count,
@@ -197,6 +192,18 @@ func handleExecuteAction(action *lite.ActionExecute, ctx *ExecutionContext) Acti
 			break
 		}
 
+		// Clear stale outputs from previous attempts and prepare fresh directory
+		if step.Id != "" {
+			data.GetState().ClearStepOutputs(step.Id)
+			if err := data.PrepareOutputsDir(); err != nil {
+				return ActionResult{
+					ContinueExecution: false,
+					Error:             err,
+					ErrorCode:         constants.CodeInternal,
+				}
+			}
+		}
+
 		hasTimeout.Store(false)
 		hasOwnTimeout.Store(false)
 		stopTimeoutWatcher := orchestration.WatchTimeout(finalizeTimeout, leaf...)
@@ -234,6 +241,13 @@ func handleExecuteAction(action *lite.ActionExecute, ctx *ExecutionContext) Acti
 
 		now := time.Now()
 		step.StartedAt = &now
+	}
+
+	// Scan per-step outputs directory after execution
+	if step.Id != "" {
+		if err := data.ScanStepOutputs(step.Id); err != nil {
+			fmt.Fprintf(os.Stderr, "warn: failed to scan step outputs: %s\n", err.Error())
+		}
 	}
 
 	return ActionResult{ContinueExecution: true}


### PR DESCRIPTION
## Summary

- File-based per-step output mechanism via `/testkube/outputs/` directory
- Users write files to `/testkube/outputs/<key>`, values accessible via `step.<id>.outputs.<key>` expressions
- Outputs stay in-pod only (not sent to the database), safe for sensitive values
- Init process clears the outputs dir before each attempt (including retries) and scans after completion
- 4KB size cap per output, with a warning pointing to `step.results` for larger data
- Also includes `step.results` and `step.<id>.results` accessors for results directories

Example:
```yaml
steps:
- name: Get auth token
  id: auth
  shell: curl -s https://auth/token > /testkube/outputs/token
- name: Call API
  id: call
  shell: curl -H "Auth: ${{ step.auth.outputs.token }}" https://api
```

## Test plan

- [x] `step.<id>.outputs.<key>` resolves stored output values
- [x] Outputs isolated between steps (no key collision)
- [x] Template expressions with outputs work in shell commands
- [x] File scanning: reads files, trims whitespace, skips hidden and oversized
- [x] Noop when step has no ID or directory doesn't exist
- [x] `step.results` and `step.<id>.results` resolve to directory paths
- [x] All existing init process tests pass

Depends on #7358

Closes TKC-5168