### PR TITLE
feat(TKC-5494): Adding hints to open the execution viewer

### DIFF
--- a/cmd/kubectl-testkube/commands/artifacts/artifacts.go
+++ b/cmd/kubectl-testkube/commands/artifacts/artifacts.go
@@ -35,6 +35,10 @@ func NewListArtifactsCmd() *cobra.Command {
 				artifacts, errArtifacts = client.GetTestWorkflowExecutionArtifacts(twExecution.Id)
 				ui.ExitOnError("getting test workflow artifacts", errArtifacts)
 				ui.Table(artifacts, os.Stdout)
+				ui.ShellCommand(
+					"View test workflow execution in your browser",
+					"kubectl testkube view "+twExecution.Id,
+				)
 				return
 			}
 			if err == nil {

--- a/cmd/kubectl-testkube/commands/artifacts/artifacts.go
+++ b/cmd/kubectl-testkube/commands/artifacts/artifacts.go
@@ -35,10 +35,7 @@ func NewListArtifactsCmd() *cobra.Command {
 				artifacts, errArtifacts = client.GetTestWorkflowExecutionArtifacts(twExecution.Id)
 				ui.ExitOnError("getting test workflow artifacts", errArtifacts)
 				ui.Table(artifacts, os.Stdout)
-				ui.ShellCommand(
-					"View test workflow execution in your browser",
-					"kubectl testkube view "+twExecution.Id,
-				)
+				common.UIShellViewExecution(twExecution.Id)
 				return
 			}
 			if err == nil {

--- a/cmd/kubectl-testkube/commands/common/uihints.go
+++ b/cmd/kubectl-testkube/commands/common/uihints.go
@@ -1,0 +1,27 @@
+package common
+
+import "github.com/kubeshop/testkube/pkg/ui"
+
+// UIShellGetExecution prints kubectl command to get test workflow execution details.
+func UIShellGetExecution(id string) {
+	ui.ShellCommand(
+		"Use following command to get test workflow execution details",
+		"testkube get twe "+id,
+	)
+}
+
+// UIShellViewExecution prints kubectl command to view test workflow execution in the browser.
+func UIShellViewExecution(id string) {
+	ui.ShellCommand(
+		"View test workflow execution in your browser",
+		"testkube view "+id,
+	)
+}
+
+// UIShellWatchExecution prints kubectl command to watch a test workflow execution until complete.
+func UIShellWatchExecution(id string) {
+	ui.ShellCommand(
+		"Watch test workflow execution until complete",
+		"testkube watch twe "+id,
+	)
+}

--- a/cmd/kubectl-testkube/commands/download.go
+++ b/cmd/kubectl-testkube/commands/download.go
@@ -64,6 +64,10 @@ func NewDownloadSingleArtifactsCmd() *cobra.Command {
 				f, err := client.DownloadTestWorkflowArtifact(executionID, filename, destination)
 				ui.ExitOnError("downloading file "+filename, err)
 				ui.Info(fmt.Sprintf("File %s downloaded.\n", f))
+				ui.ShellCommand(
+					"View test workflow execution in your browser",
+					"kubectl testkube view "+exec.Id,
+				)
 				return
 			}
 
@@ -96,6 +100,10 @@ func NewDownloadAllArtifactsCmd() *cobra.Command {
 			exec, err := client.GetTestWorkflowExecution(executionID)
 			if err == nil && exec.Id != "" {
 				common.DownloadTestWorkflowArtifacts(executionID, downloadDir, format, masks, client, true)
+				ui.ShellCommand(
+					"View test workflow execution in your browser",
+					"kubectl testkube view "+exec.Id,
+				)
 				return
 			}
 		},

--- a/cmd/kubectl-testkube/commands/download.go
+++ b/cmd/kubectl-testkube/commands/download.go
@@ -64,10 +64,7 @@ func NewDownloadSingleArtifactsCmd() *cobra.Command {
 				f, err := client.DownloadTestWorkflowArtifact(executionID, filename, destination)
 				ui.ExitOnError("downloading file "+filename, err)
 				ui.Info(fmt.Sprintf("File %s downloaded.\n", f))
-				ui.ShellCommand(
-					"View test workflow execution in your browser",
-					"kubectl testkube view "+exec.Id,
-				)
+				common.UIShellViewExecution(exec.Id)
 				return
 			}
 
@@ -100,10 +97,7 @@ func NewDownloadAllArtifactsCmd() *cobra.Command {
 			exec, err := client.GetTestWorkflowExecution(executionID)
 			if err == nil && exec.Id != "" {
 				common.DownloadTestWorkflowArtifacts(executionID, downloadDir, format, masks, client, true)
-				ui.ShellCommand(
-					"View test workflow execution in your browser",
-					"kubectl testkube view "+exec.Id,
-				)
+				common.UIShellViewExecution(exec.Id)
 				return
 			}
 		},

--- a/cmd/kubectl-testkube/commands/testworkflows/executions.go
+++ b/cmd/kubectl-testkube/commands/testworkflows/executions.go
@@ -85,7 +85,7 @@ func NewGetTestWorkflowExecutionsCmd() *cobra.Command {
 				printRawLogLines(logs, sigs, execution)
 				if !logsOnly {
 					render.PrintTestWorkflowExecutionURIs(&execution)
-					uiShellViewExecution(execution.Id)
+					common.UIShellViewExecution(execution.Id)
 				}
 			}
 		},

--- a/cmd/kubectl-testkube/commands/testworkflows/executions.go
+++ b/cmd/kubectl-testkube/commands/testworkflows/executions.go
@@ -85,6 +85,7 @@ func NewGetTestWorkflowExecutionsCmd() *cobra.Command {
 				printRawLogLines(logs, sigs, execution)
 				if !logsOnly {
 					render.PrintTestWorkflowExecutionURIs(&execution)
+					uiShellViewExecution(execution.Id)
 				}
 			}
 		},

--- a/cmd/kubectl-testkube/commands/testworkflows/get.go
+++ b/cmd/kubectl-testkube/commands/testworkflows/get.go
@@ -64,7 +64,7 @@ func NewGetTestWorkflowsCmd() *cobra.Command {
 					ui.NL()
 					err = render.Obj(cmd, *workflow.LatestExecution, os.Stdout, renderer.TestWorkflowExecutionRenderer)
 					ui.ExitOnError("rendering obj", err)
-					uiShellViewExecution(workflow.LatestExecution.Id)
+					common.UIShellViewExecution(workflow.LatestExecution.Id)
 				}
 			}
 		},

--- a/cmd/kubectl-testkube/commands/testworkflows/get.go
+++ b/cmd/kubectl-testkube/commands/testworkflows/get.go
@@ -64,6 +64,7 @@ func NewGetTestWorkflowsCmd() *cobra.Command {
 					ui.NL()
 					err = render.Obj(cmd, *workflow.LatestExecution, os.Stdout, renderer.TestWorkflowExecutionRenderer)
 					ui.ExitOnError("rendering obj", err)
+					uiShellViewExecution(workflow.LatestExecution.Id)
 				}
 			}
 		},

--- a/cmd/kubectl-testkube/commands/testworkflows/rerun.go
+++ b/cmd/kubectl-testkube/commands/testworkflows/rerun.go
@@ -136,6 +136,7 @@ func NewReRunTestWorkflowExecutionCmd() *cobra.Command {
 
 				render.PrintTestWorkflowExecutionURIs(&execution)
 				uiShellGetExecution(execution.Id)
+				uiShellViewExecution(execution.Id)
 			}
 
 			if exitCode != 0 {

--- a/cmd/kubectl-testkube/commands/testworkflows/rerun.go
+++ b/cmd/kubectl-testkube/commands/testworkflows/rerun.go
@@ -127,7 +127,7 @@ func NewReRunTestWorkflowExecutionCmd() *cobra.Command {
 							common.DownloadTestWorkflowArtifacts(execution.Id, downloadDir, format, masks, client, outputPretty)
 						}
 					} else {
-						uiShellWatchExecution(execution.Id)
+						common.UIShellWatchExecution(execution.Id)
 					}
 				}
 
@@ -135,8 +135,8 @@ func NewReRunTestWorkflowExecutionCmd() *cobra.Command {
 				ui.ExitOnError("get test workflow execution failed", err)
 
 				render.PrintTestWorkflowExecutionURIs(&execution)
-				uiShellGetExecution(execution.Id)
-				uiShellViewExecution(execution.Id)
+				common.UIShellGetExecution(execution.Id)
+				common.UIShellViewExecution(execution.Id)
 			}
 
 			if exitCode != 0 {

--- a/cmd/kubectl-testkube/commands/testworkflows/run.go
+++ b/cmd/kubectl-testkube/commands/testworkflows/run.go
@@ -547,6 +547,7 @@ func processExecutions(
 
 			render.PrintTestWorkflowExecutionURIs(&execution)
 			uiShellGetExecution(executionId)
+			uiShellViewExecution(executionId)
 		}
 	}
 
@@ -739,6 +740,14 @@ func uiShellGetExecution(id string) {
 	ui.ShellCommand(
 		"Use following command to get test workflow execution details",
 		"kubectl testkube get twe "+id,
+	)
+}
+
+// uiShellViewExecution prints kubectl command to view execution in the browser
+func uiShellViewExecution(id string) {
+	ui.ShellCommand(
+		"View test workflow execution in your browser",
+		"kubectl testkube view "+id,
 	)
 }
 

--- a/cmd/kubectl-testkube/commands/testworkflows/run.go
+++ b/cmd/kubectl-testkube/commands/testworkflows/run.go
@@ -530,7 +530,7 @@ func processExecutions(
 					exitCode = handleWatchMode(cmd, args, &execution, &wg, &mu, &exitCode,
 						client, watchOpts, outputPretty)
 				} else {
-					uiShellWatchExecution(execution.Id)
+					common.UIShellWatchExecution(execution.Id)
 				}
 			}
 
@@ -546,8 +546,8 @@ func processExecutions(
 			}
 
 			render.PrintTestWorkflowExecutionURIs(&execution)
-			uiShellGetExecution(executionId)
-			uiShellViewExecution(executionId)
+			common.UIShellGetExecution(executionId)
+			common.UIShellViewExecution(executionId)
 		}
 	}
 
@@ -733,30 +733,6 @@ func uiWatch(
 		ui.Success("test workflow execution completed with success in " + result.FinishedAt.Sub(result.QueuedAt).String())
 	}
 	return 0
-}
-
-// uiShellGetExecution prints kubectl command to get execution details
-func uiShellGetExecution(id string) {
-	ui.ShellCommand(
-		"Use following command to get test workflow execution details",
-		"kubectl testkube get twe "+id,
-	)
-}
-
-// uiShellViewExecution prints kubectl command to view execution in the browser
-func uiShellViewExecution(id string) {
-	ui.ShellCommand(
-		"View test workflow execution in your browser",
-		"kubectl testkube view "+id,
-	)
-}
-
-// uiShellWatchExecution prints kubectl command to watch execution
-func uiShellWatchExecution(id string) {
-	ui.ShellCommand(
-		"Watch test workflow execution until complete",
-		"kubectl testkube watch twe "+id,
-	)
 }
 
 // printSingleResultDifference prints status change between two step results, returns true if changed

--- a/cmd/kubectl-testkube/commands/testworkflows/watch.go
+++ b/cmd/kubectl-testkube/commands/testworkflows/watch.go
@@ -53,7 +53,7 @@ func NewWatchTestWorkflowExecutionCmd() *cobra.Command {
 			ui.ExitOnError("get execution failed", err)
 
 			render.PrintTestWorkflowExecutionURIs(&execution)
-			uiShellGetExecution(execution.Id)
+			common.UIShellGetExecution(execution.Id)
 			os.Exit(exitCode)
 		},
 	}


### PR DESCRIPTION
## Pull request description 


We should guide users to view execution results in the browser by adding contextual hints in CLI outputs for execution-related commands.

## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [x] tested locally
- [ ] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Breaking changes

-

## Changes

-

## Fixes

-