### PR TITLE
fix: [TKC-5565] add CloudNativePG repo to helm release

### DIFF
--- a/.github/workflows/new-build.yaml
+++ b/.github/workflows/new-build.yaml
@@ -166,6 +166,7 @@ jobs:
           REGISTRY_GAR=${{ env.GAR_LOCATION }}-docker.pkg.dev
 
           echo ${{ secrets.DOCKERHUB_TOKEN }} | helm registry login ${REGISTRY} --username ${{ secrets.DOCKERHUB_USERNAME }} --password-stdin
+          helm repo add cloudnative-pg https://cloudnative-pg.github.io/charts --force-update
 
           # testkube chart
           helm dependency build k8s/helm/testkube


### PR DESCRIPTION
## Summary
- add the CloudNativePG Helm repo before release chart dependency builds
- unblock 2.9.0 Helm chart publishing after the new CloudNativePG dependencies were added

## Validation
- `helm repo add cloudnative-pg https://cloudnative-pg.github.io/charts --force-update`
- `helm dependency build <temp>/helm/testkube`

Linear: TKC-5565

Failed run: https://github.com/kubeshop/testkube/actions/runs/24841727551