### PR TITLE
fix(executions): Improving executions query performance

### DIFF
--- a/pkg/controlplane/scheduling/sqlc/execution_querier.sql.go
+++ b/pkg/controlplane/scheduling/sqlc/execution_querier.sql.go
@@ -11,7 +11,7 @@ import (
 
 const getExecutionsByStatus = `-- name: GetExecutionsByStatus :many
 SELECT
-    e.id, e.name, e.namespace, e.number, e.test_workflow_execution_name, e.group_id, e.runner_id, e.runner_target, e.runner_original_target, e.disable_webhooks, e.tags, e.running_context, e.config_params, e.scheduled_at, e.assigned_at, e.status_at, e.created_at, e.updated_at, e.organization_id, e.environment_id, e.runtime, e.silent_mode,
+    e.id, e.name, e.namespace, e.number, e.test_workflow_execution_name, e.group_id, e.runner_id, e.runner_target, e.runner_original_target, e.disable_webhooks, e.tags, e.running_context, e.config_params, e.scheduled_at, e.assigned_at, e.status_at, e.created_at, e.updated_at, e.organization_id, e.environment_id, e.runtime, e.silent_mode, e.workflow_name, e.status,
     r.execution_id, r.status, r.predicted_status, r.duration, r.total_duration, r.duration_ms, r.paused_ms, r.total_duration_ms, r.pauses, r.initialization, r.steps, r.queued_at, r.started_at, r.finished_at, r.created_at, r.updated_at
 FROM
     test_workflow_executions e
@@ -63,6 +63,8 @@ func (q *Queries) GetExecutionsByStatus(ctx context.Context, arg GetExecutionsBy
 			&i.TestWorkflowExecution.EnvironmentID,
 			&i.TestWorkflowExecution.Runtime,
 			&i.TestWorkflowExecution.SilentMode,
+			&i.TestWorkflowExecution.WorkflowName,
+			&i.TestWorkflowExecution.Status,
 			&i.TestWorkflowResult.ExecutionID,
 			&i.TestWorkflowResult.Status,
 			&i.TestWorkflowResult.PredictedStatus,
@@ -92,7 +94,7 @@ func (q *Queries) GetExecutionsByStatus(ctx context.Context, arg GetExecutionsBy
 
 const getExecutionsByStatuses = `-- name: GetExecutionsByStatuses :many
 SELECT
-    e.id, e.name, e.namespace, e.number, e.test_workflow_execution_name, e.group_id, e.runner_id, e.runner_target, e.runner_original_target, e.disable_webhooks, e.tags, e.running_context, e.config_params, e.scheduled_at, e.assigned_at, e.status_at, e.created_at, e.updated_at, e.organization_id, e.environment_id, e.runtime, e.silent_mode,
+    e.id, e.name, e.namespace, e.number, e.test_workflow_execution_name, e.group_id, e.runner_id, e.runner_target, e.runner_original_target, e.disable_webhooks, e.tags, e.running_context, e.config_params, e.scheduled_at, e.assigned_at, e.status_at, e.created_at, e.updated_at, e.organization_id, e.environment_id, e.runtime, e.silent_mode, e.workflow_name, e.status,
     r.execution_id, r.status, r.predicted_status, r.duration, r.total_duration, r.duration_ms, r.paused_ms, r.total_duration_ms, r.pauses, r.initialization, r.steps, r.queued_at, r.started_at, r.finished_at, r.created_at, r.updated_at
 FROM
     test_workflow_executions e
@@ -138,6 +140,8 @@ func (q *Queries) GetExecutionsByStatuses(ctx context.Context, statuses []string
 			&i.TestWorkflowExecution.EnvironmentID,
 			&i.TestWorkflowExecution.Runtime,
 			&i.TestWorkflowExecution.SilentMode,
+			&i.TestWorkflowExecution.WorkflowName,
+			&i.TestWorkflowExecution.Status,
 			&i.TestWorkflowResult.ExecutionID,
 			&i.TestWorkflowResult.Status,
 			&i.TestWorkflowResult.PredictedStatus,

--- a/pkg/controlplane/scheduling/sqlc/models.go
+++ b/pkg/controlplane/scheduling/sqlc/models.go
@@ -68,6 +68,8 @@ type TestWorkflowExecution struct {
 	EnvironmentID             string                                               `db:"environment_id" json:"environment_id"`
 	Runtime                   *testkube.TestWorkflowExecutionRuntime               `db:"runtime" json:"runtime"`
 	SilentMode                *testkube.SilentMode                                 `db:"silent_mode" json:"silent_mode"`
+	WorkflowName              pgtype.Text                                          `db:"workflow_name" json:"workflow_name"`
+	Status                    pgtype.Text                                          `db:"status" json:"status"`
 }
 
 type TestWorkflowOutput struct {

--- a/pkg/controlplane/scheduling/sqlc/scheduler.sql.go
+++ b/pkg/controlplane/scheduling/sqlc/scheduler.sql.go
@@ -55,7 +55,7 @@ SET
     status_at = $2::timestamptz,
     assigned_at = $2::timestamptz,
     updated_at = $2::timestamptz
-WHERE id = $3::text RETURNING id, name, namespace, number, test_workflow_execution_name, group_id, runner_id, runner_target, runner_original_target, disable_webhooks, tags, running_context, config_params, scheduled_at, assigned_at, status_at, created_at, updated_at, organization_id, environment_id, runtime, silent_mode
+WHERE id = $3::text RETURNING id, name, namespace, number, test_workflow_execution_name, group_id, runner_id, runner_target, runner_original_target, disable_webhooks, tags, running_context, config_params, scheduled_at, assigned_at, status_at, created_at, updated_at, organization_id, environment_id, runtime, silent_mode, workflow_name, status
 `
 
 type AssignExecutionRootParams struct {
@@ -90,6 +90,8 @@ func (q *Queries) AssignExecutionRoot(ctx context.Context, arg AssignExecutionRo
 		&i.EnvironmentID,
 		&i.Runtime,
 		&i.SilentMode,
+		&i.WorkflowName,
+		&i.Status,
 	)
 	return i, err
 }
@@ -275,7 +277,7 @@ func (q *Queries) GetExecutionWorkflow(ctx context.Context, executionID string) 
 
 const getNextExecution = `-- name: GetNextExecution :one
 SELECT
-    e.id, e.name, e.namespace, e.number, e.test_workflow_execution_name, e.group_id, e.runner_id, e.runner_target, e.runner_original_target, e.disable_webhooks, e.tags, e.running_context, e.config_params, e.scheduled_at, e.assigned_at, e.status_at, e.created_at, e.updated_at, e.organization_id, e.environment_id, e.runtime, e.silent_mode,
+    e.id, e.name, e.namespace, e.number, e.test_workflow_execution_name, e.group_id, e.runner_id, e.runner_target, e.runner_original_target, e.disable_webhooks, e.tags, e.running_context, e.config_params, e.scheduled_at, e.assigned_at, e.status_at, e.created_at, e.updated_at, e.organization_id, e.environment_id, e.runtime, e.silent_mode, e.workflow_name, e.status,
     r.execution_id, r.status, r.predicted_status, r.duration, r.total_duration, r.duration_ms, r.paused_ms, r.total_duration_ms, r.pauses, r.initialization, r.steps, r.queued_at, r.started_at, r.finished_at, r.created_at, r.updated_at
 FROM
     test_workflow_executions e
@@ -321,6 +323,8 @@ func (q *Queries) GetNextExecution(ctx context.Context) (GetNextExecutionRow, er
 		&i.TestWorkflowExecution.EnvironmentID,
 		&i.TestWorkflowExecution.Runtime,
 		&i.TestWorkflowExecution.SilentMode,
+		&i.TestWorkflowExecution.WorkflowName,
+		&i.TestWorkflowExecution.Status,
 		&i.TestWorkflowResult.ExecutionID,
 		&i.TestWorkflowResult.Status,
 		&i.TestWorkflowResult.PredictedStatus,

--- a/pkg/database/postgres/migrations/20260422120000_denormalize_execution_status_name.sql
+++ b/pkg/database/postgres/migrations/20260422120000_denormalize_execution_status_name.sql
@@ -1,0 +1,94 @@
+-- +goose Up
+-- +goose StatementBegin
+-- Denormalize workflow_name and status onto test_workflow_executions so that
+-- aggregations (totals) and ordered list queries do not need to join
+-- test_workflows / test_workflow_results in the hot path. Both columns are
+-- kept in sync via triggers on the source-of-truth tables.
+ALTER TABLE test_workflow_executions
+    ADD COLUMN workflow_name VARCHAR(255),
+    ADD COLUMN status        VARCHAR(50);
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+-- Backfill workflow_name from the canonical "workflow" row in test_workflows.
+UPDATE test_workflow_executions e
+   SET workflow_name = w.name
+  FROM test_workflows w
+ WHERE w.execution_id = e.id
+   AND w.workflow_type = 'workflow'
+   AND e.workflow_name IS NULL;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+-- Backfill status from test_workflow_results.
+UPDATE test_workflow_executions e
+   SET status = r.status
+  FROM test_workflow_results r
+ WHERE r.execution_id = e.id
+   AND e.status IS NULL;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+-- Trigger: keep test_workflow_executions.status in sync with test_workflow_results.status.
+CREATE OR REPLACE FUNCTION sync_execution_status() RETURNS trigger AS $$
+BEGIN
+    UPDATE test_workflow_executions
+       SET status = NEW.status
+     WHERE id = NEW.execution_id
+       AND status IS DISTINCT FROM NEW.status;
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+CREATE TRIGGER trg_sync_execution_status
+AFTER INSERT OR UPDATE OF status ON test_workflow_results
+FOR EACH ROW EXECUTE FUNCTION sync_execution_status();
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+-- Trigger: keep test_workflow_executions.workflow_name in sync with the
+-- canonical "workflow" row in test_workflows. Only fires when the workflow_type
+-- row is the source-of-truth one ('workflow'), not 'resolved_workflow'.
+CREATE OR REPLACE FUNCTION sync_execution_workflow_name() RETURNS trigger AS $$
+BEGIN
+    IF NEW.workflow_type = 'workflow' THEN
+        UPDATE test_workflow_executions
+           SET workflow_name = NEW.name
+         WHERE id = NEW.execution_id
+           AND workflow_name IS DISTINCT FROM NEW.name;
+    END IF;
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+CREATE TRIGGER trg_sync_execution_workflow_name
+AFTER INSERT OR UPDATE OF name, workflow_type ON test_workflows
+FOR EACH ROW EXECUTE FUNCTION sync_execution_workflow_name();
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+DROP TRIGGER IF EXISTS trg_sync_execution_workflow_name ON test_workflows;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+DROP TRIGGER IF EXISTS trg_sync_execution_status ON test_workflow_results;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+DROP FUNCTION IF EXISTS sync_execution_workflow_name();
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+DROP FUNCTION IF EXISTS sync_execution_status();
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+ALTER TABLE test_workflow_executions
+    DROP COLUMN IF EXISTS workflow_name,
+    DROP COLUMN IF EXISTS status;
+-- +goose StatementEnd

--- a/pkg/database/postgres/migrations/20260422120001_index_executions_status_name.sql
+++ b/pkg/database/postgres/migrations/20260422120001_index_executions_status_name.sql
@@ -1,0 +1,17 @@
+-- +goose NO TRANSACTION
+
+-- +goose Up
+-- Composite index that covers totals (org/env/workflow_name/status) and lets
+-- counts grouped by status come straight from the index.
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_twe_org_env_wfname_status
+    ON test_workflow_executions (organization_id, environment_id, workflow_name, status);
+
+-- Composite index that covers the summary list query (org/env/workflow_name +
+-- ORDER BY scheduled_at DESC LIMIT N), letting the executor walk the index
+-- backwards and stop at the page boundary.
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_twe_org_env_wfname_sched
+    ON test_workflow_executions (organization_id, environment_id, workflow_name, scheduled_at DESC);
+
+-- +goose Down
+DROP INDEX CONCURRENTLY IF EXISTS idx_twe_org_env_wfname_sched;
+DROP INDEX CONCURRENTLY IF EXISTS idx_twe_org_env_wfname_status;

--- a/pkg/database/postgres/queries/executions.sql
+++ b/pkg/database/postgres/queries/executions.sql
@@ -461,19 +461,19 @@ LIMIT NULLIF(@lmt, 0) OFFSET @fst;
 
 -- name: GetTestWorkflowExecutionsTotals :many
 SELECT
-    r.status,
+    e.status,
     COUNT(*) as count
 FROM test_workflow_executions e
 LEFT JOIN test_workflow_results r ON e.id = r.execution_id
 LEFT JOIN test_workflows w ON e.id = w.execution_id AND w.workflow_type = 'workflow'
 WHERE (e.organization_id = @organization_id AND e.environment_id = @environment_id)
-    AND (COALESCE(@workflow_name::text, '') = '' OR w.name = @workflow_name::text)
-    AND (COALESCE(@workflow_names::text[], ARRAY[]::text[]) = ARRAY[]::text[] OR w.name = ANY(@workflow_names::text[]))
+    AND (COALESCE(@workflow_name::text, '') = '' OR e.workflow_name = @workflow_name::text)
+    AND (COALESCE(@workflow_names::text[], ARRAY[]::text[]) = ARRAY[]::text[] OR e.workflow_name = ANY(@workflow_names::text[]))
     AND (COALESCE(@text_search::text, '') = '' OR e.name ILIKE '%' || @text_search::text || '%')
     AND (COALESCE(@start_date::timestamptz, '1900-01-01'::timestamptz) = '1900-01-01'::timestamptz OR e.scheduled_at >= @start_date::timestamptz)
     AND (COALESCE(@end_date::timestamptz, '2100-01-01'::timestamptz) = '2100-01-01'::timestamptz OR e.scheduled_at <= @end_date::timestamptz)
     AND (COALESCE(@last_n_days::integer, 0) = 0 OR e.scheduled_at >= NOW() - (COALESCE(@last_n_days::integer, 0) || ' days')::interval)
-    AND (COALESCE(@statuses::text[], ARRAY[]::text[]) = ARRAY[]::text[] OR r.status = ANY(@statuses::text[]))
+    AND (COALESCE(@statuses::text[], ARRAY[]::text[]) = ARRAY[]::text[] OR e.status = ANY(@statuses::text[]))
     AND (COALESCE(@runner_id::text, '') = '' OR e.runner_id = @runner_id::text)
     AND (COALESCE(@assigned, NULL) IS NULL OR
          (@assigned::boolean = true AND e.runner_id IS NOT NULL AND e.runner_id != '') OR
@@ -482,8 +482,8 @@ WHERE (e.organization_id = @organization_id AND e.environment_id = @environment_
     AND (COALESCE(@actor_type::text, '') = '' OR e.running_context->'actor'->>'type_' = @actor_type::text)
     AND (COALESCE(@group_id::text, '') = '' OR e.id = @group_id::text OR e.group_id = @group_id::text)
     AND (COALESCE(@initialized, NULL) IS NULL OR
-         (@initialized::boolean = true AND (r.status != 'queued' OR r.steps IS NOT NULL)) OR
-         (@initialized::boolean = false AND r.status = 'queued' AND (r.steps IS NULL OR r.steps = '{}'::jsonb)))
+         (@initialized::boolean = true AND (e.status != 'queued' OR r.steps IS NOT NULL)) OR
+         (@initialized::boolean = false AND e.status = 'queued' AND (r.steps IS NULL OR r.steps = '{}'::jsonb)))
     AND (COALESCE(@health_ranges::jsonb, '[]'::jsonb) = '[]'::jsonb OR
           EXISTS (
               SELECT 1 FROM jsonb_array_elements(@health_ranges::jsonb) AS range_obj
@@ -549,7 +549,7 @@ WHERE (e.organization_id = @organization_id AND e.environment_id = @environment_
             ) = (SELECT COUNT(DISTINCT split_part(cond, '=', 1)) FROM unnest(@selector_conditions::text[]) AS cond)
         )
     )
-GROUP BY r.status;
+GROUP BY e.status;
 
 -- name: GetTestWorkflowExecutions :many
 SELECT

--- a/pkg/database/postgres/sqlc/executions.sql.go
+++ b/pkg/database/postgres/sqlc/executions.sql.go
@@ -2914,14 +2914,6 @@ type GetTestWorkflowExecutionsTotalsRow struct {
 	Count  int64       `db:"count" json:"count"`
 }
 
-// Totals are read from denormalized columns on test_workflow_executions
-// (status, workflow_name) maintained by triggers on test_workflow_results and
-// test_workflows. The LEFT JOINs are kept only because the @initialized,
-// @label_*, @selector_* and @health_ranges filters reference r.steps,
-// w.labels and w.status; when none of those filters are set, the planner
-// elides both joins (the right sides are unique on execution_id), letting the
-// query be served by an index-only scan over
-// idx_twe_org_env_wfname_status.
 func (q *Queries) GetTestWorkflowExecutionsTotals(ctx context.Context, arg GetTestWorkflowExecutionsTotalsParams) ([]GetTestWorkflowExecutionsTotalsRow, error) {
 	rows, err := q.db.Query(ctx, getTestWorkflowExecutionsTotals,
 		arg.OrganizationID,

--- a/pkg/database/postgres/sqlc/executions.sql.go
+++ b/pkg/database/postgres/sqlc/executions.sql.go
@@ -2793,19 +2793,19 @@ func (q *Queries) GetTestWorkflowExecutionsSummary(ctx context.Context, arg GetT
 
 const getTestWorkflowExecutionsTotals = `-- name: GetTestWorkflowExecutionsTotals :many
 SELECT
-    r.status,
+    e.status,
     COUNT(*) as count
 FROM test_workflow_executions e
 LEFT JOIN test_workflow_results r ON e.id = r.execution_id
 LEFT JOIN test_workflows w ON e.id = w.execution_id AND w.workflow_type = 'workflow'
 WHERE (e.organization_id = $1 AND e.environment_id = $2)
-    AND (COALESCE($3::text, '') = '' OR w.name = $3::text)
-    AND (COALESCE($4::text[], ARRAY[]::text[]) = ARRAY[]::text[] OR w.name = ANY($4::text[]))
+    AND (COALESCE($3::text, '') = '' OR e.workflow_name = $3::text)
+    AND (COALESCE($4::text[], ARRAY[]::text[]) = ARRAY[]::text[] OR e.workflow_name = ANY($4::text[]))
     AND (COALESCE($5::text, '') = '' OR e.name ILIKE '%' || $5::text || '%')
     AND (COALESCE($6::timestamptz, '1900-01-01'::timestamptz) = '1900-01-01'::timestamptz OR e.scheduled_at >= $6::timestamptz)
     AND (COALESCE($7::timestamptz, '2100-01-01'::timestamptz) = '2100-01-01'::timestamptz OR e.scheduled_at <= $7::timestamptz)
     AND (COALESCE($8::integer, 0) = 0 OR e.scheduled_at >= NOW() - (COALESCE($8::integer, 0) || ' days')::interval)
-    AND (COALESCE($9::text[], ARRAY[]::text[]) = ARRAY[]::text[] OR r.status = ANY($9::text[]))
+    AND (COALESCE($9::text[], ARRAY[]::text[]) = ARRAY[]::text[] OR e.status = ANY($9::text[]))
     AND (COALESCE($10::text, '') = '' OR e.runner_id = $10::text)
     AND (COALESCE($11, NULL) IS NULL OR
          ($11::boolean = true AND e.runner_id IS NOT NULL AND e.runner_id != '') OR
@@ -2814,8 +2814,8 @@ WHERE (e.organization_id = $1 AND e.environment_id = $2)
     AND (COALESCE($13::text, '') = '' OR e.running_context->'actor'->>'type_' = $13::text)
     AND (COALESCE($14::text, '') = '' OR e.id = $14::text OR e.group_id = $14::text)
     AND (COALESCE($15, NULL) IS NULL OR
-         ($15::boolean = true AND (r.status != 'queued' OR r.steps IS NOT NULL)) OR
-         ($15::boolean = false AND r.status = 'queued' AND (r.steps IS NULL OR r.steps = '{}'::jsonb)))
+         ($15::boolean = true AND (e.status != 'queued' OR r.steps IS NOT NULL)) OR
+         ($15::boolean = false AND e.status = 'queued' AND (r.steps IS NULL OR r.steps = '{}'::jsonb)))
     AND (COALESCE($16::jsonb, '[]'::jsonb) = '[]'::jsonb OR
           EXISTS (
               SELECT 1 FROM jsonb_array_elements($16::jsonb) AS range_obj
@@ -2881,7 +2881,7 @@ WHERE (e.organization_id = $1 AND e.environment_id = $2)
             ) = (SELECT COUNT(DISTINCT split_part(cond, '=', 1)) FROM unnest($22::text[]) AS cond)
         )
     )
-GROUP BY r.status
+GROUP BY e.status
 `
 
 type GetTestWorkflowExecutionsTotalsParams struct {
@@ -2914,6 +2914,14 @@ type GetTestWorkflowExecutionsTotalsRow struct {
 	Count  int64       `db:"count" json:"count"`
 }
 
+// Totals are read from denormalized columns on test_workflow_executions
+// (status, workflow_name) maintained by triggers on test_workflow_results and
+// test_workflows. The LEFT JOINs are kept only because the @initialized,
+// @label_*, @selector_* and @health_ranges filters reference r.steps,
+// w.labels and w.status; when none of those filters are set, the planner
+// elides both joins (the right sides are unique on execution_id), letting the
+// query be served by an index-only scan over
+// idx_twe_org_env_wfname_status.
 func (q *Queries) GetTestWorkflowExecutionsTotals(ctx context.Context, arg GetTestWorkflowExecutionsTotalsParams) ([]GetTestWorkflowExecutionsTotalsRow, error) {
 	rows, err := q.db.Query(ctx, getTestWorkflowExecutionsTotals,
 		arg.OrganizationID,

--- a/pkg/database/postgres/sqlc/models.go
+++ b/pkg/database/postgres/sqlc/models.go
@@ -67,6 +67,8 @@ type TestWorkflowExecution struct {
 	EnvironmentID             string             `db:"environment_id" json:"environment_id"`
 	Runtime                   []byte             `db:"runtime" json:"runtime"`
 	SilentMode                []byte             `db:"silent_mode" json:"silent_mode"`
+	WorkflowName              pgtype.Text        `db:"workflow_name" json:"workflow_name"`
+	Status                    pgtype.Text        `db:"status" json:"status"`
 }
 
 type TestWorkflowOutput struct {

--- a/pkg/repository/testworkflow/postgres/postgres_integration_test.go
+++ b/pkg/repository/testworkflow/postgres/postgres_integration_test.go
@@ -384,3 +384,192 @@ func TestPostgresRepositoryCountExecutions_Integration(t *testing.T) {
 func StringPtr(s string) *string {
 	return &s
 }
+
+func TestPostgresDenormalizedExecutionColumns_Integration(t *testing.T) {
+	test.IntegrationTest(t)
+	testDB, cleanup := testpostgres.PreparePostgresTestDatabase(t, "repo_denorm_status_name")
+	t.Cleanup(cleanup)
+
+	ctx := context.Background()
+
+	orgID := "test-org"
+	envID := "test-env"
+	repo := NewPostgresRepository(
+		testDB.Pool,
+		WithOrganizationID(orgID),
+		WithEnvironmentID(envID),
+	)
+
+	insertExecution := func(t *testing.T, id string, num int32) {
+		t.Helper()
+		_, err := testDB.Pool.Exec(ctx, `
+			INSERT INTO test_workflow_executions
+			(id, organization_id, environment_id, name, namespace, number, scheduled_at, created_at, updated_at)
+			VALUES ($1, $2, $3, $4, $5, $6, NOW(), NOW(), NOW())
+		`, id, orgID, envID, id, "default", num)
+		require.NoError(t, err)
+	}
+
+	readDenormalized := func(t *testing.T, id string) (workflowName, status *string) {
+		t.Helper()
+		err := testDB.Pool.QueryRow(ctx,
+			`SELECT workflow_name, status FROM test_workflow_executions WHERE id = $1`,
+			id,
+		).Scan(&workflowName, &status)
+		require.NoError(t, err)
+		return
+	}
+
+	t.Run("status trigger populates on insert into test_workflow_results", func(t *testing.T) {
+		insertExecution(t, "exec-status-insert", 1)
+
+		// Before any result exists, status is NULL.
+		_, status := readDenormalized(t, "exec-status-insert")
+		assert.Nil(t, status, "status should be NULL before any test_workflow_results row exists")
+
+		_, err := testDB.Pool.Exec(ctx, `
+			INSERT INTO test_workflow_results (execution_id, status, created_at, updated_at)
+			VALUES ($1, $2, NOW(), NOW())
+		`, "exec-status-insert", "queued")
+		require.NoError(t, err)
+
+		_, status = readDenormalized(t, "exec-status-insert")
+		require.NotNil(t, status)
+		assert.Equal(t, "queued", *status)
+	})
+
+	t.Run("status trigger updates on test_workflow_results.status change", func(t *testing.T) {
+		insertExecution(t, "exec-status-update", 2)
+		_, err := testDB.Pool.Exec(ctx, `
+			INSERT INTO test_workflow_results (execution_id, status, created_at, updated_at)
+			VALUES ($1, $2, NOW(), NOW())
+		`, "exec-status-update", "running")
+		require.NoError(t, err)
+
+		_, err = testDB.Pool.Exec(ctx,
+			`UPDATE test_workflow_results SET status = $1 WHERE execution_id = $2`,
+			"passed", "exec-status-update",
+		)
+		require.NoError(t, err)
+
+		_, status := readDenormalized(t, "exec-status-update")
+		require.NotNil(t, status)
+		assert.Equal(t, "passed", *status)
+	})
+
+	t.Run("workflow_name trigger populates on insert with workflow_type='workflow'", func(t *testing.T) {
+		insertExecution(t, "exec-name-insert", 3)
+
+		name, _ := readDenormalized(t, "exec-name-insert")
+		assert.Nil(t, name, "workflow_name should be NULL before any test_workflows row exists")
+
+		_, err := testDB.Pool.Exec(ctx, `
+			INSERT INTO test_workflows (execution_id, workflow_type, name, namespace, created, updated)
+			VALUES ($1, $2, $3, $4, NOW(), NOW())
+		`, "exec-name-insert", "workflow", "my-workflow", "default")
+		require.NoError(t, err)
+
+		name, _ = readDenormalized(t, "exec-name-insert")
+		require.NotNil(t, name)
+		assert.Equal(t, "my-workflow", *name)
+	})
+
+	t.Run("workflow_name trigger ignores workflow_type='resolved_workflow'", func(t *testing.T) {
+		insertExecution(t, "exec-name-resolved", 4)
+
+		// Insert only the resolved_workflow row — should not populate workflow_name.
+		_, err := testDB.Pool.Exec(ctx, `
+			INSERT INTO test_workflows (execution_id, workflow_type, name, namespace, created, updated)
+			VALUES ($1, $2, $3, $4, NOW(), NOW())
+		`, "exec-name-resolved", "resolved_workflow", "resolved-name", "default")
+		require.NoError(t, err)
+
+		name, _ := readDenormalized(t, "exec-name-resolved")
+		assert.Nil(t, name, "workflow_name must not be populated by resolved_workflow rows")
+
+		// Now insert the canonical 'workflow' row — workflow_name should appear.
+		_, err = testDB.Pool.Exec(ctx, `
+			INSERT INTO test_workflows (execution_id, workflow_type, name, namespace, created, updated)
+			VALUES ($1, $2, $3, $4, NOW(), NOW())
+		`, "exec-name-resolved", "workflow", "canonical-name", "default")
+		require.NoError(t, err)
+
+		name, _ = readDenormalized(t, "exec-name-resolved")
+		require.NotNil(t, name)
+		assert.Equal(t, "canonical-name", *name)
+	})
+
+	t.Run("workflow_name trigger updates when canonical row's name changes", func(t *testing.T) {
+		insertExecution(t, "exec-name-update", 5)
+		_, err := testDB.Pool.Exec(ctx, `
+			INSERT INTO test_workflows (execution_id, workflow_type, name, namespace, created, updated)
+			VALUES ($1, $2, $3, $4, NOW(), NOW())
+		`, "exec-name-update", "workflow", "old-name", "default")
+		require.NoError(t, err)
+
+		_, err = testDB.Pool.Exec(ctx,
+			`UPDATE test_workflows SET name = $1 WHERE execution_id = $2 AND workflow_type = 'workflow'`,
+			"new-name", "exec-name-update",
+		)
+		require.NoError(t, err)
+
+		name, _ := readDenormalized(t, "exec-name-update")
+		require.NotNil(t, name)
+		assert.Equal(t, "new-name", *name)
+	})
+
+	t.Run("GetExecutionsTotals reads denormalized columns and filters by workflow_name", func(t *testing.T) {
+		// Set up two distinct workflows with mixed statuses.
+		// wf-a: 2 passed, 1 failed
+		// wf-b: 1 passed, 2 failed
+		cases := []struct {
+			id       string
+			num      int32
+			workflow string
+			status   string
+		}{
+			{"tot-a-1", 100, "wf-a", "passed"},
+			{"tot-a-2", 101, "wf-a", "passed"},
+			{"tot-a-3", 102, "wf-a", "failed"},
+			{"tot-b-1", 103, "wf-b", "passed"},
+			{"tot-b-2", 104, "wf-b", "failed"},
+			{"tot-b-3", 105, "wf-b", "failed"},
+		}
+		for _, c := range cases {
+			insertExecution(t, c.id, c.num)
+			_, err := testDB.Pool.Exec(ctx, `
+				INSERT INTO test_workflow_results (execution_id, status, created_at, updated_at)
+				VALUES ($1, $2, NOW(), NOW())
+			`, c.id, c.status)
+			require.NoError(t, err)
+			_, err = testDB.Pool.Exec(ctx, `
+				INSERT INTO test_workflows (execution_id, workflow_type, name, namespace, created, updated)
+				VALUES ($1, $2, $3, $4, NOW(), NOW())
+			`, c.id, "workflow", c.workflow, "default")
+			require.NoError(t, err)
+		}
+
+		// Sanity: triggers populated all rows.
+		var nullCount int
+		require.NoError(t, testDB.Pool.QueryRow(ctx, `
+			SELECT COUNT(*) FROM test_workflow_executions
+			WHERE id LIKE 'tot-%' AND (status IS NULL OR workflow_name IS NULL)
+		`).Scan(&nullCount))
+		assert.Equal(t, 0, nullCount, "all denormalized columns should be populated by triggers")
+
+		// Filter by workflow_name — must match what the trigger wrote into e.workflow_name.
+		filterA := testworkflow.NewExecutionsFilter().WithName("wf-a")
+		resultA, err := repo.GetExecutionsTotals(ctx, *filterA)
+		require.NoError(t, err)
+		assert.Equal(t, int32(2), resultA.Passed, "wf-a should have 2 passed")
+		assert.Equal(t, int32(1), resultA.Failed, "wf-a should have 1 failed")
+		assert.Equal(t, int32(3), resultA.Results, "wf-a should have 3 total")
+
+		filterB := testworkflow.NewExecutionsFilter().WithName("wf-b")
+		resultB, err := repo.GetExecutionsTotals(ctx, *filterB)
+		require.NoError(t, err)
+		assert.Equal(t, int32(1), resultB.Passed, "wf-b should have 1 passed")
+		assert.Equal(t, int32(2), resultB.Failed, "wf-b should have 2 failed")
+		assert.Equal(t, int32(3), resultB.Results, "wf-b should have 3 total")
+	})
+}


### PR DESCRIPTION
## Pull request description

Speeds up `GetTestWorkflowExecutionsTotals` (the totals call behind `GET /executions`) by denormalizing `status` and `workflow_name` onto `test_workflow_executions` and rewriting the query to read them directly. Mirrors MongoDB's embedded-document shape so the planner can serve totals from a single composite index instead of a parallel seq-scan + hash-join + temp-spill.

Validated on a 250k-row dataset:
- Old: ~161 ms hot / ~1.4 s cold
- New: ~27 ms (Bitmap Index Scan on `idx_twe_org_env_wfname_status`, both LEFT JOINs elided)

## Checklist

- [ ] breaking change! (describe)
- [x] tested locally
- [x] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [x] added a test

## Breaking changes

- None.

## Changes

- New migration `20260422120000_denormalize_execution_status_name.sql`: adds `status` and `workflow_name` columns, backfills, installs `AFTER INSERT/UPDATE` triggers on `test_workflow_results` and `test_workflows` to keep them in sync (idempotent via `IS DISTINCT FROM`).
- New migration `20260422120001_index_executions_status_name.sql`: composite covering indexes `idx_twe_org_env_wfname_status` and `idx_twe_org_env_wfname_sched` (CONCURRENTLY).
- Rewrote `GetTestWorkflowExecutionsTotals` in `executions.sql` to read `e.status` / `e.workflow_name`. LEFT JOINs kept only because `@initialized`, `@health_ranges`, `@label_*`, `@selector_*` still reference `r`/`w` — planner elides them when those filters are absent.
- Regenerated sqlc.
- Added `TestPostgresDenormalizedExecutionColumns_Integration` covering trigger sync (insert/update/`resolved_workflow` ignore) and the rewritten query end-to-end.

## Fixes

- Slow / 504 responses on the executions list endpoint when totals run cold or against large workflow histories.