### PR TITLE
feat(triggers): add match[] field to TestTrigger for field-change filtering

### DIFF
--- a/api/testtriggers/v1/testtrigger_types.go
+++ b/api/testtriggers/v1/testtrigger_types.go
@@ -20,6 +20,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	commonv1 "github.com/kubeshop/testkube/api/common/v1"
+	workflowtriggersv1 "github.com/kubeshop/testkube/api/workflowtriggers/v1"
 )
 
 // EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!
@@ -56,6 +57,10 @@ type TestTriggerSpec struct {
 	ResourceSelector TestTriggerSelector `json:"resourceSelector,omitempty"`
 	// On which Event for a Resource should an Action be triggered
 	Event TestTriggerEvent `json:"event"`
+	// Match filters which object changes fire the trigger.
+	// Each entry evaluates a dot-path on the watched object (e.g. ".status.currentStepIndex",
+	// ".spec.template.spec.containers.0.image") with an operator. All entries must pass (AND logic).
+	Match []workflowtriggersv1.WorkflowTriggerFieldCondition `json:"match,omitempty"`
 	// What resource conditions should be matched
 	ConditionSpec *TestTriggerConditionSpec `json:"conditionSpec,omitempty"`
 	// What resource probes should be matched

--- a/api/testtriggers/v1/validation.go
+++ b/api/testtriggers/v1/validation.go
@@ -1,0 +1,49 @@
+package v1
+
+import (
+	"fmt"
+
+	workflowtriggersv1 "github.com/kubeshop/testkube/api/workflowtriggers/v1"
+)
+
+// Validate checks the TestTriggerSpec for logical errors that can't be caught
+// by CRD schema validation alone. Called from REST create/update handlers.
+// Currently scoped to the match[] field, mirroring WorkflowTriggerSpec.Validate.
+func (s *TestTriggerSpec) Validate() []error {
+	var errs []error
+
+	for i, cond := range s.Match {
+		if cond.Path == "" {
+			errs = append(errs, fmt.Errorf("match[%d].path is required", i))
+			continue
+		}
+
+		switch cond.Operator {
+		case workflowtriggersv1.FieldOperatorEquals,
+			workflowtriggersv1.FieldOperatorNotEquals,
+			workflowtriggersv1.FieldOperatorChangedTo,
+			workflowtriggersv1.FieldOperatorChangedFrom:
+			if cond.Value == "" {
+				errs = append(errs, fmt.Errorf("match[%d]: operator %q requires a value", i, cond.Operator))
+			}
+		case workflowtriggersv1.FieldOperatorExists,
+			workflowtriggersv1.FieldOperatorNotExists,
+			workflowtriggersv1.FieldOperatorChanged:
+			// no value needed
+		default:
+			errs = append(errs, fmt.Errorf("match[%d]: unknown operator %q", i, cond.Operator))
+		}
+
+		// change-based operators require the modified event
+		switch cond.Operator {
+		case workflowtriggersv1.FieldOperatorChanged,
+			workflowtriggersv1.FieldOperatorChangedTo,
+			workflowtriggersv1.FieldOperatorChangedFrom:
+			if s.Event != "" && s.Event != TestTriggerEventModified {
+				errs = append(errs, fmt.Errorf("match[%d]: operator %q requires event to be %q", i, cond.Operator, TestTriggerEventModified))
+			}
+		}
+	}
+
+	return errs
+}

--- a/api/testtriggers/v1/zz_generated.deepcopy.go
+++ b/api/testtriggers/v1/zz_generated.deepcopy.go
@@ -6,6 +6,7 @@ package v1
 
 import (
 	commonv1 "github.com/kubeshop/testkube/api/common/v1"
+	workflowtriggersv1 "github.com/kubeshop/testkube/api/workflowtriggers/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 )
@@ -238,6 +239,11 @@ func (in *TestTriggerSpec) DeepCopyInto(out *TestTriggerSpec) {
 		**out = **in
 	}
 	in.ResourceSelector.DeepCopyInto(&out.ResourceSelector)
+	if in.Match != nil {
+		in, out := &in.Match, &out.Match
+		*out = make([]workflowtriggersv1.WorkflowTriggerFieldCondition, len(*in))
+		copy(*out, *in)
+	}
 	if in.ConditionSpec != nil {
 		in, out := &in.ConditionSpec, &out.ConditionSpec
 		*out = new(TestTriggerConditionSpec)

--- a/internal/app/api/v1/testtriggers.go
+++ b/internal/app/api/v1/testtriggers.go
@@ -2,6 +2,7 @@ package v1
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"net/http"
 	"strings"
@@ -59,6 +60,10 @@ func (s *TestkubeAPI) CreateTestTriggerHandler() fiber.Handler {
 
 		errPrefix = errPrefix + " " + testTrigger.Name
 
+		if errs := testTrigger.Spec.Validate(); len(errs) > 0 {
+			return s.Error(c, http.StatusBadRequest, fmt.Errorf("%s: %w", errPrefix, errors.Join(errs...)))
+		}
+
 		s.Log.Infow("creating test trigger", "testTrigger", testTrigger)
 
 		// Convert CRD to API object for the new interface
@@ -106,6 +111,10 @@ func (s *TestkubeAPI) UpdateTestTriggerHandler() fiber.Handler {
 			namespace = request.Namespace
 		}
 		errPrefix = errPrefix + " " + request.Name
+
+		if errs := validateUpsertMatchConditions(request.Match, request.Event); len(errs) > 0 {
+			return s.Error(c, http.StatusBadRequest, fmt.Errorf("%s: %w", errPrefix, errors.Join(errs...)))
+		}
 
 		// we need to get resource first to validate it exists
 		existingTrigger, err := s.TestTriggersClient.Get(c.Context(), s.getEnvironmentId(), request.Name, namespace)
@@ -236,6 +245,10 @@ func (s *TestkubeAPI) BulkUpdateTestTriggersHandler() fiber.Handler {
 				crdTestTrigger.Name = generateTestTriggerName(&crdTestTrigger)
 			}
 
+			if errs := crdTestTrigger.Spec.Validate(); len(errs) > 0 {
+				return s.Error(c, http.StatusBadRequest, fmt.Errorf("%s %s: %w", errPrefix, crdTestTrigger.Name, errors.Join(errs...)))
+			}
+
 			// Convert CRD to API object for the new interface
 			apiTrigger := testtriggersmapper.MapCRDToAPI(&crdTestTrigger)
 
@@ -361,6 +374,45 @@ func (s *TestkubeAPI) GetTestTriggerKeyMapHandler() fiber.Handler {
 	return func(c *fiber.Ctx) error {
 		return c.JSON(triggerskeymapmapper.MapTestTriggerKeyMapToAPI(triggers.NewKeyMap()))
 	}
+}
+
+// validateUpsertMatchConditions mirrors TestTriggerSpec.Validate for the REST upsert path,
+// where we only have the OpenAPI type (not the CRD) and building the CRD via the mapper
+// would require non-nil selectors we don't have.
+func validateUpsertMatchConditions(match []testkube.TestTriggerFieldCondition, event string) []error {
+	var errs []error
+	for i, cond := range match {
+		if cond.Path == "" {
+			errs = append(errs, fmt.Errorf("match[%d].path is required", i))
+			continue
+		}
+
+		op := testkube.TestTriggerFieldOperator(cond.Operator)
+		switch op {
+		case testkube.TestTriggerFieldOperatorEquals,
+			testkube.TestTriggerFieldOperatorNotEquals,
+			testkube.TestTriggerFieldOperatorChangedTo,
+			testkube.TestTriggerFieldOperatorChangedFrom:
+			if cond.Value == "" {
+				errs = append(errs, fmt.Errorf("match[%d]: operator %q requires a value", i, op))
+			}
+		case testkube.TestTriggerFieldOperatorExists,
+			testkube.TestTriggerFieldOperatorNotExists,
+			testkube.TestTriggerFieldOperatorChanged:
+		default:
+			errs = append(errs, fmt.Errorf("match[%d]: unknown operator %q", i, cond.Operator))
+		}
+
+		switch op {
+		case testkube.TestTriggerFieldOperatorChanged,
+			testkube.TestTriggerFieldOperatorChangedTo,
+			testkube.TestTriggerFieldOperatorChangedFrom:
+			if event != "" && event != string(testtriggersv1.TestTriggerEventModified) {
+				errs = append(errs, fmt.Errorf("match[%d]: operator %q requires event to be %q", i, op, testtriggersv1.TestTriggerEventModified))
+			}
+		}
+	}
+	return errs
 }
 
 // generateTestTriggerName function generates a trigger name from the TestTrigger spec

--- a/k8s/crd/tests.testkube.io_testtriggers.yaml
+++ b/k8s/crd/tests.testkube.io_testtriggers.yaml
@@ -194,6 +194,40 @@ spec:
                 - testsuite
                 - testworkflow
                 type: string
+              match:
+                description: |-
+                  Match filters which object changes fire the trigger.
+                  Each entry evaluates a dot-path on the watched object (e.g. ".status.currentStepIndex",
+                  ".spec.template.spec.containers.0.image") with an operator. All entries must pass (AND logic).
+                items:
+                  description: WorkflowTriggerFieldCondition defines a field-level
+                    match condition.
+                  properties:
+                    operator:
+                      description: Operator is the comparison operator.
+                      enum:
+                      - equals
+                      - not_equals
+                      - exists
+                      - not_exists
+                      - changed
+                      - changed_to
+                      - changed_from
+                      type: string
+                    path:
+                      description: |-
+                        Path is a dot-path to a field on the K8s object, e.g. ".spec.replicas",
+                        ".spec.template.spec.containers.0.image". Array elements use .N syntax.
+                      type: string
+                    value:
+                      description: Value to compare against. Required for equals,
+                        not_equals, changed_to, changed_from.
+                      type: string
+                  required:
+                  - operator
+                  - path
+                  type: object
+                type: array
               probeSpec:
                 description: What resource probes should be matched
                 properties:

--- a/k8s/helm/testkube-crds/templates/_generated_crds.tpl
+++ b/k8s/helm/testkube-crds/templates/_generated_crds.tpl
@@ -6633,6 +6633,40 @@ spec:
                 - testsuite
                 - testworkflow
                 type: string
+              match:
+                description: |-
+                  Match filters which object changes fire the trigger.
+                  Each entry evaluates a dot-path on the watched object (e.g. ".status.currentStepIndex",
+                  ".spec.template.spec.containers.0.image") with an operator. All entries must pass (AND logic).
+                items:
+                  description: WorkflowTriggerFieldCondition defines a field-level
+                    match condition.
+                  properties:
+                    operator:
+                      description: Operator is the comparison operator.
+                      enum:
+                      - equals
+                      - not_equals
+                      - exists
+                      - not_exists
+                      - changed
+                      - changed_to
+                      - changed_from
+                      type: string
+                    path:
+                      description: |-
+                        Path is a dot-path to a field on the K8s object, e.g. ".spec.replicas",
+                        ".spec.template.spec.containers.0.image". Array elements use .N syntax.
+                      type: string
+                    value:
+                      description: Value to compare against. Required for equals,
+                        not_equals, changed_to, changed_from.
+                      type: string
+                  required:
+                  - operator
+                  - path
+                  type: object
+                type: array
               probeSpec:
                 description: What resource probes should be matched
                 properties:

--- a/k8s/helm/testkube-operator/charts/testkube-crds/templates/_generated_crds.tpl
+++ b/k8s/helm/testkube-operator/charts/testkube-crds/templates/_generated_crds.tpl
@@ -6633,6 +6633,40 @@ spec:
                 - testsuite
                 - testworkflow
                 type: string
+              match:
+                description: |-
+                  Match filters which object changes fire the trigger.
+                  Each entry evaluates a dot-path on the watched object (e.g. ".status.currentStepIndex",
+                  ".spec.template.spec.containers.0.image") with an operator. All entries must pass (AND logic).
+                items:
+                  description: WorkflowTriggerFieldCondition defines a field-level
+                    match condition.
+                  properties:
+                    operator:
+                      description: Operator is the comparison operator.
+                      enum:
+                      - equals
+                      - not_equals
+                      - exists
+                      - not_exists
+                      - changed
+                      - changed_to
+                      - changed_from
+                      type: string
+                    path:
+                      description: |-
+                        Path is a dot-path to a field on the K8s object, e.g. ".spec.replicas",
+                        ".spec.template.spec.containers.0.image". Array elements use .N syntax.
+                      type: string
+                    value:
+                      description: Value to compare against. Required for equals,
+                        not_equals, changed_to, changed_from.
+                      type: string
+                  required:
+                  - operator
+                  - path
+                  type: object
+                type: array
               probeSpec:
                 description: What resource probes should be matched
                 properties:

--- a/k8s/helm/testkube-runner/charts/testkube-crds/templates/_generated_crds.tpl
+++ b/k8s/helm/testkube-runner/charts/testkube-crds/templates/_generated_crds.tpl
@@ -6633,6 +6633,40 @@ spec:
                 - testsuite
                 - testworkflow
                 type: string
+              match:
+                description: |-
+                  Match filters which object changes fire the trigger.
+                  Each entry evaluates a dot-path on the watched object (e.g. ".status.currentStepIndex",
+                  ".spec.template.spec.containers.0.image") with an operator. All entries must pass (AND logic).
+                items:
+                  description: WorkflowTriggerFieldCondition defines a field-level
+                    match condition.
+                  properties:
+                    operator:
+                      description: Operator is the comparison operator.
+                      enum:
+                      - equals
+                      - not_equals
+                      - exists
+                      - not_exists
+                      - changed
+                      - changed_to
+                      - changed_from
+                      type: string
+                    path:
+                      description: |-
+                        Path is a dot-path to a field on the K8s object, e.g. ".spec.replicas",
+                        ".spec.template.spec.containers.0.image". Array elements use .N syntax.
+                      type: string
+                    value:
+                      description: Value to compare against. Required for equals,
+                        not_equals, changed_to, changed_from.
+                      type: string
+                  required:
+                  - operator
+                  - path
+                  type: object
+                type: array
               probeSpec:
                 description: What resource probes should be matched
                 properties:

--- a/pkg/api/v1/testkube/model_test_trigger.go
+++ b/pkg/api/v1/testkube/model_test_trigger.go
@@ -23,7 +23,9 @@ type TestTrigger struct {
 	ResourceRef      *TestTriggerResourceRef                      `json:"resourceRef,omitempty"`
 	ResourceSelector *TestTriggerSelector                         `json:"resourceSelector,omitempty"`
 	// listen for event for selected resource
-	Event             string                          `json:"event"`
+	Event string `json:"event"`
+	// Match filters which object changes fire the trigger (ANDed).
+	Match             []TestTriggerFieldCondition     `json:"match,omitempty"`
 	ConditionSpec     *TestTriggerConditionSpec       `json:"conditionSpec,omitempty"`
 	ProbeSpec         *TestTriggerProbeSpec           `json:"probeSpec,omitempty"`
 	Action            *TestTriggerActions             `json:"action"`

--- a/pkg/api/v1/testkube/model_test_trigger_field_condition.go
+++ b/pkg/api/v1/testkube/model_test_trigger_field_condition.go
@@ -1,0 +1,25 @@
+package testkube
+
+// TestTriggerFieldCondition defines a field-level match condition. Entries are ANDed.
+type TestTriggerFieldCondition struct {
+	// Dot-path to a field on the K8s object (e.g. ".spec.replicas", ".spec.template.spec.containers.0.image")
+	Path string `json:"path"`
+	// Comparison operator. One of: equals, not_equals, exists, not_exists, changed, changed_to, changed_from.
+	Operator TestTriggerFieldOperator `json:"operator"`
+	// Value to compare against. Required for equals, not_equals, changed_to, changed_from.
+	Value string `json:"value,omitempty"`
+}
+
+// TestTriggerFieldOperator : supported comparison operators for TestTrigger match conditions
+type TestTriggerFieldOperator string
+
+// List of TestTriggerFieldOperator
+const (
+	TestTriggerFieldOperatorEquals      TestTriggerFieldOperator = "equals"
+	TestTriggerFieldOperatorNotEquals   TestTriggerFieldOperator = "not_equals"
+	TestTriggerFieldOperatorExists      TestTriggerFieldOperator = "exists"
+	TestTriggerFieldOperatorNotExists   TestTriggerFieldOperator = "not_exists"
+	TestTriggerFieldOperatorChanged     TestTriggerFieldOperator = "changed"
+	TestTriggerFieldOperatorChangedTo   TestTriggerFieldOperator = "changed_to"
+	TestTriggerFieldOperatorChangedFrom TestTriggerFieldOperator = "changed_from"
+)

--- a/pkg/api/v1/testkube/model_test_trigger_upsert_request.go
+++ b/pkg/api/v1/testkube/model_test_trigger_upsert_request.go
@@ -24,7 +24,9 @@ type TestTriggerUpsertRequest struct {
 	ResourceRef      *TestTriggerResourceRef                      `json:"resourceRef,omitempty"`
 	ResourceSelector *TestTriggerSelector                         `json:"resourceSelector,omitempty"`
 	// listen for event for selected resource
-	Event             string                          `json:"event"`
+	Event string `json:"event"`
+	// Match filters which object changes fire the trigger (ANDed).
+	Match             []TestTriggerFieldCondition     `json:"match,omitempty"`
 	ConditionSpec     *TestTriggerConditionSpec       `json:"conditionSpec,omitempty"`
 	ProbeSpec         *TestTriggerProbeSpec           `json:"probeSpec,omitempty"`
 	Action            *TestTriggerActions             `json:"action"`

--- a/pkg/mapper/testtriggers/kube_openapi.go
+++ b/pkg/mapper/testtriggers/kube_openapi.go
@@ -4,6 +4,7 @@ import (
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	testsv1 "github.com/kubeshop/testkube/api/testtriggers/v1"
+	workflowtriggersv1 "github.com/kubeshop/testkube/api/workflowtriggers/v1"
 	"github.com/kubeshop/testkube/internal/common"
 	"github.com/kubeshop/testkube/pkg/api/v1/testkube"
 	commonmapper "github.com/kubeshop/testkube/pkg/mapper/common"
@@ -59,6 +60,7 @@ func MapCRDToAPI(crd *testsv1.TestTrigger) testkube.TestTrigger {
 		ResourceRef:       resourceRef,
 		ResourceSelector:  mapSelectorFromCRD(crd.Spec.ResourceSelector),
 		Event:             string(crd.Spec.Event),
+		Match:             mapFieldConditionsFromCRD(crd.Spec.Match),
 		ConditionSpec:     mapConditionSpecFromCRD(crd.Spec.ConditionSpec),
 		ProbeSpec:         mapProbeSpecFromCRD(crd.Spec.ProbeSpec),
 		Action:            action,
@@ -98,6 +100,21 @@ func mapLabelSelectorFromCRD(labelSelector *v1.LabelSelector) *testkube.IoK8sApi
 		MatchExpressions: matchExpressions,
 		MatchLabels:      labelSelector.MatchLabels,
 	}
+}
+
+func mapFieldConditionsFromCRD(in []workflowtriggersv1.WorkflowTriggerFieldCondition) []testkube.TestTriggerFieldCondition {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make([]testkube.TestTriggerFieldCondition, 0, len(in))
+	for _, c := range in {
+		out = append(out, testkube.TestTriggerFieldCondition{
+			Path:     c.Path,
+			Operator: testkube.TestTriggerFieldOperator(c.Operator),
+			Value:    c.Value,
+		})
+	}
+	return out
 }
 
 func mapConditionSpecFromCRD(conditionSpec *testsv1.TestTriggerConditionSpec) *testkube.TestTriggerConditionSpec {
@@ -174,6 +191,7 @@ func MapTestTriggerCRDToTestTriggerUpsertRequest(request testsv1.TestTrigger) te
 		ResourceRef:       resourceRef,
 		ResourceSelector:  mapSelectorFromCRD(request.Spec.ResourceSelector),
 		Event:             string(request.Spec.Event),
+		Match:             mapFieldConditionsFromCRD(request.Spec.Match),
 		ConditionSpec:     mapConditionSpecFromCRD(request.Spec.ConditionSpec),
 		ProbeSpec:         mapProbeSpecFromCRD(request.Spec.ProbeSpec),
 		Action:            action,

--- a/pkg/mapper/testtriggers/openapi_kube.go
+++ b/pkg/mapper/testtriggers/openapi_kube.go
@@ -4,6 +4,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	testsv1 "github.com/kubeshop/testkube/api/testtriggers/v1"
+	workflowtriggersv1 "github.com/kubeshop/testkube/api/workflowtriggers/v1"
 	"github.com/kubeshop/testkube/internal/common"
 	"github.com/kubeshop/testkube/pkg/api/v1/testkube"
 	commonmapper "github.com/kubeshop/testkube/pkg/mapper/common"
@@ -42,6 +43,7 @@ func MapTestTriggerUpsertRequestToTestTriggerCRD(request testkube.TestTriggerUps
 			ResourceRef:       mapResourceRefToCRD(request.ResourceRef),
 			ResourceSelector:  mapSelectorToCRD(request.ResourceSelector),
 			Event:             testsv1.TestTriggerEvent(request.Event),
+			Match:             mapFieldConditionsToCRD(request.Match),
 			ConditionSpec:     mapConditionSpecCRD(request.ConditionSpec),
 			ProbeSpec:         mapProbeSpecCRD(request.ProbeSpec),
 			Action:            action,
@@ -105,6 +107,7 @@ func MapTestTriggerUpsertRequestToTestTriggerCRDWithExistingMeta(request testkub
 			ResourceRef:       mapResourceRefToCRD(request.ResourceRef),
 			ResourceSelector:  mapSelectorToCRD(request.ResourceSelector),
 			Event:             testsv1.TestTriggerEvent(request.Event),
+			Match:             mapFieldConditionsToCRD(request.Match),
 			ConditionSpec:     mapConditionSpecCRD(request.ConditionSpec),
 			ProbeSpec:         mapProbeSpecCRD(request.ProbeSpec),
 			Action:            action,
@@ -198,6 +201,21 @@ func mapProbeSpecCRD(probeSpec *testkube.TestTriggerProbeSpec) *testsv1.TestTrig
 		Delay:   probeSpec.Delay,
 		Probes:  probes,
 	}
+}
+
+func mapFieldConditionsToCRD(in []testkube.TestTriggerFieldCondition) []workflowtriggersv1.WorkflowTriggerFieldCondition {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make([]workflowtriggersv1.WorkflowTriggerFieldCondition, 0, len(in))
+	for _, c := range in {
+		out = append(out, workflowtriggersv1.WorkflowTriggerFieldCondition{
+			Path:     c.Path,
+			Operator: workflowtriggersv1.WorkflowTriggerFieldOperator(c.Operator),
+			Value:    c.Value,
+		})
+	}
+	return out
 }
 
 func mapActionParametersCRD(actionParameters *testkube.TestTriggerActionParameters) *testsv1.TestTriggerActionParameters {

--- a/pkg/triggers/internal_trigger.go
+++ b/pkg/triggers/internal_trigger.go
@@ -109,6 +109,7 @@ func convertV1ToInternal(t *testtriggersv1.TestTrigger) *internalTrigger {
 		Source:             triggerSourceV1,
 		Event:              string(t.Spec.Event),
 		EventLabelSelector: t.Spec.Selector,
+		FieldConditions:    t.Spec.Match,
 		Execution:          string(t.Spec.Execution),
 		Disabled:           t.Spec.Disabled,
 	}
@@ -123,7 +124,7 @@ func convertV1ToInternal(t *testtriggersv1.TestTrigger) *internalTrigger {
 		it.ResourceKind = string(t.Spec.Resource)
 	}
 
-	// If ResourceRef is set, use it directly (overrides Resource enum)
+	// ResourceRef overrides the Resource enum when set.
 	if t.Spec.ResourceRef != nil {
 		it.ResourceGroup = t.Spec.ResourceRef.Group
 		it.ResourceVersion = t.Spec.ResourceRef.Version

--- a/pkg/triggers/internal_trigger_test.go
+++ b/pkg/triggers/internal_trigger_test.go
@@ -30,6 +30,10 @@ func TestConvertV1ToInternal(t *testing.T) {
 				NameRegex: "api-.*",
 			},
 			Event: testtriggersv1.TestTriggerEventModified,
+			Match: []workflowtriggersv1.WorkflowTriggerFieldCondition{
+				{Path: ".status.currentStepIndex", Operator: workflowtriggersv1.FieldOperatorChanged},
+				{Path: ".status.phase", Operator: workflowtriggersv1.FieldOperatorEquals, Value: "Progressing"},
+			},
 			ConditionSpec: &testtriggersv1.TestTriggerConditionSpec{
 				Conditions: []testtriggersv1.TestTriggerCondition{
 					{Type_: "Available", Status: &condStatus, Reason: "MinimumReplicasAvailable"},
@@ -73,8 +77,12 @@ func TestConvertV1ToInternal(t *testing.T) {
 	// Event
 	assert.Equal(t, "modified", it.Event)
 
-	// No field conditions in v1
-	assert.Empty(t, it.FieldConditions)
+	// Field conditions (match) passthrough
+	require.Len(t, it.FieldConditions, 2)
+	assert.Equal(t, ".status.currentStepIndex", it.FieldConditions[0].Path)
+	assert.Equal(t, workflowtriggersv1.FieldOperatorChanged, it.FieldConditions[0].Operator)
+	assert.Equal(t, ".status.phase", it.FieldConditions[1].Path)
+	assert.Equal(t, "Progressing", it.FieldConditions[1].Value)
 
 	// Conditions
 	require.NotNil(t, it.Conditions)

--- a/pkg/triggers/matcher_test.go
+++ b/pkg/triggers/matcher_test.go
@@ -9,9 +9,11 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	testtriggersv1 "github.com/kubeshop/testkube/api/testtriggers/v1"
+	workflowtriggersv1 "github.com/kubeshop/testkube/api/workflowtriggers/v1"
 	"github.com/kubeshop/testkube/internal/app/api/metrics"
 	"github.com/kubeshop/testkube/pkg/log"
 	"github.com/kubeshop/testkube/pkg/operator/validation/tests/v1/testtrigger"
@@ -520,6 +522,75 @@ func TestService_noMatch(t *testing.T) {
 
 	err := s.match(context.Background(), e)
 	assert.NoError(t, err)
+}
+
+// TestService_match_v1WithFieldConditions verifies that a v1 TestTrigger with
+// spec.match[] filters firings through the shared WorkflowTrigger field-matcher
+// engine — equivalent-value change skips, actual change fires.
+func TestService_match_v1WithFieldConditions(t *testing.T) {
+	makeDeploy := func(replicas int32) *appsv1.Deployment {
+		return &appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{Name: "api", Namespace: "default"},
+			Spec:       appsv1.DeploymentSpec{Replicas: int32Ptr(replicas)},
+		}
+	}
+
+	trigger := &testtriggersv1.TestTrigger{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "testkube", Name: "replicas-changed"},
+		Spec: testtriggersv1.TestTriggerSpec{
+			Resource:         "deployment",
+			ResourceSelector: testtriggersv1.TestTriggerSelector{Name: "api"},
+			Event:            "modified",
+			Match: []workflowtriggersv1.WorkflowTriggerFieldCondition{
+				{Path: ".spec.replicas", Operator: workflowtriggersv1.FieldOperatorChanged},
+			},
+			Action:            "run",
+			Execution:         "testworkflow",
+			ConcurrencyPolicy: "allow",
+			TestSelector:      testtriggersv1.TestTriggerSelector{Name: "smoke"},
+		},
+	}
+	key := newStatusKey(triggerSourceV1, trigger.Namespace, trigger.Name)
+	status := &triggerStatus{trigger: convertV1ToInternal(trigger)}
+
+	// Sanity: the conversion populated FieldConditions on the internal form.
+	require.Len(t, status.trigger.FieldConditions, 1)
+	assert.Equal(t, workflowtriggersv1.FieldOperatorChanged, status.trigger.FieldConditions[0].Operator)
+
+	cases := []struct {
+		name       string
+		oldObj     any
+		newObj     any
+		shouldFire bool
+	}{
+		{"replicas changed 3->5 fires", makeDeploy(3), makeDeploy(5), true},
+		{"replicas unchanged 5->5 skips", makeDeploy(5), makeDeploy(5), false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			fired := false
+			s := &Service{
+				triggerExecutor: func(ctx context.Context, e *watcherEvent, it *internalTrigger) error {
+					fired = true
+					return nil
+				},
+				triggerStatus: map[statusKey]*triggerStatus{key: status},
+				logger:        log.DefaultLogger,
+				metrics:       metrics.NewMetrics(),
+			}
+			err := s.match(context.Background(), &watcherEvent{
+				resource:  "deployment",
+				name:      "api",
+				Namespace: "default",
+				eventType: "modified",
+				Object:    tc.newObj,
+				OldObject: tc.oldObj,
+			})
+			require.NoError(t, err)
+			assert.Equal(t, tc.shouldFire, fired)
+		})
+	}
 }
 
 func newDefaultTestTriggersService(t *testing.T, trigger *testtriggersv1.TestTrigger) *Service {

--- a/pkg/triggers/watcher.go
+++ b/pkg/triggers/watcher.go
@@ -365,6 +365,7 @@ func (s *Service) startCloudTestTriggerWatch(ctx context.Context, stop <-chan st
 			ResourceRef:       t.ResourceRef,
 			ResourceSelector:  t.ResourceSelector,
 			Event:             t.Event,
+			Match:             t.Match,
 			ConditionSpec:     t.ConditionSpec,
 			ProbeSpec:         t.ProbeSpec,
 			Action:            t.Action,


### PR DESCRIPTION
## Summary

- Adds `spec.match[]` to TestTrigger: array of `{path, operator, value}` predicates evaluated against the watched object. Supported operators: `equals`, `not_equals`, `exists`, `not_exists`, `changed`, `changed_to`, `changed_from`.
- Reuses the WorkflowTrigger v2 engine (\`pkg/triggers/field_matcher.go\`), which was already wired in the unified matcher (\`matcher.go:55-58\`) but silently passed for v1 because the CRD had no field to populate. One-line change in \`internal_trigger.go\` closes that gap.
- OpenAPI models, CRD, mappers (both directions) updated. Matches the hand-edit pattern already used for \`resourceRef\`.

## Why

Customer was running TestTrigger on an Argo Rollouts Rollout (\`resourceRef: argoproj.io/v1alpha1/Rollout\`, event: \`modified\`) and seeing the trigger fire on every status mutation — replica count updates, pod hash changes, condition flips — not just meaningful step changes. Before this, the only way to express ''fire on \`.status.currentStepIndex\` change'' was WorkflowTrigger v2, which the customer is not ready to migrate to.

## Customer YAML, now supported

\`\`\`yaml
apiVersion: tests.testkube.io/v1
kind: TestTrigger
spec:
  resourceRef: {group: argoproj.io, version: v1alpha1, kind: Rollout}
  resourceSelector: {name: api-server}
  event: modified
  match:
    - path: \".status.currentStepIndex\"
      operator: changed
  action: run
  execution: testworkflow
  testSelector: {name: canary-smoke-test}
  actionParameters:
    config:
      STEP:  \"jsonpath={.status.currentStepIndex}\"
      IMAGE: \"jsonpath={.spec.template.spec.containers[0].image}\"
  concurrencyPolicy: allow
\`\`\`

## Validation (live, local k3d cluster)

- Rollout canary nginx:1.28 → nginx:1.30 progressed 0→6; trigger fired exactly 6×, one per \`.status.currentStepIndex\` transition.
- Metadata-only mutations (label/annotation churn) produced **zero** firings.
- \`jsonpath=\` resolution confirmed — stored \`configparams\` shows \`STEP=6\`, \`IMAGE=nginx:1.30\` per run (mongo + postgres both verified).
- Mongo + postgres sync paths both preserve \`match\` as JSONB. Postgres wiring lives in the companion cp-api PR.

## Test plan

- [x] \`go test ./pkg/triggers/... ./pkg/mapper/testtriggers/...\`
- [x] \`make generate-crds\` clean (no drift)
- [x] Trigger fires exactly on step changes
- [x] Negative case — metadata-only mutation does not fire
- [x] jsonpath templating resolves to runtime values