### PR TITLE
feat: [TKC-5485] allow disabling TestWorkflow fsGroup defaulting

### DIFF
--- a/api/testworkflows/v1/types.go
+++ b/api/testworkflows/v1/types.go
@@ -102,6 +102,9 @@ type PodConfig struct {
 	// SecurityContext holds pod-level security attributes and common container settings.
 	SecurityContext *corev1.PodSecurityContext `json:"securityContext,omitempty" expr:"force"`
 
+	// disable automatic pod fsGroup inference/defaulting; explicit securityContext.fsGroup still applies
+	DisableFsGroupDefaulting *bool `json:"disableFsGroupDefaulting,omitempty" expr:"template"`
+
 	// Specifies the hostname of the Pod
 	Hostname string `json:"hostname,omitempty" expr:"template"`
 

--- a/api/testworkflows/v1/zz_generated.deepcopy.go
+++ b/api/testworkflows/v1/zz_generated.deepcopy.go
@@ -640,6 +640,11 @@ func (in *PodConfig) DeepCopyInto(out *PodConfig) {
 		*out = new(corev1.PodSecurityContext)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.DisableFsGroupDefaulting != nil {
+		in, out := &in.DisableFsGroupDefaulting, &out.DisableFsGroupDefaulting
+		*out = new(bool)
+		**out = **in
+	}
 	if in.Affinity != nil {
 		in, out := &in.Affinity, &out.Affinity
 		*out = new(corev1.Affinity)

--- a/api/v1/testkube.yaml
+++ b/api/v1/testkube.yaml
@@ -10195,6 +10195,8 @@ components:
           type: string
         securityContext:
           $ref: "#/components/schemas/PodSecurityContext"
+        disableFsGroupDefaulting:
+          $ref: "#/components/schemas/BoxedBoolean"
         hostname:
           type: string
         subdomain:

--- a/cmd/kubectl-testkube/commands/testworkflows/run.go
+++ b/cmd/kubectl-testkube/commands/testworkflows/run.go
@@ -845,10 +845,11 @@ func printTestWorkflowLogs(signature []testkube.TestWorkflowSignature, notificat
 				continue
 			}
 			if l.SeqNo > 0 {
-				if l.SeqNo <= nextSeqNo {
+				seqNo := uint32(l.SeqNo)
+				if seqNo <= nextSeqNo {
 					continue
 				}
-				nextSeqNo = l.SeqNo
+				nextSeqNo = seqNo
 			}
 
 			if l.Output != nil {

--- a/internal/app/api/v1/testworkflowexecutions.go
+++ b/internal/app/api/v1/testworkflowexecutions.go
@@ -75,7 +75,7 @@ func streamableWorkflowNotifications(source <-chan *testkube.TestWorkflowExecuti
 			}
 			if workflowNotificationResumable(streamNotification) {
 				seqNo++
-				streamNotification.SeqNo = seqNo
+				streamNotification.SeqNo = int32(seqNo)
 				if seqNo <= resumeAfterSeqNo {
 					continue
 				}

--- a/internal/app/api/v1/testworkflowexecutions_notifications_test.go
+++ b/internal/app/api/v1/testworkflowexecutions_notifications_test.go
@@ -31,7 +31,7 @@ func TestStreamableWorkflowNotificationsAppliesResumeCursorAndSequencing(t *test
 	assert.Equal(t, "log", notifications[0].EventType)
 	assert.Equal(t, "temporary", notifications[0].Log)
 
-	assert.Equal(t, uint32(2), notifications[1].SeqNo)
+	assert.Equal(t, int32(2), notifications[1].SeqNo)
 	assert.Equal(t, "result", notifications[1].EventType)
 	require.NotNil(t, notifications[1].Result)
 }

--- a/k8s/crd/testworkflows.testkube.io_testworkflows.yaml
+++ b/k8s/crd/testworkflows.testkube.io_testworkflows.yaml
@@ -2792,6 +2792,9 @@ spec:
                                     type: string
                                   description: annotations added to the scheduled pod
                                   type: object
+                                disableFsGroupDefaulting:
+                                  description: disable automatic pod fsGroup inference/defaulting; explicit securityContext.fsGroup still applies
+                                  type: boolean
                                 dnsConfig:
                                   properties:
                                     nameservers:
@@ -4222,6 +4225,9 @@ spec:
                         type: string
                       description: annotations added to the scheduled pod
                       type: object
+                    disableFsGroupDefaulting:
+                      description: disable automatic pod fsGroup inference/defaulting; explicit securityContext.fsGroup still applies
+                      type: boolean
                     dnsConfig:
                       properties:
                         nameservers:
@@ -5052,6 +5058,9 @@ spec:
                               type: string
                             description: annotations added to the scheduled pod
                             type: object
+                          disableFsGroupDefaulting:
+                            description: disable automatic pod fsGroup inference/defaulting; explicit securityContext.fsGroup still applies
+                            type: boolean
                           dnsConfig:
                             properties:
                               nameservers:
@@ -8339,6 +8348,9 @@ spec:
                                     type: string
                                   description: annotations added to the scheduled pod
                                   type: object
+                                disableFsGroupDefaulting:
+                                  description: disable automatic pod fsGroup inference/defaulting; explicit securityContext.fsGroup still applies
+                                  type: boolean
                                 dnsConfig:
                                   properties:
                                     nameservers:
@@ -11680,6 +11692,9 @@ spec:
                                     type: string
                                   description: annotations added to the scheduled pod
                                   type: object
+                                disableFsGroupDefaulting:
+                                  description: disable automatic pod fsGroup inference/defaulting; explicit securityContext.fsGroup still applies
+                                  type: boolean
                                 dnsConfig:
                                   properties:
                                     nameservers:

--- a/k8s/crd/testworkflows.testkube.io_testworkflowtemplates.yaml
+++ b/k8s/crd/testworkflows.testkube.io_testworkflowtemplates.yaml
@@ -2727,6 +2727,9 @@ spec:
                                     type: string
                                   description: annotations added to the scheduled pod
                                   type: object
+                                disableFsGroupDefaulting:
+                                  description: disable automatic pod fsGroup inference/defaulting; explicit securityContext.fsGroup still applies
+                                  type: boolean
                                 dnsConfig:
                                   properties:
                                     nameservers:
@@ -4100,6 +4103,9 @@ spec:
                         type: string
                       description: annotations added to the scheduled pod
                       type: object
+                    disableFsGroupDefaulting:
+                      description: disable automatic pod fsGroup inference/defaulting; explicit securityContext.fsGroup still applies
+                      type: boolean
                     dnsConfig:
                       properties:
                         nameservers:
@@ -4930,6 +4936,9 @@ spec:
                               type: string
                             description: annotations added to the scheduled pod
                             type: object
+                          disableFsGroupDefaulting:
+                            description: disable automatic pod fsGroup inference/defaulting; explicit securityContext.fsGroup still applies
+                            type: boolean
                           dnsConfig:
                             properties:
                               nameservers:
@@ -8132,6 +8141,9 @@ spec:
                                     type: string
                                   description: annotations added to the scheduled pod
                                   type: object
+                                disableFsGroupDefaulting:
+                                  description: disable automatic pod fsGroup inference/defaulting; explicit securityContext.fsGroup still applies
+                                  type: boolean
                                 dnsConfig:
                                   properties:
                                     nameservers:
@@ -11351,6 +11363,9 @@ spec:
                                     type: string
                                   description: annotations added to the scheduled pod
                                   type: object
+                                disableFsGroupDefaulting:
+                                  description: disable automatic pod fsGroup inference/defaulting; explicit securityContext.fsGroup still applies
+                                  type: boolean
                                 dnsConfig:
                                   properties:
                                     nameservers:

--- a/k8s/helm/testkube-crds/templates/_generated_crds.tpl
+++ b/k8s/helm/testkube-crds/templates/_generated_crds.tpl
@@ -10216,6 +10216,9 @@ spec:
                                     type: string
                                   description: annotations added to the scheduled pod
                                   type: object
+                                disableFsGroupDefaulting:
+                                  description: disable automatic pod fsGroup inference/defaulting; explicit securityContext.fsGroup still applies
+                                  type: boolean
                                 dnsConfig:
                                   properties:
                                     nameservers:
@@ -11646,6 +11649,9 @@ spec:
                         type: string
                       description: annotations added to the scheduled pod
                       type: object
+                    disableFsGroupDefaulting:
+                      description: disable automatic pod fsGroup inference/defaulting; explicit securityContext.fsGroup still applies
+                      type: boolean
                     dnsConfig:
                       properties:
                         nameservers:
@@ -12476,6 +12482,9 @@ spec:
                               type: string
                             description: annotations added to the scheduled pod
                             type: object
+                          disableFsGroupDefaulting:
+                            description: disable automatic pod fsGroup inference/defaulting; explicit securityContext.fsGroup still applies
+                            type: boolean
                           dnsConfig:
                             properties:
                               nameservers:
@@ -15763,6 +15772,9 @@ spec:
                                     type: string
                                   description: annotations added to the scheduled pod
                                   type: object
+                                disableFsGroupDefaulting:
+                                  description: disable automatic pod fsGroup inference/defaulting; explicit securityContext.fsGroup still applies
+                                  type: boolean
                                 dnsConfig:
                                   properties:
                                     nameservers:
@@ -19104,6 +19116,9 @@ spec:
                                     type: string
                                   description: annotations added to the scheduled pod
                                   type: object
+                                disableFsGroupDefaulting:
+                                  description: disable automatic pod fsGroup inference/defaulting; explicit securityContext.fsGroup still applies
+                                  type: boolean
                                 dnsConfig:
                                   properties:
                                     nameservers:
@@ -22661,6 +22676,9 @@ spec:
                                     type: string
                                   description: annotations added to the scheduled pod
                                   type: object
+                                disableFsGroupDefaulting:
+                                  description: disable automatic pod fsGroup inference/defaulting; explicit securityContext.fsGroup still applies
+                                  type: boolean
                                 dnsConfig:
                                   properties:
                                     nameservers:
@@ -24034,6 +24052,9 @@ spec:
                         type: string
                       description: annotations added to the scheduled pod
                       type: object
+                    disableFsGroupDefaulting:
+                      description: disable automatic pod fsGroup inference/defaulting; explicit securityContext.fsGroup still applies
+                      type: boolean
                     dnsConfig:
                       properties:
                         nameservers:
@@ -24864,6 +24885,9 @@ spec:
                               type: string
                             description: annotations added to the scheduled pod
                             type: object
+                          disableFsGroupDefaulting:
+                            description: disable automatic pod fsGroup inference/defaulting; explicit securityContext.fsGroup still applies
+                            type: boolean
                           dnsConfig:
                             properties:
                               nameservers:
@@ -28066,6 +28090,9 @@ spec:
                                     type: string
                                   description: annotations added to the scheduled pod
                                   type: object
+                                disableFsGroupDefaulting:
+                                  description: disable automatic pod fsGroup inference/defaulting; explicit securityContext.fsGroup still applies
+                                  type: boolean
                                 dnsConfig:
                                   properties:
                                     nameservers:
@@ -31285,6 +31312,9 @@ spec:
                                     type: string
                                   description: annotations added to the scheduled pod
                                   type: object
+                                disableFsGroupDefaulting:
+                                  description: disable automatic pod fsGroup inference/defaulting; explicit securityContext.fsGroup still applies
+                                  type: boolean
                                 dnsConfig:
                                   properties:
                                     nameservers:

--- a/k8s/helm/testkube-operator/charts/testkube-crds/templates/_generated_crds.tpl
+++ b/k8s/helm/testkube-operator/charts/testkube-crds/templates/_generated_crds.tpl
@@ -10216,6 +10216,9 @@ spec:
                                     type: string
                                   description: annotations added to the scheduled pod
                                   type: object
+                                disableFsGroupDefaulting:
+                                  description: disable automatic pod fsGroup inference/defaulting; explicit securityContext.fsGroup still applies
+                                  type: boolean
                                 dnsConfig:
                                   properties:
                                     nameservers:
@@ -11646,6 +11649,9 @@ spec:
                         type: string
                       description: annotations added to the scheduled pod
                       type: object
+                    disableFsGroupDefaulting:
+                      description: disable automatic pod fsGroup inference/defaulting; explicit securityContext.fsGroup still applies
+                      type: boolean
                     dnsConfig:
                       properties:
                         nameservers:
@@ -12476,6 +12482,9 @@ spec:
                               type: string
                             description: annotations added to the scheduled pod
                             type: object
+                          disableFsGroupDefaulting:
+                            description: disable automatic pod fsGroup inference/defaulting; explicit securityContext.fsGroup still applies
+                            type: boolean
                           dnsConfig:
                             properties:
                               nameservers:
@@ -15763,6 +15772,9 @@ spec:
                                     type: string
                                   description: annotations added to the scheduled pod
                                   type: object
+                                disableFsGroupDefaulting:
+                                  description: disable automatic pod fsGroup inference/defaulting; explicit securityContext.fsGroup still applies
+                                  type: boolean
                                 dnsConfig:
                                   properties:
                                     nameservers:
@@ -19104,6 +19116,9 @@ spec:
                                     type: string
                                   description: annotations added to the scheduled pod
                                   type: object
+                                disableFsGroupDefaulting:
+                                  description: disable automatic pod fsGroup inference/defaulting; explicit securityContext.fsGroup still applies
+                                  type: boolean
                                 dnsConfig:
                                   properties:
                                     nameservers:
@@ -22661,6 +22676,9 @@ spec:
                                     type: string
                                   description: annotations added to the scheduled pod
                                   type: object
+                                disableFsGroupDefaulting:
+                                  description: disable automatic pod fsGroup inference/defaulting; explicit securityContext.fsGroup still applies
+                                  type: boolean
                                 dnsConfig:
                                   properties:
                                     nameservers:
@@ -24034,6 +24052,9 @@ spec:
                         type: string
                       description: annotations added to the scheduled pod
                       type: object
+                    disableFsGroupDefaulting:
+                      description: disable automatic pod fsGroup inference/defaulting; explicit securityContext.fsGroup still applies
+                      type: boolean
                     dnsConfig:
                       properties:
                         nameservers:
@@ -24864,6 +24885,9 @@ spec:
                               type: string
                             description: annotations added to the scheduled pod
                             type: object
+                          disableFsGroupDefaulting:
+                            description: disable automatic pod fsGroup inference/defaulting; explicit securityContext.fsGroup still applies
+                            type: boolean
                           dnsConfig:
                             properties:
                               nameservers:
@@ -28066,6 +28090,9 @@ spec:
                                     type: string
                                   description: annotations added to the scheduled pod
                                   type: object
+                                disableFsGroupDefaulting:
+                                  description: disable automatic pod fsGroup inference/defaulting; explicit securityContext.fsGroup still applies
+                                  type: boolean
                                 dnsConfig:
                                   properties:
                                     nameservers:
@@ -31285,6 +31312,9 @@ spec:
                                     type: string
                                   description: annotations added to the scheduled pod
                                   type: object
+                                disableFsGroupDefaulting:
+                                  description: disable automatic pod fsGroup inference/defaulting; explicit securityContext.fsGroup still applies
+                                  type: boolean
                                 dnsConfig:
                                   properties:
                                     nameservers:

--- a/k8s/helm/testkube-runner/charts/testkube-crds/templates/_generated_crds.tpl
+++ b/k8s/helm/testkube-runner/charts/testkube-crds/templates/_generated_crds.tpl
@@ -10216,6 +10216,9 @@ spec:
                                     type: string
                                   description: annotations added to the scheduled pod
                                   type: object
+                                disableFsGroupDefaulting:
+                                  description: disable automatic pod fsGroup inference/defaulting; explicit securityContext.fsGroup still applies
+                                  type: boolean
                                 dnsConfig:
                                   properties:
                                     nameservers:
@@ -11646,6 +11649,9 @@ spec:
                         type: string
                       description: annotations added to the scheduled pod
                       type: object
+                    disableFsGroupDefaulting:
+                      description: disable automatic pod fsGroup inference/defaulting; explicit securityContext.fsGroup still applies
+                      type: boolean
                     dnsConfig:
                       properties:
                         nameservers:
@@ -12476,6 +12482,9 @@ spec:
                               type: string
                             description: annotations added to the scheduled pod
                             type: object
+                          disableFsGroupDefaulting:
+                            description: disable automatic pod fsGroup inference/defaulting; explicit securityContext.fsGroup still applies
+                            type: boolean
                           dnsConfig:
                             properties:
                               nameservers:
@@ -15763,6 +15772,9 @@ spec:
                                     type: string
                                   description: annotations added to the scheduled pod
                                   type: object
+                                disableFsGroupDefaulting:
+                                  description: disable automatic pod fsGroup inference/defaulting; explicit securityContext.fsGroup still applies
+                                  type: boolean
                                 dnsConfig:
                                   properties:
                                     nameservers:
@@ -19104,6 +19116,9 @@ spec:
                                     type: string
                                   description: annotations added to the scheduled pod
                                   type: object
+                                disableFsGroupDefaulting:
+                                  description: disable automatic pod fsGroup inference/defaulting; explicit securityContext.fsGroup still applies
+                                  type: boolean
                                 dnsConfig:
                                   properties:
                                     nameservers:
@@ -22661,6 +22676,9 @@ spec:
                                     type: string
                                   description: annotations added to the scheduled pod
                                   type: object
+                                disableFsGroupDefaulting:
+                                  description: disable automatic pod fsGroup inference/defaulting; explicit securityContext.fsGroup still applies
+                                  type: boolean
                                 dnsConfig:
                                   properties:
                                     nameservers:
@@ -24034,6 +24052,9 @@ spec:
                         type: string
                       description: annotations added to the scheduled pod
                       type: object
+                    disableFsGroupDefaulting:
+                      description: disable automatic pod fsGroup inference/defaulting; explicit securityContext.fsGroup still applies
+                      type: boolean
                     dnsConfig:
                       properties:
                         nameservers:
@@ -24864,6 +24885,9 @@ spec:
                               type: string
                             description: annotations added to the scheduled pod
                             type: object
+                          disableFsGroupDefaulting:
+                            description: disable automatic pod fsGroup inference/defaulting; explicit securityContext.fsGroup still applies
+                            type: boolean
                           dnsConfig:
                             properties:
                               nameservers:
@@ -28066,6 +28090,9 @@ spec:
                                     type: string
                                   description: annotations added to the scheduled pod
                                   type: object
+                                disableFsGroupDefaulting:
+                                  description: disable automatic pod fsGroup inference/defaulting; explicit securityContext.fsGroup still applies
+                                  type: boolean
                                 dnsConfig:
                                   properties:
                                     nameservers:
@@ -31285,6 +31312,9 @@ spec:
                                     type: string
                                   description: annotations added to the scheduled pod
                                   type: object
+                                disableFsGroupDefaulting:
+                                  description: disable automatic pod fsGroup inference/defaulting; explicit securityContext.fsGroup still applies
+                                  type: boolean
                                 dnsConfig:
                                   properties:
                                     nameservers:

--- a/pkg/api/v1/client/common_test.go
+++ b/pkg/api/v1/client/common_test.go
@@ -61,9 +61,9 @@ func TestStreamToTestWorkflowExecutionNotificationsChannel_HandlesSSEEventFields
 	}
 
 	require.Len(t, received, 2)
-	assert.Equal(t, uint32(7), received[0].SeqNo)
+	assert.Equal(t, int32(7), received[0].SeqNo)
 	assert.Equal(t, "heartbeat", received[0].EventType)
-	assert.Equal(t, uint32(8), received[1].SeqNo)
+	assert.Equal(t, int32(8), received[1].SeqNo)
 	assert.Equal(t, "log", received[1].EventType)
 	assert.Equal(t, "hello", received[1].Log)
 }

--- a/pkg/api/v1/testkube/model_test_workflow_execution_notification.go
+++ b/pkg/api/v1/testkube/model_test_workflow_execution_notification.go
@@ -17,7 +17,7 @@ type TestWorkflowExecutionNotification struct {
 	// timestamp for the notification if available
 	Ts time.Time `json:"ts,omitempty"`
 	// monotonic application-event cursor for resumable log streams
-	SeqNo uint32 `json:"seqNo,omitempty"`
+	SeqNo int32 `json:"seqNo,omitempty"`
 	// stream event type, such as log, output, result, ready, heartbeat, or resume_unavailable
 	EventType string              `json:"eventType,omitempty"`
 	Result    *TestWorkflowResult `json:"result,omitempty"`

--- a/pkg/api/v1/testkube/model_test_workflow_execution_schema.go
+++ b/pkg/api/v1/testkube/model_test_workflow_execution_schema.go
@@ -13,5 +13,6 @@ package testkube
 type TestWorkflowExecutionSchema struct {
 	Tags   map[string]string `json:"tags,omitempty"`
 	Target *ExecutionTarget  `json:"target,omitempty"`
-	Silent *bool             `json:"silent,omitempty"`
+	// indicates that all executions should be silent by default. When true, SilentMode is activated for all executions (Webhooks, Insights, Health, Metrics, Cdevents all set to true).
+	Silent bool `json:"silent,omitempty"`
 }

--- a/pkg/api/v1/testkube/model_test_workflow_pod_config.go
+++ b/pkg/api/v1/testkube/model_test_workflow_pod_config.go
@@ -26,6 +26,7 @@ type TestWorkflowPodConfig struct {
 	DnsPolicy                 string                     `json:"dnsPolicy,omitempty"`
 	NodeName                  string                     `json:"nodeName,omitempty"`
 	SecurityContext           *PodSecurityContext        `json:"securityContext,omitempty"`
+	DisableFsGroupDefaulting  *BoxedBoolean              `json:"disableFsGroupDefaulting,omitempty"`
 	Hostname                  string                     `json:"hostname,omitempty"`
 	Subdomain                 string                     `json:"subdomain,omitempty"`
 	Affinity                  *Affinity                  `json:"affinity,omitempty"`

--- a/pkg/api/v1/testkube/model_webhook.go
+++ b/pkg/api/v1/testkube/model_webhook.go
@@ -41,6 +41,5 @@ type Webhook struct {
 	Parameters         []WebhookParameterSchema      `json:"parameters,omitempty"`
 	WebhookTemplateRef *WebhookTemplateRef           `json:"webhookTemplateRef,omitempty"`
 	Sync               *Syncable                     `json:"sync,omitempty"`
-	// Target helps decide on which agent the webhook is executed.
-	Target *ExecutionTarget `json:"target,omitempty"`
+	Target             *ExecutionTarget              `json:"target,omitempty"`
 }

--- a/pkg/api/v1/testkube/model_webhook_create_request.go
+++ b/pkg/api/v1/testkube/model_webhook_create_request.go
@@ -41,6 +41,5 @@ type WebhookCreateRequest struct {
 	Parameters         []WebhookParameterSchema      `json:"parameters,omitempty"`
 	WebhookTemplateRef *WebhookTemplateRef           `json:"webhookTemplateRef,omitempty"`
 	Sync               *Syncable                     `json:"sync,omitempty"`
-	// Target helps decide on which agent the webhook is executed.
-	Target *ExecutionTarget `json:"target,omitempty"`
+	Target             *ExecutionTarget              `json:"target,omitempty"`
 }

--- a/pkg/api/v1/testkube/model_webhook_template.go
+++ b/pkg/api/v1/testkube/model_webhook_template.go
@@ -34,6 +34,5 @@ type WebhookTemplate struct {
 	Config     map[string]WebhookConfigValue `json:"config,omitempty"`
 	Parameters []WebhookParameterSchema      `json:"parameters,omitempty"`
 	Sync       *Syncable                     `json:"sync,omitempty"`
-	// Target helps decide on which agent the webhook is executed.
-	Target *ExecutionTarget `json:"target,omitempty"`
+	Target     *ExecutionTarget              `json:"target,omitempty"`
 }

--- a/pkg/api/v1/testkube/model_webhook_template_create_request.go
+++ b/pkg/api/v1/testkube/model_webhook_template_create_request.go
@@ -34,6 +34,5 @@ type WebhookTemplateCreateRequest struct {
 	Config     map[string]WebhookConfigValue `json:"config,omitempty"`
 	Parameters []WebhookParameterSchema      `json:"parameters,omitempty"`
 	Sync       *Syncable                     `json:"sync,omitempty"`
-	// Target helps decide on which agent the webhook is executed.
-	Target *ExecutionTarget `json:"target,omitempty"`
+	Target     *ExecutionTarget              `json:"target,omitempty"`
 }

--- a/pkg/api/v1/testkube/model_webhook_template_update_request.go
+++ b/pkg/api/v1/testkube/model_webhook_template_update_request.go
@@ -34,6 +34,5 @@ type WebhookTemplateUpdateRequest struct {
 	Config     *map[string]WebhookConfigValue `json:"config,omitempty"`
 	Parameters *[]WebhookParameterSchema      `json:"parameters,omitempty"`
 	Sync       *Syncable                      `json:"sync,omitempty"`
-	// Target helps decide on which agent the webhook is executed.
-	Target **ExecutionTarget `json:"target,omitempty"`
+	Target     *ExecutionTarget               `json:"target,omitempty"`
 }

--- a/pkg/api/v1/testkube/model_webhook_update_request.go
+++ b/pkg/api/v1/testkube/model_webhook_update_request.go
@@ -41,6 +41,5 @@ type WebhookUpdateRequest struct {
 	Parameters         *[]WebhookParameterSchema      `json:"parameters,omitempty"`
 	WebhookTemplateRef **WebhookTemplateRef           `json:"webhookTemplateRef,omitempty"`
 	Sync               *Syncable                      `json:"sync,omitempty"`
-	// Target helps decide on which agent the webhook is executed.
-	Target **ExecutionTarget `json:"target,omitempty"`
+	Target             *ExecutionTarget               `json:"target,omitempty"`
 }

--- a/pkg/mapper/testworkflows/kube_openapi.go
+++ b/pkg/mapper/testworkflows/kube_openapi.go
@@ -779,6 +779,7 @@ func MapPodConfigKubeToAPI(v testworkflowsv1.PodConfig) testkube.TestWorkflowPod
 		DnsPolicy:                 common.MapEnumToString(v.DNSPolicy),
 		NodeName:                  v.NodeName,
 		SecurityContext:           common.MapPtr(v.SecurityContext, MapPodSecurityContextKubeToAPI),
+		DisableFsGroupDefaulting:  MapBoolToBoxedBoolean(v.DisableFsGroupDefaulting),
 		Hostname:                  v.Hostname,
 		Subdomain:                 v.Subdomain,
 		Affinity:                  common.MapPtr(v.Affinity, MapAffinityKubeToAPI),
@@ -1385,7 +1386,7 @@ func MapTestWorkflowTagSchemaKubeToAPI(v testworkflowsv1.TestWorkflowExecutionSc
 	return testkube.TestWorkflowExecutionSchema{
 		Tags:   v.Tags,
 		Target: common.MapPtr(v.Target, commonmapper.MapTargetKubeToAPI),
-		Silent: v.Silent,
+		Silent: common.ResolvePtr(v.Silent, false),
 	}
 }
 

--- a/pkg/mapper/testworkflows/openapi_kube.go
+++ b/pkg/mapper/testworkflows/openapi_kube.go
@@ -816,6 +816,7 @@ func MapPodConfigAPIToKube(v testkube.TestWorkflowPodConfig) testworkflowsv1.Pod
 		DNSPolicy:                 corev1.DNSPolicy(v.DnsPolicy),
 		NodeName:                  v.NodeName,
 		SecurityContext:           common.MapPtr(v.SecurityContext, MapPodSecurityContextAPIToKube),
+		DisableFsGroupDefaulting:  MapBoxedBooleanToBool(v.DisableFsGroupDefaulting),
 		Hostname:                  v.Hostname,
 		Subdomain:                 v.Subdomain,
 		Affinity:                  common.MapPtr(v.Affinity, MapAffinityAPIToKube),
@@ -1624,7 +1625,7 @@ func MapTestWorkflowTagSchemaAPIToKube(v testkube.TestWorkflowExecutionSchema) t
 	return testworkflowsv1.TestWorkflowExecutionSchema{
 		Tags:   v.Tags,
 		Target: common.MapPtr(v.Target, commonmapper.MapTargetApiToKube),
-		Silent: v.Silent,
+		Silent: common.PtrOrNil(v.Silent),
 	}
 }
 

--- a/pkg/mapper/webhooks/mapper.go
+++ b/pkg/mapper/webhooks/mapper.go
@@ -280,7 +280,7 @@ func MapUpdateToSpec(request testkube.WebhookUpdateRequest, webhook *executorv1.
 	}
 
 	if request.Target != nil {
-		webhook.Spec.Target = common.MapPtr(*request.Target, commonmapper.MapTargetApiToKube)
+		webhook.Spec.Target = common.MapPtr(request.Target, commonmapper.MapTargetApiToKube)
 	}
 
 	return webhook
@@ -336,7 +336,7 @@ func MapSpecToUpdate(webhook *executorv1.Webhook) (request testkube.WebhookUpdat
 	request.Config = common.Ptr(common.MapMap(webhook.Spec.Config, MapConfigValueCRDToAPI))
 	request.Parameters = common.Ptr(common.MapSlice(webhook.Spec.Parameters, MapParameterSchemaCRDToAPI))
 	request.WebhookTemplateRef = common.Ptr(common.MapPtr(webhook.Spec.WebhookTemplateRef, MapTemplateRefCRDToAPI))
-	request.Target = common.Ptr(common.MapPtr(webhook.Spec.Target, commonmapper.MapTargetKubeToAPI))
+	request.Target = common.MapPtr(webhook.Spec.Target, commonmapper.MapTargetKubeToAPI)
 
 	return request
 }

--- a/pkg/mapper/webhooktemplates/mapper.go
+++ b/pkg/mapper/webhooktemplates/mapper.go
@@ -222,7 +222,7 @@ func MapUpdateToSpec(request testkube.WebhookTemplateUpdateRequest, webhookTempl
 	}
 
 	if request.Target != nil {
-		webhookTemplate.Spec.Target = common.MapPtr(*request.Target, commonmapper.MapTargetApiToKube)
+		webhookTemplate.Spec.Target = common.MapPtr(request.Target, commonmapper.MapTargetApiToKube)
 	}
 
 	return webhookTemplate
@@ -277,7 +277,7 @@ func MapSpecToUpdate(webhookTemplate *executorv1.WebhookTemplate) (request testk
 	request.Disabled = &webhookTemplate.Spec.Disabled
 	request.Config = common.Ptr(common.MapMap(webhookTemplate.Spec.Config, MapConfigValueCRDToAPI))
 	request.Parameters = common.Ptr(common.MapSlice(webhookTemplate.Spec.Parameters, MapParameterSchemaCRDToAPI))
-	request.Target = common.Ptr(common.MapPtr(webhookTemplate.Spec.Target, commonmapper.MapTargetKubeToAPI))
+	request.Target = common.MapPtr(webhookTemplate.Spec.Target, commonmapper.MapTargetKubeToAPI)
 
 	return request
 }

--- a/pkg/tcl/testworkflowstcl/testworkflowprocessor/operations.go
+++ b/pkg/tcl/testworkflowstcl/testworkflowprocessor/operations.go
@@ -127,17 +127,11 @@ func ProcessParallel(_ testworkflowprocessor.InternalProcessor, layer testworkfl
 		EnableToolkit(stage.Ref()).
 		AppendVolumeMounts(layer.AddEmptyDirVolume(nil, constants.DefaultTransferDirPath))
 
-	// Pass down image pull secrets
-	parallel := step.Parallel
-	if pod := layer.PodConfig(); len(pod.ImagePullSecrets) > 0 {
-		parallel = parallel.DeepCopy()
-		if parallel.Pod == nil {
-			parallel.Pod = &testworkflowsv1.PodConfig{}
-		} else {
-			parallel.Pod = parallel.Pod.DeepCopy()
-		}
-		parallel.Pod.ImagePullSecrets = append(parallel.Pod.ImagePullSecrets, pod.ImagePullSecrets...)
-	}
+	// Parallel workers should inherit the resolved root pod config, while allowing
+	// the parallel block to override any pod-level fields explicitly.
+	parallel := step.Parallel.DeepCopy()
+	pod := layer.PodConfig()
+	parallel.Pod = testworkflowresolver.MergePodConfig(pod.DeepCopy(), parallel.Pod)
 
 	// Base64 encode to prevent testworkflow-init from prematurely resolving expressions.
 	// The parallel spec can contain expressions that need matrix/shard/count variables

--- a/pkg/testworkflows/testworkflowprocessor/presets/processor_test.go
+++ b/pkg/testworkflows/testworkflowprocessor/presets/processor_test.go
@@ -1095,6 +1095,35 @@ func TestProcessShellDisableFsGroupDefaulting(t *testing.T) {
 
 func TestProcessParallelWorkerDisableFsGroupDefaulting(t *testing.T) {
 	wf := &testworkflowsv1.TestWorkflow{
+		Spec: testworkflowsv1.TestWorkflowSpec{
+			TestWorkflowSpecBase: testworkflowsv1.TestWorkflowSpecBase{
+				Pod: &testworkflowsv1.PodConfig{
+					DisableFsGroupDefaulting: common.Ptr(true),
+				},
+			},
+			Steps: []testworkflowsv1.Step{{
+				Parallel: &testworkflowsv1.StepParallel{
+					Steps: []testworkflowsv1.Step{
+						{StepOperations: testworkflowsv1.StepOperations{Run: &testworkflowsv1.StepRun{Shell: common.Ptr("shell-test")}}},
+					},
+				},
+			}},
+		},
+	}
+
+	res, err := proc.Bundle(context.Background(), wf, testworkflowprocessor.BundleOptions{Config: testConfig})
+
+	assert.NoError(t, err)
+	if assert.NotNil(t, res.Job.Spec.Template.Spec.SecurityContext) {
+		assert.Nil(t, res.Job.Spec.Template.Spec.SecurityContext.FSGroup)
+	}
+	if assert.Len(t, res.Job.Spec.Template.Spec.Containers, 1) && res.Job.Spec.Template.Spec.Containers[0].SecurityContext != nil {
+		assert.Nil(t, res.Job.Spec.Template.Spec.Containers[0].SecurityContext.RunAsGroup)
+	}
+}
+
+func TestProcessParallelWorkerDisableFsGroupDefaultingOverride(t *testing.T) {
+	wf := &testworkflowsv1.TestWorkflow{
 		Spec: *(&testworkflowsv1.StepParallel{
 			Pod: &testworkflowsv1.PodConfig{
 				DisableFsGroupDefaulting: common.Ptr(true),

--- a/pkg/testworkflows/testworkflowprocessor/presets/processor_test.go
+++ b/pkg/testworkflows/testworkflowprocessor/presets/processor_test.go
@@ -398,6 +398,37 @@ func TestProcessShellWithNonStandardImage(t *testing.T) {
 	assert.True(t, volumeMounts[3].Name == volumes[3].Name)
 }
 
+func TestProcessShellWithNonStandardImageDisableFsGroupDefaulting(t *testing.T) {
+	wf := &testworkflowsv1.TestWorkflow{
+		Spec: testworkflowsv1.TestWorkflowSpec{
+			TestWorkflowSpecBase: testworkflowsv1.TestWorkflowSpecBase{
+				Pod: &testworkflowsv1.PodConfig{
+					DisableFsGroupDefaulting: common.Ptr(true),
+				},
+			},
+			Steps: []testworkflowsv1.Step{
+				{
+					StepDefaults:   testworkflowsv1.StepDefaults{Container: &testworkflowsv1.ContainerConfig{Image: "custom:1.2.3"}},
+					StepOperations: testworkflowsv1.StepOperations{Shell: "shell-test"},
+				},
+			},
+		},
+	}
+
+	res, err := proc.Bundle(context.Background(), wf, testworkflowprocessor.BundleOptions{Config: testConfig, ScheduledAt: dummyTime})
+
+	assert.NoError(t, err)
+	if assert.NotNil(t, res.Job.Spec.Template.Spec.SecurityContext) {
+		assert.Nil(t, res.Job.Spec.Template.Spec.SecurityContext.FSGroup)
+	}
+	if assert.Len(t, res.Job.Spec.Template.Spec.Containers, 1) && assert.NotNil(t, res.Job.Spec.Template.Spec.Containers[0].SecurityContext) {
+		assert.Equal(t, common.Ptr(int64(dummyGroupId)), res.Job.Spec.Template.Spec.Containers[0].SecurityContext.RunAsGroup)
+	}
+	if assert.Len(t, res.Job.Spec.Template.Spec.InitContainers, 1) && res.Job.Spec.Template.Spec.InitContainers[0].SecurityContext != nil {
+		assert.Nil(t, res.Job.Spec.Template.Spec.InitContainers[0].SecurityContext.RunAsGroup)
+	}
+}
+
 func TestProcessBasicEnvReference(t *testing.T) {
 	wf := &testworkflowsv1.TestWorkflow{
 		Spec: testworkflowsv1.TestWorkflowSpec{
@@ -1007,6 +1038,82 @@ func TestProcessShell(t *testing.T) {
 
 	assert.NoError(t, err)
 	assert.Equal(t, want, res.LiteActions())
+}
+
+func TestProcessShellExplicitFsGroup(t *testing.T) {
+	explicitFsGroup := int64(2222)
+	wf := &testworkflowsv1.TestWorkflow{
+		Spec: testworkflowsv1.TestWorkflowSpec{
+			TestWorkflowSpecBase: testworkflowsv1.TestWorkflowSpecBase{
+				Pod: &testworkflowsv1.PodConfig{
+					SecurityContext: &corev1.PodSecurityContext{
+						FSGroup: common.Ptr(explicitFsGroup),
+					},
+				},
+			},
+			Steps: []testworkflowsv1.Step{
+				{StepOperations: testworkflowsv1.StepOperations{Run: &testworkflowsv1.StepRun{Shell: common.Ptr("shell-test")}}},
+			},
+		},
+	}
+
+	res, err := proc.Bundle(context.Background(), wf, testworkflowprocessor.BundleOptions{Config: testConfig})
+
+	assert.NoError(t, err)
+	if assert.NotNil(t, res.Job.Spec.Template.Spec.SecurityContext) {
+		assert.Equal(t, common.Ptr(explicitFsGroup), res.Job.Spec.Template.Spec.SecurityContext.FSGroup)
+	}
+	if assert.Len(t, res.Job.Spec.Template.Spec.Containers, 1) && assert.NotNil(t, res.Job.Spec.Template.Spec.Containers[0].SecurityContext) {
+		assert.Equal(t, common.Ptr(explicitFsGroup), res.Job.Spec.Template.Spec.Containers[0].SecurityContext.RunAsGroup)
+	}
+}
+
+func TestProcessShellDisableFsGroupDefaulting(t *testing.T) {
+	wf := &testworkflowsv1.TestWorkflow{
+		Spec: testworkflowsv1.TestWorkflowSpec{
+			TestWorkflowSpecBase: testworkflowsv1.TestWorkflowSpecBase{
+				Pod: &testworkflowsv1.PodConfig{
+					DisableFsGroupDefaulting: common.Ptr(true),
+				},
+			},
+			Steps: []testworkflowsv1.Step{
+				{StepOperations: testworkflowsv1.StepOperations{Run: &testworkflowsv1.StepRun{Shell: common.Ptr("shell-test")}}},
+			},
+		},
+	}
+
+	res, err := proc.Bundle(context.Background(), wf, testworkflowprocessor.BundleOptions{Config: testConfig})
+
+	assert.NoError(t, err)
+	if assert.NotNil(t, res.Job.Spec.Template.Spec.SecurityContext) {
+		assert.Nil(t, res.Job.Spec.Template.Spec.SecurityContext.FSGroup)
+	}
+	if assert.Len(t, res.Job.Spec.Template.Spec.Containers, 1) && res.Job.Spec.Template.Spec.Containers[0].SecurityContext != nil {
+		assert.Nil(t, res.Job.Spec.Template.Spec.Containers[0].SecurityContext.RunAsGroup)
+	}
+}
+
+func TestProcessParallelWorkerDisableFsGroupDefaulting(t *testing.T) {
+	wf := &testworkflowsv1.TestWorkflow{
+		Spec: *(&testworkflowsv1.StepParallel{
+			Pod: &testworkflowsv1.PodConfig{
+				DisableFsGroupDefaulting: common.Ptr(true),
+			},
+			Steps: []testworkflowsv1.Step{
+				{StepOperations: testworkflowsv1.StepOperations{Run: &testworkflowsv1.StepRun{Shell: common.Ptr("shell-test")}}},
+			},
+		}).NewTestWorkflowSpec(),
+	}
+
+	res, err := proc.Bundle(context.Background(), wf, testworkflowprocessor.BundleOptions{Config: testConfig})
+
+	assert.NoError(t, err)
+	if assert.NotNil(t, res.Job.Spec.Template.Spec.SecurityContext) {
+		assert.Nil(t, res.Job.Spec.Template.Spec.SecurityContext.FSGroup)
+	}
+	if assert.Len(t, res.Job.Spec.Template.Spec.Containers, 1) && res.Job.Spec.Template.Spec.Containers[0].SecurityContext != nil {
+		assert.Nil(t, res.Job.Spec.Template.Spec.Containers[0].SecurityContext.RunAsGroup)
+	}
 }
 
 func TestProcessConsecutiveAlways(t *testing.T) {

--- a/pkg/testworkflows/testworkflowprocessor/processor.go
+++ b/pkg/testworkflows/testworkflowprocessor/processor.go
@@ -256,6 +256,7 @@ func (p *processor) Bundle(ctx context.Context, workflow *testworkflowsv1.TestWo
 	if err != nil {
 		return nil, errors.Wrap(err, "finalizing pod config")
 	}
+	disableFsGroupDefaulting := podConfig.DisableFsGroupDefaulting != nil && *podConfig.DisableFsGroupDefaulting
 
 	// Build signature
 	sig := root.Signature().Children()
@@ -310,13 +311,16 @@ func (p *processor) Bundle(ctx context.Context, workflow *testworkflowsv1.TestWo
 			sc.RunAsGroup = common.Ptr(images[image].Group)
 			otherContainers[0].Container().SetSecurityContext(sc)
 		}
-		if podConfig.SecurityContext.FSGroup == nil {
+		if !disableFsGroupDefaulting && podConfig.SecurityContext.FSGroup == nil {
 			podConfig.SecurityContext.FSGroup = sc.RunAsGroup
 		}
 	}
 
 	// Determine FS Group for the containers
-	fsGroup := common.Ptr(constants.DefaultFsGroup)
+	var fsGroup *int64
+	if !disableFsGroupDefaulting {
+		fsGroup = common.Ptr(constants.DefaultFsGroup)
+	}
 	if podConfig.SecurityContext != nil && podConfig.SecurityContext.FSGroup != nil {
 		fsGroup = podConfig.SecurityContext.FSGroup
 	}
@@ -407,7 +411,7 @@ func (p *processor) Bundle(ctx context.Context, workflow *testworkflowsv1.TestWo
 	if podConfig.SecurityContext == nil {
 		podConfig.SecurityContext = &corev1.PodSecurityContext{}
 	}
-	if podConfig.SecurityContext.FSGroup == nil {
+	if !disableFsGroupDefaulting && podConfig.SecurityContext.FSGroup == nil {
 		podConfig.SecurityContext.FSGroup = common.Ptr(constants.DefaultFsGroup)
 	}
 	hostPID := false

--- a/pkg/testworkflows/testworkflowresolver/merge.go
+++ b/pkg/testworkflows/testworkflowresolver/merge.go
@@ -41,6 +41,9 @@ func MergePodConfig(dst, include *testworkflowsv1.PodConfig) *testworkflowsv1.Po
 		dst.NodeName = include.NodeName
 	}
 	dst.SecurityContext = MergePodSecurityContext(dst.SecurityContext, include.SecurityContext)
+	if include.DisableFsGroupDefaulting != nil {
+		dst.DisableFsGroupDefaulting = include.DisableFsGroupDefaulting
+	}
 	if include.Hostname != "" {
 		dst.Hostname = include.Hostname
 	}

--- a/pkg/testworkflows/utils.go
+++ b/pkg/testworkflows/utils.go
@@ -33,10 +33,10 @@ func FlattenSignatures(sig []testkube.TestWorkflowSignature) []testkube.TestWork
 }
 
 func IsWorkflowSilent(workflow *testkube.TestWorkflow) bool {
-	if workflow == nil || workflow.Spec == nil || workflow.Spec.Execution == nil || workflow.Spec.Execution.Silent == nil {
+	if workflow == nil || workflow.Spec == nil || workflow.Spec.Execution == nil {
 		return false
 	}
-	return *workflow.Spec.Execution.Silent
+	return workflow.Spec.Execution.Silent
 }
 
 // NewSilenceAllSilentMode returns a SilentMode that silences all processing.


### PR DESCRIPTION
## Summary
- add `spec.pod.disableFsGroupDefaulting` to opt out of automatic pod `fsGroup` defaulting
- honor the opt-out in the TestWorkflow processor for normal workflow jobs and parallel worker jobs
- regenerate OpenAPI and CRD artifacts and update affected mapper/test call sites to match generated model changes
