### PR TITLE
fix: update exportArchiveMaxSize to string format in values.yaml

### DIFF
--- a/cmd/kubectl-testkube/commands/pro/connect_test.go
+++ b/cmd/kubectl-testkube/commands/pro/connect_test.go
@@ -32,11 +32,11 @@ func TestHelmRelease_JSONParsing(t *testing.T) {
 
 func TestHelmRelease_FindRunnerChartPrefix(t *testing.T) {
 	tests := []struct {
-		name          string
-		releases      []helmRelease
-		expectName    string
-		expectNs      string
-		expectFound   bool
+		name        string
+		releases    []helmRelease
+		expectName  string
+		expectNs    string
+		expectFound bool
 	}{
 		{
 			name: "runner release found",

--- a/k8s/helm/testkube/values.yaml
+++ b/k8s/helm/testkube/values.yaml
@@ -543,7 +543,7 @@ testkube-api:
   enableDebugMode: false
 
   # Maximum export archive size in bytes (default 100 MB). Set to 0 to use the compiled-in default.
-  exportArchiveMaxSize: 104857600
+  exportArchiveMaxSize: "104857600"
 
   # jobPodAnnotations adds annotations to the pods spawned to execute tests using
   # prebuilt and container executors.


### PR DESCRIPTION
## Pull request description 

Fixes property that is passing as number and generating an error when deploying agent.

## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [x] tested locally
- [x] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Fixes

- Threat as string a number value that will be a deployment env var. 