### PR TITLE
fix: agent artifact route to support filenames with slashes

### DIFF
--- a/internal/app/api/v1/server.go
+++ b/internal/app/api/v1/server.go
@@ -188,7 +188,7 @@ func (s *TestkubeAPI) Init(server server.HTTPServer) {
 	testWorkflowExecutions.Post("/:executionID/resume", s.ResumeTestWorkflowExecutionHandler())
 	testWorkflowExecutions.Get("/:executionID/logs", s.GetTestWorkflowExecutionLogsHandler())
 	testWorkflowExecutions.Get("/:executionID/artifacts", s.ListTestWorkflowExecutionArtifactsHandler())
-	testWorkflowExecutions.Get("/:executionID/artifacts/:filename", s.GetTestWorkflowArtifactHandler())
+	testWorkflowExecutions.Get("/:executionID/artifacts/:filename+", s.GetTestWorkflowArtifactHandler())
 	testWorkflowExecutions.Get("/:executionID/artifact-archive", s.GetTestWorkflowArtifactArchiveHandler())
 	testWorkflowExecutions.Post("/:executionID/rerun", s.ReRunTestWorkflowExecutionHandler())
 	testWorkflowExecutions.Patch("/:executionID/tags", s.UpdateTestWorkflowExecutionTagsHandler())

--- a/internal/app/api/v1/testworkflowexecutions.go
+++ b/internal/app/api/v1/testworkflowexecutions.go
@@ -732,8 +732,13 @@ func (s *TestkubeAPI) ListTestWorkflowExecutionArtifactsHandler() fiber.Handler 
 func (s *TestkubeAPI) GetTestWorkflowArtifactHandler() fiber.Handler {
 	return func(c *fiber.Ctx) error {
 		executionID := c.Params("executionID")
-		fileName := c.Params("filename")
+		fileName := c.Params("filename+")
 		errPrefix := fmt.Sprintf("failed to get artifact %s for workflow execution %s", fileName, executionID)
+
+		// Fiber greedy params keep percent-encoding intact, so decode first.
+		if decoded, err := url.PathUnescape(fileName); err == nil {
+			fileName = decoded
+		}
 
 		// TODO fix this someday :) we don't know 15 mins before release why it's working this way
 		// remember about CLI client and Dashboard client too!

--- a/internal/app/api/v1/testworkflowexecutions_artifact_test.go
+++ b/internal/app/api/v1/testworkflowexecutions_artifact_test.go
@@ -1,0 +1,104 @@
+package v1
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gofiber/fiber/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	gomock "go.uber.org/mock/gomock"
+
+	"github.com/kubeshop/testkube/pkg/api/v1/testkube"
+	"github.com/kubeshop/testkube/pkg/log"
+	"github.com/kubeshop/testkube/pkg/repository/testworkflow"
+	"github.com/kubeshop/testkube/pkg/storage"
+)
+
+// TestGetArtifactWithSlashedFilename verifies that fetching an artifact whose
+// name contains forward slashes (e.g. "results/junit.xml") works end-to-end
+// through the real Fiber route → handler → storage chain.
+//
+// Before the fix, the route used /:filename (single-segment), so Fiber couldn't
+// match the decoded path and the agent returned no response (causing a 408 timeout
+// at the cloud API level).
+func TestGetArtifactWithSlashedFilename(t *testing.T) {
+	t.Parallel()
+
+	const (
+		execID  = "exec-1"
+		wfName  = "my-workflow"
+		content = "<testsuites/>"
+	)
+
+	tests := []struct {
+		name        string
+		filename    string // decoded filename as stored in artifact storage
+		urlFilename string // filename as it appears in the URL (%2F for /)
+	}{
+		{
+			name:        "simple filename",
+			filename:    "report.xml",
+			urlFilename: "report.xml",
+		},
+		{
+			name:        "filename with one subdirectory",
+			filename:    "results/junit.xml",
+			urlFilename: "results%2Fjunit.xml",
+		},
+		{
+			name:        "filename with nested subdirectories",
+			filename:    "a/b/c/report.xml",
+			urlFilename: "a%2Fb%2Fc%2Freport.xml",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			mockResults := testworkflow.NewMockRepository(ctrl)
+			mockStorage := storage.NewMockArtifactsStorage(ctrl)
+
+			mockResults.EXPECT().Get(gomock.Any(), execID).Return(testkube.TestWorkflowExecution{
+				Id:       execID,
+				Workflow: &testkube.TestWorkflow{Name: wfName},
+			}, nil)
+
+			mockStorage.EXPECT().
+				DownloadFile(gomock.Any(), tc.filename, execID, "", "", wfName).
+				Return(io.NopCloser(strings.NewReader(content)), nil)
+
+			testAPI := &TestkubeAPI{
+				TestWorkflowResults: mockResults,
+				ArtifactsStorage:    mockStorage,
+				Log:                 log.DefaultLogger,
+			}
+
+			app := fiber.New()
+			execGroup := app.Group("/v1/test-workflow-executions")
+			execGroup.Get("/:executionID/artifacts/:filename+", testAPI.GetTestWorkflowArtifactHandler())
+
+			url := "/v1/test-workflow-executions/" + execID + "/artifacts/" + tc.urlFilename
+			req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, url, nil)
+
+			resp, err := app.Test(req)
+			require.NoError(t, err)
+			defer resp.Body.Close()
+
+			body, err := io.ReadAll(resp.Body)
+			require.NoError(t, err)
+
+			assert.Equal(t, http.StatusOK, resp.StatusCode,
+				"expected 200 but got %d — if no response, the route didn't match the slashed filename", resp.StatusCode)
+			assert.Equal(t, content, string(body))
+		})
+	}
+}

--- a/pkg/runner/agent_conn_test.go
+++ b/pkg/runner/agent_conn_test.go
@@ -144,7 +144,7 @@ func TestAgentLoop_GetRunnerRequests_ReconnectionOnReceiveTimeout(t *testing.T) 
 	)
 
 	// Create context with timeout longer than 2x receive timeout + reconnect timeout
-	ctx, cancel := context.WithTimeout(context.Background(), (2*testTimeout)+agentLoopReconnectionDelay)
+	ctx, cancel := context.WithTimeout(context.Background(), (3*testTimeout)+(2*agentLoopReconnectionDelay))
 	defer cancel()
 
 	// Start the agent loop
@@ -160,7 +160,7 @@ func TestAgentLoop_GetRunnerRequests_ReconnectionOnReceiveTimeout(t *testing.T) 
 		"Expected at least 2 calls due to receive timeout reconnections, got %d", testServer.GetCallCount())
 }
 
-func TestAgentLoop_GetNotifications_ReconnectionOnReceiveTimeout(t *testing.T) {
+func TestAgentLoop_GetNotifications_ReconnectionOnReceiveTimeout(t *testing.T) { //nolint:dupl // intentionally mirrors GetRunnerRequests test
 	testServer := &testGRPCServer{
 		getRunnerRequestSendPing:                         true,
 		getTestWorkflowNotificationsSendPing:             false,
@@ -214,7 +214,7 @@ func TestAgentLoop_GetNotifications_ReconnectionOnReceiveTimeout(t *testing.T) {
 	)
 
 	// Create context with timeout longer than 2x receive timeout + reconnect timeout
-	ctx, cancel := context.WithTimeout(context.Background(), (2*testTimeout)+agentLoopReconnectionDelay)
+	ctx, cancel := context.WithTimeout(context.Background(), (3*testTimeout)+(2*agentLoopReconnectionDelay))
 	defer cancel()
 
 	// Start the agent loop


### PR DESCRIPTION
Companion fix to kubeshop/testkube-cloud-api#3489 - resolves the second layer of the artifact 410/408 bug.

- Artifact filenames can contain subdirectory paths (e.g. `results/junit.xml`); the cloud API proxies these to the agent via NATS with `%2F`-encoded slashes
- fasthttp's `URI.Parse` decodes `%2F` → `/` before Fiber routing, so `:filename` (single-segment) can't match multi-segment decoded paths — the agent silently drops the request, causing a 408 timeout at the cloud API
- Change `:filename` → `:filename+` (Fiber greedy param) so the route matches filenames with slashes, matching the cloud API fix (`{filename:.*}`)
