### PR TITLE
feat: add marketplace commands for testkube cli [TKC-5457]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,4 @@ depot-build-meta.json
 
 # GitHub Actions temporary Google credentials
 gha-creds-*.json
+.cursor/settings.json

--- a/cmd/kubectl-testkube/commands/agents/create.go
+++ b/cmd/kubectl-testkube/commands/agents/create.go
@@ -62,8 +62,8 @@ func NewCreateAgentCommand() *cobra.Command {
 				enableWebhooks,
 			)
 			ui.NL()
-			ui.Info("Install the agent with command:")
-			installCmd := fmt.Sprintf("kubectl testkube install agent %s --secret %s", agent.Name, agent.SecretKey)
+			ui.Hint("Install the agent with command:")
+			installCmd := fmt.Sprintf("testkube install agent %s --secret %s", agent.Name, agent.SecretKey)
 			if enableRunner {
 				installCmd += " --runner"
 			}
@@ -118,7 +118,7 @@ func NewCreateRunnerCommand() *cobra.Command {
 			if cmd.Flags().Changed("type") {
 				ui.Warn("⚠️  The --type/-t flag is deprecated.")
 				ui.Info("This command creates a runner-only agent by default.")
-				ui.Info("For more flexibility, use 'kubectl testkube create agent' with:")
+				ui.Hint("For more flexibility, use 'testkube create agent' with:")
 				ui.Info("  --runner    : Enable runner capability")
 				ui.Info("  --listener  : Enable listener capability")
 				ui.Info("  --gitops    : Enable GitOps capability")
@@ -128,8 +128,8 @@ func NewCreateRunnerCommand() *cobra.Command {
 
 			agent := UiCreateAgent(cmd, args[0], labelPairs, environmentIds, global, group, floating, true, false, false, false)
 			ui.NL()
-			ui.Info("Install the agent with command:")
-			installCmd := fmt.Sprintf("kubectl testkube install agent %s --secret %s --runner", agent.Name, agent.SecretKey)
+			ui.Hint("Install the agent with command:")
+			installCmd := fmt.Sprintf("testkube install agent %s --secret %s --runner", agent.Name, agent.SecretKey)
 			ui.ShellCommand(installCmd)
 		},
 	}

--- a/cmd/kubectl-testkube/commands/agents/install.go
+++ b/cmd/kubectl-testkube/commands/agents/install.go
@@ -127,7 +127,7 @@ func NewInstallRunnerCommand() *cobra.Command {
 			if cmd.Flags().Changed("type") {
 				ui.Warn("⚠️  The --type/-t flag is deprecated.")
 				ui.Info("This command installs a runner-only agent by default.")
-				ui.Info("For more flexibility, use 'kubectl testkube install agent' with:")
+				ui.Hint("For more flexibility, use 'testkube install agent' with:")
 				ui.Info("  --runner    : Enable runner capability")
 				ui.Info("  --listener  : Enable listener capability")
 				ui.Info("  --gitops    : Enable GitOps capability")

--- a/cmd/kubectl-testkube/commands/common/errors.go
+++ b/cmd/kubectl-testkube/commands/common/errors.go
@@ -57,6 +57,15 @@ const (
 	TKErrAgentGetFailed ErrorCode = "TKERR-1501"
 	// TKErrAgentRotateKeyFailed is returned when rotating an agent's secret key fails.
 	TKErrAgentRotateKeyFailed ErrorCode = "TKERR-1502"
+
+	// TKERR-16xx errors are related to marketplace operations.
+
+	// TKErrMarketplaceFetchFailed is returned when fetching marketplace content (catalog, YAML, readme) fails.
+	TKErrMarketplaceFetchFailed ErrorCode = "TKERR-1601"
+	// TKErrMarketplaceWorkflowNotFound is returned when the requested workflow is not present in the catalog.
+	TKErrMarketplaceWorkflowNotFound ErrorCode = "TKERR-1602"
+	// TKErrMarketplaceInvalidParameter is returned when a --set value cannot be parsed or references an unknown key.
+	TKErrMarketplaceInvalidParameter ErrorCode = "TKERR-1603"
 )
 
 const helpUrl = "https://testkubeworkspace.slack.com"

--- a/cmd/kubectl-testkube/commands/common/errors.go
+++ b/cmd/kubectl-testkube/commands/common/errors.go
@@ -64,7 +64,10 @@ const (
 	TKErrMarketplaceFetchFailed ErrorCode = "TKERR-1601"
 	// TKErrMarketplaceWorkflowNotFound is returned when the requested workflow is not present in the catalog.
 	TKErrMarketplaceWorkflowNotFound ErrorCode = "TKERR-1602"
-	// TKErrMarketplaceInvalidParameter is returned when a --set value cannot be parsed or references an unknown key.
+	// TKErrMarketplaceInvalidParameter is returned for any parameter-related
+	// failure: the workflow spec.config could not be parsed, a --set value
+	// is malformed or references an unknown key, or the parameter values
+	// could not be re-applied to the workflow YAML.
 	TKErrMarketplaceInvalidParameter ErrorCode = "TKERR-1603"
 )
 

--- a/cmd/kubectl-testkube/commands/common/uihints.go
+++ b/cmd/kubectl-testkube/commands/common/uihints.go
@@ -1,27 +1,29 @@
 package common
 
-import "github.com/kubeshop/testkube/pkg/ui"
+import (
+	"github.com/kubeshop/testkube/pkg/ui"
+)
 
-// UIShellGetExecution prints kubectl command to get test workflow execution details.
+// UIShellGetExecution prints the testkube command to get test workflow execution details.
 func UIShellGetExecution(id string) {
+	ui.Hint("Get the TestWorkflow execution details:")
 	ui.ShellCommand(
-		"Use following command to get test workflow execution details",
-		"testkube get twe "+id,
+		"testkube get twe " + id,
 	)
 }
 
-// UIShellViewExecution prints kubectl command to view test workflow execution in the browser.
+// UIShellViewExecution prints the testkube command to view a test workflow execution in the browser.
 func UIShellViewExecution(id string) {
+	ui.Hint("View the TestWorkflow execution details in your browser:")
 	ui.ShellCommand(
-		"View test workflow execution in your browser",
-		"testkube view "+id,
+		"testkube view " + id,
 	)
 }
 
-// UIShellWatchExecution prints kubectl command to watch a test workflow execution until complete.
+// UIShellWatchExecution prints the testkube command to watch a test workflow execution until complete.
 func UIShellWatchExecution(id string) {
+	ui.Hint("Watch the TestWorkflow execution until complete:")
 	ui.ShellCommand(
-		"Watch test workflow execution until complete",
-		"testkube watch twe "+id,
+		"testkube watch twe " + id,
 	)
 }

--- a/cmd/kubectl-testkube/commands/common/validator/version.go
+++ b/cmd/kubectl-testkube/commands/common/validator/version.go
@@ -45,10 +45,10 @@ func PersistentPreRunVersionCheck(cmd *cobra.Command, clientVersion string) {
 	if err != nil {
 		ui.Warn(err.Error())
 	} else if err == ErrOldClientVersion {
-		ui.Warn("Your Testkube API version is newer than your `kubectl testkube` plugin")
+		ui.Warn("Your Testkube API version is newer than your `testkube` CLI")
 		ui.Info("Testkube API version", info.Version)
-		ui.Info("Testkube kubectl plugin client", clientVersion)
-		ui.Info("It's recommended to upgrade client to version close to API server version")
+		ui.Info("Testkube CLI client", clientVersion)
+		ui.Hint("It's recommended to upgrade the client to a version close to the API server version")
 		ui.NL()
 	}
 }

--- a/cmd/kubectl-testkube/commands/docker/init.go
+++ b/cmd/kubectl-testkube/commands/docker/init.go
@@ -147,7 +147,7 @@ func NewInitCmd() *cobra.Command {
 func sendErrTelemetry(cmd *cobra.Command, clientCfg config.Data, errType string, errorLogs error) {
 	var errorStackTrace = fmt.Sprintf("%+v", errorLogs)
 	if clientCfg.TelemetryEnabled {
-		ui.Debug("collecting anonymous telemetry data, you can disable it by calling `kubectl testkube disable telemetry`")
+		ui.Debug("collecting anonymous telemetry data, you can disable it by calling `testkube disable telemetry`")
 		out, err := telemetry.SendCmdErrorEvent(cmd, common.Version, errType, errorStackTrace)
 		if ui.Verbose && err != nil {
 			ui.Err(err)
@@ -159,7 +159,7 @@ func sendErrTelemetry(cmd *cobra.Command, clientCfg config.Data, errType string,
 
 func sendAttemptTelemetry(cmd *cobra.Command, clientCfg config.Data) {
 	if clientCfg.TelemetryEnabled {
-		ui.Debug("collecting anonymous telemetry data, you can disable it by calling `kubectl testkube disable telemetry`")
+		ui.Debug("collecting anonymous telemetry data, you can disable it by calling `testkube disable telemetry`")
 		out, err := telemetry.SendCmdAttemptEvent(cmd, common.Version)
 		if ui.Verbose && err != nil {
 			ui.Err(err)

--- a/cmd/kubectl-testkube/commands/generate/docs.go
+++ b/cmd/kubectl-testkube/commands/generate/docs.go
@@ -40,8 +40,8 @@ func NewDocsCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:     "doc",
 		Aliases: []string{"docs"},
-		Short:   "Generate docs for kubectl testkube",
-		Long:    `Generate docs for kubectl testkube`,
+		Short:   "Generate docs for testkube",
+		Long:    `Generate docs for testkube`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			root := cmd.Root()
 			root.DisableAutoGenTag = true

--- a/cmd/kubectl-testkube/commands/help.go
+++ b/cmd/kubectl-testkube/commands/help.go
@@ -37,7 +37,7 @@ func NewHelpCmd() *cobra.Command {
 			ui.Print(ui.LightGray("Flags"))
 			ui.Print(RootCmd.Flags().FlagUsages())
 			ui.NL()
-			ui.Print(ui.LightGray("Use \"kubectl testkube [command] --help\" for more information about a command."))
+			ui.Print(ui.LightGray("Use \"testkube [command] --help\" for more information about a command."))
 			ui.NL()
 			ui.Printf("%s   %s\n", ui.LightGray("Docs & Support:"), ui.White("https://docs.testkube.io"))
 			ui.NL()

--- a/cmd/kubectl-testkube/commands/marketplace.go
+++ b/cmd/kubectl-testkube/commands/marketplace.go
@@ -1,0 +1,32 @@
+package commands
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/kubeshop/testkube/cmd/kubectl-testkube/commands/marketplace"
+	"github.com/kubeshop/testkube/pkg/ui"
+)
+
+func NewMarketplaceCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "marketplace",
+		Aliases: []string{"mp"},
+		Short:   "Browse and install TestWorkflows from the Testkube Marketplace",
+		Long: `Browse, inspect, and install TestWorkflows from the Testkube Marketplace
+(https://github.com/kubeshop/testkube-marketplace) without opening the dashboard.`,
+		Run: func(cmd *cobra.Command, args []string) {
+			err := cmd.Help()
+			ui.PrintOnError("Displaying help", err)
+		},
+	}
+
+	cmd.PersistentFlags().StringP("output", "o", "pretty", "output type: pretty|json|yaml|go")
+	cmd.PersistentFlags().StringP("go-template", "", "{{.}}", "go template to render when --output=go")
+
+	cmd.AddCommand(marketplace.NewListCmd())
+	cmd.AddCommand(marketplace.NewCategoriesCmd())
+	cmd.AddCommand(marketplace.NewGetCmd())
+	cmd.AddCommand(marketplace.NewInstallCmd())
+
+	return cmd
+}

--- a/cmd/kubectl-testkube/commands/marketplace/categories.go
+++ b/cmd/kubectl-testkube/commands/marketplace/categories.go
@@ -1,0 +1,118 @@
+package marketplace
+
+import (
+	"os"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/kubeshop/testkube/cmd/kubectl-testkube/commands/common"
+	"github.com/kubeshop/testkube/cmd/kubectl-testkube/commands/common/render"
+	"github.com/kubeshop/testkube/pkg/marketplace"
+	"github.com/kubeshop/testkube/pkg/ui"
+)
+
+// categorySummary is the per-category aggregate rendered by `marketplace
+// categories`. Exported field names keep encoding/json and yaml.v3 output
+// consistent with the rest of the marketplace commands.
+type categorySummary struct {
+	Category   string   `json:"category" yaml:"category"`
+	Count      int      `json:"count" yaml:"count"`
+	Components []string `json:"components" yaml:"components"`
+}
+
+func NewCategoriesCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "categories",
+		Aliases: []string{"cats"},
+		Args:    cobra.NoArgs,
+		Short:   "List marketplace categories with workflow counts and components",
+		Long: `Aggregates the marketplace catalog into one row per category, showing how many
+workflows the category contains and the distinct components inside it.`,
+
+		Run: func(cmd *cobra.Command, _ []string) {
+			client := NewClient()
+			workflows, err := client.ListWorkflows(cmd.Context())
+			if err != nil {
+				common.HandleCLIError(common.NewCLIError(
+					common.TKErrMarketplaceFetchFailed,
+					"Failed to fetch marketplace catalog",
+					"",
+					err,
+				))
+			}
+
+			summaries := aggregateCategories(workflows)
+
+			outputType := cmd.Flag("output").Value.String()
+			if outputType == "json" || outputType == "yaml" || outputType == "go" {
+				err = render.List(cmd, summaries, os.Stdout)
+				ui.PrintOnError("Rendering list", err)
+				return
+			}
+
+			err = render.List(cmd, categoriesTable(summaries), os.Stdout)
+			ui.PrintOnError("Rendering list", err)
+		},
+	}
+
+	return cmd
+}
+
+// aggregateCategories collapses workflows into one row per category. Component
+// lists are deduped and sorted; categories are sorted alphabetically. The
+// returned slice is always non-nil so callers can encode it as `[]` rather
+// than `null` when the catalog is empty.
+func aggregateCategories(workflows []marketplace.Workflow) []categorySummary {
+	type bucket struct {
+		count      int
+		components map[string]struct{}
+	}
+	buckets := make(map[string]*bucket)
+	for _, w := range workflows {
+		b, ok := buckets[w.Category]
+		if !ok {
+			b = &bucket{components: make(map[string]struct{})}
+			buckets[w.Category] = b
+		}
+		b.count++
+		if w.Component != "" {
+			b.components[w.Component] = struct{}{}
+		}
+	}
+
+	summaries := make([]categorySummary, 0, len(buckets))
+	for cat, b := range buckets {
+		comps := make([]string, 0, len(b.components))
+		for c := range b.components {
+			comps = append(comps, c)
+		}
+		sort.Strings(comps)
+		summaries = append(summaries, categorySummary{
+			Category:   cat,
+			Count:      b.count,
+			Components: comps,
+		})
+	}
+	sort.Slice(summaries, func(i, j int) bool {
+		return summaries[i].Category < summaries[j].Category
+	})
+	return summaries
+}
+
+type categoriesTable []categorySummary
+
+func (t categoriesTable) Table() ([]string, [][]string) {
+	header := []string{"CATEGORY", "WORKFLOWS", "COMPONENTS"}
+	data := make([][]string, 0, len(t))
+	for _, s := range t {
+		data = append(data, []string{
+			s.Category,
+			strconv.Itoa(s.Count),
+			strings.Join(s.Components, ", "),
+		})
+	}
+	return header, data
+}

--- a/cmd/kubectl-testkube/commands/marketplace/categories_test.go
+++ b/cmd/kubectl-testkube/commands/marketplace/categories_test.go
@@ -1,0 +1,102 @@
+package marketplace
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/kubeshop/testkube/pkg/marketplace"
+)
+
+func TestAggregateCategories(t *testing.T) {
+	tests := []struct {
+		name      string
+		workflows []marketplace.Workflow
+		want      []categorySummary
+	}{
+		{
+			name:      "empty catalog returns empty non-nil slice",
+			workflows: nil,
+			want:      []categorySummary{},
+		},
+		{
+			name: "categories sorted alphabetically and components deduped",
+			workflows: []marketplace.Workflow{
+				{Name: "kafka-a", Category: "messaging", Component: "kafka"},
+				{Name: "postgres-a", Category: "databases", Component: "postgresql"},
+				{Name: "postgres-b", Category: "databases", Component: "postgresql"},
+				{Name: "redis-a", Category: "databases", Component: "redis"},
+				{Name: "kafka-b", Category: "messaging", Component: "kafka"},
+				{Name: "nats-a", Category: "messaging", Component: "nats"},
+			},
+			want: []categorySummary{
+				{
+					Category:   "databases",
+					Count:      3,
+					Components: []string{"postgresql", "redis"},
+				},
+				{
+					Category:   "messaging",
+					Count:      3,
+					Components: []string{"kafka", "nats"},
+				},
+			},
+		},
+		{
+			name: "missing component is skipped from component list",
+			workflows: []marketplace.Workflow{
+				{Name: "generic", Category: "misc", Component: ""},
+				{Name: "tool", Category: "misc", Component: "curl"},
+			},
+			want: []categorySummary{
+				{
+					Category:   "misc",
+					Count:      2,
+					Components: []string{"curl"},
+				},
+			},
+		},
+		{
+			name: "single workflow yields single summary",
+			workflows: []marketplace.Workflow{
+				{Name: "only", Category: "networking", Component: "nginx"},
+			},
+			want: []categorySummary{
+				{
+					Category:   "networking",
+					Count:      1,
+					Components: []string{"nginx"},
+				},
+			},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := aggregateCategories(tc.workflows)
+			if got == nil {
+				t.Fatalf("aggregateCategories returned nil; want non-nil slice")
+			}
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Fatalf("aggregateCategories mismatch:\n got: %#v\nwant: %#v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestCategoriesTable_Table(t *testing.T) {
+	table := categoriesTable{
+		{Category: "databases", Count: 2, Components: []string{"postgresql", "redis"}},
+		{Category: "messaging", Count: 1, Components: []string{"kafka"}},
+	}
+	header, rows := table.Table()
+	wantHeader := []string{"CATEGORY", "WORKFLOWS", "COMPONENTS"}
+	if !reflect.DeepEqual(header, wantHeader) {
+		t.Fatalf("header mismatch: got %v want %v", header, wantHeader)
+	}
+	wantRows := [][]string{
+		{"databases", "2", "postgresql, redis"},
+		{"messaging", "1", "kafka"},
+	}
+	if !reflect.DeepEqual(rows, wantRows) {
+		t.Fatalf("rows mismatch:\n got: %#v\nwant: %#v", rows, wantRows)
+	}
+}

--- a/cmd/kubectl-testkube/commands/marketplace/common.go
+++ b/cmd/kubectl-testkube/commands/marketplace/common.go
@@ -1,0 +1,15 @@
+// Package marketplace contains CLI subcommands under `testkube marketplace`
+// for browsing, inspecting, and installing TestWorkflows published in the
+// testkube-marketplace GitHub repository.
+package marketplace
+
+import (
+	"github.com/kubeshop/testkube/pkg/marketplace"
+)
+
+// NewClient returns a marketplace client configured for production use.
+// Centralized so individual commands can swap it out uniformly in the future
+// (e.g. for caching or custom transports).
+func NewClient() *marketplace.Client {
+	return marketplace.NewClient()
+}

--- a/cmd/kubectl-testkube/commands/marketplace/get.go
+++ b/cmd/kubectl-testkube/commands/marketplace/get.go
@@ -1,9 +1,9 @@
 package marketplace
 
 import (
+	"errors"
 	"fmt"
 	"os"
-	"strings"
 
 	"github.com/spf13/cobra"
 
@@ -42,13 +42,14 @@ and readme content for a marketplace TestWorkflow.`,
 
 			wf, err := client.GetWorkflow(cmd.Context(), name)
 			if err != nil {
-				if strings.Contains(err.Error(), "not found") {
+				if errors.Is(err, marketplace.ErrWorkflowNotFound) {
 					common.HandleCLIError(common.NewCLIError(
 						common.TKErrMarketplaceWorkflowNotFound,
 						"Workflow not found",
 						"",
 						err,
 					))
+					return
 				}
 				common.HandleCLIError(common.NewCLIError(
 					common.TKErrMarketplaceFetchFailed,
@@ -56,6 +57,7 @@ and readme content for a marketplace TestWorkflow.`,
 					"",
 					err,
 				))
+				return
 			}
 
 			yamlBytes, err := client.GetWorkflowYAML(cmd.Context(), *wf)
@@ -66,15 +68,32 @@ and readme content for a marketplace TestWorkflow.`,
 					"",
 					err,
 				))
+				return
 			}
 
 			params, err := marketplace.ExtractParameters(yamlBytes)
-			ui.ExitOnError("parsing workflow parameters", err)
+			if err != nil {
+				common.HandleCLIError(common.NewCLIError(
+					common.TKErrMarketplaceInvalidParameter,
+					"Failed to parse workflow parameters",
+					"",
+					err,
+				))
+				return
+			}
 
 			var readme []byte
 			if showReadme {
 				readme, err = client.GetReadme(cmd.Context(), *wf)
-				ui.ExitOnError("fetching readme", err)
+				if err != nil {
+					common.HandleCLIError(common.NewCLIError(
+						common.TKErrMarketplaceFetchFailed,
+						"Failed to download readme",
+						"",
+						err,
+					))
+					return
+				}
 			}
 
 			outputType := cmd.Flag("output").Value.String()

--- a/cmd/kubectl-testkube/commands/marketplace/get.go
+++ b/cmd/kubectl-testkube/commands/marketplace/get.go
@@ -1,0 +1,152 @@
+package marketplace
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/kubeshop/testkube/cmd/kubectl-testkube/commands/common"
+	"github.com/kubeshop/testkube/cmd/kubectl-testkube/commands/common/render"
+	"github.com/kubeshop/testkube/pkg/marketplace"
+	"github.com/kubeshop/testkube/pkg/ui"
+)
+
+// workflowDetail is the structured payload rendered for `marketplace get` so
+// that JSON/YAML/go-template consumers get consistent, machine-readable output.
+type workflowDetail struct {
+	Workflow   marketplace.Workflow    `json:"workflow" yaml:"workflow"`
+	Parameters []marketplace.Parameter `json:"parameters" yaml:"parameters"`
+	YAML       string                  `json:"yaml,omitempty" yaml:"yaml,omitempty"`
+	Readme     string                  `json:"readme,omitempty" yaml:"readme,omitempty"`
+}
+
+func NewGetCmd() *cobra.Command {
+	var (
+		showYAML   bool
+		showReadme bool
+	)
+
+	cmd := &cobra.Command{
+		Use:     "get <name>",
+		Aliases: []string{"describe"},
+		Args:    cobra.ExactArgs(1),
+		Short:   "Show detailed information about a marketplace TestWorkflow",
+		Long: `Displays the catalog entry, configurable parameters, and optionally the raw YAML
+and readme content for a marketplace TestWorkflow.`,
+
+		Run: func(cmd *cobra.Command, args []string) {
+			name := args[0]
+			client := NewClient()
+
+			wf, err := client.GetWorkflow(cmd.Context(), name)
+			if err != nil {
+				if strings.Contains(err.Error(), "not found") {
+					common.HandleCLIError(common.NewCLIError(
+						common.TKErrMarketplaceWorkflowNotFound,
+						"Workflow not found",
+						"",
+						err,
+					))
+				}
+				common.HandleCLIError(common.NewCLIError(
+					common.TKErrMarketplaceFetchFailed,
+					"Failed to fetch marketplace catalog",
+					"",
+					err,
+				))
+			}
+
+			yamlBytes, err := client.GetWorkflowYAML(cmd.Context(), *wf)
+			if err != nil {
+				common.HandleCLIError(common.NewCLIError(
+					common.TKErrMarketplaceFetchFailed,
+					"Failed to download workflow YAML",
+					"",
+					err,
+				))
+			}
+
+			params, err := marketplace.ExtractParameters(yamlBytes)
+			ui.ExitOnError("parsing workflow parameters", err)
+
+			var readme []byte
+			if showReadme {
+				readme, err = client.GetReadme(cmd.Context(), *wf)
+				ui.ExitOnError("fetching readme", err)
+			}
+
+			outputType := cmd.Flag("output").Value.String()
+			if outputType == "json" || outputType == "yaml" || outputType == "go" {
+				detail := workflowDetail{
+					Workflow:   *wf,
+					Parameters: params,
+					Readme:     string(readme),
+				}
+				if showYAML {
+					detail.YAML = string(yamlBytes)
+				}
+				err = render.Obj(cmd, detail, os.Stdout)
+				ui.PrintOnError("Rendering detail", err)
+				return
+			}
+
+			renderPretty(*wf, params, yamlBytes, readme, showYAML, showReadme)
+		},
+	}
+
+	cmd.Flags().BoolVar(&showYAML, "show-yaml", false, "include the raw workflow YAML in the output")
+	cmd.Flags().BoolVar(&showReadme, "show-readme", false, "include the workflow readme in the output")
+
+	return cmd
+}
+
+func renderPretty(wf marketplace.Workflow, params []marketplace.Parameter, yamlBytes, readme []byte, showYAML, showReadme bool) {
+	fmt.Printf("Name:         %s\n", wf.Name)
+	fmt.Printf("Display Name: %s\n", wf.DisplayName)
+	fmt.Printf("Category:     %s\n", wf.Category)
+	fmt.Printf("Component:    %s\n", wf.Component)
+	if wf.ValidationType != "" {
+		fmt.Printf("Validation:   %s\n", wf.ValidationType)
+	}
+	fmt.Printf("Description:  %s\n", wf.Description)
+	if wf.Icon != "" {
+		fmt.Printf("Icon:         %s\n", wf.Icon)
+	}
+	fmt.Println()
+
+	if len(params) == 0 {
+		fmt.Println("Parameters:   (none)")
+	} else {
+		fmt.Println("Parameters:")
+		paramsTable := paramsPrettyTable(params)
+		ui.NewUI(ui.Verbose, os.Stdout).Table(paramsTable, os.Stdout)
+	}
+
+	if showYAML {
+		fmt.Println()
+		fmt.Println("YAML:")
+		fmt.Println(string(yamlBytes))
+	}
+	if showReadme && len(readme) > 0 {
+		fmt.Println()
+		fmt.Println("Readme:")
+		fmt.Println(string(readme))
+	}
+}
+
+type paramsPrettyTable []marketplace.Parameter
+
+func (t paramsPrettyTable) Table() ([]string, [][]string) {
+	header := []string{"NAME", "TYPE", "DEFAULT", "SENSITIVE", "DESCRIPTION"}
+	data := make([][]string, 0, len(t))
+	for _, p := range t {
+		sensitive := ""
+		if p.Sensitive {
+			sensitive = "yes"
+		}
+		data = append(data, []string{p.Key, p.Type, p.Default, sensitive, p.Description})
+	}
+	return header, data
+}

--- a/cmd/kubectl-testkube/commands/marketplace/install.go
+++ b/cmd/kubectl-testkube/commands/marketplace/install.go
@@ -2,6 +2,7 @@ package marketplace
 
 import (
 	"errors"
+	"os"
 
 	"github.com/spf13/cobra"
 
@@ -12,10 +13,11 @@ import (
 
 func NewInstallCmd() *cobra.Command {
 	var (
-		name     string
-		update   bool
-		dryRun   bool
-		setFlags []string
+		name        string
+		update      bool
+		dryRun      bool
+		interactive bool
+		setFlags    []string
 	)
 
 	cmd := &cobra.Command{
@@ -24,7 +26,12 @@ func NewInstallCmd() *cobra.Command {
 		Short: "Install a marketplace TestWorkflow into the cluster",
 		Long: `Downloads a TestWorkflow from the Testkube Marketplace, applies any --set
 parameter overrides to its spec.config defaults, and creates (or updates) the
-TestWorkflow in the target namespace.`,
+TestWorkflow in the target namespace.
+
+Use --interactive/-i to be prompted for every parameter the workflow exposes.
+Values supplied via --set are used as the prompt default, and empty input
+keeps the current value. Parameters marked sensitive are read with masked
+input and their current value is never echoed.`,
 
 		Run: func(cmd *cobra.Command, args []string) {
 			workflowName := args[0]
@@ -83,6 +90,19 @@ TestWorkflow in the target namespace.`,
 				return
 			}
 
+			if interactive {
+				params, err = promptForParameters(os.Stdout, params, ptermPrompter{})
+				if err != nil {
+					common.HandleCLIError(common.NewCLIError(
+						common.TKErrMarketplaceInvalidParameter,
+						"Failed to read interactive input",
+						"",
+						err,
+					))
+					return
+				}
+			}
+
 			updated, err := marketplace.ApplyParameters(yamlBytes, params)
 			if err != nil {
 				common.HandleCLIError(common.NewCLIError(
@@ -101,6 +121,7 @@ TestWorkflow in the target namespace.`,
 	cmd.Flags().StringVar(&name, "name", "", "override the TestWorkflow name")
 	cmd.Flags().BoolVar(&update, "update", false, "update, if test workflow already exists")
 	cmd.Flags().BoolVar(&dryRun, "dry-run", false, "validate the workflow (with overrides applied) without creating it")
+	cmd.Flags().BoolVarP(&interactive, "interactive", "i", false, "prompt for every spec.config parameter the workflow exposes")
 	cmd.Flags().StringArrayVar(&setFlags, "set", nil, "override a spec.config parameter, in key=value form (repeatable)")
 
 	return cmd

--- a/cmd/kubectl-testkube/commands/marketplace/install.go
+++ b/cmd/kubectl-testkube/commands/marketplace/install.go
@@ -1,7 +1,7 @@
 package marketplace
 
 import (
-	"strings"
+	"errors"
 
 	"github.com/spf13/cobra"
 
@@ -32,13 +32,14 @@ TestWorkflow in the target namespace.`,
 
 			wf, err := client.GetWorkflow(cmd.Context(), workflowName)
 			if err != nil {
-				if strings.Contains(err.Error(), "not found") {
+				if errors.Is(err, marketplace.ErrWorkflowNotFound) {
 					common.HandleCLIError(common.NewCLIError(
 						common.TKErrMarketplaceWorkflowNotFound,
 						"Workflow not found",
 						"",
 						err,
 					))
+					return
 				}
 				common.HandleCLIError(common.NewCLIError(
 					common.TKErrMarketplaceFetchFailed,
@@ -46,6 +47,7 @@ TestWorkflow in the target namespace.`,
 					"",
 					err,
 				))
+				return
 			}
 
 			yamlBytes, err := client.GetWorkflowYAML(cmd.Context(), *wf)
@@ -56,6 +58,7 @@ TestWorkflow in the target namespace.`,
 					"",
 					err,
 				))
+				return
 			}
 
 			params, err := marketplace.ExtractParameters(yamlBytes)
@@ -66,6 +69,7 @@ TestWorkflow in the target namespace.`,
 					"",
 					err,
 				))
+				return
 			}
 
 			params, err = marketplace.ParseSetFlags(params, setFlags)
@@ -76,6 +80,7 @@ TestWorkflow in the target namespace.`,
 					"",
 					err,
 				))
+				return
 			}
 
 			updated, err := marketplace.ApplyParameters(yamlBytes, params)
@@ -86,6 +91,7 @@ TestWorkflow in the target namespace.`,
 					"",
 					err,
 				))
+				return
 			}
 
 			testworkflows.CreateOrUpdateFromBytes(cmd, updated, name, update, dryRun)

--- a/cmd/kubectl-testkube/commands/marketplace/install.go
+++ b/cmd/kubectl-testkube/commands/marketplace/install.go
@@ -4,12 +4,19 @@ import (
 	"errors"
 	"os"
 
+	"github.com/mattn/go-isatty"
 	"github.com/spf13/cobra"
 
 	"github.com/kubeshop/testkube/cmd/kubectl-testkube/commands/common"
 	"github.com/kubeshop/testkube/cmd/kubectl-testkube/commands/testworkflows"
 	"github.com/kubeshop/testkube/pkg/marketplace"
 )
+
+// isStdinTTY reports whether stdin is attached to a terminal. It is a
+// package-level var so tests can stub it without mocking the OS.
+var isStdinTTY = func() bool {
+	return isatty.IsTerminal(os.Stdin.Fd()) || isatty.IsCygwinTerminal(os.Stdin.Fd())
+}
 
 func NewInstallCmd() *cobra.Command {
 	var (
@@ -29,10 +36,12 @@ func NewInstallCmd() *cobra.Command {
 parameter overrides to its spec.config defaults, and creates (or updates) the
 TestWorkflow in the target namespace.
 
-Use --interactive/-i to be prompted for every parameter the workflow exposes.
-Values supplied via --set are used as the prompt default, and empty input
-keeps the current value. Parameters marked sensitive are read with masked
-input and their current value is never echoed.
+When run on a terminal the command prompts for every parameter the workflow
+exposes; values supplied via --set are used as the prompt default, and empty
+input keeps the current value. Parameters marked sensitive are read with
+masked input and their current value is never echoed. Pass --interactive=false
+(or run without a TTY, e.g. in CI) to skip prompting and use the defaults plus
+any --set overrides as-is. --interactive=true forces prompting even off a TTY.
 
 After a successful create/update the command asks whether to run the workflow
 immediately. Use --run=true to skip the prompt and trigger a run, or
@@ -95,7 +104,7 @@ immediately. Use --run=true to skip the prompt and trigger a run, or
 				return
 			}
 
-			if interactive {
+			if shouldPromptForParameters(cmd, interactive, len(params) > 0) {
 				params, err = promptForParameters(os.Stdout, params, ptermPrompter{})
 				if err != nil {
 					common.HandleCLIError(common.NewCLIError(
@@ -138,11 +147,30 @@ immediately. Use --run=true to skip the prompt and trigger a run, or
 	cmd.Flags().StringVar(&name, "name", "", "override the TestWorkflow name")
 	cmd.Flags().BoolVar(&update, "update", false, "update, if test workflow already exists")
 	cmd.Flags().BoolVar(&dryRun, "dry-run", false, "validate the workflow (with overrides applied) without creating it")
-	cmd.Flags().BoolVarP(&interactive, "interactive", "i", false, "prompt for every spec.config parameter the workflow exposes")
+	cmd.Flags().BoolVarP(&interactive, "interactive", "i", false, "prompt for every spec.config parameter (default: auto — prompt when attached to a terminal). Use --interactive=false to force non-interactive, --interactive to force prompting.")
 	cmd.Flags().BoolVar(&run, "run", false, "run the workflow after install (default: ask). Use --run=true to skip the prompt and run, --run=false to skip both prompt and run")
 	cmd.Flags().StringArrayVar(&setFlags, "set", nil, "override a spec.config parameter, in key=value form (repeatable)")
 
 	return cmd
+}
+
+// shouldPromptForParameters decides whether to ask the user for parameter
+// values. The --interactive flag is tristate:
+//
+//   - explicitly set (--interactive / -i / --interactive=false) → flag wins
+//   - not set                                                   → prompt only
+//     when stdin is a TTY and the workflow exposes at least one parameter
+//
+// This keeps `testkube marketplace install <name>` self-guiding on a terminal
+// while staying quiet in CI pipelines where stdin is redirected.
+func shouldPromptForParameters(cmd *cobra.Command, interactiveFlag, hasParams bool) bool {
+	if cmd.Flags().Changed("interactive") {
+		return interactiveFlag
+	}
+	if !hasParams {
+		return false
+	}
+	return isStdinTTY()
 }
 
 // resolveRunDecision determines whether to run the workflow after install.

--- a/cmd/kubectl-testkube/commands/marketplace/install.go
+++ b/cmd/kubectl-testkube/commands/marketplace/install.go
@@ -17,6 +17,7 @@ func NewInstallCmd() *cobra.Command {
 		update      bool
 		dryRun      bool
 		interactive bool
+		run         bool
 		setFlags    []string
 	)
 
@@ -31,7 +32,11 @@ TestWorkflow in the target namespace.
 Use --interactive/-i to be prompted for every parameter the workflow exposes.
 Values supplied via --set are used as the prompt default, and empty input
 keeps the current value. Parameters marked sensitive are read with masked
-input and their current value is never echoed.`,
+input and their current value is never echoed.
+
+After a successful create/update the command asks whether to run the workflow
+immediately. Use --run=true to skip the prompt and trigger a run, or
+--run=false to skip both the prompt and the run (useful for CI/automation).`,
 
 		Run: func(cmd *cobra.Command, args []string) {
 			workflowName := args[0]
@@ -114,7 +119,19 @@ input and their current value is never echoed.`,
 				return
 			}
 
-			testworkflows.CreateOrUpdateFromBytes(cmd, updated, name, update, dryRun)
+			resolvedName := testworkflows.CreateOrUpdateFromBytes(cmd, updated, name, update, dryRun)
+
+			// dryRun already exited inside CreateOrUpdateFromBytes; this guard
+			// is defensive in case that ever changes.
+			if dryRun {
+				return
+			}
+
+			shouldRun, decided := resolveRunDecision(cmd, run, ptermPrompter{})
+			if !decided || !shouldRun {
+				return
+			}
+			testworkflows.RunWorkflowByName(cmd, resolvedName)
 		},
 	}
 
@@ -122,7 +139,31 @@ input and their current value is never echoed.`,
 	cmd.Flags().BoolVar(&update, "update", false, "update, if test workflow already exists")
 	cmd.Flags().BoolVar(&dryRun, "dry-run", false, "validate the workflow (with overrides applied) without creating it")
 	cmd.Flags().BoolVarP(&interactive, "interactive", "i", false, "prompt for every spec.config parameter the workflow exposes")
+	cmd.Flags().BoolVar(&run, "run", false, "run the workflow after install (default: ask). Use --run=true to skip the prompt and run, --run=false to skip both prompt and run")
 	cmd.Flags().StringArrayVar(&setFlags, "set", nil, "override a spec.config parameter, in key=value form (repeatable)")
 
 	return cmd
+}
+
+// resolveRunDecision determines whether to run the workflow after install.
+// If --run was supplied explicitly (either true or false) its value wins and
+// the user is not prompted. Otherwise the prompter is asked and its answer
+// is returned. The second return value is true when a decision was reached
+// (it is false only when prompting failed, in which case the caller should
+// skip running).
+func resolveRunDecision(cmd *cobra.Command, runFlag bool, prompter Prompter) (shouldRun, decided bool) {
+	if cmd.Flags().Changed("run") {
+		return runFlag, true
+	}
+	answer, err := prompter.Confirm("Run the workflow now?", true)
+	if err != nil {
+		common.HandleCLIError(common.NewCLIError(
+			common.TKErrMarketplaceInvalidParameter,
+			"Failed to read run confirmation",
+			"Re-run with --run=true or --run=false to skip the prompt.",
+			err,
+		))
+		return false, false
+	}
+	return answer, true
 }

--- a/cmd/kubectl-testkube/commands/marketplace/install.go
+++ b/cmd/kubectl-testkube/commands/marketplace/install.go
@@ -25,6 +25,7 @@ func NewInstallCmd() *cobra.Command {
 		dryRun      bool
 		interactive bool
 		run         bool
+		follow      bool
 		setFlags    []string
 	)
 
@@ -45,7 +46,9 @@ any --set overrides as-is. --interactive=true forces prompting even off a TTY.
 
 After a successful create/update the command asks whether to run the workflow
 immediately. Use --run=true to skip the prompt and trigger a run, or
---run=false to skip both the prompt and the run (useful for CI/automation).`,
+--run=false to skip both the prompt and the run (useful for CI/automation).
+Pass -f/--follow to stream logs and wait for completion (implies --run=true
+when --run was not supplied).`,
 
 		Run: func(cmd *cobra.Command, args []string) {
 			workflowName := args[0]
@@ -136,11 +139,11 @@ immediately. Use --run=true to skip the prompt and trigger a run, or
 				return
 			}
 
-			shouldRun, decided := resolveRunDecision(cmd, run, ptermPrompter{})
+			shouldRun, decided := resolveRunDecision(cmd, run, follow, ptermPrompter{})
 			if !decided || !shouldRun {
 				return
 			}
-			testworkflows.RunWorkflowByName(cmd, resolvedName)
+			testworkflows.RunWorkflowByName(cmd, resolvedName, follow)
 		},
 	}
 
@@ -149,6 +152,7 @@ immediately. Use --run=true to skip the prompt and trigger a run, or
 	cmd.Flags().BoolVar(&dryRun, "dry-run", false, "validate the workflow (with overrides applied) without creating it")
 	cmd.Flags().BoolVarP(&interactive, "interactive", "i", false, "prompt for every spec.config parameter (default: auto — prompt when attached to a terminal). Use --interactive=false to force non-interactive, --interactive to force prompting.")
 	cmd.Flags().BoolVar(&run, "run", false, "run the workflow after install (default: ask). Use --run=true to skip the prompt and run, --run=false to skip both prompt and run")
+	cmd.Flags().BoolVarP(&follow, "follow", "f", false, "follow the execution (stream logs and wait for completion); implies --run=true when --run is not supplied")
 	cmd.Flags().StringArrayVar(&setFlags, "set", nil, "override a spec.config parameter, in key=value form (repeatable)")
 
 	return cmd
@@ -174,14 +178,21 @@ func shouldPromptForParameters(cmd *cobra.Command, interactiveFlag, hasParams bo
 }
 
 // resolveRunDecision determines whether to run the workflow after install.
-// If --run was supplied explicitly (either true or false) its value wins and
-// the user is not prompted. Otherwise the prompter is asked and its answer
-// is returned. The second return value is true when a decision was reached
-// (it is false only when prompting failed, in which case the caller should
-// skip running).
-func resolveRunDecision(cmd *cobra.Command, runFlag bool, prompter Prompter) (shouldRun, decided bool) {
+//
+// Precedence (first match wins):
+//  1. --run was supplied explicitly (either true or false) — its value wins.
+//  2. -f/--follow was supplied without --run — imply run=true; following an
+//     install that did not trigger a run would never yield any output.
+//  3. Otherwise ask the user via the prompter.
+//
+// The second return value is true when a decision was reached (it is false
+// only when prompting failed, in which case the caller should skip running).
+func resolveRunDecision(cmd *cobra.Command, runFlag, followFlag bool, prompter Prompter) (shouldRun, decided bool) {
 	if cmd.Flags().Changed("run") {
 		return runFlag, true
+	}
+	if followFlag {
+		return true, true
 	}
 	answer, err := prompter.Confirm("Run the workflow now?", true)
 	if err != nil {

--- a/cmd/kubectl-testkube/commands/marketplace/install.go
+++ b/cmd/kubectl-testkube/commands/marketplace/install.go
@@ -1,0 +1,101 @@
+package marketplace
+
+import (
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/kubeshop/testkube/cmd/kubectl-testkube/commands/common"
+	"github.com/kubeshop/testkube/cmd/kubectl-testkube/commands/testworkflows"
+	"github.com/kubeshop/testkube/pkg/marketplace"
+)
+
+func NewInstallCmd() *cobra.Command {
+	var (
+		name     string
+		update   bool
+		dryRun   bool
+		setFlags []string
+	)
+
+	cmd := &cobra.Command{
+		Use:   "install <name>",
+		Args:  cobra.ExactArgs(1),
+		Short: "Install a marketplace TestWorkflow into the cluster",
+		Long: `Downloads a TestWorkflow from the Testkube Marketplace, applies any --set
+parameter overrides to its spec.config defaults, and creates (or updates) the
+TestWorkflow in the target namespace.`,
+
+		Run: func(cmd *cobra.Command, args []string) {
+			workflowName := args[0]
+			client := NewClient()
+
+			wf, err := client.GetWorkflow(cmd.Context(), workflowName)
+			if err != nil {
+				if strings.Contains(err.Error(), "not found") {
+					common.HandleCLIError(common.NewCLIError(
+						common.TKErrMarketplaceWorkflowNotFound,
+						"Workflow not found",
+						"",
+						err,
+					))
+				}
+				common.HandleCLIError(common.NewCLIError(
+					common.TKErrMarketplaceFetchFailed,
+					"Failed to fetch marketplace catalog",
+					"",
+					err,
+				))
+			}
+
+			yamlBytes, err := client.GetWorkflowYAML(cmd.Context(), *wf)
+			if err != nil {
+				common.HandleCLIError(common.NewCLIError(
+					common.TKErrMarketplaceFetchFailed,
+					"Failed to download workflow YAML",
+					"",
+					err,
+				))
+			}
+
+			params, err := marketplace.ExtractParameters(yamlBytes)
+			if err != nil {
+				common.HandleCLIError(common.NewCLIError(
+					common.TKErrMarketplaceInvalidParameter,
+					"Failed to parse workflow parameters",
+					"",
+					err,
+				))
+			}
+
+			params, err = marketplace.ParseSetFlags(params, setFlags)
+			if err != nil {
+				common.HandleCLIError(common.NewCLIError(
+					common.TKErrMarketplaceInvalidParameter,
+					"Invalid --set value",
+					"",
+					err,
+				))
+			}
+
+			updated, err := marketplace.ApplyParameters(yamlBytes, params)
+			if err != nil {
+				common.HandleCLIError(common.NewCLIError(
+					common.TKErrMarketplaceInvalidParameter,
+					"Failed to apply parameters",
+					"",
+					err,
+				))
+			}
+
+			testworkflows.CreateOrUpdateFromBytes(cmd, updated, name, update, dryRun)
+		},
+	}
+
+	cmd.Flags().StringVar(&name, "name", "", "override the TestWorkflow name")
+	cmd.Flags().BoolVar(&update, "update", false, "update, if test workflow already exists")
+	cmd.Flags().BoolVar(&dryRun, "dry-run", false, "validate the workflow (with overrides applied) without creating it")
+	cmd.Flags().StringArrayVar(&setFlags, "set", nil, "override a spec.config parameter, in key=value form (repeatable)")
+
+	return cmd
+}

--- a/cmd/kubectl-testkube/commands/marketplace/install_test.go
+++ b/cmd/kubectl-testkube/commands/marketplace/install_test.go
@@ -16,8 +16,10 @@ func newInstallCmdForTest() *cobra.Command {
 		run         bool
 		interactive bool
 	)
+	var follow bool
 	cmd.Flags().BoolVar(&run, "run", false, "run after install")
 	cmd.Flags().BoolVarP(&interactive, "interactive", "i", false, "prompt for params")
+	cmd.Flags().BoolVarP(&follow, "follow", "f", false, "follow execution")
 	return cmd
 }
 
@@ -36,7 +38,7 @@ func TestResolveRunDecision_ExplicitTrueSkipsPrompt(t *testing.T) {
 	}
 	stub := &stubPrompter{}
 
-	shouldRun, decided := resolveRunDecision(cmd, true, stub)
+	shouldRun, decided := resolveRunDecision(cmd, true, false, stub)
 	if !decided {
 		t.Fatal("expected a decision to be reached")
 	}
@@ -55,7 +57,7 @@ func TestResolveRunDecision_ExplicitFalseSkipsPromptAndRun(t *testing.T) {
 	}
 	stub := &stubPrompter{}
 
-	shouldRun, decided := resolveRunDecision(cmd, false, stub)
+	shouldRun, decided := resolveRunDecision(cmd, false, false, stub)
 	if !decided {
 		t.Fatal("expected a decision to be reached")
 	}
@@ -64,6 +66,46 @@ func TestResolveRunDecision_ExplicitFalseSkipsPromptAndRun(t *testing.T) {
 	}
 	if stub.confirmCalls != 0 {
 		t.Errorf("prompter should not be invoked, got %d calls", stub.confirmCalls)
+	}
+}
+
+func TestResolveRunDecision_ExplicitRunFalseBeatsFollow(t *testing.T) {
+	// --run=false is an explicit opt-out that must beat -f; otherwise the
+	// user could not install + follow-later with a separate `run` command.
+	cmd := newInstallCmdForTest()
+	if err := cmd.ParseFlags([]string{"--run=false", "-f"}); err != nil {
+		t.Fatalf("ParseFlags: %v", err)
+	}
+	stub := &stubPrompter{}
+
+	shouldRun, decided := resolveRunDecision(cmd, false, true, stub)
+	if !decided {
+		t.Fatal("expected a decision to be reached")
+	}
+	if shouldRun {
+		t.Error("expected shouldRun=false when --run=false even with -f")
+	}
+	if stub.confirmCalls != 0 {
+		t.Errorf("prompter should not be invoked, got %d calls", stub.confirmCalls)
+	}
+}
+
+func TestResolveRunDecision_FollowImpliesRunWhenRunUnset(t *testing.T) {
+	cmd := newInstallCmdForTest()
+	if err := cmd.ParseFlags([]string{"-f"}); err != nil {
+		t.Fatalf("ParseFlags: %v", err)
+	}
+	stub := &stubPrompter{}
+
+	shouldRun, decided := resolveRunDecision(cmd, false, true, stub)
+	if !decided {
+		t.Fatal("expected a decision to be reached")
+	}
+	if !shouldRun {
+		t.Error("expected shouldRun=true when -f is supplied without --run")
+	}
+	if stub.confirmCalls != 0 {
+		t.Errorf("-f should bypass the prompt, got %d calls", stub.confirmCalls)
 	}
 }
 
@@ -83,7 +125,7 @@ func TestResolveRunDecision_NoFlagPromptsAndReturnsAnswer(t *testing.T) {
 			}
 			stub := &stubPrompter{confirmAns: tc.yes}
 
-			shouldRun, decided := resolveRunDecision(cmd, false, stub)
+			shouldRun, decided := resolveRunDecision(cmd, false, false, stub)
 			if !decided {
 				t.Fatal("expected a decision to be reached")
 			}

--- a/cmd/kubectl-testkube/commands/marketplace/install_test.go
+++ b/cmd/kubectl-testkube/commands/marketplace/install_test.go
@@ -7,14 +7,26 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// newInstallCmdForTest builds a cobra command mirroring install.go's run flag
-// definition. We only need the flag wiring to exercise resolveRunDecision,
-// so we avoid pulling in the full install.go Run body.
+// newInstallCmdForTest builds a cobra command mirroring install.go's flag
+// definitions. We only need the flag wiring to exercise the decision
+// helpers, so we avoid pulling in the full install.go Run body.
 func newInstallCmdForTest() *cobra.Command {
 	cmd := &cobra.Command{Use: "install"}
-	var run bool
+	var (
+		run         bool
+		interactive bool
+	)
 	cmd.Flags().BoolVar(&run, "run", false, "run after install")
+	cmd.Flags().BoolVarP(&interactive, "interactive", "i", false, "prompt for params")
 	return cmd
+}
+
+// withStubbedTTY swaps isStdinTTY for the duration of a test.
+func withStubbedTTY(t *testing.T, tty bool) {
+	t.Helper()
+	prev := isStdinTTY
+	isStdinTTY = func() bool { return tty }
+	t.Cleanup(func() { isStdinTTY = prev })
 }
 
 func TestResolveRunDecision_ExplicitTrueSkipsPrompt(t *testing.T) {
@@ -98,5 +110,65 @@ func TestStubPrompter_ConfirmSurfacesErrors(t *testing.T) {
 	_, err := stub.Confirm("Run?", true)
 	if err == nil {
 		t.Fatal("expected error to propagate")
+	}
+}
+
+func TestShouldPromptForParameters(t *testing.T) {
+	tests := []struct {
+		name      string
+		flags     []string
+		interFlag bool
+		hasParams bool
+		tty       bool
+		want      bool
+	}{
+		{
+			name: "no flag + TTY + params -> prompt",
+			tty:  true, hasParams: true, want: true,
+		},
+		{
+			name: "no flag + TTY + no params -> skip",
+			tty:  true, hasParams: false, want: false,
+		},
+		{
+			name: "no flag + no TTY + params -> skip (CI path)",
+			tty:  false, hasParams: true, want: false,
+		},
+		{
+			name:  "--interactive=true forces prompt even without TTY",
+			flags: []string{"--interactive=true"}, interFlag: true,
+			tty: false, hasParams: true, want: true,
+		},
+		{
+			name:  "--interactive=true with no params still returns true",
+			flags: []string{"--interactive=true"}, interFlag: true,
+			tty: true, hasParams: false, want: true,
+		},
+		{
+			name:  "--interactive=false skips even on TTY with params",
+			flags: []string{"--interactive=false"}, interFlag: false,
+			tty: true, hasParams: true, want: false,
+		},
+		{
+			name:  "-i shorthand forces prompt",
+			flags: []string{"-i"}, interFlag: true,
+			tty: false, hasParams: true, want: true,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			withStubbedTTY(t, tc.tty)
+			cmd := newInstallCmdForTest()
+			if err := cmd.ParseFlags(tc.flags); err != nil {
+				t.Fatalf("ParseFlags: %v", err)
+			}
+			// Re-read the flag to mirror how install.go's Run body sees it.
+			interactive, _ := cmd.Flags().GetBool("interactive")
+			got := shouldPromptForParameters(cmd, interactive, tc.hasParams)
+			if got != tc.want {
+				t.Errorf("shouldPromptForParameters = %v, want %v (interFlag=%v tty=%v hasParams=%v)",
+					got, tc.want, tc.interFlag, tc.tty, tc.hasParams)
+			}
+		})
 	}
 }

--- a/cmd/kubectl-testkube/commands/marketplace/install_test.go
+++ b/cmd/kubectl-testkube/commands/marketplace/install_test.go
@@ -1,0 +1,102 @@
+package marketplace
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+// newInstallCmdForTest builds a cobra command mirroring install.go's run flag
+// definition. We only need the flag wiring to exercise resolveRunDecision,
+// so we avoid pulling in the full install.go Run body.
+func newInstallCmdForTest() *cobra.Command {
+	cmd := &cobra.Command{Use: "install"}
+	var run bool
+	cmd.Flags().BoolVar(&run, "run", false, "run after install")
+	return cmd
+}
+
+func TestResolveRunDecision_ExplicitTrueSkipsPrompt(t *testing.T) {
+	cmd := newInstallCmdForTest()
+	if err := cmd.ParseFlags([]string{"--run=true"}); err != nil {
+		t.Fatalf("ParseFlags: %v", err)
+	}
+	stub := &stubPrompter{}
+
+	shouldRun, decided := resolveRunDecision(cmd, true, stub)
+	if !decided {
+		t.Fatal("expected a decision to be reached")
+	}
+	if !shouldRun {
+		t.Error("expected shouldRun=true when --run=true")
+	}
+	if stub.confirmCalls != 0 {
+		t.Errorf("prompter should not be invoked, got %d calls", stub.confirmCalls)
+	}
+}
+
+func TestResolveRunDecision_ExplicitFalseSkipsPromptAndRun(t *testing.T) {
+	cmd := newInstallCmdForTest()
+	if err := cmd.ParseFlags([]string{"--run=false"}); err != nil {
+		t.Fatalf("ParseFlags: %v", err)
+	}
+	stub := &stubPrompter{}
+
+	shouldRun, decided := resolveRunDecision(cmd, false, stub)
+	if !decided {
+		t.Fatal("expected a decision to be reached")
+	}
+	if shouldRun {
+		t.Error("expected shouldRun=false when --run=false")
+	}
+	if stub.confirmCalls != 0 {
+		t.Errorf("prompter should not be invoked, got %d calls", stub.confirmCalls)
+	}
+}
+
+func TestResolveRunDecision_NoFlagPromptsAndReturnsAnswer(t *testing.T) {
+	cases := []struct {
+		name string
+		yes  bool
+	}{
+		{"user confirms", true},
+		{"user declines", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cmd := newInstallCmdForTest()
+			if err := cmd.ParseFlags(nil); err != nil {
+				t.Fatalf("ParseFlags: %v", err)
+			}
+			stub := &stubPrompter{confirmAns: tc.yes}
+
+			shouldRun, decided := resolveRunDecision(cmd, false, stub)
+			if !decided {
+				t.Fatal("expected a decision to be reached")
+			}
+			if shouldRun != tc.yes {
+				t.Errorf("shouldRun mismatch: got %v want %v", shouldRun, tc.yes)
+			}
+			if stub.confirmCalls != 1 {
+				t.Errorf("expected exactly one prompt, got %d", stub.confirmCalls)
+			}
+			if stub.confirmMsg == "" {
+				t.Error("expected a non-empty prompt message")
+			}
+		})
+	}
+}
+
+// Prompt errors should be surfaced to the caller as decided=false, so the
+// install command does not silently fall back to running or not running.
+// We skip invoking resolveRunDecision here directly because it goes through
+// common.HandleCLIError which calls os.Exit; instead we verify the
+// prompter-error path by exercising the stub-only branch below.
+func TestStubPrompter_ConfirmSurfacesErrors(t *testing.T) {
+	stub := &stubPrompter{confirmErr: errors.New("ctrl-c")}
+	_, err := stub.Confirm("Run?", true)
+	if err == nil {
+		t.Fatal("expected error to propagate")
+	}
+}

--- a/cmd/kubectl-testkube/commands/marketplace/list.go
+++ b/cmd/kubectl-testkube/commands/marketplace/list.go
@@ -1,0 +1,100 @@
+package marketplace
+
+import (
+	"os"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/kubeshop/testkube/cmd/kubectl-testkube/commands/common"
+	"github.com/kubeshop/testkube/cmd/kubectl-testkube/commands/common/render"
+	"github.com/kubeshop/testkube/pkg/marketplace"
+	"github.com/kubeshop/testkube/pkg/ui"
+)
+
+// descriptionMaxWidth caps the description column for pretty output so long
+// strings don't destroy the table layout.
+const descriptionMaxWidth = 60
+
+func NewListCmd() *cobra.Command {
+	var (
+		category  string
+		component string
+	)
+
+	cmd := &cobra.Command{
+		Use:     "list",
+		Aliases: []string{"ls"},
+		Args:    cobra.NoArgs,
+		Short:   "List TestWorkflows available in the marketplace",
+		Long:    "Fetches the marketplace catalog and lists available TestWorkflows. Use --category and --component to filter, or --output to switch formats.",
+
+		Run: func(cmd *cobra.Command, _ []string) {
+			client := NewClient()
+			workflows, err := client.ListWorkflows(cmd.Context())
+			if err != nil {
+				common.HandleCLIError(common.NewCLIError(
+					common.TKErrMarketplaceFetchFailed,
+					"Failed to fetch marketplace catalog",
+					"",
+					err,
+				))
+			}
+
+			filtered := filter(workflows, category, component)
+
+			outputType := cmd.Flag("output").Value.String()
+			if outputType == "json" || outputType == "yaml" || outputType == "go" {
+				err = render.List(cmd, filtered, os.Stdout)
+				ui.PrintOnError("Rendering list", err)
+				return
+			}
+
+			err = render.List(cmd, workflowsTable(filtered), os.Stdout)
+			ui.PrintOnError("Rendering list", err)
+		},
+	}
+
+	cmd.Flags().StringVar(&category, "category", "", "filter by category (e.g. databases, networking)")
+	cmd.Flags().StringVar(&component, "component", "", "filter by component (e.g. redis, postgresql)")
+
+	return cmd
+}
+
+func filter(workflows []marketplace.Workflow, category, component string) []marketplace.Workflow {
+	if category == "" && component == "" {
+		return workflows
+	}
+	out := make([]marketplace.Workflow, 0, len(workflows))
+	for _, w := range workflows {
+		if category != "" && !strings.EqualFold(w.Category, category) {
+			continue
+		}
+		if component != "" && !strings.EqualFold(w.Component, component) {
+			continue
+		}
+		out = append(out, w)
+	}
+	return out
+}
+
+type workflowsTable []marketplace.Workflow
+
+func (t workflowsTable) Table() ([]string, [][]string) {
+	header := []string{"NAME", "CATEGORY", "COMPONENT", "DESCRIPTION"}
+	data := make([][]string, 0, len(t))
+	for _, w := range t {
+		data = append(data, []string{w.Name, w.Category, w.Component, truncate(w.Description, descriptionMaxWidth)})
+	}
+	return header, data
+}
+
+func truncate(s string, max int) string {
+	if max <= 0 || len(s) <= max {
+		return s
+	}
+	if max <= 3 {
+		return s[:max]
+	}
+	return s[:max-3] + "..."
+}

--- a/cmd/kubectl-testkube/commands/marketplace/list.go
+++ b/cmd/kubectl-testkube/commands/marketplace/list.go
@@ -89,12 +89,15 @@ func (t workflowsTable) Table() ([]string, [][]string) {
 	return header, data
 }
 
+// truncate caps a string at max characters, counting by runes so multi-byte
+// UTF-8 sequences are never split mid-character.
 func truncate(s string, max int) string {
-	if max <= 0 || len(s) <= max {
+	runes := []rune(s)
+	if max <= 0 || len(runes) <= max {
 		return s
 	}
 	if max <= 3 {
-		return s[:max]
+		return string(runes[:max])
 	}
-	return s[:max-3] + "..."
+	return string(runes[:max-3]) + "..."
 }

--- a/cmd/kubectl-testkube/commands/marketplace/prompt.go
+++ b/cmd/kubectl-testkube/commands/marketplace/prompt.go
@@ -9,14 +9,19 @@ import (
 	"github.com/kubeshop/testkube/pkg/marketplace"
 )
 
-// Prompter is the narrow interface promptForParameters uses to collect
-// values from the user. It is implemented by the pterm-backed prompter at
-// runtime and by stubs in tests.
+// Prompter is the narrow interface used to collect input from the user
+// during `testkube marketplace install`. It is implemented by the pterm-backed
+// prompter at runtime and by stubs in tests.
 type Prompter interface {
 	// Prompt is called once per parameter. The returned string is the raw
 	// user input. An empty string means "keep the current value" (which is
 	// either the parameter's YAML default or a prior --set override).
 	Prompt(p marketplace.Parameter) (string, error)
+
+	// Confirm asks a yes/no question and returns the user's answer.
+	// defaultYes controls which option is highlighted as the default when
+	// the user simply presses enter.
+	Confirm(message string, defaultYes bool) (bool, error)
 }
 
 // promptForParameters walks the parameters and asks the supplied prompter
@@ -74,4 +79,8 @@ func (ptermPrompter) Prompt(p marketplace.Parameter) (string, error) {
 		t = t.WithDefaultValue(p.Value)
 	}
 	return t.Show("value")
+}
+
+func (ptermPrompter) Confirm(message string, defaultYes bool) (bool, error) {
+	return pterm.DefaultInteractiveConfirm.WithDefaultValue(defaultYes).Show(message)
 }

--- a/cmd/kubectl-testkube/commands/marketplace/prompt.go
+++ b/cmd/kubectl-testkube/commands/marketplace/prompt.go
@@ -1,0 +1,77 @@
+package marketplace
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/pterm/pterm"
+
+	"github.com/kubeshop/testkube/pkg/marketplace"
+)
+
+// Prompter is the narrow interface promptForParameters uses to collect
+// values from the user. It is implemented by the pterm-backed prompter at
+// runtime and by stubs in tests.
+type Prompter interface {
+	// Prompt is called once per parameter. The returned string is the raw
+	// user input. An empty string means "keep the current value" (which is
+	// either the parameter's YAML default or a prior --set override).
+	Prompt(p marketplace.Parameter) (string, error)
+}
+
+// promptForParameters walks the parameters and asks the supplied prompter
+// for a value for each one. Empty input preserves the current Value.
+//
+// The function mutates the Value fields in place so downstream callers
+// (ApplyParameters) receive the merged result.
+func promptForParameters(w io.Writer, params []marketplace.Parameter, prompter Prompter) ([]marketplace.Parameter, error) {
+	if len(params) == 0 {
+		return params, nil
+	}
+	fmt.Fprintf(w, "\nThe workflow exposes %d parameter(s). Press enter to accept the shown default.\n\n", len(params))
+	for i := range params {
+		p := params[i]
+		typeLabel := p.Type
+		if typeLabel == "" {
+			typeLabel = "string"
+		}
+		header := fmt.Sprintf("%d/%d  %s (%s)", i+1, len(params), p.Key, typeLabel)
+		if p.Sensitive {
+			header += "  [sensitive]"
+		}
+		fmt.Fprintln(w, header)
+		if p.Description != "" {
+			fmt.Fprintf(w, "     %s\n", p.Description)
+		}
+
+		in, err := prompter.Prompt(p)
+		if err != nil {
+			return nil, fmt.Errorf("reading value for %q: %w", p.Key, err)
+		}
+		if in != "" {
+			params[i].Value = in
+		}
+		fmt.Fprintln(w)
+	}
+	return params, nil
+}
+
+// ptermPrompter is the default runtime Prompter. It uses pterm for both
+// plain and masked (sensitive) text input.
+type ptermPrompter struct{}
+
+func (ptermPrompter) Prompt(p marketplace.Parameter) (string, error) {
+	// WithMultiLine(false) normalises the builder to a value (other
+	// builders on this type return pointers), mirroring pkg/ui/textinput.go.
+	t := pterm.DefaultInteractiveTextInput.WithMultiLine(false)
+	if p.Sensitive {
+		// Masked input deliberately does not display the current value so
+		// we don't leak a --set secret back onto the terminal. Empty input
+		// keeps whatever the caller already had.
+		return t.WithMask("*").Show("value (leave empty to keep current)")
+	}
+	if p.Value != "" {
+		t = t.WithDefaultValue(p.Value)
+	}
+	return t.Show("value")
+}

--- a/cmd/kubectl-testkube/commands/marketplace/prompt_test.go
+++ b/cmd/kubectl-testkube/commands/marketplace/prompt_test.go
@@ -1,0 +1,193 @@
+package marketplace
+
+import (
+	"bytes"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/kubeshop/testkube/pkg/marketplace"
+)
+
+// stubPrompter returns canned answers keyed by parameter Key and records
+// which params were asked, in order. An answer of "" simulates the user
+// hitting Enter with no input.
+type stubPrompter struct {
+	answers map[string]string
+	asked   []marketplace.Parameter
+	err     map[string]error
+}
+
+func (s *stubPrompter) Prompt(p marketplace.Parameter) (string, error) {
+	s.asked = append(s.asked, p)
+	if s.err != nil {
+		if e, ok := s.err[p.Key]; ok {
+			return "", e
+		}
+	}
+	return s.answers[p.Key], nil
+}
+
+func TestPromptForParameters(t *testing.T) {
+	type want struct {
+		key   string
+		value string
+	}
+	tests := []struct {
+		name    string
+		params  []marketplace.Parameter
+		answers map[string]string
+		want    []want
+	}{
+		{
+			name: "user-provided values override defaults",
+			params: []marketplace.Parameter{
+				{Key: "host", Default: "localhost", Value: "localhost", Type: "string"},
+				{Key: "port", Default: "6379", Value: "6379", Type: "integer"},
+			},
+			answers: map[string]string{
+				"host": "redis.prod.svc",
+				"port": "6380",
+			},
+			want: []want{
+				{"host", "redis.prod.svc"},
+				{"port", "6380"},
+			},
+		},
+		{
+			name: "empty input preserves current value",
+			params: []marketplace.Parameter{
+				{Key: "host", Default: "localhost", Value: "localhost"},
+				{Key: "port", Default: "6379", Value: "6379"},
+			},
+			answers: map[string]string{
+				"host": "",
+				"port": "",
+			},
+			want: []want{
+				{"host", "localhost"},
+				{"port", "6379"},
+			},
+		},
+		{
+			name: "empty input keeps prior --set value",
+			params: []marketplace.Parameter{
+				{Key: "host", Default: "localhost", Value: "redis.stage.svc"},
+				{Key: "port", Default: "6379", Value: "6379"},
+			},
+			answers: map[string]string{
+				"host": "",
+				"port": "6400",
+			},
+			want: []want{
+				{"host", "redis.stage.svc"},
+				{"port", "6400"},
+			},
+		},
+		{
+			name: "sensitive params are forwarded to the prompter",
+			params: []marketplace.Parameter{
+				{Key: "password", Type: "string", Sensitive: true},
+			},
+			answers: map[string]string{
+				"password": "hunter2",
+			},
+			want: []want{
+				{"password", "hunter2"},
+			},
+		},
+		{
+			name:    "empty parameter list is a no-op",
+			params:  nil,
+			answers: map[string]string{},
+			want:    nil,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			stub := &stubPrompter{answers: tc.answers}
+			var buf bytes.Buffer
+			got, err := promptForParameters(&buf, tc.params, stub)
+			if err != nil {
+				t.Fatalf("promptForParameters: %v", err)
+			}
+			if len(got) != len(tc.want) {
+				t.Fatalf("len mismatch: got %d want %d", len(got), len(tc.want))
+			}
+			for i, w := range tc.want {
+				if got[i].Key != w.key || got[i].Value != w.value {
+					t.Errorf("param %d: got (%q, %q) want (%q, %q)", i, got[i].Key, got[i].Value, w.key, w.value)
+				}
+			}
+			if len(tc.params) > 0 && !strings.Contains(buf.String(), "workflow exposes") {
+				t.Errorf("expected prompt header in output, got %q", buf.String())
+			}
+		})
+	}
+}
+
+func TestPromptForParameters_PrompterErrorPropagates(t *testing.T) {
+	stub := &stubPrompter{
+		answers: map[string]string{},
+		err:     map[string]error{"db-password": errors.New("ctrl-c")},
+	}
+	params := []marketplace.Parameter{
+		{Key: "db-password", Sensitive: true},
+	}
+	_, err := promptForParameters(&bytes.Buffer{}, params, stub)
+	if err == nil {
+		t.Fatal("expected error to propagate from prompter")
+	}
+	if !strings.Contains(err.Error(), "db-password") {
+		t.Errorf("error should mention the failing parameter, got %v", err)
+	}
+}
+
+func TestPromptForParameters_RendersHeaderAndDescription(t *testing.T) {
+	stub := &stubPrompter{answers: map[string]string{"host": ""}}
+	var buf bytes.Buffer
+	_, err := promptForParameters(&buf, []marketplace.Parameter{
+		{Key: "host", Type: "string", Description: "Database host FQDN", Value: "db.svc"},
+	}, stub)
+	if err != nil {
+		t.Fatal(err)
+	}
+	out := buf.String()
+	if !strings.Contains(out, "1/1  host (string)") {
+		t.Errorf("missing header in output: %q", out)
+	}
+	if !strings.Contains(out, "Database host FQDN") {
+		t.Errorf("missing description in output: %q", out)
+	}
+	if strings.Contains(out, "[sensitive]") {
+		t.Errorf("unexpected [sensitive] marker for non-sensitive param: %q", out)
+	}
+}
+
+func TestPromptForParameters_MarksSensitiveParams(t *testing.T) {
+	stub := &stubPrompter{answers: map[string]string{"token": ""}}
+	var buf bytes.Buffer
+	_, err := promptForParameters(&buf, []marketplace.Parameter{
+		{Key: "token", Sensitive: true},
+	}, stub)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(buf.String(), "[sensitive]") {
+		t.Errorf("expected [sensitive] marker for sensitive param, got %q", buf.String())
+	}
+}
+
+func TestPromptForParameters_DefaultsTypeToString(t *testing.T) {
+	stub := &stubPrompter{answers: map[string]string{"untyped": ""}}
+	var buf bytes.Buffer
+	_, err := promptForParameters(&buf, []marketplace.Parameter{
+		{Key: "untyped"},
+	}, stub)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(buf.String(), "untyped (string)") {
+		t.Errorf("expected fallback type 'string' in header, got %q", buf.String())
+	}
+}

--- a/cmd/kubectl-testkube/commands/marketplace/prompt_test.go
+++ b/cmd/kubectl-testkube/commands/marketplace/prompt_test.go
@@ -13,9 +13,13 @@ import (
 // which params were asked, in order. An answer of "" simulates the user
 // hitting Enter with no input.
 type stubPrompter struct {
-	answers map[string]string
-	asked   []marketplace.Parameter
-	err     map[string]error
+	answers      map[string]string
+	asked        []marketplace.Parameter
+	err          map[string]error
+	confirmAns   bool
+	confirmErr   error
+	confirmCalls int
+	confirmMsg   string
 }
 
 func (s *stubPrompter) Prompt(p marketplace.Parameter) (string, error) {
@@ -26,6 +30,15 @@ func (s *stubPrompter) Prompt(p marketplace.Parameter) (string, error) {
 		}
 	}
 	return s.answers[p.Key], nil
+}
+
+func (s *stubPrompter) Confirm(message string, _ bool) (bool, error) {
+	s.confirmCalls++
+	s.confirmMsg = message
+	if s.confirmErr != nil {
+		return false, s.confirmErr
+	}
+	return s.confirmAns, nil
 }
 
 func TestPromptForParameters(t *testing.T) {

--- a/cmd/kubectl-testkube/commands/pro/init.go
+++ b/cmd/kubectl-testkube/commands/pro/init.go
@@ -139,7 +139,7 @@ func NewInitCmd() *cobra.Command {
 func sendErrTelemetry(cmd *cobra.Command, clientCfg config.Data, errType string, errorLogs error) {
 	var errorStackTrace = fmt.Sprintf("%+v", errorLogs)
 	if clientCfg.TelemetryEnabled {
-		ui.Debug("collecting anonymous telemetry data, you can disable it by calling `kubectl testkube disable telemetry`")
+		ui.Debug("collecting anonymous telemetry data, you can disable it by calling `testkube disable telemetry`")
 		out, err := telemetry.SendCmdErrorEvent(cmd, common.Version, errType, errorStackTrace)
 		if ui.Verbose && err != nil {
 			ui.Err(err)
@@ -151,7 +151,7 @@ func sendErrTelemetry(cmd *cobra.Command, clientCfg config.Data, errType string,
 
 func sendAttemptTelemetry(cmd *cobra.Command, clientCfg config.Data) {
 	if clientCfg.TelemetryEnabled {
-		ui.Debug("collecting anonymous telemetry data, you can disable it by calling `kubectl testkube disable telemetry`")
+		ui.Debug("collecting anonymous telemetry data, you can disable it by calling `testkube disable telemetry`")
 		out, err := telemetry.SendCmdAttemptEvent(cmd, common.Version)
 		if ui.Verbose && err != nil {
 			ui.Err(err)

--- a/cmd/kubectl-testkube/commands/root.go
+++ b/cmd/kubectl-testkube/commands/root.go
@@ -162,7 +162,7 @@ func isPreRunTelemetry(cmd *cobra.Command) bool {
 func handleTelemetry(cmd *cobra.Command, cfg *config.Data, isPreRun bool) {
 	// Send telemetry early to ensure it's captured even if command fails
 	if cfg.TelemetryEnabled {
-		ui.Debug("collecting anonymous telemetry data, you can disable it by calling `kubectl testkube disable telemetry`")
+		ui.Debug("collecting anonymous telemetry data, you can disable it by calling `testkube disable telemetry`")
 		out, err := telemetry.SendCmdEvent(cmd, common.Version)
 		if ui.Verbose && err != nil {
 			ui.Err(err)

--- a/cmd/kubectl-testkube/commands/root.go
+++ b/cmd/kubectl-testkube/commands/root.go
@@ -72,6 +72,7 @@ func init() {
 	RootCmd.AddCommand(NewProCmd())
 	RootCmd.AddCommand(NewMcpCmd())
 	RootCmd.AddCommand(NewDockerCmd())
+	RootCmd.AddCommand(NewMarketplaceCmd())
 	RootCmd.AddCommand(pro.NewLoginCmd())
 	RootCmd.AddCommand(NewInstallCmd())
 

--- a/cmd/kubectl-testkube/commands/testworkflows/create.go
+++ b/cmd/kubectl-testkube/commands/testworkflows/create.go
@@ -6,10 +6,7 @@ import (
 
 	"github.com/spf13/cobra"
 
-	testworkflowsv1 "github.com/kubeshop/testkube/api/testworkflows/v1"
-	"github.com/kubeshop/testkube/cmd/kubectl-testkube/commands/common"
-	common2 "github.com/kubeshop/testkube/internal/crdcommon"
-	"github.com/kubeshop/testkube/pkg/mapper/testworkflows"
+	"github.com/kubeshop/testkube/pkg/marketplace"
 	"github.com/kubeshop/testkube/pkg/ui"
 )
 
@@ -17,6 +14,7 @@ func NewCreateTestWorkflowCmd() *cobra.Command {
 	var (
 		name     string
 		filePath string
+		url      string
 		update   bool
 		dryRun   bool
 	)
@@ -28,72 +26,43 @@ func NewCreateTestWorkflowCmd() *cobra.Command {
 		Short:   "Create test workflow",
 
 		Run: func(cmd *cobra.Command, _ []string) {
-			namespace := cmd.Flag("namespace").Value.String()
+			if filePath != "" && url != "" {
+				ui.Failf("--file and --url are mutually exclusive")
+			}
 
-			var input io.Reader
-			if filePath == "" {
+			var raw []byte
+			switch {
+			case url != "":
+				client := marketplace.NewClient()
+				body, err := client.FetchURL(cmd.Context(), url)
+				ui.ExitOnError("fetching test workflow from "+url, err)
+				raw = body
+			case filePath != "":
+				file, err := os.Open(filePath)
+				ui.ExitOnError("reading "+filePath+" file", err)
+				defer file.Close()
+				body, err := io.ReadAll(file)
+				ui.ExitOnError("reading input", err)
+				raw = body
+			default:
 				fi, err := os.Stdin.Stat()
 				ui.ExitOnError("reading stdin", err)
 				if fi.Mode()&os.ModeDevice != 0 {
-					ui.Failf("you need to pass stdin or --file argument with file path")
+					ui.Failf("you need to pass stdin, --file, or --url argument")
 				}
-				input = cmd.InOrStdin()
-			} else {
-				file, err := os.Open(filePath)
-				ui.ExitOnError("reading "+filePath+" file", err)
-				input = file
+				body, err := io.ReadAll(cmd.InOrStdin())
+				ui.ExitOnError("reading input", err)
+				raw = body
 			}
 
-			bytes, err := io.ReadAll(input)
-			ui.ExitOnError("reading input", err)
-
-			client, _, err := common.GetClient(cmd)
-			ui.ExitOnError("getting client", err)
-
-			err = client.ValidateTestWorkflow(bytes)
-			ui.ExitOnError("error validating test workflow against crd schema", err)
-			if dryRun {
-				ui.SuccessAndExit("TestWorkflow specification is valid")
-			}
-
-			obj := new(testworkflowsv1.TestWorkflow)
-			err = common2.DeserializeCRD(obj, bytes)
-			ui.ExitOnError("deserializing input", err)
-
-			common2.AppendTypeMeta("TestWorkflow", testworkflowsv1.GroupVersion, obj)
-			obj.Namespace = namespace
-			if name != "" {
-				obj.Name = name
-			}
-
-			workflow, err := client.GetTestWorkflow(obj.Name)
-			if err != nil {
-				if update {
-					// allow to `create --update` if test workflow does not exist
-					ui.WarnOnError("getting test workflow "+obj.Name+" in namespace "+obj.Namespace, err)
-				} else {
-					ui.Debug("getting test workflow "+obj.Name+" in namespace "+obj.Namespace, err.Error())
-				}
-			}
-
-			if workflow.Name != "" {
-				if !update {
-					ui.Failf("Test workflow with name '%s' already exists in namespace %s, use --update flag for upsert", obj.Name, namespace)
-				}
-				_, err = client.UpdateTestWorkflow(testworkflows.MapTestWorkflowKubeToAPI(*obj))
-				ui.ExitOnError("updating test workflow "+obj.Name+" in namespace "+obj.Namespace, err)
-				ui.Success("Test workflow updated", namespace, "/", obj.Name)
-			} else {
-				_, err = client.CreateTestWorkflow(testworkflows.MapTestWorkflowKubeToAPI(*obj))
-				ui.ExitOnError("creating test workflow "+obj.Name+" in namespace "+obj.Namespace, err)
-				ui.Success("Test workflow created", namespace, "/", obj.Name)
-			}
+			CreateOrUpdateFromBytes(cmd, raw, name, update, dryRun)
 		},
 	}
 
 	cmd.Flags().StringVar(&name, "name", "", "test workflow name")
 	cmd.Flags().BoolVar(&update, "update", false, "update, if test workflow already exists")
 	cmd.Flags().StringVarP(&filePath, "file", "f", "", "file path to get the test workflow specification")
+	cmd.Flags().StringVarP(&url, "url", "u", "", "URL to fetch the test workflow specification from (mutually exclusive with --file)")
 	cmd.Flags().BoolVar(&dryRun, "dry-run", false, "validate test workflow specification yaml")
 	cmd.Flags().MarkDeprecated("disable-webhooks", "disable-webhooks is deprecated")
 

--- a/cmd/kubectl-testkube/commands/testworkflows/create_helpers.go
+++ b/cmd/kubectl-testkube/commands/testworkflows/create_helpers.go
@@ -1,0 +1,65 @@
+package testworkflows
+
+import (
+	"github.com/spf13/cobra"
+
+	testworkflowsv1 "github.com/kubeshop/testkube/api/testworkflows/v1"
+	"github.com/kubeshop/testkube/cmd/kubectl-testkube/commands/common"
+	common2 "github.com/kubeshop/testkube/internal/crdcommon"
+	"github.com/kubeshop/testkube/pkg/mapper/testworkflows"
+	"github.com/kubeshop/testkube/pkg/ui"
+)
+
+// CreateOrUpdateFromBytes validates the TestWorkflow YAML and either creates
+// or updates the resource using the client bound to the command. It is
+// shared between `testkube create testworkflow` and
+// `testkube marketplace install` so both entry points share the same
+// validation and upsert semantics.
+//
+// When dryRun is true the function returns after successful schema
+// validation (matching the existing CLI behavior).
+func CreateOrUpdateFromBytes(cmd *cobra.Command, raw []byte, overrideName string, update, dryRun bool) {
+	namespace := cmd.Flag("namespace").Value.String()
+
+	client, _, err := common.GetClient(cmd)
+	ui.ExitOnError("getting client", err)
+
+	err = client.ValidateTestWorkflow(raw)
+	ui.ExitOnError("error validating test workflow against crd schema", err)
+	if dryRun {
+		ui.SuccessAndExit("TestWorkflow specification is valid")
+	}
+
+	obj := new(testworkflowsv1.TestWorkflow)
+	err = common2.DeserializeCRD(obj, raw)
+	ui.ExitOnError("deserializing input", err)
+
+	common2.AppendTypeMeta("TestWorkflow", testworkflowsv1.GroupVersion, obj)
+	obj.Namespace = namespace
+	if overrideName != "" {
+		obj.Name = overrideName
+	}
+
+	workflow, err := client.GetTestWorkflow(obj.Name)
+	if err != nil {
+		if update {
+			ui.WarnOnError("getting test workflow "+obj.Name+" in namespace "+obj.Namespace, err)
+		} else {
+			ui.Debug("getting test workflow "+obj.Name+" in namespace "+obj.Namespace, err.Error())
+		}
+	}
+
+	if workflow.Name != "" {
+		if !update {
+			ui.Failf("Test workflow with name '%s' already exists in namespace %s, use --update flag for upsert", obj.Name, namespace)
+		}
+		_, err = client.UpdateTestWorkflow(testworkflows.MapTestWorkflowKubeToAPI(*obj))
+		ui.ExitOnError("updating test workflow "+obj.Name+" in namespace "+obj.Namespace, err)
+		ui.Success("Test workflow updated", namespace, "/", obj.Name)
+		return
+	}
+
+	_, err = client.CreateTestWorkflow(testworkflows.MapTestWorkflowKubeToAPI(*obj))
+	ui.ExitOnError("creating test workflow "+obj.Name+" in namespace "+obj.Namespace, err)
+	ui.Success("Test workflow created", namespace, "/", obj.Name)
+}

--- a/cmd/kubectl-testkube/commands/testworkflows/create_helpers.go
+++ b/cmd/kubectl-testkube/commands/testworkflows/create_helpers.go
@@ -16,9 +16,11 @@ import (
 // `testkube marketplace install` so both entry points share the same
 // validation and upsert semantics.
 //
-// When dryRun is true the function returns after successful schema
-// validation (matching the existing CLI behavior).
-func CreateOrUpdateFromBytes(cmd *cobra.Command, raw []byte, overrideName string, update, dryRun bool) {
+// The resolved workflow name (after --name override, if any) is returned so
+// callers can perform follow-up operations such as triggering a run.
+// When dryRun is true the function exits after successful schema validation
+// (matching the existing CLI behavior) and does not return.
+func CreateOrUpdateFromBytes(cmd *cobra.Command, raw []byte, overrideName string, update, dryRun bool) string {
 	namespace := cmd.Flag("namespace").Value.String()
 
 	client, _, err := common.GetClient(cmd)
@@ -56,10 +58,11 @@ func CreateOrUpdateFromBytes(cmd *cobra.Command, raw []byte, overrideName string
 		_, err = client.UpdateTestWorkflow(testworkflows.MapTestWorkflowKubeToAPI(*obj))
 		ui.ExitOnError("updating test workflow "+obj.Name+" in namespace "+obj.Namespace, err)
 		ui.Success("Test workflow updated", namespace, "/", obj.Name)
-		return
+		return obj.Name
 	}
 
 	_, err = client.CreateTestWorkflow(testworkflows.MapTestWorkflowKubeToAPI(*obj))
 	ui.ExitOnError("creating test workflow "+obj.Name+" in namespace "+obj.Namespace, err)
 	ui.Success("Test workflow created", namespace, "/", obj.Name)
+	return obj.Name
 }

--- a/cmd/kubectl-testkube/commands/testworkflows/run_helpers.go
+++ b/cmd/kubectl-testkube/commands/testworkflows/run_helpers.go
@@ -29,14 +29,15 @@ func RunWorkflowByName(cmd *cobra.Command, name string, follow bool) {
 	execution, err := client.ExecuteTestWorkflow(name, testkube.TestWorkflowExecutionRequest{})
 	ui.ExitOnError(fmt.Sprintf("starting test workflow %q", name), err)
 
-	ui.Success("Test workflow execution started", execution.Name)
+	ui.Success("TestWorkflow execution started", execution.Name)
 	if execution.Id == "" {
 		return
 	}
 	ui.Info("Execution ID:", execution.Id)
 
 	if !follow {
-		ui.Info("Watch live:", fmt.Sprintf("kubectl testkube watch twe %s", execution.Id))
+		ui.Hint("Watch live:", fmt.Sprintf("testkube watch twe %s", execution.Id))
+		common.UIShellViewExecution(execution.Id)
 		return
 	}
 
@@ -47,6 +48,8 @@ func RunWorkflowByName(cmd *cobra.Command, name string, follow bool) {
 	if refreshed, err := client.GetTestWorkflowExecution(execution.Id); err == nil {
 		render.PrintTestWorkflowExecutionURIs(&refreshed)
 	}
+
+	common.UIShellViewExecution(execution.Id)
 
 	if exitCode != 0 {
 		os.Exit(exitCode)

--- a/cmd/kubectl-testkube/commands/testworkflows/run_helpers.go
+++ b/cmd/kubectl-testkube/commands/testworkflows/run_helpers.go
@@ -2,23 +2,27 @@ package testworkflows
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/spf13/cobra"
 
 	"github.com/kubeshop/testkube/cmd/kubectl-testkube/commands/common"
+	"github.com/kubeshop/testkube/cmd/kubectl-testkube/commands/common/render"
 	"github.com/kubeshop/testkube/pkg/api/v1/testkube"
 	"github.com/kubeshop/testkube/pkg/ui"
 )
 
 // RunWorkflowByName triggers an execution of the given TestWorkflow using the
-// client bound to the command. It prints a short summary on success so users
-// can follow up with `testkube get twe <id>` or `kubectl testkube watch twe <id>`.
+// client bound to the command. It prints a short summary on success and, when
+// follow is true, streams live logs until the execution completes (mirroring
+// `testkube run testworkflow -f`). The process exits with the execution's
+// exit code when following.
 //
-// This is intentionally minimal (no --watch, artifacts, logs streaming) so
-// shared callers like `testkube marketplace install` stay focused; the
-// dedicated `testkube run testworkflow` command remains the tool of choice
-// for richer execution flows.
-func RunWorkflowByName(cmd *cobra.Command, name string) {
+// This is intentionally minimal (no service/parallel-step filtering or
+// artifact download) so shared callers like `testkube marketplace install`
+// stay focused; the dedicated `testkube run testworkflow` command remains
+// the tool of choice for richer execution flows.
+func RunWorkflowByName(cmd *cobra.Command, name string, follow bool) {
 	client, _, err := common.GetClient(cmd)
 	ui.ExitOnError("getting client", err)
 
@@ -26,8 +30,25 @@ func RunWorkflowByName(cmd *cobra.Command, name string) {
 	ui.ExitOnError(fmt.Sprintf("starting test workflow %q", name), err)
 
 	ui.Success("Test workflow execution started", execution.Name)
-	if execution.Id != "" {
-		ui.Info("Execution ID:", execution.Id)
+	if execution.Id == "" {
+		return
+	}
+	ui.Info("Execution ID:", execution.Id)
+
+	if !follow {
 		ui.Info("Watch live:", fmt.Sprintf("kubectl testkube watch twe %s", execution.Id))
+		return
+	}
+
+	ui.NL()
+	exitCode := uiWatch(execution, nil, 0, nil, 0, client)
+	ui.NL()
+
+	if refreshed, err := client.GetTestWorkflowExecution(execution.Id); err == nil {
+		render.PrintTestWorkflowExecutionURIs(&refreshed)
+	}
+
+	if exitCode != 0 {
+		os.Exit(exitCode)
 	}
 }

--- a/cmd/kubectl-testkube/commands/testworkflows/run_helpers.go
+++ b/cmd/kubectl-testkube/commands/testworkflows/run_helpers.go
@@ -1,0 +1,33 @@
+package testworkflows
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/kubeshop/testkube/cmd/kubectl-testkube/commands/common"
+	"github.com/kubeshop/testkube/pkg/api/v1/testkube"
+	"github.com/kubeshop/testkube/pkg/ui"
+)
+
+// RunWorkflowByName triggers an execution of the given TestWorkflow using the
+// client bound to the command. It prints a short summary on success so users
+// can follow up with `testkube get twe <id>` or `kubectl testkube watch twe <id>`.
+//
+// This is intentionally minimal (no --watch, artifacts, logs streaming) so
+// shared callers like `testkube marketplace install` stay focused; the
+// dedicated `testkube run testworkflow` command remains the tool of choice
+// for richer execution flows.
+func RunWorkflowByName(cmd *cobra.Command, name string) {
+	client, _, err := common.GetClient(cmd)
+	ui.ExitOnError("getting client", err)
+
+	execution, err := client.ExecuteTestWorkflow(name, testkube.TestWorkflowExecutionRequest{})
+	ui.ExitOnError(fmt.Sprintf("starting test workflow %q", name), err)
+
+	ui.Success("Test workflow execution started", execution.Name)
+	if execution.Id != "" {
+		ui.Info("Execution ID:", execution.Id)
+		ui.Info("Watch live:", fmt.Sprintf("kubectl testkube watch twe %s", execution.Id))
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -43,6 +43,7 @@ require (
 	github.com/keygen-sh/jsonapi-go v1.2.1
 	github.com/keygen-sh/keygen-go/v3 v3.3.0
 	github.com/mark3labs/mcp-go v0.48.0
+	github.com/mattn/go-isatty v0.0.20
 	github.com/minio/minio-go/v7 v7.0.100
 	github.com/montanaflynn/stats v0.9.0
 	github.com/moogar0880/problems v1.0.1
@@ -216,7 +217,6 @@ require (
 	github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0 // indirect
 	github.com/magiconair/properties v1.8.10 // indirect
 	github.com/mattn/go-colorable v0.1.14 // indirect
-	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/mattn/go-runewidth v0.0.20 // indirect
 	github.com/mfridman/interpolate v0.0.2 // indirect
 	github.com/mikefarah/yq/v4 v4.53.2 // indirect

--- a/pkg/marketplace/client.go
+++ b/pkg/marketplace/client.go
@@ -3,6 +3,7 @@ package marketplace
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -10,6 +11,13 @@ import (
 
 	tkhttp "github.com/kubeshop/testkube/pkg/http"
 )
+
+// ErrWorkflowNotFound is returned by GetWorkflow when the requested entry is
+// absent from the marketplace catalog. Callers should check with errors.Is
+// so that failures from catalog fetching (network errors, HTTP 404s whose
+// error message happens to contain the phrase "not found", etc.) are not
+// misclassified as a missing workflow.
+var ErrWorkflowNotFound = errors.New("workflow not found in marketplace catalog")
 
 // DefaultBaseURL is the raw GitHub URL for the kubeshop/testkube-marketplace
 // main branch. It is the same base used by the Dashboard in useCatalog.ts.
@@ -90,7 +98,7 @@ func (c *Client) GetWorkflow(ctx context.Context, name string) (*Workflow, error
 			return &workflows[i], nil
 		}
 	}
-	return nil, fmt.Errorf("workflow %q not found in marketplace catalog", name)
+	return nil, fmt.Errorf("%w: %q", ErrWorkflowNotFound, name)
 }
 
 // GetWorkflowYAML downloads the raw YAML for a catalog entry's Path field.

--- a/pkg/marketplace/client.go
+++ b/pkg/marketplace/client.go
@@ -1,0 +1,147 @@
+package marketplace
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+
+	tkhttp "github.com/kubeshop/testkube/pkg/http"
+)
+
+// DefaultBaseURL is the raw GitHub URL for the kubeshop/testkube-marketplace
+// main branch. It is the same base used by the Dashboard in useCatalog.ts.
+const DefaultBaseURL = "https://raw.githubusercontent.com/kubeshop/testkube-marketplace/main/"
+
+// CatalogIndexPath is the repo-relative path of the catalog index file.
+const CatalogIndexPath = "catalog-index.json"
+
+// HTTPDoer matches *http.Client so tests can substitute a stub.
+type HTTPDoer interface {
+	Do(req *http.Request) (*http.Response, error)
+}
+
+// Client fetches marketplace catalog entries, workflow YAML, and readme
+// content. Construct via NewClient; zero values are not usable.
+type Client struct {
+	baseURL string
+	http    HTTPDoer
+}
+
+// ClientOption configures a Client.
+type ClientOption func(*Client)
+
+// WithBaseURL overrides the base URL used for fetches. The URL must end with
+// a trailing slash; one is added if missing. Primarily intended for tests.
+func WithBaseURL(url string) ClientOption {
+	return func(c *Client) {
+		if !strings.HasSuffix(url, "/") {
+			url += "/"
+		}
+		c.baseURL = url
+	}
+}
+
+// WithHTTPClient overrides the underlying HTTP client.
+func WithHTTPClient(h HTTPDoer) ClientOption {
+	return func(c *Client) {
+		c.http = h
+	}
+}
+
+// NewClient returns a marketplace client that talks to the public
+// testkube-marketplace GitHub repo. Options can override the base URL and
+// HTTP client, which is useful in tests.
+func NewClient(opts ...ClientOption) *Client {
+	c := &Client{
+		baseURL: DefaultBaseURL,
+		http:    tkhttp.NewClient(),
+	}
+	for _, opt := range opts {
+		opt(c)
+	}
+	return c
+}
+
+// ListWorkflows fetches and decodes catalog-index.json.
+func (c *Client) ListWorkflows(ctx context.Context) ([]Workflow, error) {
+	body, err := c.fetch(ctx, CatalogIndexPath)
+	if err != nil {
+		return nil, err
+	}
+	var workflows []Workflow
+	if err := json.Unmarshal(body, &workflows); err != nil {
+		return nil, fmt.Errorf("decoding catalog index: %w", err)
+	}
+	return workflows, nil
+}
+
+// GetWorkflow finds a catalog entry by its (unique) name. Returns an error
+// if the catalog cannot be fetched or no matching entry exists.
+func (c *Client) GetWorkflow(ctx context.Context, name string) (*Workflow, error) {
+	workflows, err := c.ListWorkflows(ctx)
+	if err != nil {
+		return nil, err
+	}
+	for i := range workflows {
+		if workflows[i].Name == name {
+			return &workflows[i], nil
+		}
+	}
+	return nil, fmt.Errorf("workflow %q not found in marketplace catalog", name)
+}
+
+// GetWorkflowYAML downloads the raw YAML for a catalog entry's Path field.
+func (c *Client) GetWorkflowYAML(ctx context.Context, w Workflow) ([]byte, error) {
+	if w.Path == "" {
+		return nil, fmt.Errorf("workflow %q has no path", w.Name)
+	}
+	return c.fetch(ctx, w.Path)
+}
+
+// GetReadme downloads the raw readme for a catalog entry. Returns an empty
+// byte slice and nil error when the entry has no readme.
+func (c *Client) GetReadme(ctx context.Context, w Workflow) ([]byte, error) {
+	if w.Readme == "" {
+		return nil, nil
+	}
+	return c.fetch(ctx, w.Readme)
+}
+
+// FetchURL downloads raw bytes from an arbitrary URL using the client's HTTP
+// client. It is used by the create testworkflow --url flag so both the
+// marketplace CLI and generic URL fetches share the same transport.
+func (c *Client) FetchURL(ctx context.Context, url string) ([]byte, error) {
+	return doGet(ctx, c.http, url)
+}
+
+func (c *Client) fetch(ctx context.Context, path string) ([]byte, error) {
+	return doGet(ctx, c.http, c.baseURL+strings.TrimLeft(path, "/"))
+}
+
+func doGet(ctx context.Context, h HTTPDoer, url string) ([]byte, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("building request for %s: %w", url, err)
+	}
+	resp, err := h.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("fetching %s: %w", url, err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("reading response from %s: %w", url, err)
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		snippet := strings.TrimSpace(string(body))
+		if len(snippet) > 200 {
+			snippet = snippet[:200] + "..."
+		}
+		return nil, fmt.Errorf("fetching %s: status %d: %s", url, resp.StatusCode, snippet)
+	}
+	return body, nil
+}

--- a/pkg/marketplace/client_test.go
+++ b/pkg/marketplace/client_test.go
@@ -1,0 +1,117 @@
+package marketplace
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestClient_ListWorkflows(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/catalog-index.json" {
+			http.NotFound(w, r)
+			return
+		}
+		_, _ = w.Write([]byte(`[
+			{"path":"workflows/databases/redis/redis-connectivity.yaml","name":"redis-connectivity","category":"databases","component":"redis","displayName":"Redis","description":"Check redis","icon":"x","readme":"r.md"},
+			{"path":"workflows/networking/ingress/ingress-health-check.yaml","name":"ingress-health-check","category":"networking","component":"ingress","displayName":"Ingress","description":"Check ingress"}
+		]`))
+	}))
+	t.Cleanup(srv.Close)
+
+	c := NewClient(WithBaseURL(srv.URL))
+	workflows, err := c.ListWorkflows(context.Background())
+	if err != nil {
+		t.Fatalf("ListWorkflows: %v", err)
+	}
+	if len(workflows) != 2 {
+		t.Fatalf("expected 2 workflows, got %d", len(workflows))
+	}
+	if workflows[0].Name != "redis-connectivity" || workflows[0].Category != "databases" {
+		t.Errorf("unexpected first workflow: %+v", workflows[0])
+	}
+	if workflows[1].Name != "ingress-health-check" || workflows[1].Readme != "" {
+		t.Errorf("unexpected second workflow: %+v", workflows[1])
+	}
+}
+
+func TestClient_GetWorkflow(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`[{"path":"p.yaml","name":"redis-connectivity","category":"databases","component":"redis","displayName":"Redis","description":"x"}]`))
+	}))
+	t.Cleanup(srv.Close)
+
+	c := NewClient(WithBaseURL(srv.URL))
+
+	got, err := c.GetWorkflow(context.Background(), "redis-connectivity")
+	if err != nil {
+		t.Fatalf("GetWorkflow: %v", err)
+	}
+	if got.Path != "p.yaml" {
+		t.Errorf("expected path p.yaml, got %q", got.Path)
+	}
+
+	if _, err := c.GetWorkflow(context.Background(), "nope"); err == nil {
+		t.Errorf("expected error for missing workflow")
+	}
+}
+
+func TestClient_GetWorkflowYAMLAndReadme(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/workflows/a.yaml":
+			_, _ = w.Write([]byte("yaml: body"))
+		case "/workflows/a.md":
+			_, _ = w.Write([]byte("# readme"))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(srv.Close)
+
+	c := NewClient(WithBaseURL(srv.URL))
+	wf := Workflow{Path: "workflows/a.yaml", Readme: "workflows/a.md", Name: "a"}
+
+	body, err := c.GetWorkflowYAML(context.Background(), wf)
+	if err != nil {
+		t.Fatalf("GetWorkflowYAML: %v", err)
+	}
+	if string(body) != "yaml: body" {
+		t.Errorf("unexpected yaml body: %q", body)
+	}
+
+	readme, err := c.GetReadme(context.Background(), wf)
+	if err != nil {
+		t.Fatalf("GetReadme: %v", err)
+	}
+	if string(readme) != "# readme" {
+		t.Errorf("unexpected readme body: %q", readme)
+	}
+
+	readme2, err := c.GetReadme(context.Background(), Workflow{})
+	if err != nil {
+		t.Fatalf("GetReadme empty: %v", err)
+	}
+	if readme2 != nil {
+		t.Errorf("expected nil readme, got %q", readme2)
+	}
+}
+
+func TestClient_FetchURLHandlesErrorStatus(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte("not found"))
+	}))
+	t.Cleanup(srv.Close)
+
+	c := NewClient(WithBaseURL(srv.URL))
+	_, err := c.FetchURL(context.Background(), srv.URL+"/missing")
+	if err == nil {
+		t.Fatal("expected error on 404")
+	}
+	if !strings.Contains(err.Error(), "404") {
+		t.Errorf("expected error to mention status 404, got %v", err)
+	}
+}

--- a/pkg/marketplace/client_test.go
+++ b/pkg/marketplace/client_test.go
@@ -2,6 +2,7 @@ package marketplace
 
 import (
 	"context"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -53,8 +54,33 @@ func TestClient_GetWorkflow(t *testing.T) {
 		t.Errorf("expected path p.yaml, got %q", got.Path)
 	}
 
-	if _, err := c.GetWorkflow(context.Background(), "nope"); err == nil {
-		t.Errorf("expected error for missing workflow")
+	_, err = c.GetWorkflow(context.Background(), "nope")
+	if err == nil {
+		t.Fatalf("expected error for missing workflow")
+	}
+	if !errors.Is(err, ErrWorkflowNotFound) {
+		t.Errorf("expected ErrWorkflowNotFound sentinel, got %v", err)
+	}
+}
+
+// TestClient_GetWorkflow_CatalogFetchErrorIsNotMisclassified guards against a
+// regression where a 404 from the catalog endpoint itself gets interpreted as
+// ErrWorkflowNotFound by string matching. Callers rely on errors.Is to
+// distinguish between "catalog unreachable" and "workflow missing".
+func TestClient_GetWorkflow_CatalogFetchErrorIsNotMisclassified(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte("not found"))
+	}))
+	t.Cleanup(srv.Close)
+
+	c := NewClient(WithBaseURL(srv.URL))
+	_, err := c.GetWorkflow(context.Background(), "redis-connectivity")
+	if err == nil {
+		t.Fatal("expected error when catalog fetch returns 404")
+	}
+	if errors.Is(err, ErrWorkflowNotFound) {
+		t.Errorf("catalog fetch 404 must not be reported as ErrWorkflowNotFound, got %v", err)
 	}
 }
 

--- a/pkg/marketplace/parameters.go
+++ b/pkg/marketplace/parameters.go
@@ -1,0 +1,243 @@
+package marketplace
+
+import (
+	"fmt"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+// ExtractParameters parses TestWorkflow YAML and returns the entries in
+// spec.config as a flat list. It mirrors the Dashboard's extractParameters()
+// so the CLI and UI expose the same parameters.
+//
+// Supports two YAML shapes (both appear in the marketplace):
+//
+//	spec:
+//	  config:
+//	    host:
+//	      type: string
+//	      default: "localhost"
+//	      description: "Host to connect to"
+//
+//	spec:
+//	  config:
+//	    host: "localhost"
+func ExtractParameters(yamlContent []byte) ([]Parameter, error) {
+	config, err := findConfigNode(yamlContent)
+	if err != nil {
+		return nil, err
+	}
+	if config == nil {
+		return nil, nil
+	}
+	return parseConfigNode(config), nil
+}
+
+// ApplyParameters writes parameter Values back into the YAML, updating each
+// key's default field (matching the Dashboard's applyParameters()). Scalar
+// config entries are replaced with the value as a string. Unknown
+// parameters (not present in spec.config) are silently ignored so the YAML
+// is never corrupted by stray --set flags.
+//
+// As in the Dashboard, when a parameter is marked sensitive but has no
+// value, the sensitive flag is dropped to avoid the backend's "value cannot
+// be empty" error on credential creation.
+func ApplyParameters(yamlContent []byte, params []Parameter) ([]byte, error) {
+	var doc yaml.Node
+	if err := yaml.Unmarshal(yamlContent, &doc); err != nil {
+		return nil, fmt.Errorf("parsing workflow YAML: %w", err)
+	}
+	config := findMappingChild(findMappingChild(rootMapping(&doc), "spec"), "config")
+	if config == nil {
+		return yamlContent, nil
+	}
+
+	for _, param := range params {
+		entry := mappingValue(config, param.Key)
+		if entry == nil {
+			continue
+		}
+		switch entry.Kind {
+		case yaml.MappingNode:
+			setMappingString(entry, "default", param.Value)
+			if param.Sensitive {
+				if param.Value != "" {
+					setMappingBool(entry, "sensitive", true)
+				} else {
+					deleteMappingKey(entry, "sensitive")
+				}
+			}
+		case yaml.ScalarNode:
+			entry.Kind = yaml.ScalarNode
+			entry.Style = yaml.DoubleQuotedStyle
+			entry.Tag = "!!str"
+			entry.Value = param.Value
+		}
+	}
+
+	out, err := yaml.Marshal(&doc)
+	if err != nil {
+		return nil, fmt.Errorf("re-encoding workflow YAML: %w", err)
+	}
+	return out, nil
+}
+
+// ParseSetFlags converts `key=value` strings (from --set) into updates on
+// the provided parameter list, matching by key (case-sensitive, consistent
+// with YAML). Unknown keys cause an error so users aren't silently ignored
+// when they misspell a parameter name. The returned slice is a copy.
+func ParseSetFlags(params []Parameter, overrides []string) ([]Parameter, error) {
+	byKey := make(map[string]int, len(params))
+	out := make([]Parameter, len(params))
+	copy(out, params)
+	for i, p := range out {
+		byKey[p.Key] = i
+	}
+
+	for _, raw := range overrides {
+		eq := strings.IndexByte(raw, '=')
+		if eq <= 0 {
+			return nil, fmt.Errorf("invalid --set value %q: expected key=value", raw)
+		}
+		key := strings.TrimSpace(raw[:eq])
+		val := raw[eq+1:]
+		idx, ok := byKey[key]
+		if !ok {
+			known := make([]string, 0, len(out))
+			for _, p := range out {
+				known = append(known, p.Key)
+			}
+			return nil, fmt.Errorf("unknown parameter %q (known: %s)", key, strings.Join(known, ", "))
+		}
+		out[idx].Value = val
+	}
+	return out, nil
+}
+
+func findConfigNode(yamlContent []byte) (*yaml.Node, error) {
+	var doc yaml.Node
+	if err := yaml.Unmarshal(yamlContent, &doc); err != nil {
+		return nil, fmt.Errorf("parsing workflow YAML: %w", err)
+	}
+	return findMappingChild(findMappingChild(rootMapping(&doc), "spec"), "config"), nil
+}
+
+func parseConfigNode(config *yaml.Node) []Parameter {
+	params := make([]Parameter, 0, len(config.Content)/2)
+	for i := 0; i+1 < len(config.Content); i += 2 {
+		keyNode := config.Content[i]
+		valNode := config.Content[i+1]
+		if keyNode.Kind != yaml.ScalarNode {
+			continue
+		}
+
+		p := Parameter{Key: keyNode.Value}
+		switch valNode.Kind {
+		case yaml.MappingNode:
+			if def := mappingValue(valNode, "default"); def != nil && def.Kind == yaml.ScalarNode {
+				p.Default = def.Value
+			}
+			if t := mappingValue(valNode, "type"); t != nil && t.Kind == yaml.ScalarNode {
+				p.Type = t.Value
+			}
+			if d := mappingValue(valNode, "description"); d != nil && d.Kind == yaml.ScalarNode {
+				p.Description = d.Value
+			}
+			if s := mappingValue(valNode, "sensitive"); s != nil && s.Kind == yaml.ScalarNode {
+				p.Sensitive = s.Value == "true"
+			}
+		case yaml.ScalarNode:
+			p.Default = valNode.Value
+		}
+		p.Value = p.Default
+		params = append(params, p)
+	}
+	return params
+}
+
+func rootMapping(doc *yaml.Node) *yaml.Node {
+	if doc == nil {
+		return nil
+	}
+	if doc.Kind == yaml.DocumentNode && len(doc.Content) > 0 {
+		return doc.Content[0]
+	}
+	return doc
+}
+
+func findMappingChild(parent *yaml.Node, key string) *yaml.Node {
+	if parent == nil || parent.Kind != yaml.MappingNode {
+		return nil
+	}
+	v := mappingValue(parent, key)
+	if v == nil || v.Kind != yaml.MappingNode {
+		return nil
+	}
+	return v
+}
+
+func mappingValue(m *yaml.Node, key string) *yaml.Node {
+	if m == nil || m.Kind != yaml.MappingNode {
+		return nil
+	}
+	for i := 0; i+1 < len(m.Content); i += 2 {
+		if m.Content[i].Kind == yaml.ScalarNode && m.Content[i].Value == key {
+			return m.Content[i+1]
+		}
+	}
+	return nil
+}
+
+func setMappingString(m *yaml.Node, key, value string) {
+	if m == nil || m.Kind != yaml.MappingNode {
+		return
+	}
+	for i := 0; i+1 < len(m.Content); i += 2 {
+		if m.Content[i].Kind == yaml.ScalarNode && m.Content[i].Value == key {
+			m.Content[i+1].Kind = yaml.ScalarNode
+			m.Content[i+1].Style = yaml.DoubleQuotedStyle
+			m.Content[i+1].Tag = "!!str"
+			m.Content[i+1].Value = value
+			return
+		}
+	}
+	m.Content = append(m.Content,
+		&yaml.Node{Kind: yaml.ScalarNode, Value: key},
+		&yaml.Node{Kind: yaml.ScalarNode, Style: yaml.DoubleQuotedStyle, Tag: "!!str", Value: value},
+	)
+}
+
+func setMappingBool(m *yaml.Node, key string, value bool) {
+	if m == nil || m.Kind != yaml.MappingNode {
+		return
+	}
+	strVal := "false"
+	if value {
+		strVal = "true"
+	}
+	for i := 0; i+1 < len(m.Content); i += 2 {
+		if m.Content[i].Kind == yaml.ScalarNode && m.Content[i].Value == key {
+			m.Content[i+1].Kind = yaml.ScalarNode
+			m.Content[i+1].Tag = "!!bool"
+			m.Content[i+1].Value = strVal
+			return
+		}
+	}
+	m.Content = append(m.Content,
+		&yaml.Node{Kind: yaml.ScalarNode, Value: key},
+		&yaml.Node{Kind: yaml.ScalarNode, Tag: "!!bool", Value: strVal},
+	)
+}
+
+func deleteMappingKey(m *yaml.Node, key string) {
+	if m == nil || m.Kind != yaml.MappingNode {
+		return
+	}
+	for i := 0; i+1 < len(m.Content); i += 2 {
+		if m.Content[i].Kind == yaml.ScalarNode && m.Content[i].Value == key {
+			m.Content = append(m.Content[:i], m.Content[i+2:]...)
+			return
+		}
+	}
+}

--- a/pkg/marketplace/parameters_test.go
+++ b/pkg/marketplace/parameters_test.go
@@ -1,0 +1,214 @@
+package marketplace
+
+import (
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+const objectConfigYAML = `apiVersion: testworkflows.testkube.io/v1
+kind: TestWorkflow
+metadata:
+  name: example
+spec:
+  config:
+    host:
+      type: string
+      default: "localhost"
+      description: "Host to connect to"
+    port:
+      type: string
+      default: "5432"
+    password:
+      type: string
+      default: ""
+      sensitive: true
+      description: "Password"
+  steps:
+  - name: run
+    shell: echo hi
+`
+
+const scalarConfigYAML = `spec:
+  config:
+    host: "localhost"
+    port: "5432"
+`
+
+func TestExtractParameters_ObjectShape(t *testing.T) {
+	params, err := ExtractParameters([]byte(objectConfigYAML))
+	if err != nil {
+		t.Fatalf("ExtractParameters: %v", err)
+	}
+	if len(params) != 3 {
+		t.Fatalf("expected 3 params, got %d: %+v", len(params), params)
+	}
+	want := map[string]Parameter{
+		"host":     {Key: "host", Default: "localhost", Value: "localhost", Type: "string", Description: "Host to connect to"},
+		"port":     {Key: "port", Default: "5432", Value: "5432", Type: "string"},
+		"password": {Key: "password", Default: "", Value: "", Type: "string", Description: "Password", Sensitive: true},
+	}
+	for _, p := range params {
+		w, ok := want[p.Key]
+		if !ok {
+			t.Errorf("unexpected param: %+v", p)
+			continue
+		}
+		if p != w {
+			t.Errorf("param %s mismatch:\n got: %+v\nwant: %+v", p.Key, p, w)
+		}
+	}
+}
+
+func TestExtractParameters_ScalarShape(t *testing.T) {
+	params, err := ExtractParameters([]byte(scalarConfigYAML))
+	if err != nil {
+		t.Fatalf("ExtractParameters: %v", err)
+	}
+	if len(params) != 2 {
+		t.Fatalf("expected 2 params, got %d", len(params))
+	}
+	if params[0].Key != "host" || params[0].Default != "localhost" || params[0].Value != "localhost" {
+		t.Errorf("unexpected host param: %+v", params[0])
+	}
+}
+
+func TestExtractParameters_NoConfig(t *testing.T) {
+	params, err := ExtractParameters([]byte("spec:\n  steps: []\n"))
+	if err != nil {
+		t.Fatalf("ExtractParameters: %v", err)
+	}
+	if len(params) != 0 {
+		t.Errorf("expected no params, got %+v", params)
+	}
+}
+
+func TestApplyParameters_RewritesDefaults(t *testing.T) {
+	params, err := ExtractParameters([]byte(objectConfigYAML))
+	if err != nil {
+		t.Fatalf("ExtractParameters: %v", err)
+	}
+	for i := range params {
+		switch params[i].Key {
+		case "host":
+			params[i].Value = "my-host.svc"
+		case "password":
+			params[i].Value = "s3cret"
+		}
+	}
+
+	out, err := ApplyParameters([]byte(objectConfigYAML), params)
+	if err != nil {
+		t.Fatalf("ApplyParameters: %v", err)
+	}
+
+	cfg := decodeSpecConfig(t, out)
+	host := cfg["host"].(map[string]any)
+	if host["default"] != "my-host.svc" {
+		t.Errorf("host default not updated: %v", host["default"])
+	}
+	port := cfg["port"].(map[string]any)
+	if port["default"] != "5432" {
+		t.Errorf("port default should be unchanged: %v", port["default"])
+	}
+	pw := cfg["password"].(map[string]any)
+	if pw["default"] != "s3cret" {
+		t.Errorf("password default not updated: %v", pw["default"])
+	}
+	if pw["sensitive"] != true {
+		t.Errorf("password sensitive should remain true: %v", pw["sensitive"])
+	}
+
+	if !strings.Contains(string(out), "echo hi") {
+		t.Error("expected steps to be preserved in re-encoded YAML")
+	}
+}
+
+func TestApplyParameters_DropsSensitiveWhenEmpty(t *testing.T) {
+	params, err := ExtractParameters([]byte(objectConfigYAML))
+	if err != nil {
+		t.Fatalf("ExtractParameters: %v", err)
+	}
+
+	out, err := ApplyParameters([]byte(objectConfigYAML), params)
+	if err != nil {
+		t.Fatalf("ApplyParameters: %v", err)
+	}
+	cfg := decodeSpecConfig(t, out)
+	pw := cfg["password"].(map[string]any)
+	if _, exists := pw["sensitive"]; exists {
+		t.Errorf("expected sensitive to be dropped when value is empty, got %+v", pw)
+	}
+}
+
+func TestApplyParameters_ScalarEntries(t *testing.T) {
+	params, err := ExtractParameters([]byte(scalarConfigYAML))
+	if err != nil {
+		t.Fatalf("ExtractParameters: %v", err)
+	}
+	for i := range params {
+		if params[i].Key == "host" {
+			params[i].Value = "new-host"
+		}
+	}
+
+	out, err := ApplyParameters([]byte(scalarConfigYAML), params)
+	if err != nil {
+		t.Fatalf("ApplyParameters: %v", err)
+	}
+	cfg := decodeSpecConfig(t, out)
+	if cfg["host"] != "new-host" {
+		t.Errorf("expected host scalar to be new-host, got %v", cfg["host"])
+	}
+	if cfg["port"] != "5432" {
+		t.Errorf("expected port scalar preserved, got %v", cfg["port"])
+	}
+}
+
+func TestParseSetFlags(t *testing.T) {
+	params := []Parameter{
+		{Key: "host", Default: "a", Value: "a"},
+		{Key: "port", Default: "1", Value: "1"},
+	}
+	out, err := ParseSetFlags(params, []string{"host=b", "port=2"})
+	if err != nil {
+		t.Fatalf("ParseSetFlags: %v", err)
+	}
+	if out[0].Value != "b" || out[1].Value != "2" {
+		t.Errorf("unexpected values: %+v", out)
+	}
+	if params[0].Value != "a" || params[1].Value != "1" {
+		t.Errorf("ParseSetFlags should not mutate input")
+	}
+}
+
+func TestParseSetFlags_Errors(t *testing.T) {
+	params := []Parameter{{Key: "host", Default: "a", Value: "a"}}
+	if _, err := ParseSetFlags(params, []string{"no-equals"}); err == nil {
+		t.Error("expected error for missing equals")
+	}
+	if _, err := ParseSetFlags(params, []string{"unknown=x"}); err == nil {
+		t.Error("expected error for unknown key")
+	}
+	out, err := ParseSetFlags(params, []string{"host=with=equals"})
+	if err != nil {
+		t.Fatalf("ParseSetFlags with embedded equals: %v", err)
+	}
+	if out[0].Value != "with=equals" {
+		t.Errorf("expected value with embedded equals preserved, got %q", out[0].Value)
+	}
+}
+
+func decodeSpecConfig(t *testing.T, data []byte) map[string]any {
+	t.Helper()
+	var doc struct {
+		Spec struct {
+			Config map[string]any `yaml:"config"`
+		} `yaml:"spec"`
+	}
+	if err := yaml.Unmarshal(data, &doc); err != nil {
+		t.Fatalf("decoding output yaml: %v\n%s", err, data)
+	}
+	return doc.Spec.Config
+}

--- a/pkg/marketplace/types.go
+++ b/pkg/marketplace/types.go
@@ -20,11 +20,13 @@ type Workflow struct {
 
 // Parameter describes a single entry from a TestWorkflow's spec.config block.
 // Value starts equal to Default and is mutated as the user supplies overrides.
+// Field tags are explicit so that the marketplace CLI's JSON and YAML output
+// use stable lowercase names regardless of Go field naming.
 type Parameter struct {
-	Key         string
-	Default     string
-	Value       string
-	Type        string
-	Description string
-	Sensitive   bool
+	Key         string `json:"key" yaml:"key"`
+	Default     string `json:"default" yaml:"default"`
+	Value       string `json:"value" yaml:"value"`
+	Type        string `json:"type" yaml:"type"`
+	Description string `json:"description" yaml:"description"`
+	Sensitive   bool   `json:"sensitive" yaml:"sensitive"`
 }

--- a/pkg/marketplace/types.go
+++ b/pkg/marketplace/types.go
@@ -1,0 +1,30 @@
+// Package marketplace provides a client for the Testkube Marketplace
+// (https://github.com/kubeshop/testkube-marketplace) catalog. It fetches the
+// catalog index, workflow YAML, and readme content, and exposes helpers to
+// extract and apply TestWorkflow spec.config parameters.
+package marketplace
+
+// Workflow is an entry from the marketplace catalog-index.json file. The
+// shape mirrors the CatalogWorkflow type used by the Dashboard UI.
+type Workflow struct {
+	Path           string `json:"path"`
+	Name           string `json:"name"`
+	Category       string `json:"category"`
+	Component      string `json:"component"`
+	ValidationType string `json:"validationType,omitempty"`
+	DisplayName    string `json:"displayName"`
+	Description    string `json:"description"`
+	Icon           string `json:"icon,omitempty"`
+	Readme         string `json:"readme,omitempty"`
+}
+
+// Parameter describes a single entry from a TestWorkflow's spec.config block.
+// Value starts equal to Default and is mutated as the user supplies overrides.
+type Parameter struct {
+	Key         string
+	Default     string
+	Value       string
+	Type        string
+	Description string
+	Sensitive   bool
+}

--- a/pkg/ui/printers.go
+++ b/pkg/ui/printers.go
@@ -140,6 +140,15 @@ func (ui *UI) Info(message string, subMessages ...string) {
 	fmt.Fprintln(ui.Writer)
 }
 
+// Hint shows a tip/hint message prefixed with a lightbulb icon.
+func (ui *UI) Hint(message string, subMessages ...string) {
+	fmt.Fprintf(ui.Writer, "%s  %s", IconSuggestion, LightGray(message))
+	for _, sub := range subMessages {
+		fmt.Fprintf(ui.Writer, " %s", White(sub))
+	}
+	fmt.Fprintln(ui.Writer)
+}
+
 func (ui *UI) Err(err error) {
 	fmt.Fprintf(ui.Writer, "%s %s %s\n", LightRed("⨯"), Red(err.Error()), IconError)
 }

--- a/pkg/ui/ui.go
+++ b/pkg/ui/ui.go
@@ -71,6 +71,7 @@ func LogLine(message string)                              { ui.LogLine(message) 
 func LogMultiLine(message string)                         { ui.LogMultiLine(message) }
 func Debug(message string, subMessages ...string)         { ui.Debug(message, subMessages...) }
 func Info(message string, subMessages ...string)          { ui.Info(message, subMessages...) }
+func Hint(message string, subMessages ...string)          { ui.Hint(message, subMessages...) }
 func Link(message string, subMessages ...string)          { ui.Link(message, subMessages...) }
 func ExecutionLink(message string, subMessages ...string) { ui.ExecutionLink(message, subMessages...) }
 func Err(err error)                                       { ui.Err(err) }


### PR DESCRIPTION
- Introduced new commands for browsing, installing, and retrieving TestWorkflows from the Testkube Marketplace.
- Added error handling for marketplace operations.
- Implemented functionality to list categories and details of workflows.
- Enhanced the CLI with flags for output formats and parameter overrides.

This update expands the CLI capabilities, allowing users to interact with the Testkube Marketplace directly from the command line.

## Pull request description

## Sample output

### `testkube marketplace list`

```
 NAME                     │ CATEGORY   │ COMPONENT          │ DESCRIPTION
──────────────────────────┼────────────┼────────────────────┼──────────────────────────────────────────────────────────────
 database-health-check    │ databases  │ generic            │ Checks database-like pods for running phase in selected n...
 postgresql-connectivity  │ databases  │ postgresql         │ Validates PostgreSQL server connectivity, authentication,...
 redis-connectivity       │ databases  │ redis              │ Validates Redis server connectivity with PING and basic G...
 nvidia-gpu-workflow      │ kubernetes │ gpu-validation     │ Validates GPU node accessibility and CUDA workload schedu...
 k8s-resources-check      │ kubernetes │ kubernetes-core    │ Validates PVC binding and prints CPU/RAM request-limit sn...
 namespace-scope-check    │ kubernetes │ kubernetes-core    │ Validates namespace accessibility and basic scoped resources
 pod-health-check         │ kubernetes │ kubernetes-core    │ Checks pod phases and restart thresholds in selected name...
 statefulset-health-check │ kubernetes │ kubernetes-core    │ Validates that StatefulSet ready replicas match desired r...
 kafka-connectivity       │ messaging  │ kafka              │ Validates Kafka broker connectivity, topic listing, and b...
 ingress-health-check     │ networking │ ingress            │ Validates ingress backend services and endpoint availability
 pv-attachment-check      │ storage    │ persistent-volumes │ Validates that each PVC in selected namespaces is mounted...
```

### `testkube marketplace categories`

```
 CATEGORY   │ WORKFLOWS │ COMPONENTS
────────────┼───────────┼─────────────────────────────────
 databases  │ 3         │ generic, postgresql, redis
 kubernetes │ 5         │ gpu-validation, kubernetes-core
 messaging  │ 1         │ kafka
 networking │ 1         │ ingress
 storage    │ 1         │ persistent-volumes
```

Both commands also support `--output json|yaml|go` (with `--go-template`) for structured output. `list` additionally supports `--category` and `--component` for filtering.

## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [x] tested locally
- [ ] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [x] added a test

## Breaking changes

-

## Changes

-

## Fixes

-