### PR TITLE
fix: values for postgresql DSN secretName

### DIFF
--- a/k8s/helm/testkube-api/README.md
+++ b/k8s/helm/testkube-api/README.md
@@ -176,6 +176,8 @@ A Helm chart for Testkube api
 | podStartTimeout | string | `"30m"` | Testkube timeout for pod start |
 | postgresql.dsn | string | `"postgres://testkube:postgres5432@testkube-postgresql:5432/backend?sslmode=disable"` |  |
 | postgresql.enabled | bool | `false` |  |
+| postgresql.secretKey | string | `""` |  |
+| postgresql.secretName | string | `""` |  |
 | priorityClassName | string | `""` |  |
 | prometheus.enabled | bool | `false` |  |
 | prometheus.interval | string | `"15s"` |  |

--- a/k8s/helm/testkube-api/templates/_helpers.tpl
+++ b/k8s/helm/testkube-api/templates/_helpers.tpl
@@ -279,7 +279,7 @@ Define API environment in standalone mode
   valueFrom:
     secretKeyRef:
       name: {{ .Values.postgresql.secretName }}
-      key: {{ .Values.postgresql.secretKey }}
+      key: {{ required "postgresql.secretKey is required when postgresql.secretName is set" .Values.postgresql.secretKey }}
   {{- else }}
   value: "{{ .Values.postgresql.dsn }}"
   {{- end }}

--- a/k8s/helm/testkube-api/values.yaml
+++ b/k8s/helm/testkube-api/values.yaml
@@ -572,11 +572,12 @@ mongodb:
 postgresql:
   ## Deploy PostgreSQL server to the cluster
   enabled: false
-  ## Define dsn connection string
+  ## Define PostgreSQL DSN connection string
   dsn: "postgres://testkube:postgres5432@testkube-postgresql:5432/backend?sslmode=disable"
-  ## or use dsn in secrets
-  # secretName: testkube-secrets
-  # secretKey: postgresql-dsn
+  ## Name of the Kubernetes secret containing the PostgreSQL DSN
+  secretName: ""
+  ## Key in the Kubernetes secret containing the PostgreSQL DSN
+  secretKey: ""
 
 ## NATS parameters
 ## ref: https://github.com/nats-io/nats-server

--- a/k8s/helm/testkube/README.md
+++ b/k8s/helm/testkube/README.md
@@ -488,6 +488,8 @@ kubectl label --overwrite crds scripts.tests.testkube.io app.kubernetes.io/manag
 | testkube-operator.podSecurityContext | object | `{}` | Testkube Operator Pod Security Context |
 | testkube-api.postgresql.dsn | string | `"postgres://testkube:postgres5432@testkube-postgresql:5432/backend?sslmode=disable"` | PostgreSQL DSN |
 | testkube-api.postgresql.enabled | bool | `false` | use PostgreSQL |
+| testkube-api.postgresql.secretKey | string | `""` | Secret key for PostgreSQL DSN |
+| testkube-api.postgresql.secretName | string | `""` | Secret name with PostgreSQL DSN |
 | testkube-operator.preUpgrade.annotations | object | `{}` |  |
 | testkube-operator.preUpgrade.enabled | bool | `true` | Upgrade hook is enabled |
 | testkube-operator.preUpgrade.image | object | `{"pullPolicy":"IfNotPresent","pullSecrets":[],"registry":"docker.io","repository":"bitnami/kubectl","tag":"1.28.2"}` | Specify image |

--- a/k8s/helm/testkube/values.yaml
+++ b/k8s/helm/testkube/values.yaml
@@ -1097,11 +1097,11 @@ testkube-api:
   postgresql:
     enabled: false
     # -- PostgreSQL DSN
-    # dsn: "postgres://testkube:postgres5432@testkube-postgresql:5432/backend?sslmode=disable"
-    # -- Secret name with DSN
-    # secretName: testkube-postgresql-app
-    # -- Secret key for DSN
-    # secretKey: uri
+    dsn: "postgres://testkube:postgres5432@testkube-postgresql:5432/backend?sslmode=disable"
+    # -- Secret name with PostgreSQL DSN
+    secretName: ""
+    # -- Secret key for PostgreSQL DSN
+    secretKey: ""
   # -- Testkube API Startup probe parameters
   startupProbe:
     # -- Whether startup probe is enabled


### PR DESCRIPTION
## Pull request description 
Updates Helm support for sourcing the PostgreSQL DSN from a Kubernetes secret.


## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [x] tested locally
- [ ] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Breaking changes

-

## Changes

-

## Fixes

-