### PR TITLE
chore: [TKC-5538] earnin multiple gitops agent per namespace

### DIFF
--- a/k8s/helm/testkube-runner/templates/_helpers.tpl
+++ b/k8s/helm/testkube-runner/templates/_helpers.tpl
@@ -189,6 +189,7 @@ rules:
     resources:
       - testworkflows
       - testworkflowtemplates
+      - workflowtriggers
     verbs:
       - get
       - list

--- a/k8s/helm/testkube-runner/templates/role.yaml
+++ b/k8s/helm/testkube-runner/templates/role.yaml
@@ -214,7 +214,7 @@ metadata:
 apiVersion: {{ include "global.capabilities.rbac.apiVersion" . }}
 kind: Role
 metadata:
-  name: "watchers-role-{{ $ns }}"
+  name: "watchers-role-{{ .Release.Name }}"
   namespace: {{ $ns }}
   labels:
     {{- if .Values.global.labels }}

--- a/k8s/helm/testkube-runner/templates/rolebinding.yaml
+++ b/k8s/helm/testkube-runner/templates/rolebinding.yaml
@@ -236,7 +236,7 @@ roleRef:
 apiVersion: {{ include "global.capabilities.rbac.apiVersion" . }}
 kind: RoleBinding
 metadata:
-  name: "watchers-role-rb-{{ $ns }}"
+  name: "watchers-role-rb-{{ .Release.Name }}"
   namespace: {{ $ns }}
   labels:
     {{- if .Values.global.labels }}
@@ -257,7 +257,7 @@ subjects:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: "watchers-role-{{ $ns }}"
+  name: "watchers-role-{{ .Release.Name }}"
 {{ end }}
 {{- end }}
 {{- end }}


### PR DESCRIPTION
## Pull request description 

Allow multiple gitops agents in the same namespace

## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [x] tested locally
- [x] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Changes

- Watcher role now take suffix with release name

## Fixes

- Watcher role to allow access to Testkube CRD now include workflowtriggers