### PR TITLE
feat(api): RBAC for workflowtriggers CRD + rbac.extraWatchedResources for resourceRef targets

### DIFF
--- a/k8s/helm/testkube-api/templates/role.yaml
+++ b/k8s/helm/testkube-api/templates/role.yaml
@@ -424,6 +424,40 @@ rules:
       - get
 
 ---
+
+apiVersion: {{ include "global.capabilities.rbac.apiVersion" . }}
+kind: Role
+metadata:
+  name: workflowtriggers-role-{{ .Release.Name }}
+  labels: {{- include "testkube-api.labels" . | nindent 4 }}
+    {{- if .Values.global.labels }}
+    {{- include "global.tplvalues.render" ( dict "value" .Values.global.labels "context" $ ) | nindent 4 }}
+    {{- end }}
+  {{- if .Values.global.annotations}}
+  annotations: {{- include "global.tplvalues.render" ( dict "value" .Values.global.annotations "context" $ ) | nindent 4 }}
+  {{- end }}
+rules:
+  - apiGroups:
+      - testworkflows.testkube.io
+    resources:
+      - workflowtriggers
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+      - deletecollection
+  - apiGroups:
+      - testworkflows.testkube.io
+    resources:
+      - workflowtriggers/status
+    verbs:
+      - get
+
+---
 {{- if .Values.next.testTriggers.enabled }}
 
 apiVersion: {{ include "global.capabilities.rbac.apiVersion" . }}
@@ -498,6 +532,15 @@ rules:
       - get
       - list
       - watch
+  {{- with .Values.rbac.extraWatchedResources }}
+  # User-declared GVKs for TestTrigger / WorkflowTrigger `resourceRef` targets
+  # that aren't covered by the built-in resource list above.
+  {{- range . }}
+  - apiGroups: {{ toYaml .apiGroups | nindent 6 }}
+    resources: {{ toYaml .resources | nindent 6 }}
+    verbs: {{ .verbs | default (list "get" "list" "watch") | toYaml | nindent 6 }}
+  {{- end }}
+  {{- end }}
 {{- end }}
 ---
 {{- end }}
@@ -550,6 +593,15 @@ rules:
       - get
       - list
       - watch
+  {{- with .Values.rbac.extraWatchedResources }}
+  # User-declared GVKs for TestTrigger / WorkflowTrigger `resourceRef` targets
+  # that aren't covered by the built-in resource list above.
+  {{- range . }}
+  - apiGroups: {{ toYaml .apiGroups | nindent 6 }}
+    resources: {{ toYaml .resources | nindent 6 }}
+    verbs: {{ .verbs | default (list "get" "list" "watch") | toYaml | nindent 6 }}
+  {{- end }}
+  {{- end }}
 {{- end }}
 
 ---
@@ -598,6 +650,15 @@ rules:
       - get
       - list
       - watch
+  {{- with .Values.rbac.extraWatchedResources }}
+  # User-declared GVKs for TestTrigger / WorkflowTrigger `resourceRef` targets
+  # that aren't covered by the built-in resource list above.
+  {{- range . }}
+  - apiGroups: {{ toYaml .apiGroups | nindent 6 }}
+    resources: {{ toYaml .resources | nindent 6 }}
+    verbs: {{ .verbs | default (list "get" "list" "watch") | toYaml | nindent 6 }}
+  {{- end }}
+  {{- end }}
   {{- end }}
 
 ---

--- a/k8s/helm/testkube-api/templates/rolebinding.yaml
+++ b/k8s/helm/testkube-api/templates/rolebinding.yaml
@@ -307,6 +307,28 @@ subjects:
 
 ---
 
+apiVersion: {{ include "global.capabilities.rbac.apiVersion" . }}
+kind: RoleBinding
+metadata:
+  name: workflowtriggers-crb-{{ .Release.Name }}
+  labels: {{- include "testkube-api.labels" . | nindent 4 }}
+    {{- if .Values.global.labels }}
+    {{- include "global.tplvalues.render" ( dict "value" .Values.global.labels "context" $ ) | nindent 4 }}
+    {{- end }}
+  {{- if .Values.global.annotations}}
+  annotations: {{- include "global.tplvalues.render" ( dict "value" .Values.global.annotations "context" $ ) | nindent 4 }}
+  {{- end }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: workflowtriggers-role-{{ .Release.Name }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "testkube-api.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace }}
+
+---
+
 # RBAC for additional namespaces
 {{- if .Values.additionalNamespaces }}
 {{- range .Values.additionalNamespaces }}

--- a/k8s/helm/testkube-api/values.yaml
+++ b/k8s/helm/testkube-api/values.yaml
@@ -51,6 +51,27 @@ kubeVersion: ""
 ## create roles and rolebindings
 rbac:
   create: true
+  ## Additional resources the agent is allowed to watch.
+  ## Required when TestTriggers or WorkflowTriggers use `resourceRef` to
+  ## target a CRD that isn't covered by the default watchers role
+  ## (e.g. cert-manager.io/certificates, kafka.strimzi.io/kafkatopics).
+  ##
+  ## Applied to all three watcher role variants:
+  ##   - the cluster-wide ClusterRole (default, multinamespace.enabled=false)
+  ##   - the release-namespace Role (multinamespace.enabled=true)
+  ##   - the per-namespace Roles generated from additionalNamespaces
+  ##
+  ## Verbs default to [get, list, watch] (read-only; triggers do not mutate
+  ## the watched resource). Override per-entry if you need something else.
+  ##
+  ## Example:
+  ## extraWatchedResources:
+  ##   - apiGroups: ["cert-manager.io"]
+  ##     resources: ["certificates", "certificaterequests"]
+  ##   - apiGroups: ["kafka.strimzi.io"]
+  ##     resources: ["kafkatopics"]
+  ##     verbs: ["get", "list", "watch"]
+  extraWatchedResources: []
 
 ## Number of Testkube API Pod replicas
 replicaCount: 1

--- a/k8s/helm/testkube-runner/templates/_helpers.tpl
+++ b/k8s/helm/testkube-runner/templates/_helpers.tpl
@@ -189,8 +189,18 @@ rules:
     resources:
       - testworkflows
       - testworkflowtemplates
+      - workflowtriggers
     verbs:
       - get
       - list
       - watch
+  {{- with .Values.listener.extraWatchedResources }}
+  # User-declared GVKs for TestTrigger / WorkflowTrigger `resourceRef` targets
+  # that aren't covered by the built-in resource list above.
+  {{- range . }}
+  - apiGroups: {{ toYaml .apiGroups | nindent 6 }}
+    resources: {{ toYaml .resources | nindent 6 }}
+    verbs: {{ .verbs | default (list "get" "list" "watch") | toYaml | nindent 6 }}
+  {{- end }}
+  {{- end }}
 {{- end }}

--- a/k8s/helm/testkube-runner/values.yaml
+++ b/k8s/helm/testkube-runner/values.yaml
@@ -75,6 +75,15 @@ listener:
   eventLabels: {}
   ## Additional namespaces to watch
   additionalNamespaces: []
+  ## Extra resources the listener watchers role should cover. Required when
+  ## TestTriggers or WorkflowTriggers use `resourceRef` to target a CRD that
+  ## isn't in the default watchers role (e.g. cert-manager, Kafka, Strimzi).
+  ## Verbs default to [get, list, watch].
+  ## Example:
+  ##   extraWatchedResources:
+  ##     - apiGroups: ["cert-manager.io"]
+  ##       resources: ["certificates"]
+  extraWatchedResources: []
 
 ## Webhooks capability configuration
 webhooks:

--- a/k8s/helm/testkube/values.yaml
+++ b/k8s/helm/testkube/values.yaml
@@ -535,6 +535,19 @@ testkube-api:
   # -- Toggle whether to deploy Testkube API RBAC
   rbac:
     create: true
+    # -- Extra resources the agent watchers role should cover. Required when
+    # TestTriggers or WorkflowTriggers use `resourceRef` to target a CRD that
+    # isn't in the default watchers role (e.g. cert-manager, Kafka, Strimzi).
+    # Applied to all three role variants (cluster-wide ClusterRole, the
+    # release-namespace Role in multinamespace mode, and the per-namespace
+    # Roles in additionalNamespaces). Verbs default to `[get, list, watch]`.
+    # Example:
+    #   extraWatchedResources:
+    #     - apiGroups: ["cert-manager.io"]
+    #       resources: ["certificates"]
+    #     - apiGroups: ["kafka.strimzi.io"]
+    #       resources: ["kafkatopics"]
+    extraWatchedResources: []
 
   # Multinamespace feature. Disabled by default
   multinamespace:


### PR DESCRIPTION
## Summary

Fixes two RBAC gaps in the `testkube-api` Helm chart that surfaced when testing the new `resourceRef` feature on TestTrigger / WorkflowTrigger (PRs #7523, #7528, #7535):

### 1. Missing Role for the `workflowtriggers` CRD

The new `WorkflowTrigger` CRD (added in #7523) didn't get a matching `<kind>-role` + `<kind>-crb` in the chart. Every other CRD in this chart follows that exact pattern (`testtriggers-role`, `testworkflows-role`, `webhooktemplate-role`, etc.); `workflowtriggers` was simply missed.

Effect on a fresh install: the agent's controller-runtime manager fails to sync the `*v1.WorkflowTrigger` informer cache at startup (`Forbidden: cannot watch resource "workflowtriggers"`) and the pod enters CrashLoopBackOff.

**Fix**: add `workflowtriggers-role-{release}` + `workflowtriggers-crb-{release}` using the identical structure as `testtriggers-role` / `testtriggers-crb`.

### 2. No way for users to grant watch permissions on `resourceRef` target CRDs

`TestTrigger.spec.resourceRef` (and `WorkflowTrigger.spec.resourceRef`) let users watch **any** K8s resource by GVK — including arbitrary CRDs like `cert-manager.io/Certificate`, `kafka.strimzi.io/KafkaTopic`, etc. The trigger service starts a dynamic informer for each unique GVK.

Today there's no chart values knob to grant the agent read access on those CRDs. Admins have to hand-write a ClusterRole + ClusterRoleBinding per deployment. That's the first thing they hit when trying the feature.

**Fix**: add `rbac.extraWatchedResources` values key — a list of `{apiGroups, resources, verbs?}` entries rendered into the `watchers-role` ClusterRole.

```yaml
# values.yaml
rbac:
  extraWatchedResources:
    - apiGroups: ["cert-manager.io"]
      resources: ["certificates"]
    - apiGroups: ["kafka.strimzi.io"]
      resources: ["kafkatopics"]
      verbs: ["get", "list", "watch"]   # optional; defaults to read-only trio
```

Verbs default to `[get, list, watch]` — read-only, matching what the informers need.

## Test plan

- [x] `helm template` renders `workflowtriggers-role-{release}` and `workflowtriggers-crb-{release}` correctly.
- [x] `helm template` with `rbac.extraWatchedResources` populated renders the extra rules appended to `watchers-role`.
- [x] Applied to a running local k3d cluster with the trigger PRs: agent previously CrashLoopBackOff on `Forbidden: cannot watch workflowtriggers`, now boots clean and the trigger service acquires its lease.
- [x] End-to-end: a TestTrigger with `resourceRef: cert-manager.io/v1/Certificate` successfully watches Certificate events and schedules TestWorkflow executions on match.

## Note on trigger scoping (not a bug — learned during validation)

A `TestTrigger` without `resourceSelector` deliberately defaults to its own namespace for scope — that's intentional matcher behavior at `pkg/triggers/matcher.go:156`, not a bug. Users who want cross-namespace matching need an explicit `resourceSelector.namespace` / `resourceSelector.namespaceRegex` / label selector.
