### PR TITLE
fix: [TKC-5014] check workflow services health at the end of test workflow execution

### DIFF
--- a/build-and-load-tw-toolkit.sh
+++ b/build-and-load-tw-toolkit.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+set -eo pipefail
+
+AGENT=double-o-seven
+
+# Build
+
+tk-dev build -c=a
+
+# Setup depot on agent namespace
+if ! (kubectl get secret depot -n ${AGENT} &>/dev/null); then
+  kubectl create secret --namespace ${AGENT} docker-registry depot --docker-server=registry.depot.dev --docker-username=x-token --docker-password=${DEPOT_TOKEN}
+fi
+
+BUILD_ID=$(jq -r '."depot.build".buildID' depot-build-meta.json)
+echo deploying build ${BUILD_ID}
+
+# Update runner image first
+kubectl patch deployment testkube-${AGENT}-testkube-runner -n ${AGENT} -p '{"spec":{"template":{"spec":{"imagePullSecrets":[{"name":"depot"}]}}}}'
+kubectl set image deployment/testkube-${AGENT}-testkube-runner -n ${AGENT} testkube-runner=registry.depot.dev/3cp8bwpbj0:${BUILD_ID}-agent-server
+
+# Set toolkit image versions to latest build
+kubectl set env deployment/testkube-${AGENT}-testkube-runner -n ${AGENT} \
+  TESTKUBE_TW_TOOLKIT_IMAGE=registry.depot.dev/3cp8bwpbj0:${BUILD_ID}-testworkflow-toolkit \
+  TESTKUBE_TW_INIT_IMAGE=registry.depot.dev/3cp8bwpbj0:${BUILD_ID}-testworkflow-init \
+  TESTKUBE_GLOBAL_WORKFLOW_TEMPLATE_INLINE='{"pod":{"imagePullSecrets":[{"name":"depot"}]}}'
+

--- a/cmd/tcl/testworkflow-toolkit/commands/kill.go
+++ b/cmd/tcl/testworkflow-toolkit/commands/kill.go
@@ -14,6 +14,7 @@ import (
 	"strings"
 
 	"github.com/spf13/cobra"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 
@@ -112,9 +113,8 @@ func RunKill(ctx context.Context, worker executionworkertypes.Worker, namespace 
 			}
 		}
 
-		restarts, reason := getServiceRestarts(ctx, clientSet, item.Namespace, item.Resource.Id)
-		if restarts > 0 {
-			healthErrors = append(healthErrors, fmt.Sprintf("%s (index %d): container restarted %d time(s)%s", commontcl.ServiceLabel(service), index, restarts, reason))
+		if issues := getServiceHealth(ctx, clientSet, item.Namespace, item.Resource.Id); len(issues) > 0 {
+			healthErrors = append(healthErrors, fmt.Sprintf("%s (index %d): %s", commontcl.ServiceLabel(service), index, strings.Join(issues, "; ")))
 		}
 	}
 
@@ -184,30 +184,41 @@ func RunKill(ctx context.Context, worker executionworkertypes.Worker, namespace 
 	return nil
 }
 
-func getServiceRestarts(ctx context.Context, clientSet kubernetes.Interface, namespace, resourceId string) (int32, string) {
+func getServiceHealth(ctx context.Context, clientSet kubernetes.Interface, namespace, resourceId string) []string {
 	pods, err := clientSet.CoreV1().Pods(namespace).List(ctx, metav1.ListOptions{
 		LabelSelector: "testkube.io/resource=" + resourceId,
 		Limit:         1,
 	})
 	if err != nil {
 		fmt.Printf("warning: could not list pods for service health check in namespace %s: %v\n", namespace, err)
-		return 0, ""
+		return nil
 	}
 	if len(pods.Items) == 0 {
 		fmt.Printf("warning: no pod found for service health check: namespace=%s resource=%s\n", namespace, resourceId)
-		return 0, ""
+		return nil
 	}
 
 	pod := &pods.Items[0]
-	var totalRestarts int32
-	var reason string
+	var issues []string
 	for _, cs := range pod.Status.ContainerStatuses {
-		totalRestarts += cs.RestartCount
-		if cs.RestartCount > 0 && reason == "" {
-			if cs.LastTerminationState.Terminated != nil {
-				reason = fmt.Sprintf(": %s", cs.LastTerminationState.Terminated.Reason)
-			}
+		if term := cs.LastTerminationState.Terminated; term != nil && term.Reason != "Completed" && term.Reason != "" {
+			issues = append(issues, fmt.Sprintf("container %q previously terminated: %s", cs.Name, term.Reason))
+		}
+		if term := cs.State.Terminated; term != nil && term.Reason != "Completed" && term.Reason != "" {
+			issues = append(issues, fmt.Sprintf("container %q terminated: %s", cs.Name, term.Reason))
+		}
+		if waiting := cs.State.Waiting; waiting != nil && (waiting.Reason == "CrashLoopBackOff" || waiting.Reason == "Error") {
+			issues = append(issues, fmt.Sprintf("container %q in state: %s", cs.Name, waiting.Reason))
 		}
 	}
-	return totalRestarts, reason
+
+	if pod.Status.Phase == corev1.PodFailed {
+		reason := pod.Status.Reason
+		if reason == "" {
+			reason = "pod failed"
+		}
+		issues = append(issues, reason)
+	}
+
+	return issues
 }

--- a/cmd/tcl/testworkflow-toolkit/commands/kill.go
+++ b/cmd/tcl/testworkflow-toolkit/commands/kill.go
@@ -71,13 +71,6 @@ func NewKillCmd() *cobra.Command {
 	return cmd
 }
 
-// KillDependencies holds the dependencies needed for the kill operation.
-type KillDependencies struct {
-	Worker    executionworkertypes.Worker
-	Namespace string
-	Ref       string
-}
-
 // RunKillWithOptions stops services in a group: checks health, fetches logs,
 // and destroys resources. Returns an error if any service has failed (e.g. OOMKilled).
 func RunKillWithOptions(ctx context.Context, cfg *config.ConfigV2, groupRef string) error {
@@ -157,7 +150,7 @@ func RunKill(ctx context.Context, worker executionworkertypes.Worker, namespace 
 
 		storage, err := artifacts.InternalStorage()
 		if err != nil {
-			ui.Failf("could not create internal storage client: %v", err)
+			return fmt.Errorf("could not create internal storage client: %w", err)
 		}
 		for _, id := range ids {
 			service, index := spawn.GetServiceByResourceId(id)
@@ -167,7 +160,7 @@ func RunKill(ctx context.Context, worker executionworkertypes.Worker, namespace 
 			}
 			log := spawn.CreateLogger(service, "", index, count)
 
-			logsFilePath, err := spawn.SaveLogs(context.Background(), storage, config.Namespace(), id, service+"/", index)
+			logsFilePath, err := spawn.SaveLogs(context.Background(), storage, namespace, id, service+"/", index)
 			if err == nil {
 				instructions.PrintOutput(ref, "service", ServiceInfo{Group: groupRef, Name: service, Index: index, Logs: storage.FullPath(logsFilePath), Done: true})
 				log("saved logs")
@@ -185,7 +178,7 @@ func RunKill(ctx context.Context, worker executionworkertypes.Worker, namespace 
 	}
 
 	if len(healthErrors) > 0 {
-		ui.Failf("unhealthy services detected: %s", strings.Join(healthErrors, "; "))
+		return fmt.Errorf("unhealthy services detected: %s", strings.Join(healthErrors, "; "))
 	}
 
 	return nil

--- a/cmd/tcl/testworkflow-toolkit/commands/kill.go
+++ b/cmd/tcl/testworkflow-toolkit/commands/kill.go
@@ -149,7 +149,7 @@ func RunKill(ctx context.Context, worker executionworkertypes.Worker, namespace 
 		return fmt.Errorf("unhealthy services detected: %s", strings.Join(healthErrors, "; "))
 	}
 
-	if conditions != nil && len(conditions) > 0 && machine != nil {
+	if len(conditions) > 0 && machine != nil {
 		services := make(map[string]int64)
 		ids := make([]string, 0)
 		for _, item := range items {

--- a/cmd/tcl/testworkflow-toolkit/commands/kill.go
+++ b/cmd/tcl/testworkflow-toolkit/commands/kill.go
@@ -55,120 +55,158 @@ func NewKillCmd() *cobra.Command {
 				}
 			}
 
-			// Fetch the services when needed
-			namespace := ""
-			if len(logs) > 0 {
-				items, err := spawn.ExecutionWorker().List(context.Background(), executionworkertypes.ListOptions{
-					GroupId: groupRef,
-				})
-				ui.ExitOnError("listing service instances", err)
+			worker := spawn.ExecutionWorker()
+			namespace := config.Namespace()
 
-				if len(items) > 0 {
-					namespace = items[0].Namespace
-					for _, item := range items {
-						if item.Namespace != namespace {
-							namespace = ""
-							break
-						}
-					}
-				}
-
-				services := make(map[string]int64)
-				ids := make([]string, 0)
-				for _, item := range items {
-					service, index := spawn.GetServiceByResourceId(item.Resource.Id)
-					if _, ok := conditions[service]; !ok {
-						instructions.PrintOutput(config.Ref(), "service", ServiceInfo{Group: groupRef, Name: service, Index: index, Done: true})
-						continue
-					}
-					serviceMachine := expressions.NewMachine().
-						Register("index", index).
-						RegisterAccessorExt(func(name string) (interface{}, bool, error) {
-							if name == "count" {
-								expr, err := expressions.CompileAndResolve(fmt.Sprintf("len(%s)", data.ServicesPrefix+service))
-								return expr, true, err
-							}
-							return nil, false, nil
-						})
-					log, err := expressions.EvalExpression(conditions[service].String(), serviceMachine, machine)
-					if err != nil {
-						fmt.Printf("warning: service '%s': could not resolve condition '%s': %s", service, log.String(), err.Error())
-					} else if v, _ := log.BoolValue(); v {
-						services[service]++
-						ids = append(ids, item.Resource.Id)
-					}
-				}
-
-				for _, id := range ids {
-					service, index := spawn.GetServiceByResourceId(id)
-					count := index + 1
-					if services[service] > count {
-						count = services[service]
-					}
-
-					log := spawn.CreateLogger(service, "", index, count)
-					notifications := spawn.ExecutionWorker().Notifications(context.Background(), id,
-						executionworkertypes.NotificationsOptions{NoFollow: true})
-					if notifications.Err() != nil {
-						log("error", "failed to connect to the service", notifications.Err().Error())
-						continue
-					}
-
-					for l := range notifications.Channel() {
-						if l.Result == nil || l.Result.Status == nil {
-							continue
-						}
-
-						if l.Result.Status.Finished() {
-							if l.Result.Initialization != nil && l.Result.Initialization.ErrorMessage != "" {
-								log("warning", "initialization error", ui.Red(l.Result.Initialization.ErrorMessage))
-							} else {
-								for _, step := range l.Result.Steps {
-									if step.ErrorMessage != "" {
-										log("warning", "step error", ui.Red(step.ErrorMessage))
-									}
-								}
-							}
-						}
-					}
-				}
-
-				// Inform about detected services
-				for name, count := range services {
-					fmt.Printf("%s: fetching logs of %d instances\n", commontcl.ServiceLabel(name), count)
-				}
-
-				// Fetch logs for them
-				storage, err := artifacts.InternalStorage()
-				if err != nil {
-					ui.Failf("could not create internal storage client: %v", err)
-				}
-				for _, id := range ids {
-					service, index := spawn.GetServiceByResourceId(id)
-					count := index + 1
-					if services[service] > count {
-						count = services[service]
-					}
-					log := spawn.CreateLogger(service, "", index, count)
-
-					logsFilePath, err := spawn.SaveLogs(context.Background(), storage, config.Namespace(), id, service+"/", index)
-					if err == nil {
-						instructions.PrintOutput(config.Ref(), "service", ServiceInfo{Group: groupRef, Name: service, Index: index, Logs: storage.FullPath(logsFilePath), Done: true})
-						log("saved logs")
-					} else {
-						log("warning", "problem saving the logs", err.Error())
-					}
-				}
-			}
-
-			err := spawn.ExecutionWorker().DestroyGroup(context.Background(), groupRef, executionworkertypes.DestroyOptions{
-				Namespace: namespace,
-			})
-			ui.ExitOnError("cleaning up resources", err)
+			err := RunKill(cmd.Context(), worker, namespace, config.Ref(), groupRef, conditions, machine)
+			ui.ExitOnError("stopping services", err)
 		},
 	}
 
 	cmd.Flags().StringArrayVarP(&logs, "logs", "l", nil, "fetch the logs for specific services - pair <name>=<expression>")
 
 	return cmd
+}
+
+// KillDependencies holds the dependencies needed for the kill operation.
+type KillDependencies struct {
+	Worker    executionworkertypes.Worker
+	Namespace string
+	Ref       string
+}
+
+// RunKillWithOptions stops services in a group: checks health, fetches logs,
+// and destroys resources. Returns an error if any service has failed (e.g. OOMKilled).
+func RunKillWithOptions(ctx context.Context, cfg *config.ConfigV2, groupRef string) error {
+	worker := spawn.ParallelExecutionWorker(cfg)
+	namespace := cfg.Namespace()
+	return RunKill(ctx, worker, namespace, cfg.Internal().Resource.Id, groupRef, nil, nil)
+}
+
+// RunKill is the core kill logic, separated from the Cobra command for testability.
+// It lists service instances, checks their health, fetches logs for matching
+// services, destroys the group, and returns an error if any service has failed.
+func RunKill(ctx context.Context, worker executionworkertypes.Worker, namespace string, ref string, groupRef string, conditions map[string]expressions.Expression, machine expressions.Machine) error {
+	items, err := worker.List(ctx, executionworkertypes.ListOptions{
+		GroupId: groupRef,
+	})
+	if err != nil {
+		return fmt.Errorf("listing service instances: %w", err)
+	}
+
+	if len(items) > 0 {
+		namespace = items[0].Namespace
+		for _, item := range items {
+			if item.Namespace != namespace {
+				namespace = ""
+				break
+			}
+		}
+	}
+
+	var healthErrors []string
+
+	for _, item := range items {
+		service, index := spawn.GetServiceByResourceId(item.Resource.Id)
+		if conditions != nil {
+			if _, ok := conditions[service]; !ok {
+				instructions.PrintOutput(ref, "service", ServiceInfo{Group: groupRef, Name: service, Index: index, Done: true})
+				continue
+			}
+		}
+
+		notifications := worker.Notifications(ctx, item.Resource.Id,
+			executionworkertypes.NotificationsOptions{NoFollow: true})
+		if notifications.Err() != nil {
+			continue
+		}
+
+		for l := range notifications.Channel() {
+			if l.Result == nil {
+				continue
+			}
+			if l.Result.IsFinished() && !l.Result.IsPassed() {
+				serviceLabel := commontcl.ServiceLabel(service)
+				reason := "failed"
+				if l.Result.Initialization != nil && l.Result.Initialization.ErrorMessage != "" {
+					reason = l.Result.Initialization.ErrorMessage
+				} else {
+					for _, step := range l.Result.Steps {
+						if step.ErrorMessage != "" {
+							reason = step.ErrorMessage
+						}
+					}
+				}
+				healthErrors = append(healthErrors, fmt.Sprintf("%s (index %d): %s", serviceLabel, index, reason))
+			}
+		}
+	}
+
+	if len(healthErrors) > 0 {
+		_ = worker.DestroyGroup(ctx, groupRef, executionworkertypes.DestroyOptions{
+			Namespace: namespace,
+		})
+		return fmt.Errorf("unhealthy services detected: %s", strings.Join(healthErrors, "; "))
+	}
+
+	if conditions != nil && len(conditions) > 0 && machine != nil {
+		services := make(map[string]int64)
+		ids := make([]string, 0)
+		for _, item := range items {
+			service, index := spawn.GetServiceByResourceId(item.Resource.Id)
+			if _, ok := conditions[service]; !ok {
+				continue
+			}
+			serviceMachine := expressions.NewMachine().
+				Register("index", index).
+				RegisterAccessorExt(func(name string) (interface{}, bool, error) {
+					if name == "count" {
+						expr, err := expressions.CompileAndResolve(fmt.Sprintf("len(%s)", data.ServicesPrefix+service))
+						return expr, true, err
+					}
+					return nil, false, nil
+				})
+			log, err := expressions.EvalExpression(conditions[service].String(), serviceMachine, machine)
+			if err != nil {
+				fmt.Printf("warning: service '%s': could not resolve condition '%s': %s", service, log.String(), err.Error())
+			} else if v, _ := log.BoolValue(); v {
+				services[service]++
+				ids = append(ids, item.Resource.Id)
+			}
+		}
+
+		for name, count := range services {
+			fmt.Printf("%s: fetching logs of %d instances\n", commontcl.ServiceLabel(name), count)
+		}
+
+		storage, err := artifacts.InternalStorage()
+		if err != nil {
+			ui.Failf("could not create internal storage client: %v", err)
+		}
+		for _, id := range ids {
+			service, index := spawn.GetServiceByResourceId(id)
+			count := index + 1
+			if services[service] > count {
+				count = services[service]
+			}
+			log := spawn.CreateLogger(service, "", index, count)
+
+			logsFilePath, err := spawn.SaveLogs(context.Background(), storage, config.Namespace(), id, service+"/", index)
+			if err == nil {
+				instructions.PrintOutput(ref, "service", ServiceInfo{Group: groupRef, Name: service, Index: index, Logs: storage.FullPath(logsFilePath), Done: true})
+				log("saved logs")
+			} else {
+				log("warning", "problem saving the logs", err.Error())
+			}
+		}
+	}
+
+	err = worker.DestroyGroup(ctx, groupRef, executionworkertypes.DestroyOptions{
+		Namespace: namespace,
+	})
+	if err != nil {
+		return fmt.Errorf("cleaning up resources: %w", err)
+	}
+
+	return nil
 }

--- a/cmd/tcl/testworkflow-toolkit/commands/kill.go
+++ b/cmd/tcl/testworkflow-toolkit/commands/kill.go
@@ -108,7 +108,8 @@ func RunKill(ctx context.Context, worker executionworkertypes.Worker, namespace 
 
 	for _, item := range items {
 		service, index := spawn.GetServiceByResourceId(item.Resource.Id)
-		if conditions != nil {
+
+		if len(conditions) > 0 {
 			if _, ok := conditions[service]; !ok {
 				instructions.PrintOutput(ref, "service", ServiceInfo{Group: groupRef, Name: service, Index: index, Done: true})
 				continue

--- a/cmd/tcl/testworkflow-toolkit/commands/kill.go
+++ b/cmd/tcl/testworkflow-toolkit/commands/kill.go
@@ -14,12 +14,15 @@ import (
 	"strings"
 
 	"github.com/spf13/cobra"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
 
 	commontcl "github.com/kubeshop/testkube/cmd/tcl/testworkflow-toolkit/common"
 	"github.com/kubeshop/testkube/cmd/tcl/testworkflow-toolkit/spawn"
 	"github.com/kubeshop/testkube/cmd/testworkflow-init/data"
 	"github.com/kubeshop/testkube/cmd/testworkflow-init/instructions"
 	"github.com/kubeshop/testkube/cmd/testworkflow-toolkit/artifacts"
+	"github.com/kubeshop/testkube/cmd/testworkflow-toolkit/env"
 	"github.com/kubeshop/testkube/cmd/testworkflow-toolkit/env/config"
 	"github.com/kubeshop/testkube/pkg/credentials"
 	"github.com/kubeshop/testkube/pkg/expressions"
@@ -106,40 +109,20 @@ func RunKill(ctx context.Context, worker executionworkertypes.Worker, namespace 
 
 	var healthErrors []string
 
+	clientSet := env.Kubernetes()
+	fmt.Printf("checking health of %d services\n", len(items))
 	for _, item := range items {
 		service, index := spawn.GetServiceByResourceId(item.Resource.Id)
 
 		if len(conditions) > 0 {
 			if _, ok := conditions[service]; !ok {
 				instructions.PrintOutput(ref, "service", ServiceInfo{Group: groupRef, Name: service, Index: index, Done: true})
-				continue
 			}
 		}
 
-		notifications := worker.Notifications(ctx, item.Resource.Id,
-			executionworkertypes.NotificationsOptions{NoFollow: true})
-		if notifications.Err() != nil {
-			continue
-		}
-
-		for l := range notifications.Channel() {
-			if l.Result == nil {
-				continue
-			}
-			if l.Result.IsFinished() && !l.Result.IsPassed() {
-				serviceLabel := commontcl.ServiceLabel(service)
-				reason := "failed"
-				if l.Result.Initialization != nil && l.Result.Initialization.ErrorMessage != "" {
-					reason = l.Result.Initialization.ErrorMessage
-				} else {
-					for _, step := range l.Result.Steps {
-						if step.ErrorMessage != "" {
-							reason = step.ErrorMessage
-						}
-					}
-				}
-				healthErrors = append(healthErrors, fmt.Sprintf("%s (index %d): %s", serviceLabel, index, reason))
-			}
+		restarts, reason := getServiceRestarts(ctx, clientSet, item.Namespace, item.Resource.Id)
+		if restarts > 0 {
+			healthErrors = append(healthErrors, fmt.Sprintf("%s (index %d): container restarted %d time(s)%s", commontcl.ServiceLabel(service), index, restarts, reason))
 		}
 	}
 
@@ -210,4 +193,32 @@ func RunKill(ctx context.Context, worker executionworkertypes.Worker, namespace 
 	}
 
 	return nil
+}
+
+func getServiceRestarts(ctx context.Context, clientSet kubernetes.Interface, namespace, resourceId string) (int32, string) {
+	pods, err := clientSet.CoreV1().Pods(namespace).List(ctx, metav1.ListOptions{
+		LabelSelector: "testkube.io/resource=" + resourceId,
+		Limit:         1,
+	})
+	if err != nil {
+		fmt.Printf("warning: could not list pods for service health check in namespace %s: %v\n", namespace, err)
+		return 0, ""
+	}
+	if len(pods.Items) == 0 {
+		fmt.Printf("warning: no pod found for service health check: namespace=%s resource=%s\n", namespace, resourceId)
+		return 0, ""
+	}
+
+	pod := &pods.Items[0]
+	var totalRestarts int32
+	var reason string
+	for _, cs := range pod.Status.ContainerStatuses {
+		totalRestarts += cs.RestartCount
+		if cs.RestartCount > 0 && reason == "" {
+			if cs.LastTerminationState.Terminated != nil {
+				reason = fmt.Sprintf(": %s", cs.LastTerminationState.Terminated.Reason)
+			}
+		}
+	}
+	return totalRestarts, reason
 }

--- a/cmd/tcl/testworkflow-toolkit/commands/kill.go
+++ b/cmd/tcl/testworkflow-toolkit/commands/kill.go
@@ -108,7 +108,6 @@ func RunKill(ctx context.Context, worker executionworkertypes.Worker, namespace 
 	}
 
 	var healthErrors []string
-
 	clientSet := env.Kubernetes()
 	fmt.Printf("checking health of %d services\n", len(items))
 	for _, item := range items {
@@ -124,13 +123,6 @@ func RunKill(ctx context.Context, worker executionworkertypes.Worker, namespace 
 		if restarts > 0 {
 			healthErrors = append(healthErrors, fmt.Sprintf("%s (index %d): container restarted %d time(s)%s", commontcl.ServiceLabel(service), index, restarts, reason))
 		}
-	}
-
-	if len(healthErrors) > 0 {
-		_ = worker.DestroyGroup(ctx, groupRef, executionworkertypes.DestroyOptions{
-			Namespace: namespace,
-		})
-		return fmt.Errorf("unhealthy services detected: %s", strings.Join(healthErrors, "; "))
 	}
 
 	if len(conditions) > 0 && machine != nil {
@@ -190,6 +182,10 @@ func RunKill(ctx context.Context, worker executionworkertypes.Worker, namespace 
 	})
 	if err != nil {
 		return fmt.Errorf("cleaning up resources: %w", err)
+	}
+
+	if len(healthErrors) > 0 {
+		ui.Failf("unhealthy services detected: %s", strings.Join(healthErrors, "; "))
 	}
 
 	return nil

--- a/pkg/tcl/testworkflowstcl/testworkflowprocessor/operations.go
+++ b/pkg/tcl/testworkflowstcl/testworkflowprocessor/operations.go
@@ -213,7 +213,6 @@ func ProcessServicesStop(_ testworkflowprocessor.InternalProcessor, layer testwo
 
 	stage := stage.NewContainerStage(layer.NextRef(), container.CreateChild())
 	stage.SetCondition("always") // TODO: actually, it's enough to do it when "Start services" is not skipped
-	stage.SetOptional(true)
 	stage.SetCategory("Stop services")
 
 	// Allow to combine it within other containers

--- a/test/integration/components/toolkit/services_oomkill_test.go
+++ b/test/integration/components/toolkit/services_oomkill_test.go
@@ -69,6 +69,13 @@ func TestServiceOOMKilledAfterReadiness_Integration(t *testing.T) {
 	require.NoError(t, err,
 		"monitor marks service as ready even though it OOMKilled afterwards")
 
+	pod := waitForPodInNamespace(t, namespace, 30*time.Second)
+	require.NotNil(t, pod, "should find the service pod in the namespace")
+
+	pod = waitForContainerRestart(t, namespace, pod.Name, 60*time.Second)
+	require.True(t, hasContainerRestarted(pod, ""),
+		"some container should have restarted after OOMKill")
+
 	cfg, err := config.LoadConfigV2()
 	require.NoError(t, err)
 

--- a/test/integration/components/toolkit/services_oomkill_test.go
+++ b/test/integration/components/toolkit/services_oomkill_test.go
@@ -1,0 +1,173 @@
+package toolkit_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+
+	testworkflowsv1 "github.com/kubeshop/testkube/api/testworkflows/v1"
+	"github.com/kubeshop/testkube/cmd/tcl/testworkflow-toolkit/commands"
+	"github.com/kubeshop/testkube/cmd/testworkflow-toolkit/env/config"
+	"github.com/kubeshop/testkube/internal/common"
+	"github.com/kubeshop/testkube/pkg/utils/test"
+)
+
+// TestServiceOOMKilledAfterReadiness_Integration verifies that a service which
+// passes its readiness probe but subsequently gets OOMKilled is detected as a
+// failure by the service monitor (processNotifications), rather than being
+// silently marked as green/passed.
+//
+// This is a regression test for TKC-5014.
+func TestServiceOOMKilledAfterReadiness_Integration(t *testing.T) {
+	test.IntegrationTest(t)
+
+	namespace := createTestNamespace(t)
+	t.Cleanup(func() { deleteTestNamespace(t, namespace) })
+
+	_, _, cleanupCP := setupTestWithControlPlane(t, namespace)
+	t.Cleanup(cleanupCP)
+
+	services := map[string]testworkflowsv1.ServiceSpec{
+		"oom-after-ready": {
+			IndependentServiceSpec: testworkflowsv1.IndependentServiceSpec{
+				StepRun: testworkflowsv1.StepRun{
+					ContainerConfig: testworkflowsv1.ContainerConfig{
+						Image: "python:3.14.3-slim-trixie",
+						Resources: &testworkflowsv1.Resources{
+							Limits: map[corev1.ResourceName]intstr.IntOrString{
+								corev1.ResourceMemory: intstr.FromString("50Mi"),
+							},
+						},
+					},
+					Shell: common.Ptr(
+						"touch /tmp/ready && echo 'ready' && sleep 2 && python3 -c \"a = ' ' * 10**9\"",
+					),
+				},
+				Pod: &testworkflowsv1.PodConfig{},
+				RestartPolicy: testworkflowsv1.ServiceRestartPolicyNever,
+				ReadinessProbe: &corev1.Probe{
+					PeriodSeconds:    1,
+					SuccessThreshold: 1,
+					FailureThreshold: 3,
+					ProbeHandler: corev1.ProbeHandler{
+						Exec: &corev1.ExecAction{
+							Command: []string{"sh", "-c", "test -f /tmp/ready"},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	err := executeServices(t, services, "test-group")
+
+	assert.Error(t, err,
+		"service OOMKilled after readiness should be detected as failure (TKC-5014)")
+}
+
+// TestServiceOOMKilledDetectedAtStop_Integration verifies that the stop/kill
+// phase detects a service that was OOMKilled after readiness, even if the
+// monitoring phase missed it. This is the safety-net for TKC-5014: the kill
+// command checks service health before destroying resources.
+func TestServiceOOMKilledDetectedAtStop_Integration(t *testing.T) {
+	test.IntegrationTest(t)
+
+	namespace := createTestNamespace(t)
+	t.Cleanup(func() { deleteTestNamespace(t, namespace) })
+
+	_, _, cleanupCP := setupTestWithControlPlane(t, namespace)
+	t.Cleanup(cleanupCP)
+
+	services := map[string]testworkflowsv1.ServiceSpec{
+		"oom-after-ready": {
+			IndependentServiceSpec: testworkflowsv1.IndependentServiceSpec{
+				StepRun: testworkflowsv1.StepRun{
+					ContainerConfig: testworkflowsv1.ContainerConfig{
+						Image: "python:3.14.3-slim-trixie",
+						Resources: &testworkflowsv1.Resources{
+							Limits: map[corev1.ResourceName]intstr.IntOrString{
+								corev1.ResourceMemory: intstr.FromString("50Mi"),
+							},
+						},
+					},
+					Shell: common.Ptr(
+						"touch /tmp/ready && echo 'ready' && sleep 2 && python3 -c \"a = ' ' * 10**9\"",
+					),
+				},
+				Pod: &testworkflowsv1.PodConfig{},
+				RestartPolicy: testworkflowsv1.ServiceRestartPolicyNever,
+				ReadinessProbe: &corev1.Probe{
+					PeriodSeconds:    1,
+					SuccessThreshold: 1,
+					FailureThreshold: 3,
+					ProbeHandler: corev1.ProbeHandler{
+						Exec: &corev1.ExecAction{
+							Command: []string{"sh", "-c", "test -f /tmp/ready"},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	groupRef := "test-group-stop"
+	_ = executeServices(t, services, groupRef)
+
+	// Wait for the OOMKill to actually happen before running the stop phase.
+	pod := waitForPodInNamespace(t, namespace, 30*time.Second)
+	require.NotNil(t, pod, "should find the service pod in the namespace")
+
+	pod = waitForPodTermination(t, namespace, pod.Name, 60*time.Second)
+	require.Equal(t, corev1.PodFailed, pod.Status.Phase,
+		"pod should be in Failed phase after OOMKill")
+	require.Equal(t, "OOMKilled", getContainerTerminatedReason(pod, "2"),
+		"container should have been OOMKilled")
+
+	cfg, err := config.LoadConfigV2()
+	require.NoError(t, err)
+
+	err = commands.RunKillWithOptions(context.Background(), cfg, groupRef)
+	assert.Error(t, err,
+		"kill command should detect OOMKilled service as a failure (TKC-5014 safety net)")
+}
+
+func waitForPodInNamespace(t *testing.T, namespace string, timeout time.Duration) *corev1.Pod {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	for {
+		podList, err := globalK8sClient.CoreV1().Pods(namespace).List(ctx, metav1.ListOptions{Limit: 1})
+		require.NoError(t, err)
+
+		if len(podList.Items) > 0 {
+			return &podList.Items[0]
+		}
+
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-time.After(500 * time.Millisecond):
+		}
+	}
+}
+
+func getContainerTerminatedReason(pod *corev1.Pod, containerName string) string {
+	for _, s := range pod.Status.ContainerStatuses {
+		if s.Name == containerName && s.State.Terminated != nil {
+			return s.State.Terminated.Reason
+		}
+	}
+	for _, s := range pod.Status.InitContainerStatuses {
+		if s.Name == containerName && s.State.Terminated != nil {
+			return s.State.Terminated.Reason
+		}
+	}
+	return ""
+}

--- a/test/integration/components/toolkit/services_oomkill_test.go
+++ b/test/integration/components/toolkit/services_oomkill_test.go
@@ -49,8 +49,7 @@ func TestServiceOOMKilledAfterReadiness_Integration(t *testing.T) {
 						"touch /tmp/ready && echo 'ready' && sleep 2 && python3 -c \"a = ' ' * 10**9\"",
 					),
 				},
-				Pod:           &testworkflowsv1.PodConfig{},
-				RestartPolicy: testworkflowsv1.ServiceRestartPolicyNever,
+				Pod: &testworkflowsv1.PodConfig{},
 				ReadinessProbe: &corev1.Probe{
 					PeriodSeconds:    1,
 					SuccessThreshold: 1,
@@ -100,8 +99,7 @@ func TestServiceOOMKilledDetectedAtStop_Integration(t *testing.T) {
 						"touch /tmp/ready && echo 'ready' && sleep 2 && python3 -c \"a = ' ' * 10**9\"",
 					),
 				},
-				Pod:           &testworkflowsv1.PodConfig{},
-				RestartPolicy: testworkflowsv1.ServiceRestartPolicyNever,
+				Pod: &testworkflowsv1.PodConfig{},
 				ReadinessProbe: &corev1.Probe{
 					PeriodSeconds:    1,
 					SuccessThreshold: 1,
@@ -119,15 +117,12 @@ func TestServiceOOMKilledDetectedAtStop_Integration(t *testing.T) {
 	groupRef := "test-group-stop"
 	_ = executeServices(t, services, groupRef)
 
-	// Wait for the OOMKill to actually happen before running the stop phase.
 	pod := waitForPodInNamespace(t, namespace, 30*time.Second)
 	require.NotNil(t, pod, "should find the service pod in the namespace")
 
-	pod = waitForPodTermination(t, namespace, pod.Name, 60*time.Second)
-	require.Equal(t, corev1.PodFailed, pod.Status.Phase,
-		"pod should be in Failed phase after OOMKill")
-	require.Equal(t, "OOMKilled", getContainerTerminatedReason(pod, "2"),
-		"container should have been OOMKilled")
+	pod = waitForContainerRestart(t, namespace, pod.Name, 60*time.Second)
+	require.True(t, hasContainerRestarted(pod, "2"),
+		"container should have restarted after OOMKill")
 
 	cfg, err := config.LoadConfigV2()
 	require.NoError(t, err)
@@ -158,16 +153,32 @@ func waitForPodInNamespace(t *testing.T, namespace string, timeout time.Duration
 	}
 }
 
-func getContainerTerminatedReason(pod *corev1.Pod, containerName string) string {
+func hasContainerRestarted(pod *corev1.Pod, containerName string) bool {
 	for _, s := range pod.Status.ContainerStatuses {
-		if s.Name == containerName && s.State.Terminated != nil {
-			return s.State.Terminated.Reason
+		if s.Name == containerName && s.RestartCount > 0 {
+			return true
 		}
 	}
-	for _, s := range pod.Status.InitContainerStatuses {
-		if s.Name == containerName && s.State.Terminated != nil {
-			return s.State.Terminated.Reason
+	return false
+}
+
+func waitForContainerRestart(t *testing.T, namespace, name string, timeout time.Duration) *corev1.Pod {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	for {
+		pod, err := globalK8sClient.CoreV1().Pods(namespace).Get(ctx, name, metav1.GetOptions{})
+		require.NoError(t, err)
+
+		if hasContainerRestarted(pod, "2") {
+			return pod
+		}
+
+		select {
+		case <-ctx.Done():
+			t.Fatalf("timeout waiting for pod %s container 2 to restart", name)
+		case <-time.After(500 * time.Millisecond):
 		}
 	}
-	return ""
 }

--- a/test/integration/components/toolkit/services_oomkill_test.go
+++ b/test/integration/components/toolkit/services_oomkill_test.go
@@ -19,9 +19,9 @@ import (
 )
 
 // TestServiceOOMKilledAfterReadiness_Integration verifies that a service which
-// passes its readiness probe but subsequently gets OOMKilled is detected as a
-// failure by the service monitor (processNotifications), rather than being
-// silently marked as green/passed.
+// passes its readiness probe but subsequently gets OOMKilled is marked as ready
+// by the monitor (which stops after readiness), and the OOMKill is caught at
+// stop/kill time.
 //
 // This is a regression test for TKC-5014.
 func TestServiceOOMKilledAfterReadiness_Integration(t *testing.T) {
@@ -64,10 +64,17 @@ func TestServiceOOMKilledAfterReadiness_Integration(t *testing.T) {
 		},
 	}
 
-	err := executeServices(t, services, "test-group")
+	groupRef := "test-group-monitor"
+	err := executeServices(t, services, groupRef)
+	require.NoError(t, err,
+		"monitor marks service as ready even though it OOMKilled afterwards")
 
+	cfg, err := config.LoadConfigV2()
+	require.NoError(t, err)
+
+	err = commands.RunKillWithOptions(context.Background(), cfg, groupRef)
 	assert.Error(t, err,
-		"service OOMKilled after readiness should be detected as failure (TKC-5014)")
+		"kill command should detect OOMKilled service as a failure (TKC-5014)")
 }
 
 // TestServiceOOMKilledDetectedAtStop_Integration verifies that the stop/kill
@@ -121,8 +128,8 @@ func TestServiceOOMKilledDetectedAtStop_Integration(t *testing.T) {
 	require.NotNil(t, pod, "should find the service pod in the namespace")
 
 	pod = waitForContainerRestart(t, namespace, pod.Name, 60*time.Second)
-	require.True(t, hasContainerRestarted(pod, "2"),
-		"container should have restarted after OOMKill")
+	require.True(t, hasContainerRestarted(pod, ""),
+		"some container should have restarted after OOMKill")
 
 	cfg, err := config.LoadConfigV2()
 	require.NoError(t, err)
@@ -138,7 +145,9 @@ func waitForPodInNamespace(t *testing.T, namespace string, timeout time.Duration
 	defer cancel()
 
 	for {
-		podList, err := globalK8sClient.CoreV1().Pods(namespace).List(ctx, metav1.ListOptions{Limit: 1})
+		podList, err := globalK8sClient.CoreV1().Pods(namespace).List(ctx, metav1.ListOptions{
+			LabelSelector: "testkube.io/root=test-exec",
+		})
 		require.NoError(t, err)
 
 		if len(podList.Items) > 0 {
@@ -155,8 +164,10 @@ func waitForPodInNamespace(t *testing.T, namespace string, timeout time.Duration
 
 func hasContainerRestarted(pod *corev1.Pod, containerName string) bool {
 	for _, s := range pod.Status.ContainerStatuses {
-		if s.Name == containerName && s.RestartCount > 0 {
-			return true
+		if containerName == "" || s.Name == containerName {
+			if s.RestartCount > 0 {
+				return true
+			}
 		}
 	}
 	return false
@@ -171,13 +182,13 @@ func waitForContainerRestart(t *testing.T, namespace, name string, timeout time.
 		pod, err := globalK8sClient.CoreV1().Pods(namespace).Get(ctx, name, metav1.GetOptions{})
 		require.NoError(t, err)
 
-		if hasContainerRestarted(pod, "2") {
+		if hasContainerRestarted(pod, "") {
 			return pod
 		}
 
 		select {
 		case <-ctx.Done():
-			t.Fatalf("timeout waiting for pod %s container 2 to restart", name)
+			t.Fatalf("timeout waiting for pod %s container to restart", name)
 		case <-time.After(500 * time.Millisecond):
 		}
 	}

--- a/test/integration/components/toolkit/services_oomkill_test.go
+++ b/test/integration/components/toolkit/services_oomkill_test.go
@@ -49,7 +49,7 @@ func TestServiceOOMKilledAfterReadiness_Integration(t *testing.T) {
 						"touch /tmp/ready && echo 'ready' && sleep 2 && python3 -c \"a = ' ' * 10**9\"",
 					),
 				},
-				Pod: &testworkflowsv1.PodConfig{},
+				Pod:           &testworkflowsv1.PodConfig{},
 				RestartPolicy: testworkflowsv1.ServiceRestartPolicyNever,
 				ReadinessProbe: &corev1.Probe{
 					PeriodSeconds:    1,
@@ -100,7 +100,7 @@ func TestServiceOOMKilledDetectedAtStop_Integration(t *testing.T) {
 						"touch /tmp/ready && echo 'ready' && sleep 2 && python3 -c \"a = ' ' * 10**9\"",
 					),
 				},
-				Pod: &testworkflowsv1.PodConfig{},
+				Pod:           &testworkflowsv1.PodConfig{},
 				RestartPolicy: testworkflowsv1.ServiceRestartPolicyNever,
 				ReadinessProbe: &corev1.Probe{
 					PeriodSeconds:    1,


### PR DESCRIPTION
## Pull request description 

This PR adds a health check before killing workflow services, detecting OOMKilled (or otherwise crashed) containers by inspecting pod restart counts. Previously, once a service passed its readiness probe, no further health validation occurred, so post-startup crashes went unnoticed. The stop-services stage is also made non-optional so detected failures properly mark the execution as failed.

## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [x] tested locally
- [ ] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Breaking changes

- None

## Changes

- Executions are now marked as failures when a workflow service crashes during testing

## Fixes

- TKC-5014
