### PR TITLE
fix(crd): render resourceRef and match[] in TestTrigger YAML template

### DIFF
--- a/pkg/api/v1/testkube/model_test_trigger_extended.go
+++ b/pkg/api/v1/testkube/model_test_trigger_extended.go
@@ -62,6 +62,33 @@ func (t *TestTrigger) QuoteTextFields() {
 		return
 	}
 
+	// Quote resource ref text fields
+	if t.ResourceRef != nil {
+		if t.ResourceRef.Group != "" {
+			t.ResourceRef.Group = fmt.Sprintf("%q", t.ResourceRef.Group)
+		}
+		if t.ResourceRef.Version != "" {
+			t.ResourceRef.Version = fmt.Sprintf("%q", t.ResourceRef.Version)
+		}
+		if t.ResourceRef.Kind != "" {
+			t.ResourceRef.Kind = fmt.Sprintf("%q", t.ResourceRef.Kind)
+		}
+	}
+
+	// Quote match field conditions — path/operator/value are user-supplied strings
+	// that may collide with YAML scalars (true, null, numbers, ':' etc.) on round-trip.
+	for i := range t.Match {
+		if t.Match[i].Path != "" {
+			t.Match[i].Path = fmt.Sprintf("%q", t.Match[i].Path)
+		}
+		if t.Match[i].Operator != "" {
+			t.Match[i].Operator = TestTriggerFieldOperator(fmt.Sprintf("%q", string(t.Match[i].Operator)))
+		}
+		if t.Match[i].Value != "" {
+			t.Match[i].Value = fmt.Sprintf("%q", t.Match[i].Value)
+		}
+	}
+
 	// Quote selector text fields
 	if t.ResourceSelector != nil {
 		if t.ResourceSelector.Name != "" {

--- a/pkg/crd/templates/testtrigger.tmpl
+++ b/pkg/crd/templates/testtrigger.tmpl
@@ -30,6 +30,16 @@ spec:
   {{- if .Resource }}
   resource: {{ .Resource }}
   {{- end }}
+  {{- if .ResourceRef }}
+  resourceRef:
+    {{- if .ResourceRef.Group }}
+    group: {{ .ResourceRef.Group }}
+    {{- end }}
+    {{- if .ResourceRef.Version }}
+    version: {{ .ResourceRef.Version }}
+    {{- end }}
+    kind: {{ .ResourceRef.Kind }}
+  {{- end }}
   {{- if and .ResourceSelector (or .ResourceSelector.Name .ResourceSelector.NameRegex .ResourceSelector.Namespace (and .ResourceSelector.LabelSelector (or .ResourceSelector.LabelSelector.MatchLabels .ResourceSelector.LabelSelector.MatchExpressions))) }}
   resourceSelector:
     {{- if .ResourceSelector.Name }}
@@ -61,6 +71,16 @@ spec:
   {{- end }}
   {{- if .Event }}
   event: {{ .Event }}
+  {{- end }}
+  {{- if ne (len .Match) 0 }}
+  match:
+    {{- range $m := .Match }}
+    - path: {{ $m.Path }}
+      operator: {{ $m.Operator }}
+      {{- if $m.Value }}
+      value: {{ $m.Value }}
+      {{- end }}
+    {{- end }}
   {{- end }}
   {{- if .ConditionSpec }}
   conditionSpec:


### PR DESCRIPTION
## Summary
The TestTrigger YAML render template (`pkg/crd/templates/testtrigger.tmpl`) was missing blocks for the `resourceRef` and `match[]` fields. This made `crd.GenerateYAML(TemplateTestTrigger, ...)` silently drop those fields from the output — so any consumer that rendered a TestTrigger via this template (notably the Cloud API's `GetTestTriggerHandler` serving YAML to the Dashboard's Definition editor) returned YAML without them. Editing and re-saving a trigger from the Dashboard therefore wiped `resourceRef` / `match[]` from the database.

## Fix
- Added a `{{- if .ResourceRef }}` block after `resource:` that renders `group` / `version` / `kind`.
- Added a `{{- if ne (len .Match) 0 }}` block after `event:` that renders `path` / `operator` / `value` for each field condition.

## Test plan
- [x] Renders a TestTrigger with `argoproj.io/v1alpha1/Rollout` resourceRef and `{path: .status.phase, operator: changed_to, value: Healthy}` match entry
- [x] Local Cloud API (tilt cp --db=postgres) — UI save → DB → GET now round-trips both fields
- [x] Postgres `test_triggers` row verified to carry `resource_ref` and `match` JSONB after Definition-tab edit → reload → re-save cycle