### PR TITLE
fix: resolve MCP artifact reads via artifact lookup post

### DIFF
--- a/pkg/mcp/api.go
+++ b/pkg/mcp/api.go
@@ -226,17 +226,17 @@ func (c *APIClient) ListArtifacts(ctx context.Context, executionID string) (stri
 }
 
 func (c *APIClient) ReadArtifact(ctx context.Context, executionID, filename string) (string, error) {
-	// First, get the artifact (could be direct content or a URL)
-	// URL encode the filename to handle special characters like forward slashes
-	encodedFilename := url.QueryEscape(filename)
-
+	// First, resolve the artifact by name. The control plane returns an ArtifactURL
+	// with a signed storage link rather than the artifact content directly.
 	response, err := c.makeRequest(ctx, APIRequest{
-		Method: "GET",
-		Path:   "/agent/test-workflow-executions/{executionId}/artifacts/{filename}",
+		Method: "POST",
+		Path:   "/test-workflow-executions/{executionId}/artifacts",
 		Scope:  ApiScopeOrgEnv,
 		PathParams: map[string]string{
 			"executionId": executionID,
-			"filename":    encodedFilename,
+		},
+		Body: map[string]string{
+			"artifactID": filename,
 		},
 	})
 	if err != nil {

--- a/pkg/mcp/api_test.go
+++ b/pkg/mcp/api_test.go
@@ -31,19 +31,18 @@ func TestAPIClient_ReadArtifact_UsesArtifactLookupPost(t *testing.T) {
 
 			var body map[string]string
 			err := json.NewDecoder(r.Body).Decode(&body)
-			require.NoError(t, err)
+			assert.NoError(t, err)
 			assert.Equal(t, artifactID, body["artifactID"])
 
 			w.Header().Set("Content-Type", "application/json")
 			err = json.NewEncoder(w).Encode(map[string]string{
 				"url": serverURL + "/download/artifact",
 			})
-			require.NoError(t, err)
+			assert.NoError(t, err)
 
 		case r.Method == http.MethodGet && r.URL.Path == "/download/artifact":
 			_, err := io.WriteString(w, content)
-			require.NoError(t, err)
-
+			assert.NoError(t, err)
 		default:
 			http.NotFound(w, r)
 		}

--- a/pkg/mcp/api_test.go
+++ b/pkg/mcp/api_test.go
@@ -1,0 +1,64 @@
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAPIClient_ReadArtifact_UsesArtifactLookupPost(t *testing.T) {
+	const (
+		orgID       = "org-123"
+		envID       = "env-456"
+		executionID = "exec-789"
+		artifactID  = "results/final-junit.xml"
+		content     = "<testsuites/>"
+		token       = "test-token"
+	)
+
+	var serverURL string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodPost && r.URL.Path == "/organizations/"+orgID+"/environments/"+envID+"/test-workflow-executions/"+executionID+"/artifacts":
+			assert.Equal(t, "Bearer "+token, r.Header.Get("Authorization"))
+			assert.Equal(t, "application/json", r.Header.Get("Content-Type"))
+
+			var body map[string]string
+			err := json.NewDecoder(r.Body).Decode(&body)
+			require.NoError(t, err)
+			assert.Equal(t, artifactID, body["artifactID"])
+
+			w.Header().Set("Content-Type", "application/json")
+			err = json.NewEncoder(w).Encode(map[string]string{
+				"url": serverURL + "/download/artifact",
+			})
+			require.NoError(t, err)
+
+		case r.Method == http.MethodGet && r.URL.Path == "/download/artifact":
+			_, err := io.WriteString(w, content)
+			require.NoError(t, err)
+
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+	serverURL = server.URL
+
+	client := NewAPIClient(&MCPServerConfig{
+		ControlPlaneUrl: server.URL,
+		AccessToken:     token,
+		OrgId:           orgID,
+		EnvId:           envID,
+	}, server.Client())
+
+	body, err := client.ReadArtifact(context.Background(), executionID, artifactID)
+	require.NoError(t, err)
+	assert.Equal(t, content, body)
+}


### PR DESCRIPTION
## Summary
This updates the CLI MCP implementation used by `testkube mcp serve` so `read_artifact` resolves workflow artifacts via the public POST artifact lookup endpoint instead of the legacy agent GET route.

## Changes
- switch `pkg/mcp/api.go` `ReadArtifact` from `GET /agent/test-workflow-executions/{executionId}/artifacts/{filename}`
- use `POST /test-workflow-executions/{executionId}/artifacts` with `{ "artifactID": "..." }`
- keep the second-hop download of the returned signed URL
- add a focused regression test for the POST lookup flow

## Why
The old agent GET route caused failures for workflow artifacts, especially with slash-containing artifact names and source-of-truth environments. The POST endpoint returns an `ArtifactURL`, which the MCP client then downloads and returns as content.

## Verification
- `go test ./pkg/mcp -run TestAPIClient_ReadArtifact_UsesArtifactLookupPost -count=1`