### PR TITLE
feat: [TKC-5397] ranged artifact retrieval with line range, grep, and binary detection

### DIFF
--- a/pkg/mcp/api.go
+++ b/pkg/mcp/api.go
@@ -226,9 +226,6 @@ func (c *APIClient) ListArtifacts(ctx context.Context, executionID string) (stri
 }
 
 func (c *APIClient) ReadArtifact(ctx context.Context, executionID, filename string, params tools.ArtifactReadParams) (string, error) {
-	// URL encode the filename to handle special characters like forward slashes
-	encodedFilename := url.QueryEscape(filename)
-
 	response, err := c.makeRequest(ctx, APIRequest{
 		Method: "POST",
 		Path:   "/test-workflow-executions/{executionId}/artifacts",

--- a/pkg/mcp/api.go
+++ b/pkg/mcp/api.go
@@ -225,9 +225,10 @@ func (c *APIClient) ListArtifacts(ctx context.Context, executionID string) (stri
 	})
 }
 
-func (c *APIClient) ReadArtifact(ctx context.Context, executionID, filename string) (string, error) {
-	// First, resolve the artifact by name. The control plane returns an ArtifactURL
-	// with a signed storage link rather than the artifact content directly.
+func (c *APIClient) ReadArtifact(ctx context.Context, executionID, filename string, params tools.ArtifactReadParams) (string, error) {
+	// URL encode the filename to handle special characters like forward slashes
+	encodedFilename := url.QueryEscape(filename)
+
 	response, err := c.makeRequest(ctx, APIRequest{
 		Method: "POST",
 		Path:   "/test-workflow-executions/{executionId}/artifacts",

--- a/pkg/mcp/api_test.go
+++ b/pkg/mcp/api_test.go
@@ -10,6 +10,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/kubeshop/testkube/pkg/mcp/tools"
 )
 
 func TestAPIClient_ReadArtifact_UsesArtifactLookupPost(t *testing.T) {
@@ -57,7 +59,7 @@ func TestAPIClient_ReadArtifact_UsesArtifactLookupPost(t *testing.T) {
 		EnvId:           envID,
 	}, server.Client())
 
-	body, err := client.ReadArtifact(context.Background(), executionID, artifactID)
+	body, err := client.ReadArtifact(context.Background(), executionID, artifactID, tools.ArtifactReadParams{})
 	require.NoError(t, err)
 	assert.Equal(t, content, body)
 }

--- a/pkg/mcp/tools/artifactprocessor.go
+++ b/pkg/mcp/tools/artifactprocessor.go
@@ -15,7 +15,7 @@ const (
 // ArtifactReadParams holds optional filtering parameters for artifact retrieval.
 type ArtifactReadParams struct {
 	StartLine int    // 1-based start line. 0 = from beginning.
-	EndLine   int    // 1-based end line. 0 = to end (capped at artifactMaxLines from start).
+	EndLine   int    // 1-based end line. 0 = default window of artifactDefaultLines (100) lines from startLine.
 	Grep      string // Substring filter (case-insensitive). Includes context lines.
 }
 
@@ -38,7 +38,7 @@ func ProcessArtifact(content []byte, filename string, params ArtifactReadParams)
 	lines := strings.Split(text, "\n")
 	totalLines := len(lines)
 
-	// Grep mode
+	// Grep mode -- mutually exclusive with startLine/endLine (grep takes priority).
 	if params.Grep != "" {
 		return processGrep(lines, totalLines, filename, content, params.Grep)
 	}
@@ -61,7 +61,9 @@ func ProcessArtifact(content []byte, filename string, params ArtifactReadParams)
 
 	// Clamp to actual content
 	if startLine > totalLines {
-		startLine = totalLines
+		header := fmt.Sprintf("--- Artifact Metadata ---\nFile: %s\nTotal lines: %d\nSize: %s\nShowing: 0 lines (startLine %d exceeds total %d lines)\n---",
+			filename, totalLines, formatSize(len(content)), startLine, totalLines)
+		return header
 	}
 	if endLine > totalLines {
 		endLine = totalLines
@@ -79,10 +81,12 @@ func ProcessArtifact(content []byte, filename string, params ArtifactReadParams)
 func processGrep(lines []string, totalLines int, filename string, content []byte, pattern string) string {
 	lowerPattern := strings.ToLower(pattern)
 	matchLineNums := make([]int, 0)
+	matchSet := make(map[int]bool)
 
 	for i, line := range lines {
 		if strings.Contains(strings.ToLower(line), lowerPattern) {
 			matchLineNums = append(matchLineNums, i)
+			matchSet[i] = true
 			if len(matchLineNums) >= artifactGrepMaxMatches {
 				break
 			}
@@ -109,31 +113,44 @@ func processGrep(lines []string, totalLines int, filename string, content []byte
 			result = append(result, "...")
 		}
 		prefix := "  "
-		if containsInt(matchLineNums, i) {
+		if matchSet[i] {
 			prefix = "> "
 		}
 		result = append(result, fmt.Sprintf("%s%4d: %s", prefix, i+1, lines[i]))
 		lastIncluded = i
 	}
 
-	// Cap output
-	if len(result) > artifactMaxLines {
-		result = result[:artifactMaxLines]
-	}
-
-	header := fmt.Sprintf("--- Artifact Metadata ---\nFile: %s\nTotal lines: %d\nSize: %s\nShowing: %d grep matches for %q (with %d lines context)\n---",
-		filename, totalLines, formatSize(len(content)), len(matchLineNums), pattern, artifactGrepContext)
-
-	return header + "\n" + strings.Join(result, "\n")
-}
-
-func containsInt(slice []int, val int) bool {
-	for _, v := range slice {
-		if v == val {
-			return true
+	// Cap output (only count content lines, not separators)
+	contentCount := 0
+	capIndex := len(result)
+	for i, line := range result {
+		if line != "..." {
+			contentCount++
+		}
+		if contentCount > artifactMaxLines {
+			capIndex = i
+			break
 		}
 	}
-	return false
+	result = result[:capIndex]
+
+	// Count visible matches after capping
+	visibleMatches := 0
+	for _, line := range result {
+		if len(line) > 2 && line[0] == '>' && line[1] == ' ' {
+			visibleMatches++
+		}
+	}
+
+	truncated := ""
+	if visibleMatches < len(matchLineNums) {
+		truncated = " (truncated)"
+	}
+
+	header := fmt.Sprintf("--- Artifact Metadata ---\nFile: %s\nTotal lines: %d\nSize: %s\nShowing: %d grep matches for %q (with %d lines context)%s\n---",
+		filename, totalLines, formatSize(len(content)), visibleMatches, pattern, artifactGrepContext, truncated)
+
+	return header + "\n" + strings.Join(result, "\n")
 }
 
 func formatSize(bytes int) string {

--- a/pkg/mcp/tools/artifactprocessor.go
+++ b/pkg/mcp/tools/artifactprocessor.go
@@ -1,0 +1,148 @@
+package tools
+
+import (
+	"fmt"
+	"strings"
+)
+
+const (
+	artifactDefaultLines   = 100
+	artifactMaxLines       = 200
+	artifactGrepContext    = 3
+	artifactGrepMaxMatches = 100
+)
+
+// ArtifactReadParams holds optional filtering parameters for artifact retrieval.
+type ArtifactReadParams struct {
+	StartLine int    // 1-based start line. 0 = from beginning.
+	EndLine   int    // 1-based end line. 0 = to end (capped at artifactMaxLines from start).
+	Grep      string // Substring filter (case-insensitive). Includes context lines.
+}
+
+// ProcessArtifact filters artifact content and prepends a metadata header.
+// For binary content, returns a summary message instead.
+func ProcessArtifact(content []byte, filename string, params ArtifactReadParams) string {
+	// Binary detection: check for null bytes in first 512 bytes
+	checkLen := len(content)
+	if checkLen > 512 {
+		checkLen = 512
+	}
+	for i := 0; i < checkLen; i++ {
+		if content[i] == 0 {
+			return fmt.Sprintf("Binary artifact (%s, %s) -- line-based display not available. Use the artifact URL to view directly.",
+				filename, formatSize(len(content)))
+		}
+	}
+
+	text := string(content)
+	lines := strings.Split(text, "\n")
+	totalLines := len(lines)
+
+	// Grep mode
+	if params.Grep != "" {
+		return processGrep(lines, totalLines, filename, content, params.Grep)
+	}
+
+	// Range mode
+	startLine := params.StartLine
+	endLine := params.EndLine
+
+	if startLine == 0 {
+		startLine = 1
+	}
+	if endLine == 0 {
+		endLine = startLine + artifactDefaultLines - 1
+	}
+
+	// Cap range at artifactMaxLines
+	if endLine-startLine+1 > artifactMaxLines {
+		endLine = startLine + artifactMaxLines - 1
+	}
+
+	// Clamp to actual content
+	if startLine > totalLines {
+		startLine = totalLines
+	}
+	if endLine > totalLines {
+		endLine = totalLines
+	}
+
+	// Extract range (convert to 0-based)
+	selected := lines[startLine-1 : endLine]
+
+	header := fmt.Sprintf("--- Artifact Metadata ---\nFile: %s\nTotal lines: %d\nSize: %s\nShowing: lines %d-%d of %d\n---",
+		filename, totalLines, formatSize(len(content)), startLine, endLine, totalLines)
+
+	return header + "\n" + strings.Join(selected, "\n")
+}
+
+func processGrep(lines []string, totalLines int, filename string, content []byte, pattern string) string {
+	lowerPattern := strings.ToLower(pattern)
+	matchLineNums := make([]int, 0)
+
+	for i, line := range lines {
+		if strings.Contains(strings.ToLower(line), lowerPattern) {
+			matchLineNums = append(matchLineNums, i)
+			if len(matchLineNums) >= artifactGrepMaxMatches {
+				break
+			}
+		}
+	}
+
+	// Collect matching lines with context
+	includeSet := make(map[int]bool)
+	for _, lineNum := range matchLineNums {
+		for c := lineNum - artifactGrepContext; c <= lineNum+artifactGrepContext; c++ {
+			if c >= 0 && c < totalLines {
+				includeSet[c] = true
+			}
+		}
+	}
+
+	var result []string
+	lastIncluded := -2
+	for i := 0; i < totalLines; i++ {
+		if !includeSet[i] {
+			continue
+		}
+		if lastIncluded >= 0 && i > lastIncluded+1 {
+			result = append(result, "...")
+		}
+		prefix := "  "
+		if containsInt(matchLineNums, i) {
+			prefix = "> "
+		}
+		result = append(result, fmt.Sprintf("%s%4d: %s", prefix, i+1, lines[i]))
+		lastIncluded = i
+	}
+
+	// Cap output
+	if len(result) > artifactMaxLines {
+		result = result[:artifactMaxLines]
+	}
+
+	header := fmt.Sprintf("--- Artifact Metadata ---\nFile: %s\nTotal lines: %d\nSize: %s\nShowing: %d grep matches for %q (with %d lines context)\n---",
+		filename, totalLines, formatSize(len(content)), len(matchLineNums), pattern, artifactGrepContext)
+
+	return header + "\n" + strings.Join(result, "\n")
+}
+
+func containsInt(slice []int, val int) bool {
+	for _, v := range slice {
+		if v == val {
+			return true
+		}
+	}
+	return false
+}
+
+func formatSize(bytes int) string {
+	switch {
+	case bytes >= 1024*1024:
+		return fmt.Sprintf("%.1f MB", float64(bytes)/(1024*1024))
+	case bytes >= 1024:
+		return fmt.Sprintf("%.1f KB", float64(bytes)/1024)
+	default:
+		return fmt.Sprintf("%d B", bytes)
+	}
+}

--- a/pkg/mcp/tools/artifactprocessor_test.go
+++ b/pkg/mcp/tools/artifactprocessor_test.go
@@ -70,6 +70,24 @@ func TestProcessArtifact_StartLineOnly(t *testing.T) {
 	assert.Contains(t, result, "line 499 content")
 }
 
+func TestProcessArtifact_StartLineOnlyShortFile(t *testing.T) {
+	content := []byte(makeLines(450))
+	result := ProcessArtifact(content, "test.log", ArtifactReadParams{StartLine: 400})
+
+	assert.Contains(t, result, "Showing: lines 400-450 of 450")
+	assert.Contains(t, result, "line 400 content")
+	assert.Contains(t, result, "line 450 content")
+}
+
+func TestProcessArtifact_StartLineBeyondEnd(t *testing.T) {
+	content := []byte(makeLines(100))
+	result := ProcessArtifact(content, "test.log", ArtifactReadParams{StartLine: 200})
+
+	assert.Contains(t, result, "0 lines")
+	assert.Contains(t, result, "exceeds total")
+	assert.NotContains(t, result, "line 1 content")
+}
+
 func TestProcessArtifact_Grep(t *testing.T) {
 	lines := []string{
 		"line 1 normal",

--- a/pkg/mcp/tools/artifactprocessor_test.go
+++ b/pkg/mcp/tools/artifactprocessor_test.go
@@ -1,0 +1,121 @@
+package tools
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func makeLines(n int) string {
+	lines := make([]string, n)
+	for i := range lines {
+		lines[i] = fmt.Sprintf("line %d content", i+1)
+	}
+	return strings.Join(lines, "\n")
+}
+
+func TestProcessArtifact_DefaultFirst100Lines(t *testing.T) {
+	content := []byte(makeLines(500))
+	result := ProcessArtifact(content, "test.log", ArtifactReadParams{})
+
+	assert.Contains(t, result, "Total lines: 500")
+	assert.Contains(t, result, "Showing: lines 1-100 of 500")
+	assert.Contains(t, result, "line 1 content")
+	assert.Contains(t, result, "line 100 content")
+	assert.NotContains(t, result, "line 101 content")
+}
+
+func TestProcessArtifact_ShortFile(t *testing.T) {
+	content := []byte(makeLines(50))
+	result := ProcessArtifact(content, "test.log", ArtifactReadParams{})
+
+	assert.Contains(t, result, "Total lines: 50")
+	assert.Contains(t, result, "Showing: lines 1-50 of 50")
+	assert.Contains(t, result, "line 50 content")
+}
+
+func TestProcessArtifact_EmptyArtifact(t *testing.T) {
+	result := ProcessArtifact([]byte(""), "test.log", ArtifactReadParams{})
+	assert.Contains(t, result, "Total lines: 1")
+}
+
+func TestProcessArtifact_LineRange(t *testing.T) {
+	content := []byte(makeLines(500))
+	result := ProcessArtifact(content, "test.log", ArtifactReadParams{StartLine: 200, EndLine: 250})
+
+	assert.Contains(t, result, "Showing: lines 200-250 of 500")
+	assert.Contains(t, result, "line 200 content")
+	assert.Contains(t, result, "line 250 content")
+	assert.NotContains(t, result, "line 199 content")
+	assert.NotContains(t, result, "line 251 content")
+}
+
+func TestProcessArtifact_LineRangeExceedsMaxLines(t *testing.T) {
+	content := []byte(makeLines(500))
+	result := ProcessArtifact(content, "test.log", ArtifactReadParams{StartLine: 1, EndLine: 400})
+
+	assert.Contains(t, result, "Showing: lines 1-200 of 500")
+	assert.Contains(t, result, "line 200 content")
+	assert.NotContains(t, result, "line 201 content")
+}
+
+func TestProcessArtifact_StartLineOnly(t *testing.T) {
+	content := []byte(makeLines(500))
+	result := ProcessArtifact(content, "test.log", ArtifactReadParams{StartLine: 400})
+
+	assert.Contains(t, result, "Showing: lines 400-499 of 500")
+	assert.Contains(t, result, "line 400 content")
+	assert.Contains(t, result, "line 499 content")
+}
+
+func TestProcessArtifact_Grep(t *testing.T) {
+	lines := []string{
+		"line 1 normal",
+		"line 2 normal",
+		"line 3 ERROR something failed",
+		"line 4 normal",
+		"line 5 normal",
+		"line 6 normal",
+		"line 7 ERROR another failure",
+		"line 8 normal",
+	}
+	content := []byte(strings.Join(lines, "\n"))
+	result := ProcessArtifact(content, "test.log", ArtifactReadParams{Grep: "ERROR"})
+
+	assert.Contains(t, result, "2 grep matches")
+	assert.Contains(t, result, "ERROR something failed")
+	assert.Contains(t, result, "ERROR another failure")
+}
+
+func TestProcessArtifact_GrepCaseInsensitive(t *testing.T) {
+	content := []byte("line 1\nERROR here\nerror there\nLine 4\n")
+	result := ProcessArtifact(content, "test.log", ArtifactReadParams{Grep: "error"})
+
+	assert.Contains(t, result, "2 grep matches")
+}
+
+func TestProcessArtifact_GrepNoMatches(t *testing.T) {
+	content := []byte(makeLines(100))
+	result := ProcessArtifact(content, "test.log", ArtifactReadParams{Grep: "NONEXISTENT"})
+
+	assert.Contains(t, result, "0 grep matches")
+}
+
+func TestProcessArtifact_Binary(t *testing.T) {
+	content := []byte("PNG\x89\x00\x00binary\x00data")
+	result := ProcessArtifact(content, "image.png", ArtifactReadParams{})
+
+	assert.Contains(t, result, "Binary artifact")
+	assert.Contains(t, result, "line-based display not available")
+}
+
+func TestProcessArtifact_HardCap(t *testing.T) {
+	content := []byte(makeLines(1000))
+	result := ProcessArtifact(content, "test.log", ArtifactReadParams{StartLine: 1, EndLine: 1000})
+
+	// Should cap at 200 lines
+	assert.Contains(t, result, "Showing: lines 1-200 of 1000")
+	assert.NotContains(t, result, "line 201 content")
+}

--- a/pkg/mcp/tools/artifacts.go
+++ b/pkg/mcp/tools/artifacts.go
@@ -71,18 +71,18 @@ func ReadArtifact(client ArtifactReader) (tool mcp.Tool, handler server.ToolHand
 		params.Grep = request.GetString("grep", "")
 
 		if s := request.GetString("startLine", ""); s != "" {
-			if v, err := strconv.Atoi(s); err == nil && v > 0 {
-				params.StartLine = v
+			v, err := strconv.Atoi(s)
+			if err != nil || v <= 0 {
+				return mcp.NewToolResultError(fmt.Sprintf("startLine must be a positive integer, got %q", s)), nil
 			}
+			params.StartLine = v
 		}
 		if s := request.GetString("endLine", ""); s != "" {
-			if v, err := strconv.Atoi(s); err == nil && v > 0 {
-				params.EndLine = v
+			v, err := strconv.Atoi(s)
+			if err != nil || v <= 0 {
+				return mcp.NewToolResultError(fmt.Sprintf("endLine must be a positive integer, got %q", s)), nil
 			}
-		}
-
-		if params.StartLine > 0 && params.EndLine > 0 && params.StartLine > params.EndLine {
-			return mcp.NewToolResultError("startLine must be less than or equal to endLine"), nil
+			params.EndLine = v
 		}
 
 		content, err := client.ReadArtifact(ctx, executionId, fileName, params)

--- a/pkg/mcp/tools/artifacts.go
+++ b/pkg/mcp/tools/artifacts.go
@@ -57,14 +57,14 @@ func ReadArtifact(client ArtifactReader) (tool mcp.Tool, handler server.ToolHand
 	)
 
 	handler = func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-		executionId := request.GetString("executionId", "")
-		if executionId == "" {
-			return mcp.NewToolResultError("executionId is required"), nil
+		executionId, err := RequiredParam[string](request, "executionId")
+		if err != nil {
+			return mcp.NewToolResultError(err.Error()), nil
 		}
 
-		fileName := request.GetString("fileName", "")
-		if fileName == "" {
-			return mcp.NewToolResultError("fileName is required"), nil
+		fileName, err := RequiredParam[string](request, "fileName")
+		if err != nil {
+			return mcp.NewToolResultError(err.Error()), nil
 		}
 
 		var params ArtifactReadParams

--- a/pkg/mcp/tools/artifacts.go
+++ b/pkg/mcp/tools/artifacts.go
@@ -3,6 +3,7 @@ package tools
 import (
 	"context"
 	"fmt"
+	"strconv"
 
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
@@ -35,10 +36,8 @@ func ListArtifacts(client ArtifactLister) (tool mcp.Tool, handler server.ToolHan
 	return tool, handler
 }
 
-const MaxLines = 100
-
 type ArtifactReader interface {
-	ReadArtifact(ctx context.Context, executionId, filename string) (string, error)
+	ReadArtifact(ctx context.Context, executionId, filename string, params ArtifactReadParams) (string, error)
 }
 
 func ReadArtifact(client ArtifactReader) (tool mcp.Tool, handler server.ToolHandlerFunc) {
@@ -46,20 +45,47 @@ func ReadArtifact(client ArtifactReader) (tool mcp.Tool, handler server.ToolHand
 		mcp.WithDescription(ReadArtifactDescription),
 		mcp.WithString("executionId", mcp.Required(), mcp.Description(ExecutionIdDescription)),
 		mcp.WithString("fileName", mcp.Required(), mcp.Description(FilenameDescription)),
+		mcp.WithString("startLine",
+			mcp.Description("1-based line number to start reading from. Use with endLine for a range."),
+		),
+		mcp.WithString("endLine",
+			mcp.Description("1-based line number to stop reading at (inclusive). Use with startLine for a range."),
+		),
+		mcp.WithString("grep",
+			mcp.Description("Case-insensitive substring filter. Returns matching lines with 3 lines of context."),
+		),
 	)
 
 	handler = func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-		executionId, err := RequiredParam[string](request, "executionId")
-		if err != nil {
-			return mcp.NewToolResultError(err.Error()), nil
+		executionId := request.GetString("executionId", "")
+		if executionId == "" {
+			return mcp.NewToolResultError("executionId is required"), nil
 		}
 
-		fileName, err := RequiredParam[string](request, "fileName")
-		if err != nil {
-			return mcp.NewToolResultError(err.Error()), nil
+		fileName := request.GetString("fileName", "")
+		if fileName == "" {
+			return mcp.NewToolResultError("fileName is required"), nil
 		}
 
-		content, err := client.ReadArtifact(ctx, executionId, fileName)
+		var params ArtifactReadParams
+		params.Grep = request.GetString("grep", "")
+
+		if s := request.GetString("startLine", ""); s != "" {
+			if v, err := strconv.Atoi(s); err == nil && v > 0 {
+				params.StartLine = v
+			}
+		}
+		if s := request.GetString("endLine", ""); s != "" {
+			if v, err := strconv.Atoi(s); err == nil && v > 0 {
+				params.EndLine = v
+			}
+		}
+
+		if params.StartLine > 0 && params.EndLine > 0 && params.StartLine > params.EndLine {
+			return mcp.NewToolResultError("startLine must be less than or equal to endLine"), nil
+		}
+
+		content, err := client.ReadArtifact(ctx, executionId, fileName, params)
 		if err != nil {
 			return mcp.NewToolResultError(fmt.Sprintf("Error reading artifact: %v", err)), nil
 		}
@@ -68,9 +94,8 @@ func ReadArtifact(client ArtifactReader) (tool mcp.Tool, handler server.ToolHand
 			return mcp.NewToolResultText(fmt.Sprintf("Artifact \"%s\" is empty or not found", fileName)), nil
 		}
 
-		// Limit content to max lines
-		limitedContent := LimitContentToLines(content, MaxLines)
-		return mcp.NewToolResultText(limitedContent), nil
+		result := ProcessArtifact([]byte(content), fileName, params)
+		return mcp.NewToolResultText(result), nil
 	}
 
 	return tool, handler

--- a/pkg/mcp/tools/descriptions.go
+++ b/pkg/mcp/tools/descriptions.go
@@ -62,7 +62,7 @@ to find items containing all terms`
 
 	// Artifact tool descriptions
 	ListArtifactsDescription = "Retrieves all artifacts generated during a workflow execution. Use this tool to discover available outputs, reports, logs, or other files produced by test runs. These artifacts provide valuable context for understanding test results, accessing detailed reports, or examining generated data. The response includes artifact names, sizes, and their current status."
-	ReadArtifactDescription  = "Retrieves the content of a specific artifact from a workflow execution. This tool fetches up to 100 lines of text content from the requested file."
+	ReadArtifactDescription  = "Retrieves the content of a specific artifact from a workflow execution. Default (no params): returns the first 100 lines. Maximum: 200 lines per request. Parameters: startLine/endLine (1-based range, e.g. startLine=101 endLine=200 for the second page), grep (case-insensitive substring filter, returns matches with 3 lines of context). Note: grep and startLine/endLine are mutually exclusive -- when grep is specified, startLine/endLine are ignored. For binary artifacts (images, etc.), returns a summary message instead of content. Always work in chunks of 100-200 lines when paging -- never request unbounded ranges."
 
 	// Other tool descriptions
 	BuildDashboardUrlDescription  = "Build dashboard URLs for Testkube workflows and executions. Supports deep linking to a specific step within an execution's log view using stepRef (obtained from execution info signatures) and executionTab (defaults to 'log-output' when stepRef is provided)."

--- a/pkg/mcp/tools/helpers.go
+++ b/pkg/mcp/tools/helpers.go
@@ -3,7 +3,6 @@ package tools
 
 import (
 	"fmt"
-	"strings"
 
 	"github.com/mark3labs/mcp-go/mcp"
 )
@@ -144,15 +143,4 @@ func OptionalStringArrayParam(r mcp.CallToolRequest, p string) ([]string, error)
 	default:
 		return []string{}, fmt.Errorf("parameter %s could not be coerced to []string, is %T", p, r.GetArguments()[p])
 	}
-}
-
-// LimitContentToLines limits content to a maximum number of lines
-func LimitContentToLines(content string, maxLines int) string {
-	lines := strings.Split(content, "\n")
-	if len(lines) <= maxLines {
-		return content
-	}
-
-	limitedContent := strings.Join(lines[:maxLines], "\n")
-	return limitedContent
 }


### PR DESCRIPTION
## Summary

Adds line range and grep support to the `read_artifact` MCP tool so AI agents can efficiently read large text artifacts without blowing their context window.

## Changes

- New `ProcessArtifact` function with binary detection, line range extraction, case-insensitive grep with context lines, and metadata headers
- Updated `read_artifact` tool with `startLine`, `endLine`, and `grep` parameters
- Default: first 100 lines. Hard cap: 200 lines per request.
- Binary artifacts return a summary message instead of content
- 11 unit tests covering all behaviors

## Constraints (from Catalin)

- Never returns more than 100-200 lines
- Follows `fetch_execution_logs` pattern for parameters
- Includes grep parameter

## Companion PR

- testkube-cloud-api: bridge signature update (separate PR)

## Test plan

- [x] 11 unit tests pass (default, short file, empty, range, range exceeds max, start-only, grep, grep case-insensitive, grep no matches, binary, hard cap)
- [x] `go build ./pkg/mcp/...` clean
- [ ] Manual testing with actual artifacts in staging