### PR TITLE
feat: [TKC-5376] add email magic-link login to CLI

### DIFF
--- a/cmd/kubectl-testkube/cloudlogin/login.go
+++ b/cmd/kubectl-testkube/cloudlogin/login.go
@@ -1,6 +1,7 @@
 package cloudlogin
 
 import (
+	"bytes"
 	"context"
 	"crypto/rand"
 	"crypto/sha256"
@@ -13,6 +14,7 @@ import (
 	"net/url"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/coreos/go-oidc"
 	"golang.org/x/oauth2"
@@ -230,6 +232,232 @@ func generateCodeVerifier() (string, error) {
 func generateCodeChallenge(verifier string) string {
 	hash := sha256.Sum256([]byte(verifier))
 	return base64.RawURLEncoding.EncodeToString(hash[:])
+}
+
+func CloudLoginEmailLink(ctx context.Context, apiBaseURL, email string, port int) (chan Tokens, error) {
+	if err := checkPortAvailable(port); err != nil {
+		return nil, err
+	}
+
+	if !strings.HasSuffix(apiBaseURL, "/") {
+		apiBaseURL += "/"
+	}
+
+	// The callback only needs the oobCode; the email is the one the caller
+	// already passed to requestEmailLink, so trusting a query param is both
+	// unnecessary and a gratuitous trust surface.
+	oobCh := make(chan string, 1)
+	mux := http.NewServeMux()
+	mux.HandleFunc("/callback", func(w http.ResponseWriter, r *http.Request) {
+		oobCode := r.URL.Query().Get("oobCode")
+		if oobCode == "" {
+			w.WriteHeader(http.StatusBadRequest)
+			fmt.Fprintln(w, "Authorization failed: missing oobCode.")
+			// Don't signal on malformed callbacks — let the caller's timeout
+			// surface the error rather than completing with empty tokens.
+			return
+		}
+		fmt.Fprintln(w, "<script>window.close()</script>")
+		fmt.Fprintln(w, "Your testkube CLI is now successfully authenticated. Go back to the terminal to continue.")
+		select {
+		case oobCh <- oobCode:
+		default: // drop duplicate clicks
+		}
+	})
+	srv := &http.Server{Addr: getServerAddress(port), Handler: mux}
+	go func() {
+		srv.ListenAndServe()
+	}()
+
+	if err := requestEmailLink(ctx, apiBaseURL, email, getRedirectAddress(port)); err != nil {
+		srv.Close()
+		return nil, err
+	}
+
+	respCh := make(chan Tokens, 1)
+
+	go func() {
+		defer srv.Close()
+
+		var oobCode string
+		select {
+		case oobCode = <-oobCh:
+		case <-ctx.Done():
+			respCh <- Tokens{}
+			return
+		}
+
+		tokens, err := exchangeOOBCodeForTokens(ctx, apiBaseURL, email, oobCode)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Failed to exchange oobCode for tokens: %v\n", err)
+			respCh <- Tokens{}
+			return
+		}
+
+		respCh <- tokens
+	}()
+
+	return respCh, nil
+}
+
+// requestEmailLink asks the control plane to generate and email a sign-in link.
+// The `state=redirect=<url>` convention is what HandleOutOfBandGenerateLink expects
+// (see internal/auth/controller/out_of_band_flow.go).
+func requestEmailLink(ctx context.Context, apiBaseURL, email, redirectURL string) error {
+	form := url.Values{}
+	form.Set("email", email)
+	form.Set("state", "redirect="+redirectURL)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, apiBaseURL+"auth/link", strings.NewReader(form.Encode()))
+	if err != nil {
+		return fmt.Errorf("failed to build email-link request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("failed to request email link: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("email link request failed with status %d: %s", resp.StatusCode, string(body))
+	}
+	return nil
+}
+
+func exchangeOOBCodeForTokens(ctx context.Context, apiBaseURL, email, oobCode string) (Tokens, error) {
+	u, err := url.Parse(apiBaseURL + "auth/login/link")
+	if err != nil {
+		return Tokens{}, fmt.Errorf("invalid auth/login/link URL: %w", err)
+	}
+	q := u.Query()
+	q.Set("email", email)
+	q.Set("oobCode", oobCode)
+	u.RawQuery = q.Encode()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, u.String(), nil)
+	if err != nil {
+		return Tokens{}, fmt.Errorf("failed to build oobCode exchange request: %w", err)
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return Tokens{}, fmt.Errorf("failed to exchange oobCode: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return Tokens{}, fmt.Errorf("oobCode exchange failed with status %d: %s", resp.StatusCode, string(body))
+	}
+
+	var tokenResponse struct {
+		IDToken      string `json:"idToken"`
+		RefreshToken string `json:"refreshToken"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&tokenResponse); err != nil {
+		return Tokens{}, fmt.Errorf("failed to decode oobCode exchange response: %w", err)
+	}
+
+	return Tokens{
+		IDToken:      tokenResponse.IDToken,
+		RefreshToken: tokenResponse.RefreshToken,
+	}, nil
+}
+
+// RefreshEmailLinkToken returns a non-expired ID token, refreshing via the
+// control plane only when the current idToken is within 60s of expiry. Matches
+// the verify-first pattern used by CheckAndRefreshToken for OIDC so the common
+// case (token still valid) doesn't hit the network.
+func RefreshEmailLinkToken(ctx context.Context, apiBaseURL, idToken, refreshToken string) (string, string, error) {
+	if idToken != "" && !jwtExpired(idToken, 60*time.Second) {
+		return idToken, refreshToken, nil
+	}
+
+	if !strings.HasSuffix(apiBaseURL, "/") {
+		apiBaseURL += "/"
+	}
+
+	body, err := json.Marshal(map[string]string{"refreshToken": refreshToken})
+	if err != nil {
+		return "", "", fmt.Errorf("failed to marshal refresh request: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, apiBaseURL+"auth/callback?method=emailLink", bytes.NewReader(body))
+	if err != nil {
+		return "", "", fmt.Errorf("failed to build refresh request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return "", "", fmt.Errorf("failed to refresh email-link token: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		b, _ := io.ReadAll(resp.Body)
+		return "", "", fmt.Errorf("email-link refresh failed with status %d: %s", resp.StatusCode, string(b))
+	}
+
+	var refreshResp struct {
+		IDToken      string `json:"idToken"`
+		RefreshToken string `json:"refreshToken"`
+		AccessToken  string `json:"accessToken"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&refreshResp); err != nil {
+		return "", "", fmt.Errorf("failed to decode refresh response: %w", err)
+	}
+	return refreshResp.IDToken, refreshResp.RefreshToken, nil
+}
+
+// decodeJWTPayload returns the raw JSON payload of a JWT without verifying its
+// signature. Returns nil on any parse failure.
+func decodeJWTPayload(token string) []byte {
+	parts := strings.Split(token, ".")
+	if len(parts) != 3 {
+		return nil
+	}
+	payload, err := base64.RawURLEncoding.DecodeString(parts[1])
+	if err != nil {
+		return nil
+	}
+	return payload
+}
+
+// jwtExpired reports whether a JWT's `exp` claim is already past (accounting for
+// the provided skew). Returns true on any parse failure, so the caller errs on
+// the side of refreshing rather than trusting an unparseable token.
+func jwtExpired(token string, skew time.Duration) bool {
+	payload := decodeJWTPayload(token)
+	if payload == nil {
+		return true
+	}
+	var claims struct {
+		Exp int64 `json:"exp"`
+	}
+	if err := json.Unmarshal(payload, &claims); err != nil || claims.Exp == 0 {
+		return true
+	}
+	return time.Now().Add(skew).After(time.Unix(claims.Exp, 0))
+}
+
+// EmailFromIDToken returns the `email` claim from an ID token's payload without
+// verifying the signature. Empty string on any parse failure.
+func EmailFromIDToken(token string) string {
+	payload := decodeJWTPayload(token)
+	if payload == nil {
+		return ""
+	}
+	var claims struct {
+		Email string `json:"email"`
+	}
+	if err := json.Unmarshal(payload, &claims); err != nil {
+		return ""
+	}
+	return claims.Email
 }
 
 func exchangeCodeForTokens(apiBaseURL, code, codeVerifier string, port int) (Tokens, error) {

--- a/cmd/kubectl-testkube/cloudlogin/login_test.go
+++ b/cmd/kubectl-testkube/cloudlogin/login_test.go
@@ -1,0 +1,245 @@
+package cloudlogin
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// makeJWT builds an unsigned JWT with the given payload claims. Header/signature
+// are filler — only the payload base64 is meaningful for the helpers under test.
+func makeJWT(t *testing.T, claims map[string]any) string {
+	t.Helper()
+	payload, err := json.Marshal(claims)
+	require.NoError(t, err)
+	enc := func(b []byte) string { return base64.RawURLEncoding.EncodeToString(b) }
+	return enc([]byte(`{"alg":"none"}`)) + "." + enc(payload) + ".sig"
+}
+
+func TestJwtExpired(t *testing.T) {
+	now := time.Now()
+	tests := map[string]struct {
+		token string
+		skew  time.Duration
+		want  bool
+	}{
+		"valid token with future exp":    {token: makeJWT(t, map[string]any{"exp": now.Add(10 * time.Minute).Unix()}), skew: time.Minute, want: false},
+		"token expired past skew":        {token: makeJWT(t, map[string]any{"exp": now.Add(-time.Minute).Unix()}), skew: time.Minute, want: true},
+		"token expiring within skew":     {token: makeJWT(t, map[string]any{"exp": now.Add(30 * time.Second).Unix()}), skew: time.Minute, want: true},
+		"missing exp claim":              {token: makeJWT(t, map[string]any{"sub": "abc"}), skew: time.Minute, want: true},
+		"malformed token (not 3 parts)":  {token: "abc.def", skew: time.Minute, want: true},
+		"malformed payload (bad base64)": {token: "abc.!!!.sig", skew: time.Minute, want: true},
+		"empty token":                    {token: "", skew: time.Minute, want: true},
+	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, tc.want, jwtExpired(tc.token, tc.skew))
+		})
+	}
+}
+
+func TestEmailFromIDToken(t *testing.T) {
+	tests := map[string]struct {
+		token string
+		want  string
+	}{
+		"email claim present":          {token: makeJWT(t, map[string]any{"email": "user@example.com"}), want: "user@example.com"},
+		"missing email claim":          {token: makeJWT(t, map[string]any{"sub": "abc"}), want: ""},
+		"malformed token":              {token: "not-a-jwt", want: ""},
+		"empty token":                  {token: "", want: ""},
+		"email alongside other claims": {token: makeJWT(t, map[string]any{"email": "a@b.c", "exp": 1, "sub": "x"}), want: "a@b.c"},
+	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, tc.want, EmailFromIDToken(tc.token))
+		})
+	}
+}
+
+func TestRequestEmailLink_SendsExpectedRequest(t *testing.T) {
+	var gotPath, gotContentType, gotEmail, gotState string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		gotContentType = r.Header.Get("Content-Type")
+		gotEmail = r.PostFormValue("email")
+		gotState = r.PostFormValue("state")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	redirect := getRedirectAddress(8090)
+	err := requestEmailLink(context.Background(), srv.URL+"/", "user@example.com", redirect)
+	require.NoError(t, err)
+	assert.Equal(t, "/auth/link", gotPath)
+	assert.Equal(t, "application/x-www-form-urlencoded", gotContentType)
+	assert.Equal(t, "user@example.com", gotEmail)
+	assert.Equal(t, "redirect="+redirect, gotState)
+}
+
+func TestRequestEmailLink_ResponseHandling(t *testing.T) {
+	tests := map[string]struct {
+		status      int
+		body        string
+		wantErr     bool
+		wantErrSubs []string
+	}{
+		"200 returns nil":          {status: http.StatusOK},
+		"400 surfaces status+body": {status: http.StatusBadRequest, body: "bad email", wantErr: true, wantErrSubs: []string{"status 400", "bad email"}},
+		"500 surfaces status+body": {status: http.StatusInternalServerError, body: "boom", wantErr: true, wantErrSubs: []string{"status 500", "boom"}},
+	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(tc.status)
+				_, _ = w.Write([]byte(tc.body))
+			}))
+			defer srv.Close()
+
+			err := requestEmailLink(context.Background(), srv.URL+"/", "x@y.z", getRedirectAddress(8090))
+			if !tc.wantErr {
+				require.NoError(t, err)
+				return
+			}
+			require.Error(t, err)
+			for _, sub := range tc.wantErrSubs {
+				assert.Contains(t, err.Error(), sub)
+			}
+		})
+	}
+}
+
+func TestExchangeOOBCodeForTokens(t *testing.T) {
+	t.Run("decodes idToken and refreshToken on success", func(t *testing.T) {
+		var gotEmail, gotOOBCode string
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "/auth/login/link", r.URL.Path)
+			gotEmail = r.URL.Query().Get("email")
+			gotOOBCode = r.URL.Query().Get("oobCode")
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"idToken":"id-xyz","refreshToken":"refresh-abc"}`))
+		}))
+		defer srv.Close()
+
+		tokens, err := exchangeOOBCodeForTokens(context.Background(), srv.URL+"/", "user@example.com", "oob-123")
+		require.NoError(t, err)
+		assert.Equal(t, "user@example.com", gotEmail)
+		assert.Equal(t, "oob-123", gotOOBCode)
+		assert.Equal(t, "id-xyz", tokens.IDToken)
+		assert.Equal(t, "refresh-abc", tokens.RefreshToken)
+	})
+
+	t.Run("non-200 response surfaces error with status and body", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusUnauthorized)
+			_, _ = w.Write([]byte("invalid oobCode"))
+		}))
+		defer srv.Close()
+
+		_, err := exchangeOOBCodeForTokens(context.Background(), srv.URL+"/", "a@b.c", "bad")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "status 401")
+		assert.Contains(t, err.Error(), "invalid oobCode")
+	})
+}
+
+func TestRefreshEmailLinkToken(t *testing.T) {
+	t.Run("skips network when current token still valid", func(t *testing.T) {
+		hits := 0
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			hits++
+			w.WriteHeader(http.StatusInternalServerError)
+		}))
+		defer srv.Close()
+
+		validToken := makeJWT(t, map[string]any{"exp": time.Now().Add(10 * time.Minute).Unix()})
+		newID, newRefresh, err := RefreshEmailLinkToken(context.Background(), srv.URL+"/", validToken, "refresh-keep")
+		require.NoError(t, err)
+		assert.Equal(t, validToken, newID)
+		assert.Equal(t, "refresh-keep", newRefresh)
+		assert.Equal(t, 0, hits, "server should not have been called")
+	})
+
+	t.Run("refreshes when current token is expired", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "/auth/callback", r.URL.Path)
+			assert.Equal(t, "emailLink", r.URL.Query().Get("method"))
+			body, _ := io.ReadAll(r.Body)
+			assert.Contains(t, string(body), `"refreshToken":"old-refresh"`)
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"idToken":"new-id","refreshToken":"new-refresh","accessToken":"new-id"}`))
+		}))
+		defer srv.Close()
+
+		expired := makeJWT(t, map[string]any{"exp": time.Now().Add(-time.Minute).Unix()})
+		newID, newRefresh, err := RefreshEmailLinkToken(context.Background(), srv.URL+"/", expired, "old-refresh")
+		require.NoError(t, err)
+		assert.Equal(t, "new-id", newID)
+		assert.Equal(t, "new-refresh", newRefresh)
+	})
+
+	t.Run("refreshes when current idToken is empty", func(t *testing.T) {
+		hits := 0
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			hits++
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"idToken":"fresh","refreshToken":"r"}`))
+		}))
+		defer srv.Close()
+
+		newID, newRefresh, err := RefreshEmailLinkToken(context.Background(), srv.URL+"/", "", "r0")
+		require.NoError(t, err)
+		assert.Equal(t, 1, hits)
+		assert.Equal(t, "fresh", newID)
+		assert.Equal(t, "r", newRefresh)
+	})
+
+	t.Run("surfaces non-200 from refresh endpoint", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusUnauthorized)
+			_, _ = w.Write([]byte("refresh rejected"))
+		}))
+		defer srv.Close()
+
+		expired := makeJWT(t, map[string]any{"exp": time.Now().Add(-time.Minute).Unix()})
+		_, _, err := RefreshEmailLinkToken(context.Background(), srv.URL+"/", expired, "refresh")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "status 401")
+	})
+}
+
+func TestCloudLoginEmailLink_RequestFailurePropagates(t *testing.T) {
+	// Control plane refuses the link request; ensure the function does not
+	// leak the loopback listener when the upstream POST errors.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = w.Write([]byte("disabled"))
+	}))
+	defer srv.Close()
+
+	port := freeTestPort(t)
+	_, err := CloudLoginEmailLink(context.Background(), srv.URL+"/", "u@e.com", port)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "status 403")
+
+	// If the listener leaked, a follow-up bind on the same port would fail.
+	require.NoError(t, checkPortAvailable(port), "port should be released after upstream error")
+}
+
+// freeTestPort finds a port currently free on 127.0.0.1 for use by a test.
+func freeTestPort(t *testing.T) int {
+	t.Helper()
+	l, err := (&net.ListenConfig{}).Listen(context.Background(), "tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	port := l.Addr().(*net.TCPAddr).Port
+	require.NoError(t, l.Close())
+	return port
+}

--- a/cmd/kubectl-testkube/commands/common/client.go
+++ b/cmd/kubectl-testkube/commands/common/client.go
@@ -68,25 +68,36 @@ func GetClient(cmd *cobra.Command) (client.Client, string, error) {
 		token := cfg.CloudContext.ApiKey
 
 		if cfg.CloudContext.ApiKey != "" && cfg.CloudContext.RefreshToken != "" {
+			newTokenType := cfg.CloudContext.TokenType
 			var refreshToken string
-			authURI := cfg.CloudContext.AuthUri
-			if cfg.CloudContext.AuthUri == "" {
-				authURI = fmt.Sprintf("%s/idp", cfg.CloudContext.ApiUri)
-			}
-			token, refreshToken, err = cloudlogin.CheckAndRefreshToken(context.Background(), authURI, cfg.CloudContext.ApiKey, cfg.CloudContext.RefreshToken)
+			token, refreshToken, err = refreshUserToken(context.Background(), cfg)
 			if err != nil {
-				// Error: failed refreshing, go thru login flow
+				if cfg.CloudContext.TokenType == config.TokenTypeEmailLink {
+					// Don't auto-restart the email-link flow from inside an
+					// unrelated command — a 5-minute "check your inbox" wait
+					// mid-command is worse UX than a hard error. Surface the
+					// exact command to re-run, filling in the user's email
+					// from the stored ID token when we can recover it.
+					hint := "testkube pro login --email-link <email>"
+					if stored := cloudlogin.EmailFromIDToken(cfg.CloudContext.ApiKey); stored != "" {
+						hint = fmt.Sprintf("testkube pro login --email-link %s", stored)
+					}
+					return nil, "", fmt.Errorf("email-link token refresh failed; re-run `%s`: %w", hint, err)
+				}
+				authURI := cfg.CloudContext.AuthUri
+				if authURI == "" {
+					authURI = fmt.Sprintf("%s/idp", cfg.CloudContext.ApiUri)
+				}
 				port := config.CallbackPort
 				if cfg.CloudContext.CallbackPort != 0 {
 					port = cfg.CloudContext.CallbackPort
 				}
-
-				token, refreshToken, err = LoginUser(authURI, cfg.CloudContext.CustomAuth, port)
+				newTokenType, token, refreshToken, err = LoginUser(authURI, cfg.CloudContext.ApiUri, cfg.CloudContext.CustomAuth, port)
 				if err != nil {
 					return nil, "", fmt.Errorf("error logging in: %w", err)
 				}
 			}
-			if err := UpdateTokens(cfg, token, refreshToken); err != nil {
+			if err := UpdateTokens(cfg, newTokenType, token, refreshToken); err != nil {
 				return nil, "", fmt.Errorf("error storing new token: %w", err)
 			}
 		}

--- a/cmd/kubectl-testkube/commands/common/helper.go
+++ b/cmd/kubectl-testkube/commands/common/helper.go
@@ -63,6 +63,7 @@ const (
 	github                = "GitHub"
 	gitlab                = "GitLab"
 	google                = "Google"
+	emailLink             = "Email (magic link)"
 	dockerDaemonPrefixLen = 8
 	latestReleaseUrl      = "https://api.github.com/repos/kubeshop/testkube/releases/latest"
 )
@@ -438,7 +439,7 @@ func PopulateHelmFlags(cmd *cobra.Command, options *HelmOptions) {
 	cmd.Flags().BoolVar(&options.EmbeddedNATS, "embedded-nats", false, "embedded NATS server in agent")
 }
 
-func PopulateLoginDataToContext(orgID, envID, token, refreshToken, dockerContainerName string, options HelmOptions, cfg config.Data) error {
+func PopulateLoginDataToContext(orgID, envID, tokenType, token, refreshToken, dockerContainerName string, options HelmOptions, cfg config.Data) error {
 	if options.Master.AgentToken != "" {
 		cfg.CloudContext.AgentKey = options.Master.AgentToken
 	}
@@ -460,7 +461,7 @@ func PopulateLoginDataToContext(orgID, envID, token, refreshToken, dockerContain
 	cfg.ContextType = config.ContextTypeCloud
 	cfg.CloudContext.OrganizationId = orgID
 	cfg.CloudContext.EnvironmentId = envID
-	cfg.CloudContext.TokenType = config.TokenTypeOIDC
+	cfg.CloudContext.TokenType = tokenType
 	if token != "" {
 		cfg.CloudContext.ApiKey = token
 	}
@@ -543,7 +544,7 @@ func IsUserLoggedIn(cfg config.Data, options HelmOptions) bool {
 	return false
 }
 
-func UpdateTokens(cfg config.Data, token, refreshToken string) error {
+func UpdateTokens(cfg config.Data, tokenType, token, refreshToken string) error {
 	var updated bool
 	if token != cfg.CloudContext.ApiKey {
 		cfg.CloudContext.ApiKey = token
@@ -551,6 +552,10 @@ func UpdateTokens(cfg config.Data, token, refreshToken string) error {
 	}
 	if refreshToken != cfg.CloudContext.RefreshToken {
 		cfg.CloudContext.RefreshToken = refreshToken
+		updated = true
+	}
+	if tokenType != "" && tokenType != cfg.CloudContext.TokenType {
+		cfg.CloudContext.TokenType = tokenType
 		updated = true
 	}
 
@@ -607,19 +612,32 @@ func PopulateCloudConfig(cfg config.Data, apiKey string, dockerContainerName *st
 	return cfg
 }
 
-func LoginUser(authUri string, customConnector bool, port int) (string, string, error) {
+// LoginUser runs the interactive login method selector and returns the chosen
+// tokenType together with the tokens. Picking "Email (magic link)" delegates to
+// the email-link flow; everything else uses the Dex OIDC flow.
+func LoginUser(authUri, apiUri string, customConnector bool, port int) (tokenType, idToken, refreshToken string, err error) {
 	ui.H1("Login")
 	connectorID := ""
 	if !customConnector {
-		connectorID = ui.Select("Choose your login method", []string{github, gitlab, google})
+		connectorID = ui.Select("Choose your login method", []string{github, gitlab, google, emailLink})
 	}
 
-	// Handle the common case where th Demo instance is running on reserved port
+	if connectorID == emailLink {
+		emailAddr := ui.TextInput("Enter your email", "")
+		if emailAddr == "" {
+			return "", "", "", fmt.Errorf("email is required for magic-link login")
+		}
+		idToken, refreshToken, err = LoginUserEmailLink(apiUri, emailAddr, port)
+		if err != nil {
+			return "", "", "", err
+		}
+		return config.TokenTypeEmailLink, idToken, refreshToken, nil
+	}
 
 	ui.Debug("Logging into cloud with parameters", authUri, connectorID)
 	authUrl, tokenChan, err := cloudlogin.CloudLogin(context.Background(), authUri, strings.ToLower(connectorID), port)
 	if err != nil {
-		return "", "", fmt.Errorf("cloud login: %w", err)
+		return "", "", "", fmt.Errorf("cloud login: %w", err)
 	}
 
 	ui.Paragraph("Your browser should open automatically. If not, please open this link in your browser:")
@@ -628,18 +646,17 @@ func LoginUser(authUri string, customConnector bool, port int) (string, string, 
 	ui.Paragraph("")
 
 	if ok := ui.Confirm("Continue"); !ok {
-		return "", "", fmt.Errorf("login cancelled")
+		return "", "", "", fmt.Errorf("login cancelled")
 	}
 
 	ui.Debug("Opening login page in browser to get a token", authUrl)
-	// open browser with login page and redirect to localhost
 	open.Run(authUrl)
 
-	idToken, refreshToken, err := uiGetToken(tokenChan)
+	idToken, refreshToken, err = uiGetToken(tokenChan)
 	if err != nil {
-		return "", "", fmt.Errorf("getting token")
+		return "", "", "", fmt.Errorf("getting token: %w", err)
 	}
-	return idToken, refreshToken, nil
+	return config.TokenTypeOIDC, idToken, refreshToken, nil
 }
 
 // extractAndCleanDomain extracts domain from email and removes dots and hyphens for connector ID
@@ -725,6 +742,34 @@ func LoginUserSSO(apiUrl, authUrl, email string, port int) (string, string, erro
 	idToken, refreshToken, err := uiGetToken(tokenChan)
 	if err != nil {
 		return "", "", fmt.Errorf("getting token: %w", err)
+	}
+	return idToken, refreshToken, nil
+}
+
+func LoginUserEmailLink(apiUrl, email string, port int) (string, string, error) {
+	ui.Debug("Requesting email-link for", email)
+
+	// Bound the callback server's lifetime to the same 5-minute budget as
+	// uiGetToken so a user walking away doesn't leak the loopback listener.
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	defer cancel()
+
+	tokenChan, err := cloudlogin.CloudLoginEmailLink(ctx, apiUrl, email, port)
+	if err != nil {
+		return "", "", fmt.Errorf("email link login: %w", err)
+	}
+
+	ui.Paragraph(fmt.Sprintf("We've sent a sign-in link to %s.", email))
+	ui.Paragraph("Open the email on this machine and click the link to complete login.")
+	ui.Paragraph("(the CLI will continue automatically once the link is clicked)")
+	ui.Paragraph("")
+
+	idToken, refreshToken, err := uiGetToken(tokenChan)
+	if err != nil {
+		return "", "", fmt.Errorf("getting token: %w", err)
+	}
+	if idToken == "" || refreshToken == "" {
+		return "", "", fmt.Errorf("email-link login did not return tokens")
 	}
 	return idToken, refreshToken, nil
 }

--- a/cmd/kubectl-testkube/commands/common/oauth.go
+++ b/cmd/kubectl-testkube/commands/common/oauth.go
@@ -8,21 +8,26 @@ import (
 	"github.com/kubeshop/testkube/cmd/kubectl-testkube/config"
 )
 
-// GetOAuthAccessToken strictly checks for OAuth authentication and returns the access token
-// Returns token, error. Error is non-nil if not OAuth authenticated.
+// isUserTokenType reports whether the stored token is a user-login token
+// (OIDC or email magic-link).
+func isUserTokenType(t string) bool {
+	return t == config.TokenTypeOIDC || t == config.TokenTypeEmailLink
+}
+
+// GetOAuthAccessToken checks for user-login authentication (OIDC or email-link) and returns the access token.
+// Returns token, error. Error is non-nil if not authenticated via either user flow.
 func GetOAuthAccessToken() (string, error) {
 	cfg, err := config.Load()
 	if err != nil {
 		return "", fmt.Errorf("failed to load config: %w", err)
 	}
 
-	// Strict OAuth checks
 	if cfg.ContextType != config.ContextTypeCloud {
 		return "", fmt.Errorf("not in cloud context (current: %s)", cfg.ContextType)
 	}
 
-	if cfg.CloudContext.TokenType != config.TokenTypeOIDC {
-		return "", fmt.Errorf("not OAuth authenticated (current: %s)", cfg.CloudContext.TokenType)
+	if !isUserTokenType(cfg.CloudContext.TokenType) {
+		return "", fmt.Errorf("not authenticated via a user login flow (current: %s)", cfg.CloudContext.TokenType)
 	}
 
 	if cfg.CloudContext.ApiKey == "" {
@@ -30,7 +35,7 @@ func GetOAuthAccessToken() (string, error) {
 	}
 
 	if cfg.CloudContext.RefreshToken == "" {
-		return "", fmt.Errorf("no refresh token available - not a valid OAuth session")
+		return "", fmt.Errorf("no refresh token available - not a valid login session")
 	}
 
 	return cfg.CloudContext.ApiKey, nil
@@ -44,34 +49,21 @@ func RefreshOAuthToken() (accessToken string, err error) {
 		return "", fmt.Errorf("failed to load config: %w", err)
 	}
 
-	// Strict OAuth validation first
 	if cfg.ContextType != config.ContextTypeCloud {
 		return "", fmt.Errorf("not in cloud context")
 	}
 
-	if cfg.CloudContext.TokenType != config.TokenTypeOIDC {
-		return "", fmt.Errorf("not OAuth authenticated")
+	if !isUserTokenType(cfg.CloudContext.TokenType) {
+		return "", fmt.Errorf("not authenticated via a user login flow")
 	}
 
 	if cfg.CloudContext.ApiKey == "" || cfg.CloudContext.RefreshToken == "" {
-		return "", fmt.Errorf("missing OAuth tokens")
+		return "", fmt.Errorf("missing login tokens")
 	}
 
-	// Determine auth URI
-	authURI := cfg.CloudContext.AuthUri
-	if authURI == "" {
-		authURI = fmt.Sprintf("%s/idp", cfg.CloudContext.ApiUri)
-	}
-
-	// Try to refresh the token
-	newAccessToken, newRefreshToken, err := cloudlogin.CheckAndRefreshToken(
-		context.Background(),
-		authURI,
-		cfg.CloudContext.ApiKey,
-		cfg.CloudContext.RefreshToken,
-	)
+	newAccessToken, newRefreshToken, err := refreshUserToken(context.Background(), cfg)
 	if err != nil {
-		return "", fmt.Errorf("failed to refresh OAuth token: %w", err)
+		return "", fmt.Errorf("failed to refresh token: %w", err)
 	}
 
 	// Update tokens in config if they changed
@@ -85,6 +77,23 @@ func RefreshOAuthToken() (accessToken string, err error) {
 	}
 
 	return newAccessToken, nil
+}
+
+// refreshUserToken dispatches the refresh path based on the stored TokenType.
+// Returns a fresh (idToken, refreshToken); does not persist to config.
+// The email-link path skips the network when the current idToken is still valid
+// (verify-first), matching CheckAndRefreshToken's behavior for OIDC.
+func refreshUserToken(ctx context.Context, cfg config.Data) (string, string, error) {
+	switch cfg.CloudContext.TokenType {
+	case config.TokenTypeEmailLink:
+		return cloudlogin.RefreshEmailLinkToken(ctx, cfg.CloudContext.ApiUri, cfg.CloudContext.ApiKey, cfg.CloudContext.RefreshToken)
+	default:
+		authURI := cfg.CloudContext.AuthUri
+		if authURI == "" {
+			authURI = fmt.Sprintf("%s/idp", cfg.CloudContext.ApiUri)
+		}
+		return cloudlogin.CheckAndRefreshToken(ctx, authURI, cfg.CloudContext.ApiKey, cfg.CloudContext.RefreshToken)
+	}
 }
 
 // IsOAuthAuthenticated returns true only if strictly OAuth authenticated

--- a/cmd/kubectl-testkube/commands/docker/init.go
+++ b/cmd/kubectl-testkube/commands/docker/init.go
@@ -120,12 +120,18 @@ func NewInitCmd() *cobra.Command {
 
 			ui.H2("Saving Testkube CLI Pro context")
 			var token, refreshToken string
+			// Preserve the existing session's token type; fall back to OIDC
+			// for brand-new contexts with nothing stored yet.
+			tokenType := cfg.CloudContext.TokenType
+			if tokenType == "" {
+				tokenType = config.TokenTypeOIDC
+			}
 			if !common.IsUserLoggedIn(cfg, options) {
-				token, refreshToken, err = common.LoginUser(options.Master.URIs.Auth, options.Master.CustomAuth, options.Master.CallbackPort)
+				tokenType, token, refreshToken, err = common.LoginUser(options.Master.URIs.Auth, options.Master.URIs.Api, options.Master.CustomAuth, options.Master.CallbackPort)
 				sendErrTelemetry(cmd, cfg, "login", err)
 				ui.ExitOnError("user login", err)
 			}
-			err = common.PopulateLoginDataToContext(options.Master.OrgId, options.Master.EnvId, token, refreshToken, dockerContainerName, options, cfg)
+			err = common.PopulateLoginDataToContext(options.Master.OrgId, options.Master.EnvId, tokenType, token, refreshToken, dockerContainerName, options, cfg)
 			if err != nil {
 				sendErrTelemetry(cmd, cfg, "setting_context", err)
 				ui.ExitOnError("Setting Pro environment context", err)

--- a/cmd/kubectl-testkube/commands/pro/init.go
+++ b/cmd/kubectl-testkube/commands/pro/init.go
@@ -105,15 +105,21 @@ func NewInitCmd() *cobra.Command {
 
 			ui.H2("Saving Testkube CLI Pro context")
 			var token, refreshToken string
+			// Preserve the existing session's token type; fall back to OIDC
+			// for brand-new contexts with nothing stored yet.
+			tokenType := cfg.CloudContext.TokenType
+			if tokenType == "" {
+				tokenType = config.TokenTypeOIDC
+			}
 			if !common.IsUserLoggedIn(cfg, options) {
 				ui.NL()
 				ui.H2("Launching web browser...")
 				ui.NL()
-				token, refreshToken, err = common.LoginUser(options.Master.URIs.Auth, options.Master.CustomAuth, options.Master.CallbackPort)
+				tokenType, token, refreshToken, err = common.LoginUser(options.Master.URIs.Auth, options.Master.URIs.Api, options.Master.CustomAuth, options.Master.CallbackPort)
 				sendErrTelemetry(cmd, cfg, "login", err)
 				ui.ExitOnError("user login", err)
 			}
-			err = common.PopulateLoginDataToContext(options.Master.OrgId, options.Master.EnvId, token, refreshToken, "", options, cfg)
+			err = common.PopulateLoginDataToContext(options.Master.OrgId, options.Master.EnvId, tokenType, token, refreshToken, "", options, cfg)
 			if err != nil {
 				sendErrTelemetry(cmd, cfg, "setting_context", err)
 				ui.ExitOnError("Setting Pro environment context", err)

--- a/cmd/kubectl-testkube/commands/pro/login.go
+++ b/cmd/kubectl-testkube/commands/pro/login.go
@@ -28,6 +28,7 @@ type CloudConfig struct {
 func NewLoginCmd() *cobra.Command {
 	var opts common.HelmOptions
 	var email string
+	var emailLink string
 
 	cmd := &cobra.Command{
 		Use:     "login [apiUrl]",
@@ -137,13 +138,19 @@ func NewLoginCmd() *cobra.Command {
 			common.ProcessMasterFlags(cmd, &opts, &cfg)
 
 			var token, refreshToken string
+			tokenType := config.TokenTypeOIDC
 
-			if email != "" {
+			switch {
+			case emailLink != "":
+				// Email magic-link flow (via --email-link flag)
+				token, refreshToken, err = common.LoginUserEmailLink(opts.Master.URIs.Api, emailLink, opts.Master.CallbackPort)
+				tokenType = config.TokenTypeEmailLink
+			case email != "":
 				// SSO authentication flow
 				token, refreshToken, err = common.LoginUserSSO(opts.Master.URIs.Api, opts.Master.URIs.Auth, email, opts.Master.CallbackPort)
-			} else {
-				// Traditional OAuth flow (GitHub/GitLab)
-				token, refreshToken, err = common.LoginUser(opts.Master.URIs.Auth, opts.Master.CustomAuth, opts.Master.CallbackPort)
+			default:
+				// Interactive selector: GitHub / GitLab / Google / Email magic-link
+				tokenType, token, refreshToken, err = common.LoginUser(opts.Master.URIs.Auth, opts.Master.URIs.Api, opts.Master.CustomAuth, opts.Master.CallbackPort)
 			}
 			ui.ExitOnError("getting token", err)
 
@@ -159,7 +166,7 @@ func NewLoginCmd() *cobra.Command {
 				ui.ExitOnError("getting environment", err)
 			}
 
-			err = common.PopulateLoginDataToContext(orgID, envID, token, refreshToken, "", opts, cfg)
+			err = common.PopulateLoginDataToContext(orgID, envID, tokenType, token, refreshToken, "", opts, cfg)
 			ui.ExitOnError("saving config file", err)
 
 			ui.Success("Your config was updated with new values")
@@ -170,6 +177,8 @@ func NewLoginCmd() *cobra.Command {
 
 	common.PopulateMasterFlags(cmd, &opts, false)
 	cmd.Flags().StringVar(&email, "email", "", "email address for SSO authentication")
+	cmd.Flags().StringVar(&emailLink, "email-link", "", "email address for magic-link authentication")
+	cmd.MarkFlagsMutuallyExclusive("email", "email-link")
 
 	return cmd
 }

--- a/cmd/kubectl-testkube/config/data.go
+++ b/cmd/kubectl-testkube/config/data.go
@@ -6,8 +6,9 @@ const (
 	ContextTypeCloud      ContextType = "cloud"
 	ContextTypeKubeconfig ContextType = "kubeconfig"
 
-	TokenTypeOIDC = "oidc"
-	TokenTypeAPI  = "api"
+	TokenTypeOIDC      = "oidc"
+	TokenTypeAPI       = "api"
+	TokenTypeEmailLink = "emailLink"
 
 	CallbackPort            = 8090
 	AlternativeCallbackPort = 38090


### PR DESCRIPTION
## Summary

Adds email magic-link as a login method for the CLI, alongside GitHub/GitLab/Google/SSO. Closes the second half of TKC-5376 -> customers who signed up via email link can now authenticate the CLI and install runners via the CLI instructions in the UI (no longer forced to use Helm).

Linear: https://linear.app/kubeshop/issue/TKC-5376

## How it works

- New flag: `testkube pro login --email-link <email>`. For the interactive flow, a new **Email (magic link)** option in the selector prompts for the address and runs the same flow. Mirrors the web login page layout.
- Zero backend changes. The CLI reuses the existing `/auth/link` and `/auth/login/link` endpoints exactly as the web UI does.
- Loopback callback uses `http://127.0.0.1:8090/callback` (IPv4-only) to avoid the `localhost` IPv6/IPv4 resolver ambiguity that can route the browser to a different process on `::1:<port>`. Matches the existing Dex CLI loopback.
- New `TokenType = "emailLink"` stored in the CLI config so the refresh path picks `/auth/callback?method=emailLink` instead of the Dex OIDC route. A shared `refreshUserToken` helper dispatches on token type; both `oauth.go` and `client.go` use it.
- `RefreshEmailLinkToken` verifies the idToken's `exp` claim client-side before hitting the network, so the common case (token still valid) is free. Matches the verify-first pattern used by OIDC's `CheckAndRefreshToken`.

## Test plan

- [x] `go build ./cmd/kubectl-testkube/...` clean
- [x] `go vet ./cmd/kubectl-testkube/...` clean
- [x] Unit tests for `commands/pro`, `commands/common`, `commands/docker`, `cloudlogin` pass
- [x] End-to-end: `testkube pro login --email-link <email>` -> email received -> click link -> CLI captures callback -> tokens saved -> context set
- [ ] End-to-end via selector: run `testkube pro login ...` with no flag -> pick **Email (magic link)** -> enter email -> complete flow
- [ ] Confirm subsequent commands don't trigger re-auth when the token is still valid (exp-check short-circuit)
- [ ] Confirm existing GitHub/GitLab/Google flows unaffected
- [ ] Confirm existing `--email` SSO flow unaffected