### PR TITLE
fix: Allow TestWorkflow finalization without object storage

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -77,6 +77,11 @@ Testkube uses [Test Workflows](https://docs.testkube.io/articles/test-workflows)
 - TestWorkflow processing and step execution
 - Result aggregation and status management
 
+**Runner finalization**: [`pkg/runner/`](pkg/runner/)
+
+- The runner persists the final `TestWorkflowResult` through the control plane client when a workflow reaches a terminal state.
+- Full execution log archive upload is skipped when TestWorkflow object storage is disabled. When object storage is enabled, archive upload is required during finalization and upload failures prevent final result persistence.
+
 ### 4. Storage Layer
 
 **PostgreSQL** (Future Primary Database, currently in Preview)
@@ -96,6 +101,7 @@ Testkube uses [Test Workflows](https://docs.testkube.io/articles/test-workflows)
 **MinIO** (Object Storage)
 
 - Stores TestWorkflow execution artifacts (logs, reports, files)
+- TestWorkflow finalization treats log archive upload failures as degraded observability, not as a reason to keep the execution running.
 - Buckets: `testkube-artifacts`, `testkube-logs`
 - Storage interface: [`pkg/storage/`](pkg/storage/)
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -77,11 +77,6 @@ Testkube uses [Test Workflows](https://docs.testkube.io/articles/test-workflows)
 - TestWorkflow processing and step execution
 - Result aggregation and status management
 
-**Runner finalization**: [`pkg/runner/`](pkg/runner/)
-
-- The runner persists the final `TestWorkflowResult` through the control plane client when a workflow reaches a terminal state.
-- Full execution log archive upload is skipped when TestWorkflow object storage is disabled. When object storage is enabled, archive upload is required during finalization and upload failures prevent final result persistence.
-
 ### 4. Storage Layer
 
 **PostgreSQL** (Future Primary Database, currently in Preview)
@@ -101,7 +96,6 @@ Testkube uses [Test Workflows](https://docs.testkube.io/articles/test-workflows)
 **MinIO** (Object Storage)
 
 - Stores TestWorkflow execution artifacts (logs, reports, files)
-- TestWorkflow finalization treats log archive upload failures as degraded observability, not as a reason to keep the execution running.
 - Buckets: `testkube-artifacts`, `testkube-logs`
 - Storage interface: [`pkg/storage/`](pkg/storage/)
 

--- a/pkg/runner/executionlogswriter.go
+++ b/pkg/runner/executionlogswriter.go
@@ -25,6 +25,7 @@ type ExecutionLogsWriter interface {
 	WriteStart(ref string) error
 	Save(ctx context.Context) error
 	Saved() bool
+	Enabled() bool
 	Cleanup()
 	Reset() error
 }
@@ -34,6 +35,7 @@ type executionLogsWriter struct {
 	environmentId string
 	id            string
 	workflowName  string
+	enabled       bool
 	skipVerify    bool
 
 	writer *io.PipeWriter
@@ -41,12 +43,13 @@ type executionLogsWriter struct {
 	mu     sync.Mutex
 }
 
-func NewExecutionLogsWriter(client controlplaneclient.Client, environmentId, id string, workflowName string, skipVerify bool) (ExecutionLogsWriter, error) {
+func NewExecutionLogsWriter(client controlplaneclient.Client, environmentId, id string, workflowName string, enabled, skipVerify bool) (ExecutionLogsWriter, error) {
 	e := &executionLogsWriter{
 		client:        client,
 		environmentId: environmentId,
 		id:            id,
 		workflowName:  workflowName,
+		enabled:       enabled,
 		skipVerify:    skipVerify,
 	}
 	err := e.Reset()
@@ -93,13 +96,13 @@ func (e *executionLogsWriter) Save(ctx context.Context) error {
 	req.ContentLength = int64(contentLen)
 	httpClient := http.DefaultClient
 	if e.skipVerify {
-		transport := &http.Transport{TLSClientConfig: &tls.Config{InsecureSkipVerify: true}}
-		httpClient.Transport = transport
+		httpClient = &http.Client{Transport: &http.Transport{TLSClientConfig: &tls.Config{InsecureSkipVerify: true}}}
 	}
 	res, err := httpClient.Do(req)
 	if err != nil {
 		return errors.Wrap(err, "failed to save file in the object storage")
 	}
+	defer res.Body.Close()
 	if res.StatusCode != http.StatusOK {
 		return errors.Errorf("error saving file with presigned url: expected 200 OK response code, got %d", res.StatusCode)
 	}
@@ -130,6 +133,10 @@ func (e *executionLogsWriter) Saved() bool {
 		return e.buffer == nil
 	}
 	return false
+}
+
+func (e *executionLogsWriter) Enabled() bool {
+	return e.enabled
 }
 
 func (e *executionLogsWriter) Reset() error {

--- a/pkg/runner/executionsaver.go
+++ b/pkg/runner/executionsaver.go
@@ -147,13 +147,13 @@ func (s *executionSaver) End(ctx context.Context, result testkube.TestWorkflowRe
 		s.outputSaved.Store(true)
 	}
 
-	if !s.logs.Saved() && !s.logs.Enabled() {
-		log.DefaultLogger.Infow("TestWorkflow execution log storage is disabled; skipping log archive upload", "id", s.id)
-	}
-
-	if !s.logs.Saved() && s.logs.Enabled() {
-		if err := s.logs.Save(ctx); err != nil {
-			return err
+	if !s.logs.Saved() {
+		if s.logs.Enabled() {
+			if err := s.logs.Save(ctx); err != nil {
+				return err
+			}
+		} else {
+			log.DefaultLogger.Infow("TestWorkflow execution log storage is disabled; skipping log archive upload", "id", s.id)
 		}
 	}
 

--- a/pkg/runner/executionsaver.go
+++ b/pkg/runner/executionsaver.go
@@ -6,10 +6,9 @@ import (
 	"sync/atomic"
 	"time"
 
-	"golang.org/x/sync/errgroup"
-
 	"github.com/kubeshop/testkube/pkg/api/v1/testkube"
 	"github.com/kubeshop/testkube/pkg/controlplaneclient"
+	"github.com/kubeshop/testkube/pkg/log"
 	"github.com/kubeshop/testkube/pkg/testworkflows/executionworker/controller/store"
 )
 
@@ -139,23 +138,23 @@ func (s *executionSaver) End(ctx context.Context, result testkube.TestWorkflowRe
 	s.saveMu.Lock()
 	defer s.saveMu.Unlock()
 
-	// Save the logs and output
-	g, _ := errgroup.WithContext(ctx)
-	g.Go(func() error {
-		if s.outputSaved.Load() {
-			return nil
+	// Save structured output metadata before finalizing. This remains required
+	// because it is part of the execution record, unlike archived logs.
+	if !s.outputSaved.Load() {
+		if err := s.saveOutput(ctx); err != nil {
+			return err
 		}
-		return s.saveOutput(ctx)
-	})
-	g.Go(func() error {
-		if s.logs.Saved() {
-			return nil
+		s.outputSaved.Store(true)
+	}
+
+	if !s.logs.Saved() && !s.logs.Enabled() {
+		log.DefaultLogger.Infow("TestWorkflow execution log storage is disabled; skipping log archive upload", "id", s.id)
+	}
+
+	if !s.logs.Saved() && s.logs.Enabled() {
+		if err := s.logs.Save(ctx); err != nil {
+			return err
 		}
-		return s.logs.Save(ctx)
-	})
-	err := g.Wait()
-	if err != nil {
-		return err
 	}
 
 	// Save the final result

--- a/pkg/runner/executionsaver_test.go
+++ b/pkg/runner/executionsaver_test.go
@@ -1,0 +1,108 @@
+package runner
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+
+	"github.com/kubeshop/testkube/pkg/api/v1/testkube"
+	"github.com/kubeshop/testkube/pkg/controlplaneclient"
+)
+
+type failingExecutionLogsWriter struct {
+	enabled    bool
+	saveErr    error
+	saved      bool
+	saveCalled bool
+}
+
+func (w *failingExecutionLogsWriter) Write(p []byte) (int, error) {
+	return len(p), nil
+}
+
+func (w *failingExecutionLogsWriter) WriteStart(string) error {
+	return nil
+}
+
+func (w *failingExecutionLogsWriter) Save(context.Context) error {
+	w.saveCalled = true
+	if w.saveErr != nil {
+		return w.saveErr
+	}
+	w.saved = true
+	return nil
+}
+
+func (w *failingExecutionLogsWriter) Saved() bool {
+	return w.saved
+}
+
+func (w *failingExecutionLogsWriter) Enabled() bool {
+	return w.enabled
+}
+
+func (w *failingExecutionLogsWriter) Cleanup() {}
+
+func (w *failingExecutionLogsWriter) Reset() error {
+	w.saved = false
+	return nil
+}
+
+func TestExecutionSaverEnd_SkipsLogSaveWhenStorageDisabled(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	client := controlplaneclient.NewMockClient(ctrl)
+	logs := &failingExecutionLogsWriter{}
+	saver, err := NewExecutionSaver(context.Background(), client, "execution-id", "org-id", "env-id", "runner-id", logs)
+	require.NoError(t, err)
+
+	status := testkube.PASSED_TestWorkflowStatus
+	result := testkube.TestWorkflowResult{Status: &status}
+
+	client.EXPECT().
+		FinishExecutionResult(gomock.Any(), "env-id", "execution-id", gomock.Any()).
+		DoAndReturn(func(_ context.Context, _, _ string, got *testkube.TestWorkflowResult) error {
+			require.Same(t, &status, got.Status)
+			return nil
+		})
+
+	err = saver.End(context.Background(), result)
+	require.NoError(t, err)
+	require.False(t, logs.saveCalled)
+}
+
+func TestExecutionSaverEnd_LogSaveFailureBlocksFinalizationWhenStorageEnabled(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	client := controlplaneclient.NewMockClient(ctrl)
+	logs := &failingExecutionLogsWriter{enabled: true, saveErr: errors.New("object storage unavailable")}
+	saver, err := NewExecutionSaver(context.Background(), client, "execution-id", "org-id", "env-id", "runner-id", logs)
+	require.NoError(t, err)
+
+	status := testkube.PASSED_TestWorkflowStatus
+	result := testkube.TestWorkflowResult{Status: &status}
+
+	err = saver.End(context.Background(), result)
+	require.ErrorContains(t, err, "object storage unavailable")
+	require.True(t, logs.saveCalled)
+}
+
+func TestExecutionSaverEnd_OutputSaveFailureBlocksFinalization(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	client := controlplaneclient.NewMockClient(ctrl)
+	logs := &failingExecutionLogsWriter{enabled: true}
+	saver, err := NewExecutionSaver(context.Background(), client, "execution-id", "org-id", "env-id", "runner-id", logs)
+	require.NoError(t, err)
+
+	saver.AppendOutput(testkube.TestWorkflowOutput{Name: "artifact"})
+	status := testkube.PASSED_TestWorkflowStatus
+	result := testkube.TestWorkflowResult{Status: &status}
+
+	client.EXPECT().
+		UpdateExecutionOutput(gomock.Any(), "env-id", "execution-id", []testkube.TestWorkflowOutput{{Name: "artifact"}}).
+		Return(errors.New("database unavailable"))
+
+	err = saver.End(context.Background(), result)
+	require.ErrorContains(t, err, "database unavailable")
+}

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -122,7 +122,7 @@ func (r *runner) monitor(ctx context.Context, organizationId string, environment
 		return errors.Wrapf(notifications.Err(), "failed to listen for '%s' execution notifications", execution.Id)
 	}
 
-	logs, err := NewExecutionLogsWriter(r.client, environmentId, execution.Id, execution.Workflow.Name, r.storageSkipVerify)
+	logs, err := NewExecutionLogsWriter(r.client, environmentId, execution.Id, execution.Workflow.Name, r.proContext.CloudStorage, r.storageSkipVerify)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## Problem
fix: https://github.com/kubeshop/testkube/issues/7399

When TestWorkflow object storage is disabled, runner finalization should not try to upload the full execution log archive. That upload path can block terminal result persistence, leaving executions stuck in `running` and suppressing end-testworkflow webhooks.

Change is:

If `proContext.CloudStorage` is `false`, the runner does not call `SaveExecutionLogsPresigned` during finalization.

default is true