### PR TITLE
fix: [TKC-5460] protect trigger service state from concurrent informer events

### DIFF
--- a/pkg/triggers/event.go
+++ b/pkg/triggers/event.go
@@ -90,7 +90,7 @@ const (
 	eventLabelKeyResourceVersion   string = "testkube.io/resource-version"
 )
 
-func (s Service) newWatcherEvent(
+func (s *Service) newWatcherEvent(
 	eventType testtrigger.EventType,
 	objectMeta metav1.Object,
 	object any,
@@ -115,9 +115,16 @@ func (s Service) newWatcherEvent(
 	w.EventLabels[eventLabelKeyResourceName] = utils.TruncateName(objectMeta.GetName())
 	w.EventLabels[eventLabelKeyResourceNamespace] = objectMeta.GetNamespace()
 
+	// Snapshot under informersMu to avoid racing with the runWatcher goroutine
+	// that nils s.informers on lease release. Without the lock a DeleteFunc
+	// firing during informer teardown could observe a half-torn-down pointer.
+	s.informersMu.RLock()
+	informers := s.informers
+	s.informersMu.RUnlock()
+
 	if runtimeObject, ok := object.(runtime.Object); ok &&
-		s.informers != nil && s.informers.scheme != nil {
-		gvks, _, err := s.informers.scheme.ObjectKinds(runtimeObject)
+		informers != nil && informers.scheme != nil {
+		gvks, _, err := informers.scheme.ObjectKinds(runtimeObject)
 		if err != nil {
 			s.logger.Warnf("error getting object kinds from scheme, skipped adding event label: %v", err)
 		} else if len(gvks) > 0 {

--- a/pkg/triggers/executor.go
+++ b/pkg/triggers/executor.go
@@ -36,7 +36,14 @@ const (
 type ExecutorF func(context.Context, *watcherEvent, *testtriggersv1.TestTrigger) error
 
 func (s *Service) execute(ctx context.Context, e *watcherEvent, t *testtriggersv1.TestTrigger) error {
+	// If the trigger was removed between match() and execute() (concurrent
+	// DeleteFunc), the status entry is gone — don't fire executions for a
+	// trigger that's no longer registered.
 	status := s.getStatusForTrigger(t)
+	if status == nil {
+		s.logger.Debugf("trigger service: executor component: trigger %s/%s no longer tracked, skipping execution", t.Namespace, t.Name)
+		return nil
+	}
 
 	variables := map[string]testkube.Variable{
 		"WATCHER_EVENT_RESOURCE": {

--- a/pkg/triggers/matcher.go
+++ b/pkg/triggers/matcher.go
@@ -32,8 +32,9 @@ var (
 )
 
 func (s *Service) match(ctx context.Context, e *watcherEvent) error {
-	for _, status := range s.triggerStatus {
-		t := status.testTrigger
+	for _, entry := range s.snapshotStatuses() {
+		status := entry.status
+		t := status.getTestTrigger()
 		if t.Spec.Disabled {
 			continue
 		}
@@ -101,7 +102,6 @@ func (s *Service) match(ctx context.Context, e *watcherEvent) error {
 			}
 		}
 
-		status := s.getStatusForTrigger(t)
 		if t.Spec.ConcurrencyPolicy == testtriggersv1.TestTriggerConcurrencyPolicyForbid {
 			if status.hasActiveTests() {
 				s.logger.Infof(

--- a/pkg/triggers/scraper.go
+++ b/pkg/triggers/scraper.go
@@ -22,11 +22,12 @@ func (s *Service) runExecutionScraper(ctx context.Context) {
 			return
 		case <-ticker.C:
 			s.logger.Debugf("trigger service: execution scraper component: starting new ticker iteration")
-			for triggerName, status := range s.triggerStatus {
+			for _, entry := range s.snapshotStatuses() {
+				status := entry.status
 				if status.hasActiveTests() {
 					s.checkForRunningTestWorkflowExecutions(ctx, status)
 					if !status.hasActiveTests() {
-						s.logger.Debugf("marking status as finished for testtrigger %s", triggerName)
+						s.logger.Debugf("marking status as finished for testtrigger %s", entry.key)
 						status.done()
 					}
 				}

--- a/pkg/triggers/service.go
+++ b/pkg/triggers/service.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"strings"
+	"sync"
 	"time"
 
 	"go.uber.org/zap"
@@ -37,8 +38,21 @@ const (
 	defaultIdentifierFormat       = "testkube-api-%s"
 )
 
+// Service watches Kubernetes resources and TestTrigger CRDs in-cluster,
+// matches events against registered triggers, and executes actions.
+//
+// Lock ordering (deadlock-avoidance): acquire triggerStatusMu before any
+// per-status RWMutex. snapshotStatuses takes triggerStatusMu and releases it
+// before callers touch a status's lock; updateTrigger holds triggerStatusMu
+// across the inner setTestTrigger call. Never acquire the status lock first
+// and then triggerStatusMu.
 type Service struct {
+	// informers is set on lease acquisition (runWatcher) and nil-ed on
+	// release. informersMu guards the pointer so tests and external callers
+	// can safely observe it; runInformers reads it from the same goroutine
+	// that writes it and therefore doesn't need the lock.
 	informers                     *k8sInformers
+	informersMu                   sync.RWMutex
 	identifier                    string
 	clusterID                     string
 	agentName                     string
@@ -49,7 +63,12 @@ type Service struct {
 	defaultProbesCheckTimeout     time.Duration
 	defaultProbesCheckBackoff     time.Duration
 	watchFromDate                 time.Time
+	// triggerStatus is mutated by informer event handlers (addTrigger /
+	// updateTrigger / removeTrigger) and read by the matcher and scraper.
+	// triggerStatusMu guards the map itself; concurrency on individual
+	// *triggerStatus values is handled by their own embedded sync.RWMutex.
 	triggerStatus                 map[statusKey]*triggerStatus
+	triggerStatusMu               sync.RWMutex
 	clientset                     kubernetes.Interface
 	testKubeClientset             testkubeclientsetv1.Interface
 	testWorkflowsClient           testworkflowclient.TestWorkflowClient
@@ -204,19 +223,43 @@ func (s *Service) Run(ctx context.Context) {
 
 func (s *Service) addTrigger(t *testtriggersv1.TestTrigger) {
 	key := newStatusKey(t.Namespace, t.Name)
+	s.triggerStatusMu.Lock()
+	defer s.triggerStatusMu.Unlock()
 	s.triggerStatus[key] = newTriggerStatus(t)
 }
 
 func (s *Service) updateTrigger(target *testtriggersv1.TestTrigger) {
 	key := newStatusKey(target.Namespace, target.Name)
-	if s.triggerStatus[key] != nil {
-		s.triggerStatus[key].testTrigger = target
-	} else {
+	s.triggerStatusMu.Lock()
+	defer s.triggerStatusMu.Unlock()
+	existing := s.triggerStatus[key]
+	if existing == nil {
 		s.triggerStatus[key] = newTriggerStatus(target)
+		return
 	}
+	existing.setTestTrigger(target)
 }
 
 func (s *Service) removeTrigger(target *testtriggersv1.TestTrigger) {
 	key := newStatusKey(target.Namespace, target.Name)
+	s.triggerStatusMu.Lock()
+	defer s.triggerStatusMu.Unlock()
 	delete(s.triggerStatus, key)
+}
+
+type triggerStatusEntry struct {
+	key    statusKey
+	status *triggerStatus
+}
+
+// snapshotStatuses returns a shallow copy so match/scraper can iterate without
+// blocking high-volume informer events on the map lock.
+func (s *Service) snapshotStatuses() []triggerStatusEntry {
+	s.triggerStatusMu.RLock()
+	defer s.triggerStatusMu.RUnlock()
+	out := make([]triggerStatusEntry, 0, len(s.triggerStatus))
+	for k, v := range s.triggerStatus {
+		out = append(out, triggerStatusEntry{key: k, status: v})
+	}
+	return out
 }

--- a/pkg/triggers/status.go
+++ b/pkg/triggers/status.go
@@ -28,6 +28,18 @@ func newTriggerStatus(testTrigger *testtriggersv1.TestTrigger) *triggerStatus {
 	return &triggerStatus{testTrigger: testTrigger}
 }
 
+func (s *triggerStatus) getTestTrigger() *testtriggersv1.TestTrigger {
+	s.RLock()
+	defer s.RUnlock()
+	return s.testTrigger
+}
+
+func (s *triggerStatus) setTestTrigger(t *testtriggersv1.TestTrigger) {
+	s.Lock()
+	defer s.Unlock()
+	s.testTrigger = t
+}
+
 func (s *triggerStatus) hasActiveTests() bool {
 	defer s.RUnlock()
 
@@ -82,5 +94,7 @@ func (s *triggerStatus) done() {
 
 func (s *Service) getStatusForTrigger(t *testtriggersv1.TestTrigger) *triggerStatus {
 	key := newStatusKey(t.Namespace, t.Name)
+	s.triggerStatusMu.RLock()
+	defer s.triggerStatusMu.RUnlock()
 	return s.triggerStatus[key]
 }

--- a/pkg/triggers/watcher.go
+++ b/pkg/triggers/watcher.go
@@ -98,12 +98,17 @@ func newK8sInformers(clientset kubernetes.Interface, testKubeClientset versioned
 
 func (s *Service) runWatcher(ctx context.Context) {
 	s.logger.Infof("trigger service: instance %s in cluster %s acquired lease", s.identifier, s.clusterID)
-	s.informers = newK8sInformers(s.clientset, s.testKubeClientset, s.testkubeNamespace, s.watcherNamespaces)
+	informers := newK8sInformers(s.clientset, s.testKubeClientset, s.testkubeNamespace, s.watcherNamespaces)
+	s.informersMu.Lock()
+	s.informers = informers
+	s.informersMu.Unlock()
 
 	stopChan := make(chan struct{})
 	defer func() {
 		close(stopChan)
+		s.informersMu.Lock()
 		s.informers = nil
+		s.informersMu.Unlock()
 		s.logger.Infof("trigger service: instance %s in cluster %s released lease", s.identifier, s.clusterID)
 	}()
 

--- a/pkg/triggers/watcher_test.go
+++ b/pkg/triggers/watcher_test.go
@@ -46,6 +46,8 @@ func TestService_runWatcher_createsAndDeletesTrigger(t *testing.T) {
 	go service.runWatcher(ctx)
 
 	require.Eventually(t, func() bool {
+		service.informersMu.RLock()
+		defer service.informersMu.RUnlock()
 		return service.informers != nil
 	}, time.Second, 10*time.Millisecond)
 
@@ -57,6 +59,8 @@ func TestService_runWatcher_createsAndDeletesTrigger(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Eventually(t, func() bool {
+		service.triggerStatusMu.RLock()
+		defer service.triggerStatusMu.RUnlock()
 		_, ok := service.triggerStatus[newStatusKey(namespace, "test-trigger")]
 		return ok
 	}, time.Second, 10*time.Millisecond)
@@ -65,6 +69,8 @@ func TestService_runWatcher_createsAndDeletesTrigger(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Eventually(t, func() bool {
+		service.triggerStatusMu.RLock()
+		defer service.triggerStatusMu.RUnlock()
 		return len(service.triggerStatus) == 0
 	}, time.Second, 10*time.Millisecond)
 }
@@ -85,6 +91,8 @@ func TestService_runWatcher_stopsOnContextCancellation(t *testing.T) {
 	}()
 
 	require.Eventually(t, func() bool {
+		service.informersMu.RLock()
+		defer service.informersMu.RUnlock()
 		return service.informers != nil
 	}, time.Second, 10*time.Millisecond)
 
@@ -97,6 +105,8 @@ func TestService_runWatcher_stopsOnContextCancellation(t *testing.T) {
 	}
 
 	require.Eventually(t, func() bool {
+		service.informersMu.RLock()
+		defer service.informersMu.RUnlock()
 		return service.informers == nil
 	}, time.Second, 10*time.Millisecond)
 }


### PR DESCRIPTION
## Summary
- Kubernetes informer event handlers run in their own goroutines; under \`go test -race\` this surfaced as \"concurrent map read and map write\" on \`Service.triggerStatus\` (addTrigger/updateTrigger/removeTrigger from the TestTrigger informer vs. match/scraper ranging the map) and a write/read race on \`Service.informers\` between runWatcher and external observers. Both were latent hard crashes that would restart the agent pod under contention.
- Add a dedicated \`sync.RWMutex\` for each shared pointer and switch the matcher/scraper hot paths to snapshot-then-iterate so slow downstream work (triggerExecutor, HTTP probes) doesn't block informer-goroutine add/update/remove events.
- \`triggerStatus.testTrigger\` is now accessed only through \`getTestTrigger\` / \`setTestTrigger\` so \`updateTrigger\` can swap the trigger definition without racing an in-flight match.
- Lock ordering is documented on the \`Service\` struct: acquire \`triggerStatusMu\` before any per-status \`RWMutex\`.

## Test plan
- [x] \`go test ./pkg/triggers/...\` passes
- [x] \`go test -race ./pkg/triggers/...\` passes (previously reported WARNING: DATA RACE on \`triggerStatus\` map and \`informers\` field)
- [x] \`go build ./...\` passes