### PR TITLE
feat: [TKC-5376] add Google as CLI login method

### DIFF
--- a/cmd/kubectl-testkube/commands/common/helper.go
+++ b/cmd/kubectl-testkube/commands/common/helper.go
@@ -62,6 +62,7 @@ type HelmGenericOptions struct {
 const (
 	github                = "GitHub"
 	gitlab                = "GitLab"
+	google                = "Google"
 	dockerDaemonPrefixLen = 8
 	latestReleaseUrl      = "https://api.github.com/repos/kubeshop/testkube/releases/latest"
 )
@@ -610,7 +611,7 @@ func LoginUser(authUri string, customConnector bool, port int) (string, string, 
 	ui.H1("Login")
 	connectorID := ""
 	if !customConnector {
-		connectorID = ui.Select("Choose your login method", []string{github, gitlab})
+		connectorID = ui.Select("Choose your login method", []string{github, gitlab, google})
 	}
 
 	// Handle the common case where th Demo instance is running on reserved port

--- a/cmd/kubectl-testkube/commands/pro/connect.go
+++ b/cmd/kubectl-testkube/commands/pro/connect.go
@@ -1,6 +1,7 @@
 package pro
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -340,7 +341,7 @@ func findRunnerRelease() (releaseName, namespace string) {
 		ui.Warn("findRunnerRelease: helm not found in PATH")
 		return "", ""
 	}
-	out, execErr := exec.Command(helmPath, "list", "--all-namespaces", "--output", "json").CombinedOutput()
+	out, execErr := exec.CommandContext(context.Background(), helmPath, "list", "--all-namespaces", "--output", "json").CombinedOutput()
 	if execErr != nil {
 		ui.Warn(fmt.Sprintf("findRunnerRelease: helm list failed: %s", execErr))
 		return "", ""

--- a/cmd/kubectl-testkube/commands/pro/connect_test.go
+++ b/cmd/kubectl-testkube/commands/pro/connect_test.go
@@ -32,11 +32,11 @@ func TestHelmRelease_JSONParsing(t *testing.T) {
 
 func TestHelmRelease_FindRunnerChartPrefix(t *testing.T) {
 	tests := []struct {
-		name          string
-		releases      []helmRelease
-		expectName    string
-		expectNs      string
-		expectFound   bool
+		name        string
+		releases    []helmRelease
+		expectName  string
+		expectNs    string
+		expectFound bool
 	}{
 		{
 			name: "runner release found",


### PR DESCRIPTION
## Summary

Adds **Google** as a selectable login method in `testkube pro login` / `testkube login`, alongside GitHub and GitLab. GitLab is retained -> users still authenticate through it. No backend changes -> Dex already has the `google` connector configured and `/auth/validate?connector_id=google` returns 200 in dev.

Linear: https://linear.app/kubeshop/issue/TKC-5376

## Implementation

- `cmd/kubectl-testkube/commands/common/helper.go` -> add `google = "Google"` constant and include it in `ui.Select` options. Display label lowercases to the Dex connector id (`"Google"` -> `"google"`) via the existing `strings.ToLower` call, so no other code paths change.
- Order matches the UI (`js/packages/web/src/services/auth.tsx`): GitHub -> GitLab -> Google.
