### PR TITLE
feat(cli): CRUD commands for testtriggers

### DIFF
--- a/cmd/kubectl-testkube/commands/create.go
+++ b/cmd/kubectl-testkube/commands/create.go
@@ -6,6 +6,7 @@ import (
 	"github.com/kubeshop/testkube/cmd/kubectl-testkube/commands/agents"
 	"github.com/kubeshop/testkube/cmd/kubectl-testkube/commands/common"
 	"github.com/kubeshop/testkube/cmd/kubectl-testkube/commands/common/validator"
+	"github.com/kubeshop/testkube/cmd/kubectl-testkube/commands/testtriggers"
 	"github.com/kubeshop/testkube/cmd/kubectl-testkube/commands/testworkflows"
 	"github.com/kubeshop/testkube/cmd/kubectl-testkube/commands/testworkflowtemplates"
 	"github.com/kubeshop/testkube/cmd/kubectl-testkube/commands/webhooks"
@@ -40,6 +41,7 @@ func NewCreateCmd() *cobra.Command {
 	cmd.AddCommand(webhooks.NewCreateWebhookCmd())
 	cmd.AddCommand(webhooktemplates.NewCreateWebhookTemplateCmd())
 	cmd.AddCommand(workflowtriggers.NewCreateWorkflowTriggerCmd())
+	cmd.AddCommand(testtriggers.NewCreateTestTriggerCmd())
 	cmd.AddCommand(testworkflows.NewCreateTestWorkflowCmd())
 	cmd.AddCommand(testworkflowtemplates.NewCreateTestWorkflowTemplateCmd())
 	cmd.AddCommand(agents.NewCreateAgentCommand())

--- a/cmd/kubectl-testkube/commands/delete.go
+++ b/cmd/kubectl-testkube/commands/delete.go
@@ -6,6 +6,7 @@ import (
 	"github.com/kubeshop/testkube/cmd/kubectl-testkube/commands/agents"
 	"github.com/kubeshop/testkube/cmd/kubectl-testkube/commands/common"
 	"github.com/kubeshop/testkube/cmd/kubectl-testkube/commands/common/validator"
+	"github.com/kubeshop/testkube/cmd/kubectl-testkube/commands/testtriggers"
 	"github.com/kubeshop/testkube/cmd/kubectl-testkube/commands/testworkflows"
 	"github.com/kubeshop/testkube/cmd/kubectl-testkube/commands/testworkflowtemplates"
 	"github.com/kubeshop/testkube/cmd/kubectl-testkube/commands/webhooks"
@@ -39,6 +40,7 @@ func NewDeleteCmd() *cobra.Command {
 	cmd.AddCommand(webhooks.NewDeleteWebhookCmd())
 	cmd.AddCommand(webhooktemplates.NewDeleteWebhookTemplateCmd())
 	cmd.AddCommand(workflowtriggers.NewDeleteWorkflowTriggerCmd())
+	cmd.AddCommand(testtriggers.NewDeleteTestTriggerCmd())
 	cmd.AddCommand(testworkflows.NewDeleteTestWorkflowCmd())
 	cmd.AddCommand(testworkflowtemplates.NewDeleteTestWorkflowTemplateCmd())
 	cmd.AddCommand(agents.NewDeleteAgentCommand())

--- a/cmd/kubectl-testkube/commands/get.go
+++ b/cmd/kubectl-testkube/commands/get.go
@@ -8,6 +8,7 @@ import (
 	"github.com/kubeshop/testkube/cmd/kubectl-testkube/commands/common"
 	"github.com/kubeshop/testkube/cmd/kubectl-testkube/commands/common/validator"
 	"github.com/kubeshop/testkube/cmd/kubectl-testkube/commands/context"
+	"github.com/kubeshop/testkube/cmd/kubectl-testkube/commands/testtriggers"
 	"github.com/kubeshop/testkube/cmd/kubectl-testkube/commands/testworkflows"
 	"github.com/kubeshop/testkube/cmd/kubectl-testkube/commands/testworkflowtemplates"
 	"github.com/kubeshop/testkube/cmd/kubectl-testkube/commands/webhooks"
@@ -41,6 +42,7 @@ func NewGetCmd() *cobra.Command {
 	cmd.AddCommand(webhooks.NewGetWebhookCmd())
 	cmd.AddCommand(webhooktemplates.NewGetWebhookTemplateCmd())
 	cmd.AddCommand(workflowtriggers.NewGetWorkflowTriggerCmd())
+	cmd.AddCommand(testtriggers.NewGetTestTriggerCmd())
 	cmd.AddCommand(artifacts.NewListArtifactsCmd())
 	cmd.AddCommand(context.NewGetContextCmd())
 	cmd.AddCommand(testworkflows.NewGetTestWorkflowsCmd())

--- a/cmd/kubectl-testkube/commands/testtriggers/common.go
+++ b/cmd/kubectl-testkube/commands/testtriggers/common.go
@@ -1,0 +1,75 @@
+// Package testtriggers provides CLI commands for TestTrigger resources.
+// Mirrors the workflowtriggers/ layout: one file per CRUD operation, plus this
+// common helper file for flag wiring and input decoding.
+package testtriggers
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+
+	"sigs.k8s.io/yaml"
+
+	apiv1 "github.com/kubeshop/testkube/pkg/api/v1/client"
+	"github.com/kubeshop/testkube/pkg/api/v1/testkube"
+	testtriggersmapper "github.com/kubeshop/testkube/pkg/mapper/testtriggers"
+
+	testtriggersv1 "github.com/kubeshop/testkube/api/testtriggers/v1"
+)
+
+// readTestTriggerFromInput reads the request body from stdin or a file and
+// decodes it as JSON/YAML. Both flat API shape (TestTriggerUpsertRequest) and
+// the CRD shape (with spec:) are accepted — we detect and map.
+func readTestTriggerFromInput(file string) (testkube.TestTriggerUpsertRequest, error) {
+	var src io.Reader
+	if file == "" || file == "-" {
+		src = os.Stdin
+	} else {
+		f, err := os.Open(file)
+		if err != nil {
+			return testkube.TestTriggerUpsertRequest{}, fmt.Errorf("opening %s: %w", file, err)
+		}
+		defer f.Close()
+		src = f
+	}
+
+	data, err := io.ReadAll(src)
+	if err != nil {
+		return testkube.TestTriggerUpsertRequest{}, fmt.Errorf("reading input: %w", err)
+	}
+
+	// Try CRD shape first (kubectl apply YAML). If the top-level has `spec:`
+	// it's the CRD form; map to the flat upsert request.
+	var probe map[string]interface{}
+	if err := yaml.Unmarshal(data, &probe); err == nil {
+		if _, hasSpec := probe["spec"]; hasSpec {
+			var crd testtriggersv1.TestTrigger
+			if err := yaml.Unmarshal(data, &crd); err != nil {
+				return testkube.TestTriggerUpsertRequest{}, fmt.Errorf("parsing CRD: %w", err)
+			}
+			return testtriggersmapper.MapTestTriggerCRDToTestTriggerUpsertRequest(crd), nil
+		}
+	}
+
+	// Flat shape — try JSON, then YAML.
+	var req testkube.TestTriggerUpsertRequest
+	if err := json.Unmarshal(data, &req); err == nil {
+		return req, nil
+	}
+	if err := yaml.Unmarshal(data, &req); err != nil {
+		return testkube.TestTriggerUpsertRequest{}, fmt.Errorf("parsing input: %w", err)
+	}
+	return req, nil
+}
+
+// toCreateOptions converts an upsert request to the client's create options.
+// Both types are aliases over TestTriggerUpsertRequest.
+func toCreateOptions(req testkube.TestTriggerUpsertRequest) apiv1.CreateTestTriggerOptions {
+	return apiv1.CreateTestTriggerOptions(req)
+}
+
+// toUpdateOptions converts an upsert request to the client's update options.
+func toUpdateOptions(req testkube.TestTriggerUpsertRequest) apiv1.UpdateTestTriggerOptions {
+	return apiv1.UpdateTestTriggerOptions(req)
+}

--- a/cmd/kubectl-testkube/commands/testtriggers/common.go
+++ b/cmd/kubectl-testkube/commands/testtriggers/common.go
@@ -1,6 +1,3 @@
-// Package testtriggers provides CLI commands for TestTrigger resources.
-// Mirrors the workflowtriggers/ layout: one file per CRUD operation, plus this
-// common helper file for flag wiring and input decoding.
 package testtriggers
 
 import (
@@ -11,16 +8,13 @@ import (
 
 	"sigs.k8s.io/yaml"
 
-	apiv1 "github.com/kubeshop/testkube/pkg/api/v1/client"
 	"github.com/kubeshop/testkube/pkg/api/v1/testkube"
 	testtriggersmapper "github.com/kubeshop/testkube/pkg/mapper/testtriggers"
 
 	testtriggersv1 "github.com/kubeshop/testkube/api/testtriggers/v1"
 )
 
-// readTestTriggerFromInput reads the request body from stdin or a file and
-// decodes it as JSON/YAML. Both flat API shape (TestTriggerUpsertRequest) and
-// the CRD shape (with spec:) are accepted — we detect and map.
+// readTestTriggerFromInput accepts both the flat UpsertRequest and the CRD shape (with spec:).
 func readTestTriggerFromInput(file string) (testkube.TestTriggerUpsertRequest, error) {
 	var src io.Reader
 	if file == "" || file == "-" {
@@ -39,8 +33,6 @@ func readTestTriggerFromInput(file string) (testkube.TestTriggerUpsertRequest, e
 		return testkube.TestTriggerUpsertRequest{}, fmt.Errorf("reading input: %w", err)
 	}
 
-	// Try CRD shape first (kubectl apply YAML). If the top-level has `spec:`
-	// it's the CRD form; map to the flat upsert request.
 	var probe map[string]interface{}
 	if err := yaml.Unmarshal(data, &probe); err == nil {
 		if _, hasSpec := probe["spec"]; hasSpec {
@@ -52,7 +44,6 @@ func readTestTriggerFromInput(file string) (testkube.TestTriggerUpsertRequest, e
 		}
 	}
 
-	// Flat shape — try JSON, then YAML.
 	var req testkube.TestTriggerUpsertRequest
 	if err := json.Unmarshal(data, &req); err == nil {
 		return req, nil
@@ -61,15 +52,4 @@ func readTestTriggerFromInput(file string) (testkube.TestTriggerUpsertRequest, e
 		return testkube.TestTriggerUpsertRequest{}, fmt.Errorf("parsing input: %w", err)
 	}
 	return req, nil
-}
-
-// toCreateOptions converts an upsert request to the client's create options.
-// Both types are aliases over TestTriggerUpsertRequest.
-func toCreateOptions(req testkube.TestTriggerUpsertRequest) apiv1.CreateTestTriggerOptions {
-	return apiv1.CreateTestTriggerOptions(req)
-}
-
-// toUpdateOptions converts an upsert request to the client's update options.
-func toUpdateOptions(req testkube.TestTriggerUpsertRequest) apiv1.UpdateTestTriggerOptions {
-	return apiv1.UpdateTestTriggerOptions(req)
 }

--- a/cmd/kubectl-testkube/commands/testtriggers/create.go
+++ b/cmd/kubectl-testkube/commands/testtriggers/create.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/kubeshop/testkube/cmd/kubectl-testkube/commands/common"
 	"github.com/kubeshop/testkube/cmd/kubectl-testkube/commands/common/render"
+	apiv1 "github.com/kubeshop/testkube/pkg/api/v1/client"
 	"github.com/kubeshop/testkube/pkg/ui"
 )
 
@@ -27,10 +28,9 @@ func NewCreateTestTriggerCmd() *cobra.Command {
 			ui.ExitOnError("reading test trigger input", err)
 
 			if update {
-				// Upsert: update if exists, else create.
 				existing, getErr := client.GetTestTrigger(req.Name)
 				if getErr == nil && existing.Name != "" {
-					updated, err := client.UpdateTestTrigger(toUpdateOptions(req))
+					updated, err := client.UpdateTestTrigger(apiv1.UpdateTestTriggerOptions(req))
 					ui.ExitOnError("updating test trigger", err)
 					err = render.Obj(cmd, updated, os.Stdout)
 					ui.ExitOnError("rendering obj", err)
@@ -38,7 +38,7 @@ func NewCreateTestTriggerCmd() *cobra.Command {
 				}
 			}
 
-			created, err := client.CreateTestTrigger(toCreateOptions(req))
+			created, err := client.CreateTestTrigger(apiv1.CreateTestTriggerOptions(req))
 			ui.ExitOnError("creating test trigger", err)
 
 			err = render.Obj(cmd, created, os.Stdout)

--- a/cmd/kubectl-testkube/commands/testtriggers/create.go
+++ b/cmd/kubectl-testkube/commands/testtriggers/create.go
@@ -1,0 +1,53 @@
+package testtriggers
+
+import (
+	"os"
+
+	"github.com/spf13/cobra"
+
+	"github.com/kubeshop/testkube/cmd/kubectl-testkube/commands/common"
+	"github.com/kubeshop/testkube/cmd/kubectl-testkube/commands/common/render"
+	"github.com/kubeshop/testkube/pkg/ui"
+)
+
+func NewCreateTestTriggerCmd() *cobra.Command {
+	var file string
+	var update bool
+
+	cmd := &cobra.Command{
+		Use:     "testtrigger",
+		Aliases: []string{"testtriggers", "tt"},
+		Short:   "Create a TestTrigger from a YAML/JSON manifest",
+		Long:    `Create a TestTrigger. The manifest may be passed via --file or piped on stdin. Accepts both the flat REST shape (TestTriggerUpsertRequest) and the CRD shape (with spec:).`,
+		Run: func(cmd *cobra.Command, args []string) {
+			client, _, err := common.GetClient(cmd)
+			ui.ExitOnError("getting client", err)
+
+			req, err := readTestTriggerFromInput(file)
+			ui.ExitOnError("reading test trigger input", err)
+
+			if update {
+				// Upsert: update if exists, else create.
+				existing, getErr := client.GetTestTrigger(req.Name)
+				if getErr == nil && existing.Name != "" {
+					updated, err := client.UpdateTestTrigger(toUpdateOptions(req))
+					ui.ExitOnError("updating test trigger", err)
+					err = render.Obj(cmd, updated, os.Stdout)
+					ui.ExitOnError("rendering obj", err)
+					return
+				}
+			}
+
+			created, err := client.CreateTestTrigger(toCreateOptions(req))
+			ui.ExitOnError("creating test trigger", err)
+
+			err = render.Obj(cmd, created, os.Stdout)
+			ui.ExitOnError("rendering obj", err)
+		},
+	}
+
+	cmd.Flags().StringVarP(&file, "file", "f", "", "path to YAML/JSON manifest, or '-' / empty for stdin")
+	cmd.Flags().BoolVar(&update, "update", false, "update if exists instead of failing")
+
+	return cmd
+}

--- a/cmd/kubectl-testkube/commands/testtriggers/delete.go
+++ b/cmd/kubectl-testkube/commands/testtriggers/delete.go
@@ -1,0 +1,44 @@
+package testtriggers
+
+import (
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/kubeshop/testkube/cmd/kubectl-testkube/commands/common"
+	"github.com/kubeshop/testkube/pkg/ui"
+)
+
+func NewDeleteTestTriggerCmd() *cobra.Command {
+	var selectors []string
+
+	cmd := &cobra.Command{
+		Use:     "testtrigger [name]",
+		Aliases: []string{"testtriggers", "tt"},
+		Short:   "Delete a TestTrigger by name, or bulk-delete by selector",
+		Run: func(cmd *cobra.Command, args []string) {
+			client, _, err := common.GetClient(cmd)
+			ui.ExitOnError("getting client", err)
+
+			if len(args) > 0 {
+				name := args[0]
+				err := client.DeleteTestTrigger(name)
+				ui.ExitOnError("deleting test trigger: "+name, err)
+				ui.Success("deleted", name)
+				return
+			}
+
+			selector := strings.Join(selectors, ",")
+			if selector == "" {
+				ui.Failf("either name argument or --label selector is required")
+			}
+			err = client.DeleteTestTriggers(selector)
+			ui.ExitOnError("deleting test triggers", err)
+			ui.Success("deleted test triggers matching", selector)
+		},
+	}
+
+	cmd.Flags().StringSliceVarP(&selectors, "label", "l", nil, "label selector for bulk delete, e.g. --label app=api")
+
+	return cmd
+}

--- a/cmd/kubectl-testkube/commands/testtriggers/get.go
+++ b/cmd/kubectl-testkube/commands/testtriggers/get.go
@@ -1,0 +1,47 @@
+package testtriggers
+
+import (
+	"os"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/kubeshop/testkube/cmd/kubectl-testkube/commands/common"
+	"github.com/kubeshop/testkube/cmd/kubectl-testkube/commands/common/render"
+	"github.com/kubeshop/testkube/pkg/ui"
+)
+
+func NewGetTestTriggerCmd() *cobra.Command {
+	var selectors []string
+
+	cmd := &cobra.Command{
+		Use:     "testtrigger <name>",
+		Aliases: []string{"testtriggers", "tt"},
+		Short:   "Get TestTrigger details",
+		Long:    `Get a single TestTrigger by name, or list all matching ones. Use --label to filter.`,
+		Run: func(cmd *cobra.Command, args []string) {
+			client, _, err := common.GetClient(cmd)
+			ui.ExitOnError("getting client", err)
+
+			if len(args) > 0 {
+				name := args[0]
+				trigger, err := client.GetTestTrigger(name)
+				ui.ExitOnError("getting test trigger: "+name, err)
+
+				err = render.Obj(cmd, trigger, os.Stdout)
+				ui.ExitOnError("rendering obj", err)
+				return
+			}
+
+			triggers, err := client.ListTestTriggers(strings.Join(selectors, ","))
+			ui.ExitOnError("listing test triggers", err)
+
+			err = render.List(cmd, triggers, os.Stdout)
+			ui.ExitOnError("rendering list", err)
+		},
+	}
+
+	cmd.Flags().StringSliceVarP(&selectors, "label", "l", nil, "label selector, e.g. --label app=api")
+
+	return cmd
+}

--- a/cmd/kubectl-testkube/commands/testtriggers/get.go
+++ b/cmd/kubectl-testkube/commands/testtriggers/get.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/kubeshop/testkube/cmd/kubectl-testkube/commands/common"
 	"github.com/kubeshop/testkube/cmd/kubectl-testkube/commands/common/render"
+	"github.com/kubeshop/testkube/pkg/api/v1/testkube"
 	"github.com/kubeshop/testkube/pkg/ui"
 )
 
@@ -36,7 +37,7 @@ func NewGetTestTriggerCmd() *cobra.Command {
 			triggers, err := client.ListTestTriggers(strings.Join(selectors, ","))
 			ui.ExitOnError("listing test triggers", err)
 
-			err = render.List(cmd, triggers, os.Stdout)
+			err = render.List(cmd, testkube.TestTriggers(triggers), os.Stdout)
 			ui.ExitOnError("rendering list", err)
 		},
 	}

--- a/cmd/kubectl-testkube/commands/testtriggers/update.go
+++ b/cmd/kubectl-testkube/commands/testtriggers/update.go
@@ -1,0 +1,38 @@
+package testtriggers
+
+import (
+	"os"
+
+	"github.com/spf13/cobra"
+
+	"github.com/kubeshop/testkube/cmd/kubectl-testkube/commands/common"
+	"github.com/kubeshop/testkube/cmd/kubectl-testkube/commands/common/render"
+	"github.com/kubeshop/testkube/pkg/ui"
+)
+
+func NewUpdateTestTriggerCmd() *cobra.Command {
+	var file string
+
+	cmd := &cobra.Command{
+		Use:     "testtrigger",
+		Aliases: []string{"testtriggers", "tt"},
+		Short:   "Update an existing TestTrigger from a YAML/JSON manifest",
+		Run: func(cmd *cobra.Command, args []string) {
+			client, _, err := common.GetClient(cmd)
+			ui.ExitOnError("getting client", err)
+
+			req, err := readTestTriggerFromInput(file)
+			ui.ExitOnError("reading test trigger input", err)
+
+			updated, err := client.UpdateTestTrigger(toUpdateOptions(req))
+			ui.ExitOnError("updating test trigger", err)
+
+			err = render.Obj(cmd, updated, os.Stdout)
+			ui.ExitOnError("rendering obj", err)
+		},
+	}
+
+	cmd.Flags().StringVarP(&file, "file", "f", "", "path to YAML/JSON manifest, or '-' / empty for stdin")
+
+	return cmd
+}

--- a/cmd/kubectl-testkube/commands/testtriggers/update.go
+++ b/cmd/kubectl-testkube/commands/testtriggers/update.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/kubeshop/testkube/cmd/kubectl-testkube/commands/common"
 	"github.com/kubeshop/testkube/cmd/kubectl-testkube/commands/common/render"
+	apiv1 "github.com/kubeshop/testkube/pkg/api/v1/client"
 	"github.com/kubeshop/testkube/pkg/ui"
 )
 
@@ -24,7 +25,7 @@ func NewUpdateTestTriggerCmd() *cobra.Command {
 			req, err := readTestTriggerFromInput(file)
 			ui.ExitOnError("reading test trigger input", err)
 
-			updated, err := client.UpdateTestTrigger(toUpdateOptions(req))
+			updated, err := client.UpdateTestTrigger(apiv1.UpdateTestTriggerOptions(req))
 			ui.ExitOnError("updating test trigger", err)
 
 			err = render.Obj(cmd, updated, os.Stdout)

--- a/cmd/kubectl-testkube/commands/update.go
+++ b/cmd/kubectl-testkube/commands/update.go
@@ -6,6 +6,7 @@ import (
 	"github.com/kubeshop/testkube/cmd/kubectl-testkube/commands/agents"
 	"github.com/kubeshop/testkube/cmd/kubectl-testkube/commands/common"
 	"github.com/kubeshop/testkube/cmd/kubectl-testkube/commands/common/validator"
+	"github.com/kubeshop/testkube/cmd/kubectl-testkube/commands/testtriggers"
 	"github.com/kubeshop/testkube/cmd/kubectl-testkube/commands/testworkflows"
 	"github.com/kubeshop/testkube/cmd/kubectl-testkube/commands/webhooks"
 	"github.com/kubeshop/testkube/cmd/kubectl-testkube/commands/webhooktemplates"
@@ -35,6 +36,7 @@ func NewUpdateCmd() *cobra.Command {
 	cmd.AddCommand(webhooks.UpdateWebhookCmd())
 	cmd.AddCommand(webhooktemplates.UpdateWebhookTemplateCmd())
 	cmd.AddCommand(workflowtriggers.NewUpdateWorkflowTriggerCmd())
+	cmd.AddCommand(testtriggers.NewUpdateTestTriggerCmd())
 	cmd.AddCommand(agents.NewUpdateAgentCommand())
 	cmd.AddCommand(testworkflows.NewUpdateTestWorkflowExecutionCmd())
 

--- a/cmd/kubectl-testkube/commands/workflowtriggers/get.go
+++ b/cmd/kubectl-testkube/commands/workflowtriggers/get.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/kubeshop/testkube/cmd/kubectl-testkube/commands/common"
 	"github.com/kubeshop/testkube/cmd/kubectl-testkube/commands/common/render"
+	"github.com/kubeshop/testkube/pkg/api/v1/testkube"
 	"github.com/kubeshop/testkube/pkg/ui"
 )
 
@@ -36,7 +37,7 @@ func NewGetWorkflowTriggerCmd() *cobra.Command {
 			triggers, err := client.ListWorkflowTriggers(strings.Join(selectors, ","))
 			ui.ExitOnError("listing workflow triggers", err)
 
-			err = render.List(cmd, triggers, os.Stdout)
+			err = render.List(cmd, testkube.WorkflowTriggers(triggers), os.Stdout)
 			ui.ExitOnError("rendering list", err)
 		},
 	}

--- a/go.mod
+++ b/go.mod
@@ -91,6 +91,7 @@ require (
 	k8s.io/kube-openapi v0.0.0-20260414162039-ec9c827d403f
 	k8s.io/utils v0.0.0-20260319190234-28399d86e0b5
 	sigs.k8s.io/controller-runtime v0.23.3
+	sigs.k8s.io/yaml v1.6.0
 )
 
 require github.com/opencontainers/go-digest v1.0.0 // indirect
@@ -317,7 +318,6 @@ require (
 	sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 // indirect
 	sigs.k8s.io/randfill v1.0.0 // indirect
 	sigs.k8s.io/structured-merge-diff/v6 v6.3.2-0.20260122202528-d9cc6641c482 // indirect
-	sigs.k8s.io/yaml v1.6.0 // indirect
 )
 
 tool (

--- a/pkg/api/v1/testkube/model_test_trigger_extended.go
+++ b/pkg/api/v1/testkube/model_test_trigger_extended.go
@@ -11,6 +11,36 @@ package testkube
 
 import "fmt"
 
+type TestTriggers []TestTrigger
+
+func (list TestTriggers) Table() (header []string, output [][]string) {
+	header = []string{"Name", "Namespace", "Resource", "Event", "Action", "Execution", "Disabled"}
+	for _, t := range list {
+		resource := ""
+		if t.ResourceRef != nil && t.ResourceRef.Kind != "" {
+			if t.ResourceRef.Group == "" {
+				resource = fmt.Sprintf("%s/%s", t.ResourceRef.Version, t.ResourceRef.Kind)
+			} else {
+				resource = fmt.Sprintf("%s/%s/%s", t.ResourceRef.Group, t.ResourceRef.Version, t.ResourceRef.Kind)
+			}
+		} else if t.Resource != nil {
+			resource = string(*t.Resource)
+		}
+		action := ""
+		if t.Action != nil {
+			action = string(*t.Action)
+		}
+		execution := ""
+		if t.Execution != nil {
+			execution = string(*t.Execution)
+		}
+		output = append(output, []string{
+			t.Name, t.Namespace, resource, t.Event, action, execution, fmt.Sprint(t.Disabled),
+		})
+	}
+	return
+}
+
 func (t TestTrigger) GetName() string {
 	return t.Name
 }

--- a/pkg/api/v1/testkube/model_workflow_trigger_extended.go
+++ b/pkg/api/v1/testkube/model_workflow_trigger_extended.go
@@ -1,0 +1,28 @@
+package testkube
+
+import "fmt"
+
+type WorkflowTriggers []WorkflowTrigger
+
+func (list WorkflowTriggers) Table() (header []string, output [][]string) {
+	header = []string{"Name", "Namespace", "Resource", "Event", "Workflow", "Disabled"}
+	for _, t := range list {
+		resource := ""
+		if t.Watch != nil && t.Watch.Resource.Kind != "" {
+			r := t.Watch.Resource
+			if r.Group == "" {
+				resource = fmt.Sprintf("%s/%s", r.Version, r.Kind)
+			} else {
+				resource = fmt.Sprintf("%s/%s/%s", r.Group, r.Version, r.Kind)
+			}
+		}
+		workflow := t.Run.Workflow.Name
+		if workflow == "" && t.Run.Workflow.NameRegex != "" {
+			workflow = "~" + t.Run.Workflow.NameRegex
+		}
+		output = append(output, []string{
+			t.Name, t.Namespace, resource, t.When.Event, workflow, fmt.Sprint(t.Disabled),
+		})
+	}
+	return
+}


### PR DESCRIPTION
## Summary

The CLI has `kubectl testkube <verb> workflowtrigger` but **no equivalent for `testtrigger`** — TestTrigger was the only top-level CRD without CLI support. This PR closes the gap by adding four commands that mirror the existing `workflowtriggers/` package one-to-one.

## Commands

| Command | Aliases |
|---|---|
| `kubectl testkube get testtrigger [name]` | `testtriggers`, `tt` |
| `kubectl testkube create testtrigger -f <file>` | `testtriggers`, `tt` |
| `kubectl testkube update testtrigger -f <file>` | `testtriggers`, `tt` |
| `kubectl testkube delete testtrigger <name>` | `testtriggers`, `tt` |

## Shape

Same pattern as `workflowtriggers/`:

- **`common.go`** — `readTestTriggerFromInput()` decodes stdin/file as YAML or JSON. Detects shape: top-level `spec:` → CRD (converted via `pkg/mapper/testtriggers.MapTestTriggerCRDToTestTriggerUpsertRequest`); otherwise flat `TestTriggerUpsertRequest`.
- **`get.go`** — single-get on name arg, list on no args, `-l/--label` for filter.
- **`create.go`** — `-f/--file` for manifest, `--update` for upsert behavior.
- **`update.go`** — `-f/--file` for manifest; always replaces.
- **`delete.go`** — delete-by-name or bulk delete via `-l/--label`.

All use the existing `pkg/api/v1/client` methods (`GetTestTrigger`, `CreateTestTrigger`, `UpdateTestTrigger`, `DeleteTestTrigger`, `ListTestTriggers`, `DeleteTestTriggers`) which were already in the client interface.

## Root command wiring

Same pattern as workflowtriggers — added to `get.go`, `create.go`, `update.go`, `delete.go` alongside the existing `workflowtriggers.New...Cmd()` calls.

## Test plan

- [x] `go build ./cmd/kubectl-testkube/...` — clean compile
- [x] `testkube get testtrigger --help` renders correct usage + flags
- [x] `testkube create testtrigger --help` renders `-f/--file` and `--update`
- [x] `testkube update testtrigger --help` renders `-f/--file`
- [x] `testkube delete testtrigger --help` renders `-l/--label` and positional name arg
- [ ] CI on a real control plane with a testtrigger round-trip (create → get → update → delete)