### PR TITLE
fix: escape {{/}} in CRD descriptions before Helm template rendering

### DIFF
--- a/js/scripts/crd-postprocess.js
+++ b/js/scripts/crd-postprocess.js
@@ -26,8 +26,18 @@ for (const file of sortedFiles) {
 }
 sections.push("{{- end }}\n");
 
+// Escape `{{`/`}}` that appear inside the CRD YAML so Helm doesn't try to
+// evaluate them as template actions. controller-gen copies Go struct comments
+// verbatim into description fields, and those comments may legitimately
+// contain Testkube expression-language examples like `{{resource.spec.xyz}}`.
+// Single-pass replacement: two sequential replaces would re-process braces
+// they just introduced, producing self-nested garbage.
+function escapeHelmBraces(s) {
+  return s.replace(/\{\{|\}\}/g, (m) => (m === '{{' ? '{{`{{`}}' : '{{`}}`}}'));
+}
+
 for (const file of sortedFiles) {
-  const content = fs.readFileSync(path.join(src, file), "utf8").trimEnd();
+  const content = escapeHelmBraces(fs.readFileSync(path.join(src, file), "utf8").trimEnd());
   sections.push(renderDefineBlock(file, content));
 }
 

--- a/k8s/helm/testkube-crds/templates/_generated_crds.tpl
+++ b/k8s/helm/testkube-crds/templates/_generated_crds.tpl
@@ -31969,7 +31969,7 @@ spec:
                   parameters:
                     description: |-
                       Parameters defines config values and tags passed to the workflow.
-                      Config values support the Testkube expression language: {{resource.spec.replicas}}
+                      Config values support the Testkube expression language: {{`{{`}}resource.spec.replicas{{`}}`}}
                     properties:
                       config:
                         additionalProperties:

--- a/k8s/helm/testkube-operator/charts/testkube-crds/templates/_generated_crds.tpl
+++ b/k8s/helm/testkube-operator/charts/testkube-crds/templates/_generated_crds.tpl
@@ -31969,7 +31969,7 @@ spec:
                   parameters:
                     description: |-
                       Parameters defines config values and tags passed to the workflow.
-                      Config values support the Testkube expression language: {{resource.spec.replicas}}
+                      Config values support the Testkube expression language: {{`{{`}}resource.spec.replicas{{`}}`}}
                     properties:
                       config:
                         additionalProperties:

--- a/k8s/helm/testkube-runner/charts/testkube-crds/templates/_generated_crds.tpl
+++ b/k8s/helm/testkube-runner/charts/testkube-crds/templates/_generated_crds.tpl
@@ -31969,7 +31969,7 @@ spec:
                   parameters:
                     description: |-
                       Parameters defines config values and tags passed to the workflow.
-                      Config values support the Testkube expression language: {{resource.spec.replicas}}
+                      Config values support the Testkube expression language: {{`{{`}}resource.spec.replicas{{`}}`}}
                     properties:
                       config:
                         additionalProperties:


### PR DESCRIPTION
## Summary

The CRD Helm library generated by `js/scripts/crd-postprocess.js` fails to render under `helm template` when any CRD description contains unescaped `{{...}}` — Helm parses those as template actions and the render aborts with `parse error: function "resource" not defined`.

Example trigger: `api/workflowtriggers/v1/workflowtrigger_types.go:190` documents the `Parameters` field with:

```go
// Config values support the Testkube expression language: {{resource.spec.replicas}}
```

controller-gen copies that comment verbatim into the CRD's OpenAPI `description`, and the postprocessor then embeds the YAML into a Helm `{{- define -}} ... {{- end }}` block. Helm sees the braces as template syntax and fails.

Impact: `helm template` on `testkube`, `testkube-runner`, and `testkube-operator` all fail when the WorkflowTrigger CRD (or any future CRD description containing `{{...}}`) is included. Breaks GitOps-style render workflows and local-dev flows like `tilt up`.

## Fix

One small change in the postprocessor — before embedding each CRD YAML into a Helm template block, escape `{{` as `` `{{` `` and `}}` as `` `}}` `` using Helm's backtick-quoted literal syntax. Helm renders those back to plain `{{` / `}}` in the final CRD output, so description text round-trips unchanged.

Single-pass replace (two sequential ones self-corrupt — the second pass would re-process braces the first pass introduced).

Re-ran `make generate-crds` to regenerate:
- `k8s/helm/testkube-crds/templates/_generated_crds.tpl`
- `k8s/helm/testkube-operator/charts/testkube-crds/templates/_generated_crds.tpl`
- `k8s/helm/testkube-runner/charts/testkube-crds/templates/_generated_crds.tpl`

No change to final CRD content; only the intermediate template now parses.

## Test plan

- [x] `make generate-crds` succeeds
- [x] `make verify-crds-generated` is green (regenerate is idempotent)
- [x] `helm template k8s/helm/testkube` succeeds on a clean checkout of this branch
- [x] `helm template k8s/helm/testkube-runner` succeeds
- [x] `helm template k8s/helm/testkube-operator --set enabled=false --set installCRD=true` succeeds
- [x] Rendered CRD for WorkflowTrigger still shows the documentation example `{{resource.spec.replicas}}` unchanged in its `description` field