### PR TITLE
feat: [TKC-4032] simplify lookup_execution_id response parsing

### DIFF
--- a/pkg/mcp/tools/executions.go
+++ b/pkg/mcp/tools/executions.go
@@ -247,7 +247,7 @@ func LookupExecutionId(client ExecutionLookup) (tool mcp.Tool, handler server.To
 			return mcp.NewToolResultError(fmt.Sprintf("failed to lookup execution ID: %v", err)), nil
 		}
 
-		executionID, err := extractExecutionIdFromResponse(result)
+		executionID, err := extractExecutionIdFromResponse(result, executionName)
 		if err != nil {
 			return mcp.NewToolResultError(err.Error()), nil
 		}
@@ -272,23 +272,21 @@ func isValidExecutionName(executionName string) bool {
 // extractExecutionIdFromResponse parses a direct {"id": "..."} response from the
 // dedicated lookup endpoint. Falls back to the legacy list format for backwards
 // compatibility with the standalone API client.
-func extractExecutionIdFromResponse(responseJSON string) (string, error) {
+func extractExecutionIdFromResponse(responseJSON string, targetExecutionName string) (string, error) {
 	var response struct {
 		ID string `json:"id"`
 	}
 	if err := json.Unmarshal([]byte(responseJSON), &response); err == nil && response.ID != "" {
 		return response.ID, nil
 	}
-	// Fall back to legacy list format for backwards compatibility.
-	// The APIClient (standalone CLI) still uses the list endpoint which returns {"results": [...]}.
-	// The HandlerClient (cloud-api bridge) returns {"id": "..."} from the dedicated lookup endpoint;
-	// if the execution is not found, the handler returns HTTP 404 before reaching this point.
-	return extractExecutionIdFromListResponse(responseJSON)
+	return extractExecutionIdFromListResponse(responseJSON, targetExecutionName)
 }
 
 // extractExecutionIdFromListResponse parses the legacy list format returned by
-// the standalone API client ({"results": [{"id": "...", ...}, ...]}).
-func extractExecutionIdFromListResponse(responseJSON string) (string, error) {
+// the standalone API client ({"results": [{"id": "...", ...}, ...]}). The list
+// endpoint is a text search, so results may include substring/prefix matches --
+// verify the exact name before returning an ID.
+func extractExecutionIdFromListResponse(responseJSON string, targetExecutionName string) (string, error) {
 	var resultObject map[string]any
 	if err := json.Unmarshal([]byte(responseJSON), &resultObject); err != nil {
 		return "", fmt.Errorf("failed to parse response: %v", err)
@@ -296,16 +294,24 @@ func extractExecutionIdFromListResponse(responseJSON string) (string, error) {
 
 	results, ok := resultObject["results"].([]any)
 	if !ok || len(results) == 0 {
-		return "", fmt.Errorf("no execution found")
+		return "", fmt.Errorf("no execution found with name %q", targetExecutionName)
 	}
 
-	if execution, ok := results[0].(map[string]any); ok {
+	for _, result := range results {
+		execution, ok := result.(map[string]any)
+		if !ok {
+			continue
+		}
+		name, nameOk := execution["name"].(string)
+		if !nameOk || name != targetExecutionName {
+			continue
+		}
 		if executionID, idOk := execution["id"].(string); idOk && executionID != "" {
 			return executionID, nil
 		}
 	}
 
-	return "", fmt.Errorf("no execution ID found in response")
+	return "", fmt.Errorf("no execution ID found for %q", targetExecutionName)
 }
 
 type ExecutionTagUpdater interface {

--- a/pkg/mcp/tools/executions.go
+++ b/pkg/mcp/tools/executions.go
@@ -247,7 +247,7 @@ func LookupExecutionId(client ExecutionLookup) (tool mcp.Tool, handler server.To
 			return mcp.NewToolResultError(fmt.Sprintf("failed to lookup execution ID: %v", err)), nil
 		}
 
-		executionID, err := extractExecutionIdFromResponse(result, executionName)
+		executionID, err := extractExecutionIdFromResponse(result)
 		if err != nil {
 			return mcp.NewToolResultError(err.Error()), nil
 		}
@@ -260,7 +260,7 @@ func LookupExecutionId(client ExecutionLookup) (tool mcp.Tool, handler server.To
 
 func isValidExecutionName(executionName string) bool {
 	lastDashIndex := strings.LastIndex(executionName, "-")
-	if lastDashIndex == -1 {
+	if lastDashIndex <= 0 {
 		return false
 	}
 
@@ -269,37 +269,43 @@ func isValidExecutionName(executionName string) bool {
 	return matched
 }
 
-func extractExecutionIdFromResponse(responseJSON string, targetExecutionName string) (string, error) {
+// extractExecutionIdFromResponse parses a direct {"id": "..."} response from the
+// dedicated lookup endpoint. Falls back to the legacy list format for backwards
+// compatibility with the standalone API client.
+func extractExecutionIdFromResponse(responseJSON string) (string, error) {
+	var response struct {
+		ID string `json:"id"`
+	}
+	if err := json.Unmarshal([]byte(responseJSON), &response); err == nil && response.ID != "" {
+		return response.ID, nil
+	}
+	// Fall back to legacy list format for backwards compatibility.
+	// The APIClient (standalone CLI) still uses the list endpoint which returns {"results": [...]}.
+	// The HandlerClient (cloud-api bridge) returns {"id": "..."} from the dedicated lookup endpoint;
+	// if the execution is not found, the handler returns HTTP 404 before reaching this point.
+	return extractExecutionIdFromListResponse(responseJSON)
+}
+
+// extractExecutionIdFromListResponse parses the legacy list format returned by
+// the standalone API client ({"results": [{"id": "...", ...}, ...]}).
+func extractExecutionIdFromListResponse(responseJSON string) (string, error) {
 	var resultObject map[string]any
 	if err := json.Unmarshal([]byte(responseJSON), &resultObject); err != nil {
-		return "", fmt.Errorf("failed to parse response JSON: %v", err)
+		return "", fmt.Errorf("failed to parse response: %v", err)
 	}
 
 	results, ok := resultObject["results"].([]any)
 	if !ok || len(results) == 0 {
-		return "", fmt.Errorf("no execution found with name \"%s\"", targetExecutionName)
+		return "", fmt.Errorf("no execution found")
 	}
 
-	for _, result := range results {
-		if execution, ok := result.(map[string]any); ok {
-			if name, nameOk := execution["name"].(string); nameOk && name == targetExecutionName {
-				if executionID, idOk := execution["id"].(string); idOk && executionID != "" {
-					return executionID, nil
-				}
-			}
+	if execution, ok := results[0].(map[string]any); ok {
+		if executionID, idOk := execution["id"].(string); idOk && executionID != "" {
+			return executionID, nil
 		}
 	}
 
-	// Fallback to single result for backwards compatibility
-	if len(results) == 1 {
-		if execution, ok := results[0].(map[string]any); ok {
-			if executionID, idOk := execution["id"].(string); idOk && executionID != "" {
-				return executionID, nil
-			}
-		}
-	}
-
-	return "", fmt.Errorf("no execution ID found for \"%s\"", targetExecutionName)
+	return "", fmt.Errorf("no execution ID found in response")
 }
 
 type ExecutionTagUpdater interface {

--- a/pkg/mcp/tools/executions_test.go
+++ b/pkg/mcp/tools/executions_test.go
@@ -364,3 +364,172 @@ func TestQueryExecutions_FiltersPassedThrough(t *testing.T) {
 	assert.Equal(t, "2026-03-31", m.capturedParams.EndDate)
 	assert.Equal(t, "passed", m.capturedParams.Status)
 }
+
+func TestExtractExecutionIdFromResponse(t *testing.T) {
+	tests := []struct {
+		name          string
+		responseJSON  string
+		targetName    string
+		wantID        string
+		wantErr       bool
+		wantErrSubstr string
+	}{
+		{
+			name:         "direct id response returns id",
+			responseJSON: `{"id":"abc123"}`,
+			targetName:   "workflow-name-1",
+			wantID:       "abc123",
+		},
+		{
+			name:         "empty direct id falls back to list and resolves exact name",
+			responseJSON: `{"id":"","results":[{"name":"foo","id":"xyz"}]}`,
+			targetName:   "foo",
+			wantID:       "xyz",
+		},
+		{
+			// Top-level JSON null unmarshals cleanly into the struct with ID="", so
+			// we fall through to extractExecutionIdFromListResponse. `null` also
+			// unmarshals cleanly into a nil map[string]any, so the map parse does
+			// not error either; the `results` type-assertion fails (nil map), and
+			// the "no execution found" branch reports the miss.
+			name:          "top-level null falls through to list parser and errors on missing results",
+			responseJSON:  `null`,
+			targetName:    "workflow-name-1",
+			wantErr:       true,
+			wantErrSubstr: "no execution found",
+		},
+		{
+			// Top-level JSON array fails the struct unmarshal (err != nil branch),
+			// then the list parser's map unmarshal also fails, yielding the parse
+			// error from the list path.
+			name:          "top-level array falls through to list parser and errors on parse",
+			responseJSON:  `[]`,
+			targetName:    "workflow-name-1",
+			wantErr:       true,
+			wantErrSubstr: "failed to parse response",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			id, err := extractExecutionIdFromResponse(tc.responseJSON, tc.targetName)
+			if tc.wantErr {
+				require.Error(t, err)
+				if tc.wantErrSubstr != "" {
+					assert.Contains(t, err.Error(), tc.wantErrSubstr)
+				}
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tc.wantID, id)
+		})
+	}
+}
+
+func TestExtractExecutionIdFromListResponse(t *testing.T) {
+	// The legacy /agent/tests list endpoint is a text search, so the results slice can
+	// contain substring/prefix matches of the requested name. These tests verify the
+	// exact-name guard and a few edge cases.
+	tests := []struct {
+		name          string
+		responseJSON  string
+		targetName    string
+		wantID        string
+		wantErr       bool
+		wantErrSubstr string
+	}{
+		{
+			// Substring-collision guard: asking for "my-test-1" must not return the
+			// id of "my-test-10" or "my-test-100" just because they share a prefix.
+			name:         "substring collision: target my-test-1 returns only exact match",
+			responseJSON: `{"results":[{"name":"my-test-1","id":"ONE"},{"name":"my-test-10","id":"TEN"},{"name":"my-test-100","id":"HUNDRED"}]}`,
+			targetName:   "my-test-1",
+			wantID:       "ONE",
+		},
+		{
+			// Reverse order to prove exact matching does not depend on array position.
+			name:         "substring collision reverse order still returns exact match",
+			responseJSON: `{"results":[{"name":"my-test-100","id":"HUNDRED"},{"name":"my-test-10","id":"TEN"},{"name":"my-test-1","id":"ONE"}]}`,
+			targetName:   "my-test-1",
+			wantID:       "ONE",
+		},
+		{
+			name:         "exact match at non-first position",
+			responseJSON: `{"results":[{"name":"other","id":"X"},{"name":"target","id":"Y"}]}`,
+			targetName:   "target",
+			wantID:       "Y",
+		},
+		{
+			// First match has empty id, a later exact-name entry with a populated id wins.
+			// This reflects actual behaviour: the name-match block does not `continue` on
+			// empty id, it falls through the inner `if` and advances the loop.
+			name:         "match with empty id is skipped and later populated id wins",
+			responseJSON: `{"results":[{"name":"foo","id":""},{"name":"foo","id":"BAR"}]}`,
+			targetName:   "foo",
+			wantID:       "BAR",
+		},
+		{
+			name:          "empty results errors",
+			responseJSON:  `{"results":[]}`,
+			targetName:    "foo",
+			wantErr:       true,
+			wantErrSubstr: "no execution found",
+		},
+		{
+			name:          "no matching name errors",
+			responseJSON:  `{"results":[{"name":"bar","id":"1"},{"name":"baz","id":"2"}]}`,
+			targetName:    "foo",
+			wantErr:       true,
+			wantErrSubstr: "no execution ID found",
+		},
+		{
+			name:          "invalid JSON errors",
+			responseJSON:  `{not json`,
+			targetName:    "foo",
+			wantErr:       true,
+			wantErrSubstr: "failed to parse response",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			id, err := extractExecutionIdFromListResponse(tc.responseJSON, tc.targetName)
+			if tc.wantErr {
+				require.Error(t, err)
+				if tc.wantErrSubstr != "" {
+					assert.Contains(t, err.Error(), tc.wantErrSubstr)
+				}
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tc.wantID, id)
+		})
+	}
+}
+
+func TestIsValidExecutionName(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  bool
+	}{
+		{name: "typical workflow-number", input: "my-test-123", want: true},
+		{name: "zero-padded number", input: "workflow-name-000001", want: true},
+		// Empty-prefix input is the new behaviour from the `<=0` guard in this PR.
+		// For "-123", LastIndex returns 0 (the only dash, at position 0), which
+		// the old `== -1` check would have accepted (suffix "123" is numeric);
+		// `<=0` now correctly rejects names with an empty prefix.
+		{name: "empty prefix rejected (new guard)", input: "-123", want: false},
+		// Leading dash with a later dash is still accepted because LastIndex
+		// returns a positive index (>0). Documented for clarity; this is NOT
+		// changed by the `<=0` guard.
+		{name: "leading dash with later dash still accepted", input: "-foo-123", want: true},
+		{name: "no dash", input: "noDash", want: false},
+		{name: "trailing dash only", input: "foo-", want: false},
+		{name: "non-numeric suffix", input: "my-test-abc", want: false},
+		{name: "empty string", input: "", want: false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, isValidExecutionName(tc.input))
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Simplifies the `lookup_execution_id` MCP tool to parse the new direct `{"id": "..."}` response format from the dedicated lookup endpoint, with backwards-compatible fallback for the legacy list format.

## Changes

- `extractExecutionIdFromResponse` now tries the new direct `{"id": "..."}` format first
- Falls back to legacy `{"results": [...]}` list format for backwards compatibility (standalone CLI still uses this)
- `isValidExecutionName` now rejects names with empty prefix (e.g., `"-123"`)

## Companion PR

- testkube-cloud-api: https://github.com/kubeshop/testkube-cloud-api/pull/3510

## Test plan

- [x] `go build ./pkg/mcp/...` clean
- [x] `go test ./pkg/mcp/...` all pass
- [ ] Manual testing with both new endpoint and legacy fallback