### PR TITLE
fix: Replace deprecated scheme builders

### DIFF
--- a/api/script/v1/groupversion_info.go
+++ b/api/script/v1/groupversion_info.go
@@ -20,8 +20,9 @@ limitations under the License.
 package v1
 
 import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"sigs.k8s.io/controller-runtime/pkg/scheme"
 )
 
 var (
@@ -29,8 +30,17 @@ var (
 	GroupVersion = schema.GroupVersion{Group: "tests.testkube.io", Version: "v1"}
 
 	// SchemeBuilder is used to add go types to the GroupVersionKind scheme
-	SchemeBuilder = &scheme.Builder{GroupVersion: GroupVersion}
+	SchemeBuilder = runtime.NewSchemeBuilder(addKnownTypes)
 
 	// AddToScheme adds the types in this group-version to the given scheme.
 	AddToScheme = SchemeBuilder.AddToScheme
 )
+
+func addKnownTypes(scheme *runtime.Scheme) error {
+	scheme.AddKnownTypes(GroupVersion,
+		&Script{},
+		&ScriptList{},
+	)
+	metav1.AddToGroupVersion(scheme, GroupVersion)
+	return nil
+}

--- a/api/script/v1/script_types.go
+++ b/api/script/v1/script_types.go
@@ -86,7 +86,3 @@ type ScriptList struct {
 	metav1.ListMeta `json:"metadata,omitempty"`
 	Items           []Script `json:"items"`
 }
-
-func init() {
-	SchemeBuilder.Register(&Script{}, &ScriptList{})
-}

--- a/api/script/v2/groupversion_info.go
+++ b/api/script/v2/groupversion_info.go
@@ -17,8 +17,9 @@ limitations under the License.
 package v2
 
 import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"sigs.k8s.io/controller-runtime/pkg/scheme"
 )
 
 var (
@@ -26,8 +27,17 @@ var (
 	GroupVersion = schema.GroupVersion{Group: "tests.testkube.io", Version: "v2"}
 
 	// SchemeBuilder is used to add go types to the GroupVersionKind scheme
-	SchemeBuilder = &scheme.Builder{GroupVersion: GroupVersion}
+	SchemeBuilder = runtime.NewSchemeBuilder(addKnownTypes)
 
 	// AddToScheme adds the types in this group-version to the given scheme.
 	AddToScheme = SchemeBuilder.AddToScheme
 )
+
+func addKnownTypes(scheme *runtime.Scheme) error {
+	scheme.AddKnownTypes(GroupVersion,
+		&Script{},
+		&ScriptList{},
+	)
+	metav1.AddToGroupVersion(scheme, GroupVersion)
+	return nil
+}

--- a/api/script/v2/script_types.go
+++ b/api/script/v2/script_types.go
@@ -88,7 +88,3 @@ type ScriptList struct {
 	metav1.ListMeta `json:"metadata,omitempty"`
 	Items           []Script `json:"items"`
 }
-
-func init() {
-	SchemeBuilder.Register(&Script{}, &ScriptList{})
-}

--- a/api/template/v1/groupversion_info.go
+++ b/api/template/v1/groupversion_info.go
@@ -20,8 +20,9 @@ limitations under the License.
 package v1
 
 import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"sigs.k8s.io/controller-runtime/pkg/scheme"
 )
 
 var (
@@ -29,8 +30,17 @@ var (
 	GroupVersion = schema.GroupVersion{Group: "tests.testkube.io", Version: "v1"}
 
 	// SchemeBuilder is used to add go types to the GroupVersionKind scheme
-	SchemeBuilder = &scheme.Builder{GroupVersion: GroupVersion}
+	SchemeBuilder = runtime.NewSchemeBuilder(addKnownTypes)
 
 	// AddToScheme adds the types in this group-version to the given scheme.
 	AddToScheme = SchemeBuilder.AddToScheme
 )
+
+func addKnownTypes(scheme *runtime.Scheme) error {
+	scheme.AddKnownTypes(GroupVersion,
+		&Template{},
+		&TemplateList{},
+	)
+	metav1.AddToGroupVersion(scheme, GroupVersion)
+	return nil
+}

--- a/api/template/v1/template_types.go
+++ b/api/template/v1/template_types.go
@@ -73,7 +73,3 @@ type TemplateList struct {
 	metav1.ListMeta `json:"metadata,omitempty"`
 	Items           []Template `json:"items"`
 }
-
-func init() {
-	SchemeBuilder.Register(&Template{}, &TemplateList{})
-}

--- a/api/testexecution/v1/groupversion_info.go
+++ b/api/testexecution/v1/groupversion_info.go
@@ -20,8 +20,9 @@ limitations under the License.
 package v1
 
 import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"sigs.k8s.io/controller-runtime/pkg/scheme"
 )
 
 var (
@@ -29,8 +30,17 @@ var (
 	GroupVersion = schema.GroupVersion{Group: "tests.testkube.io", Version: "v1"}
 
 	// SchemeBuilder is used to add go types to the GroupVersionKind scheme
-	SchemeBuilder = &scheme.Builder{GroupVersion: GroupVersion}
+	SchemeBuilder = runtime.NewSchemeBuilder(addKnownTypes)
 
 	// AddToScheme adds the types in this group-version to the given scheme.
 	AddToScheme = SchemeBuilder.AddToScheme
 )
+
+func addKnownTypes(scheme *runtime.Scheme) error {
+	scheme.AddKnownTypes(GroupVersion,
+		&TestExecution{},
+		&TestExecutionList{},
+	)
+	metav1.AddToGroupVersion(scheme, GroupVersion)
+	return nil
+}

--- a/api/testexecution/v1/testexecution_types.go
+++ b/api/testexecution/v1/testexecution_types.go
@@ -422,7 +422,3 @@ type TestExecutionList struct {
 	metav1.ListMeta `json:"metadata,omitempty"`
 	Items           []TestExecution `json:"items"`
 }
-
-func init() {
-	SchemeBuilder.Register(&TestExecution{}, &TestExecutionList{})
-}

--- a/api/tests/v1/groupversion_info.go
+++ b/api/tests/v1/groupversion_info.go
@@ -20,8 +20,9 @@ limitations under the License.
 package v1
 
 import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"sigs.k8s.io/controller-runtime/pkg/scheme"
 )
 
 var (
@@ -29,8 +30,17 @@ var (
 	GroupVersion = schema.GroupVersion{Group: "tests.testkube.io", Version: "v1"}
 
 	// SchemeBuilder is used to add go types to the GroupVersionKind scheme
-	SchemeBuilder = &scheme.Builder{GroupVersion: GroupVersion}
+	SchemeBuilder = runtime.NewSchemeBuilder(addKnownTypes)
 
 	// AddToScheme adds the types in this group-version to the given scheme.
 	AddToScheme = SchemeBuilder.AddToScheme
 )
+
+func addKnownTypes(scheme *runtime.Scheme) error {
+	scheme.AddKnownTypes(GroupVersion,
+		&Test{},
+		&TestList{},
+	)
+	metav1.AddToGroupVersion(scheme, GroupVersion)
+	return nil
+}

--- a/api/tests/v1/test_types.go
+++ b/api/tests/v1/test_types.go
@@ -91,7 +91,3 @@ type TestList struct {
 	metav1.ListMeta `json:"metadata,omitempty"`
 	Items           []Test `json:"items"`
 }
-
-func init() {
-	SchemeBuilder.Register(&Test{}, &TestList{})
-}

--- a/api/tests/v2/groupversion_info.go
+++ b/api/tests/v2/groupversion_info.go
@@ -20,8 +20,9 @@ limitations under the License.
 package v2
 
 import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"sigs.k8s.io/controller-runtime/pkg/scheme"
 )
 
 var (
@@ -29,8 +30,17 @@ var (
 	GroupVersion = schema.GroupVersion{Group: "tests.testkube.io", Version: "v2"}
 
 	// SchemeBuilder is used to add go types to the GroupVersionKind scheme
-	SchemeBuilder = &scheme.Builder{GroupVersion: GroupVersion}
+	SchemeBuilder = runtime.NewSchemeBuilder(addKnownTypes)
 
 	// AddToScheme adds the types in this group-version to the given scheme.
 	AddToScheme = SchemeBuilder.AddToScheme
 )
+
+func addKnownTypes(scheme *runtime.Scheme) error {
+	scheme.AddKnownTypes(GroupVersion,
+		&Test{},
+		&TestList{},
+	)
+	metav1.AddToGroupVersion(scheme, GroupVersion)
+	return nil
+}

--- a/api/tests/v2/test_types.go
+++ b/api/tests/v2/test_types.go
@@ -107,7 +107,3 @@ type TestList struct {
 	metav1.ListMeta `json:"metadata,omitempty"`
 	Items           []Test `json:"items"`
 }
-
-func init() {
-	SchemeBuilder.Register(&Test{}, &TestList{})
-}

--- a/api/tests/v3/groupversion_info.go
+++ b/api/tests/v3/groupversion_info.go
@@ -20,8 +20,9 @@ limitations under the License.
 package v3
 
 import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"sigs.k8s.io/controller-runtime/pkg/scheme"
 )
 
 var (
@@ -41,8 +42,17 @@ var (
 	GroupVersionResource = schema.GroupVersionResource{Group: Group, Version: Version, Resource: Resource}
 
 	// SchemeBuilder is used to add go types to the GroupVersionKind scheme
-	SchemeBuilder = &scheme.Builder{GroupVersion: GroupVersion}
+	SchemeBuilder = runtime.NewSchemeBuilder(addKnownTypes)
 
 	// AddToScheme adds the types in this group-version to the given scheme.
 	AddToScheme = SchemeBuilder.AddToScheme
 )
+
+func addKnownTypes(scheme *runtime.Scheme) error {
+	scheme.AddKnownTypes(GroupVersion,
+		&Test{},
+		&TestList{},
+	)
+	metav1.AddToGroupVersion(scheme, GroupVersion)
+	return nil
+}

--- a/api/tests/v3/test_types.go
+++ b/api/tests/v3/test_types.go
@@ -325,7 +325,3 @@ type TestList struct {
 	metav1.ListMeta `json:"metadata,omitempty"`
 	Items           []Test `json:"items"`
 }
-
-func init() {
-	SchemeBuilder.Register(&Test{}, &TestList{})
-}

--- a/api/testsuite/v1/groupversion_info.go
+++ b/api/testsuite/v1/groupversion_info.go
@@ -20,8 +20,9 @@ limitations under the License.
 package v1
 
 import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"sigs.k8s.io/controller-runtime/pkg/scheme"
 )
 
 var (
@@ -29,8 +30,17 @@ var (
 	GroupVersion = schema.GroupVersion{Group: "tests.testkube.io", Version: "v1"}
 
 	// SchemeBuilder is used to add go types to the GroupVersionKind scheme
-	SchemeBuilder = &scheme.Builder{GroupVersion: GroupVersion}
+	SchemeBuilder = runtime.NewSchemeBuilder(addKnownTypes)
 
 	// AddToScheme adds the types in this group-version to the given scheme.
 	AddToScheme = SchemeBuilder.AddToScheme
 )
+
+func addKnownTypes(scheme *runtime.Scheme) error {
+	scheme.AddKnownTypes(GroupVersion,
+		&TestSuite{},
+		&TestSuiteList{},
+	)
+	metav1.AddToGroupVersion(scheme, GroupVersion)
+	return nil
+}

--- a/api/testsuite/v1/testsuite_types.go
+++ b/api/testsuite/v1/testsuite_types.go
@@ -104,7 +104,3 @@ type TestSuiteList struct {
 	metav1.ListMeta `json:"metadata,omitempty"`
 	Items           []TestSuite `json:"items"`
 }
-
-func init() {
-	SchemeBuilder.Register(&TestSuite{}, &TestSuiteList{})
-}

--- a/api/testsuite/v2/groupversion_info.go
+++ b/api/testsuite/v2/groupversion_info.go
@@ -20,8 +20,9 @@ limitations under the License.
 package v2
 
 import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"sigs.k8s.io/controller-runtime/pkg/scheme"
 )
 
 var (
@@ -41,8 +42,17 @@ var (
 	GroupVersionResource = schema.GroupVersionResource{Group: Group, Version: Version, Resource: Resource}
 
 	// SchemeBuilder is used to add go types to the GroupVersionKind scheme
-	SchemeBuilder = &scheme.Builder{GroupVersion: GroupVersion}
+	SchemeBuilder = runtime.NewSchemeBuilder(addKnownTypes)
 
 	// AddToScheme adds the types in this group-version to the given scheme.
 	AddToScheme = SchemeBuilder.AddToScheme
 )
+
+func addKnownTypes(scheme *runtime.Scheme) error {
+	scheme.AddKnownTypes(GroupVersion,
+		&TestSuite{},
+		&TestSuiteList{},
+	)
+	metav1.AddToGroupVersion(scheme, GroupVersion)
+	return nil
+}

--- a/api/testsuite/v2/testsuite_types.go
+++ b/api/testsuite/v2/testsuite_types.go
@@ -174,7 +174,3 @@ type TestSuiteList struct {
 	metav1.ListMeta `json:"metadata,omitempty"`
 	Items           []TestSuite `json:"items"`
 }
-
-func init() {
-	SchemeBuilder.Register(&TestSuite{}, &TestSuiteList{})
-}

--- a/api/testsuite/v3/groupversion_info.go
+++ b/api/testsuite/v3/groupversion_info.go
@@ -20,8 +20,9 @@ limitations under the License.
 package v3
 
 import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"sigs.k8s.io/controller-runtime/pkg/scheme"
 )
 
 var (
@@ -41,8 +42,17 @@ var (
 	GroupVersionResource = schema.GroupVersionResource{Group: Group, Version: Version, Resource: Resource}
 
 	// SchemeBuilder is used to add go types to the GroupVersionKind scheme
-	SchemeBuilder = &scheme.Builder{GroupVersion: GroupVersion}
+	SchemeBuilder = runtime.NewSchemeBuilder(addKnownTypes)
 
 	// AddToScheme adds the types in this group-version to the given scheme.
 	AddToScheme = SchemeBuilder.AddToScheme
 )
+
+func addKnownTypes(scheme *runtime.Scheme) error {
+	scheme.AddKnownTypes(GroupVersion,
+		&TestSuite{},
+		&TestSuiteList{},
+	)
+	metav1.AddToGroupVersion(scheme, GroupVersion)
+	return nil
+}

--- a/api/testsuite/v3/testsuite_types.go
+++ b/api/testsuite/v3/testsuite_types.go
@@ -190,10 +190,6 @@ type TestSuiteList struct {
 	Items           []TestSuite `json:"items"`
 }
 
-func init() {
-	SchemeBuilder.Register(&TestSuite{}, &TestSuiteList{})
-}
-
 type ArgsModeType commonv1.ArgsModeType
 
 // TestSuiteStepExecutionRequest contains parameters to be used by the executions.

--- a/api/testsuiteexecution/v1/groupversion_info.go
+++ b/api/testsuiteexecution/v1/groupversion_info.go
@@ -20,8 +20,9 @@ limitations under the License.
 package v1
 
 import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"sigs.k8s.io/controller-runtime/pkg/scheme"
 )
 
 var (
@@ -29,8 +30,17 @@ var (
 	GroupVersion = schema.GroupVersion{Group: "tests.testkube.io", Version: "v1"}
 
 	// SchemeBuilder is used to add go types to the GroupVersionKind scheme
-	SchemeBuilder = &scheme.Builder{GroupVersion: GroupVersion}
+	SchemeBuilder = runtime.NewSchemeBuilder(addKnownTypes)
 
 	// AddToScheme adds the types in this group-version to the given scheme.
 	AddToScheme = SchemeBuilder.AddToScheme
 )
+
+func addKnownTypes(scheme *runtime.Scheme) error {
+	scheme.AddKnownTypes(GroupVersion,
+		&TestSuiteExecution{},
+		&TestSuiteExecutionList{},
+	)
+	metav1.AddToGroupVersion(scheme, GroupVersion)
+	return nil
+}

--- a/api/testsuiteexecution/v1/testsuiteexecution_types.go
+++ b/api/testsuiteexecution/v1/testsuiteexecution_types.go
@@ -494,7 +494,3 @@ type TestSuiteExecutionList struct {
 	metav1.ListMeta `json:"metadata,omitempty"`
 	Items           []TestSuiteExecution `json:"items"`
 }
-
-func init() {
-	SchemeBuilder.Register(&TestSuiteExecution{}, &TestSuiteExecutionList{})
-}

--- a/api/testtriggers/v1/groupversion_info.go
+++ b/api/testtriggers/v1/groupversion_info.go
@@ -20,8 +20,9 @@ limitations under the License.
 package v1
 
 import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"sigs.k8s.io/controller-runtime/pkg/scheme"
 )
 
 var (
@@ -38,8 +39,17 @@ var (
 	GroupVersionResource = schema.GroupVersionResource{Group: Group, Version: Version, Resource: Resource}
 
 	// SchemeBuilder is used to add go types to the GroupVersionKind scheme
-	SchemeBuilder = &scheme.Builder{GroupVersion: GroupVersion}
+	SchemeBuilder = runtime.NewSchemeBuilder(addKnownTypes)
 
 	// AddToScheme adds the types in this group-version to the given scheme.
 	AddToScheme = SchemeBuilder.AddToScheme
 )
+
+func addKnownTypes(scheme *runtime.Scheme) error {
+	scheme.AddKnownTypes(GroupVersion,
+		&TestTrigger{},
+		&TestTriggerList{},
+	)
+	metav1.AddToGroupVersion(scheme, GroupVersion)
+	return nil
+}

--- a/api/testtriggers/v1/testtrigger_types.go
+++ b/api/testtriggers/v1/testtrigger_types.go
@@ -270,7 +270,3 @@ type TestTriggerList struct {
 	metav1.ListMeta `json:"metadata,omitempty"`
 	Items           []TestTrigger `json:"items"`
 }
-
-func init() {
-	SchemeBuilder.Register(&TestTrigger{}, &TestTriggerList{})
-}

--- a/api/testworkflows/v1/groupversion_info.go
+++ b/api/testworkflows/v1/groupversion_info.go
@@ -17,8 +17,9 @@ limitations under the License.
 package v1
 
 import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"sigs.k8s.io/controller-runtime/pkg/scheme"
 )
 
 var (
@@ -41,8 +42,21 @@ var (
 	GroupVersion = schema.GroupVersion{Group: Group, Version: Version}
 
 	// SchemeBuilder is used to add go types to the GroupVersionKind scheme
-	SchemeBuilder = &scheme.Builder{GroupVersion: GroupVersion}
+	SchemeBuilder = runtime.NewSchemeBuilder(addKnownTypes)
 
 	// AddToScheme adds the types in this group-version to the given scheme.
 	AddToScheme = SchemeBuilder.AddToScheme
 )
+
+func addKnownTypes(scheme *runtime.Scheme) error {
+	scheme.AddKnownTypes(GroupVersion,
+		&TestWorkflow{},
+		&TestWorkflowList{},
+		&TestWorkflowTemplate{},
+		&TestWorkflowTemplateList{},
+		&TestWorkflowExecution{},
+		&TestWorkflowExecutionList{},
+	)
+	metav1.AddToGroupVersion(scheme, GroupVersion)
+	return nil
+}

--- a/api/testworkflows/v1/testworkflow_types.go
+++ b/api/testworkflows/v1/testworkflow_types.go
@@ -95,7 +95,3 @@ type TestWorkflowList struct {
 	metav1.ListMeta `json:"metadata,omitempty"`
 	Items           []TestWorkflow `json:"items" expr:"include"`
 }
-
-func init() {
-	SchemeBuilder.Register(&TestWorkflow{}, &TestWorkflowList{})
-}

--- a/api/testworkflows/v1/testworkflowexecution_types.go
+++ b/api/testworkflows/v1/testworkflowexecution_types.go
@@ -328,7 +328,3 @@ type TestWorkflowExecutionList struct {
 	metav1.ListMeta `json:"metadata,omitempty"`
 	Items           []TestWorkflowExecution `json:"items" expr:"include"`
 }
-
-func init() {
-	SchemeBuilder.Register(&TestWorkflowExecution{}, &TestWorkflowExecutionList{})
-}

--- a/api/testworkflows/v1/testworkflowtemplate_types.go
+++ b/api/testworkflows/v1/testworkflowtemplate_types.go
@@ -62,7 +62,3 @@ type TestWorkflowTemplateList struct {
 	metav1.ListMeta `json:"metadata,omitempty"`
 	Items           []TestWorkflowTemplate `json:"items" expr:"include"`
 }
-
-func init() {
-	SchemeBuilder.Register(&TestWorkflowTemplate{}, &TestWorkflowTemplateList{})
-}

--- a/api/workflowtriggers/v1/groupversion_info.go
+++ b/api/workflowtriggers/v1/groupversion_info.go
@@ -17,8 +17,9 @@ limitations under the License.
 package v1
 
 import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"sigs.k8s.io/controller-runtime/pkg/scheme"
 )
 
 var (
@@ -44,8 +45,17 @@ var (
 	GroupVersionResource = schema.GroupVersionResource{Group: Group, Version: Version, Resource: Resource}
 
 	// SchemeBuilder is used to add go types to the GroupVersionKind scheme
-	SchemeBuilder = &scheme.Builder{GroupVersion: GroupVersion}
+	SchemeBuilder = runtime.NewSchemeBuilder(addKnownTypes)
 
 	// AddToScheme adds the types in this group-version to the given scheme.
 	AddToScheme = SchemeBuilder.AddToScheme
 )
+
+func addKnownTypes(scheme *runtime.Scheme) error {
+	scheme.AddKnownTypes(GroupVersion,
+		&WorkflowTrigger{},
+		&WorkflowTriggerList{},
+	)
+	metav1.AddToGroupVersion(scheme, GroupVersion)
+	return nil
+}

--- a/api/workflowtriggers/v1/workflowtrigger_types.go
+++ b/api/workflowtriggers/v1/workflowtrigger_types.go
@@ -227,7 +227,3 @@ type WorkflowTriggerList struct {
 	metav1.ListMeta `json:"metadata,omitempty"`
 	Items           []WorkflowTrigger `json:"items"`
 }
-
-func init() {
-	SchemeBuilder.Register(&WorkflowTrigger{}, &WorkflowTriggerList{})
-}

--- a/pkg/operator/client/templates/v1/templates_test.go
+++ b/pkg/operator/client/templates/v1/templates_test.go
@@ -5,9 +5,9 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
-	"sigs.k8s.io/controller-runtime/pkg/scheme"
 
 	templatesv1 "github.com/kubeshop/testkube/api/template/v1"
 )
@@ -55,12 +55,12 @@ func TestTemplates(t *testing.T) {
 		clientBuilder := fake.NewClientBuilder()
 
 		groupVersion := schema.GroupVersion{Group: "template.testkube.io", Version: "v1"}
-		schemaBuilder := scheme.Builder{GroupVersion: groupVersion}
-		schemaBuilder.Register(&templatesv1.TemplateList{})
-		schemaBuilder.Register(&templatesv1.Template{})
-
-		schema, err := schemaBuilder.Build()
-		assert.NoError(t, err)
+		schema := runtime.NewScheme()
+		schema.AddKnownTypes(groupVersion,
+			&templatesv1.TemplateList{},
+			&templatesv1.Template{},
+		)
+		v1.AddToGroupVersion(schema, groupVersion)
 		assert.NotEmpty(t, schema)
 		clientBuilder.WithScheme(schema)
 


### PR DESCRIPTION
## Summary
- Replace deprecated controller-runtime scheme.Builder usage in API registration packages with k8s runtime.SchemeBuilder addKnownTypes helpers
- Preserve metav1 group-version registration for all migrated object types
- Update template client test scheme setup to avoid the deprecated builder

## Linear
- TKC-5566

## Verification
- make lint
- go build ./...
- make unit-tests