### PR TITLE
fix(crd): render resourceRef and match[] in TestTrigger YAML template…

### DIFF
--- a/pkg/api/v1/testkube/model_test_trigger_extended.go
+++ b/pkg/api/v1/testkube/model_test_trigger_extended.go
@@ -62,6 +62,33 @@ func (t *TestTrigger) QuoteTextFields() {
 		return
 	}
 
+	// Quote resource ref text fields
+	if t.ResourceRef != nil {
+		if t.ResourceRef.Group != "" {
+			t.ResourceRef.Group = fmt.Sprintf("%q", t.ResourceRef.Group)
+		}
+		if t.ResourceRef.Version != "" {
+			t.ResourceRef.Version = fmt.Sprintf("%q", t.ResourceRef.Version)
+		}
+		if t.ResourceRef.Kind != "" {
+			t.ResourceRef.Kind = fmt.Sprintf("%q", t.ResourceRef.Kind)
+		}
+	}
+
+	// Quote match field conditions — path/operator/value are user-supplied strings
+	// that may collide with YAML scalars (true, null, numbers, ':' etc.) on round-trip.
+	for i := range t.Match {
+		if t.Match[i].Path != "" {
+			t.Match[i].Path = fmt.Sprintf("%q", t.Match[i].Path)
+		}
+		if t.Match[i].Operator != "" {
+			t.Match[i].Operator = TestTriggerFieldOperator(fmt.Sprintf("%q", string(t.Match[i].Operator)))
+		}
+		if t.Match[i].Value != "" {
+			t.Match[i].Value = fmt.Sprintf("%q", t.Match[i].Value)
+		}
+	}
+
 	// Quote selector text fields
 	if t.ResourceSelector != nil {
 		if t.ResourceSelector.Name != "" {

--- a/pkg/crd/templates/testtrigger.tmpl
+++ b/pkg/crd/templates/testtrigger.tmpl
@@ -30,6 +30,16 @@ spec:
   {{- if .Resource }}
   resource: {{ .Resource }}
   {{- end }}
+  {{- if .ResourceRef }}
+  resourceRef:
+    {{- if .ResourceRef.Group }}
+    group: {{ .ResourceRef.Group }}
+    {{- end }}
+    {{- if .ResourceRef.Version }}
+    version: {{ .ResourceRef.Version }}
+    {{- end }}
+    kind: {{ .ResourceRef.Kind }}
+  {{- end }}
   {{- if and .ResourceSelector (or .ResourceSelector.Name .ResourceSelector.NameRegex .ResourceSelector.Namespace (and .ResourceSelector.LabelSelector (or .ResourceSelector.LabelSelector.MatchLabels .ResourceSelector.LabelSelector.MatchExpressions))) }}
   resourceSelector:
     {{- if .ResourceSelector.Name }}
@@ -61,6 +71,16 @@ spec:
   {{- end }}
   {{- if .Event }}
   event: {{ .Event }}
+  {{- end }}
+  {{- if ne (len .Match) 0 }}
+  match:
+    {{- range $m := .Match }}
+    - path: {{ $m.Path }}
+      operator: {{ $m.Operator }}
+      {{- if $m.Value }}
+      value: {{ $m.Value }}
+      {{- end }}
+    {{- end }}
   {{- end }}
   {{- if .ConditionSpec }}
   conditionSpec:


### PR DESCRIPTION
… (#7569)

* fix(crd): render resourceRef and match[] in TestTrigger YAML template

* ci: retrigger lint with valid baseline

* fix(testtriggers): quote match and resourceRef text fields in YAML output

## Pull request description 



## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [ ] tested locally
- [ ] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Breaking changes

-

## Changes

-

## Fixes

-