### PR TITLE
fix(executions): Fixing Tags Query Performance

### DIFF
--- a/pkg/database/postgres/queries/executions.sql
+++ b/pkg/database/postgres/queries/executions.sql
@@ -883,22 +883,21 @@ LIMIT 1;
 -- name: GetTestWorkflowExecutionTags :many
 WITH tag_extracts AS (
     SELECT
-        e.id,
-        w.name as workflow_name,
         tag_pair.key as tag_key,
         tag_pair.value as tag_value
     FROM test_workflow_executions e
-    LEFT JOIN test_workflows w ON e.id = w.execution_id AND w.workflow_type = 'workflow'
     CROSS JOIN LATERAL jsonb_each_text(e.tags) AS tag_pair(key, value)
-    WHERE e.tags IS NOT NULL AND (e.organization_id = @organization_id AND e.environment_id = @environment_id)
-        AND e.tags != '{}'::jsonb
-        AND jsonb_typeof(e.tags) = 'object'
+    WHERE e.organization_id = @organization_id
+      AND e.environment_id = @environment_id
+      AND e.tags IS NOT NULL
+      AND e.tags != '{}'::jsonb
+      AND jsonb_typeof(e.tags) = 'object'
+      AND (sqlc.narg('workflow_name')::text IS NULL OR e.workflow_name = sqlc.narg('workflow_name')::text)
 )
 SELECT
     tag_key::text,
     array_agg(DISTINCT tag_value ORDER BY tag_value)::text[] as values
 FROM tag_extracts
-WHERE (COALESCE(@workflow_name::text, '') = '' OR workflow_name = @workflow_name::text)
 GROUP BY tag_key
 ORDER BY tag_key;
 

--- a/pkg/database/postgres/sqlc/executions.sql.go
+++ b/pkg/database/postgres/sqlc/executions.sql.go
@@ -1858,30 +1858,29 @@ func (q *Queries) GetTestWorkflowExecutionByNameAndTestWorkflow(ctx context.Cont
 const getTestWorkflowExecutionTags = `-- name: GetTestWorkflowExecutionTags :many
 WITH tag_extracts AS (
     SELECT
-        e.id,
-        w.name as workflow_name,
         tag_pair.key as tag_key,
         tag_pair.value as tag_value
     FROM test_workflow_executions e
-    LEFT JOIN test_workflows w ON e.id = w.execution_id AND w.workflow_type = 'workflow'
     CROSS JOIN LATERAL jsonb_each_text(e.tags) AS tag_pair(key, value)
-    WHERE e.tags IS NOT NULL AND (e.organization_id = $2 AND e.environment_id = $3)
-        AND e.tags != '{}'::jsonb
-        AND jsonb_typeof(e.tags) = 'object'
+    WHERE e.organization_id = $1
+      AND e.environment_id = $2
+      AND e.tags IS NOT NULL
+      AND e.tags != '{}'::jsonb
+      AND jsonb_typeof(e.tags) = 'object'
+      AND ($3::text IS NULL OR e.workflow_name = $3::text)
 )
 SELECT
     tag_key::text,
     array_agg(DISTINCT tag_value ORDER BY tag_value)::text[] as values
 FROM tag_extracts
-WHERE (COALESCE($1::text, '') = '' OR workflow_name = $1::text)
 GROUP BY tag_key
 ORDER BY tag_key
 `
 
 type GetTestWorkflowExecutionTagsParams struct {
-	WorkflowName   string `db:"workflow_name" json:"workflow_name"`
-	OrganizationID string `db:"organization_id" json:"organization_id"`
-	EnvironmentID  string `db:"environment_id" json:"environment_id"`
+	OrganizationID string      `db:"organization_id" json:"organization_id"`
+	EnvironmentID  string      `db:"environment_id" json:"environment_id"`
+	WorkflowName   pgtype.Text `db:"workflow_name" json:"workflow_name"`
 }
 
 type GetTestWorkflowExecutionTagsRow struct {
@@ -1890,7 +1889,7 @@ type GetTestWorkflowExecutionTagsRow struct {
 }
 
 func (q *Queries) GetTestWorkflowExecutionTags(ctx context.Context, arg GetTestWorkflowExecutionTagsParams) ([]GetTestWorkflowExecutionTagsRow, error) {
-	rows, err := q.db.Query(ctx, getTestWorkflowExecutionTags, arg.WorkflowName, arg.OrganizationID, arg.EnvironmentID)
+	rows, err := q.db.Query(ctx, getTestWorkflowExecutionTags, arg.OrganizationID, arg.EnvironmentID, arg.WorkflowName)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/repository/testworkflow/postgres/postgres.go
+++ b/pkg/repository/testworkflow/postgres/postgres.go
@@ -1749,7 +1749,7 @@ func (r *PostgresRepository) GetPreviousFinishedState(ctx context.Context, testW
 // GetExecutionTags returns execution tags
 func (r *PostgresRepository) GetExecutionTags(ctx context.Context, testWorkflowName string) (map[string][]string, error) {
 	rows, err := r.queries.GetTestWorkflowExecutionTags(ctx, sqlc.GetTestWorkflowExecutionTagsParams{
-		WorkflowName:   testWorkflowName,
+		WorkflowName:   toPgText(testWorkflowName),
 		OrganizationID: r.organizationID,
 		EnvironmentID:  r.environmentID,
 	})

--- a/pkg/repository/testworkflow/postgres/postgres_integration_test.go
+++ b/pkg/repository/testworkflow/postgres/postgres_integration_test.go
@@ -573,3 +573,82 @@ func TestPostgresDenormalizedExecutionColumns_Integration(t *testing.T) {
 		assert.Equal(t, int32(3), resultB.Results, "wf-b should have 3 total")
 	})
 }
+
+func TestPostgresGetExecutionTags_Integration(t *testing.T) {
+	test.IntegrationTest(t)
+	testDB, cleanup := testpostgres.PreparePostgresTestDatabase(t, "repo_get_execution_tags")
+	defer cleanup()
+
+	ctx := context.Background()
+
+	orgID := "tags-org"
+	envID := "tags-env"
+	repo := NewPostgresRepository(
+		testDB.Pool,
+		WithOrganizationID(orgID),
+		WithEnvironmentID(envID),
+	)
+
+	insertExec := func(t *testing.T, id, org, env, workflow, tags string) {
+		t.Helper()
+		_, err := testDB.Pool.Exec(ctx, `
+			INSERT INTO test_workflow_executions
+			(id, organization_id, environment_id, name, namespace, number, scheduled_at, created_at, updated_at, tags)
+			VALUES ($1, $2, $3, $4, 'default', 1, NOW(), NOW(), NOW(), $5::jsonb)
+		`, id, org, env, id, tags)
+		require.NoError(t, err)
+
+		_, err = testDB.Pool.Exec(ctx, `
+			INSERT INTO test_workflows (execution_id, workflow_type, name, namespace, created, updated)
+			VALUES ($1, 'workflow', $2, 'default', NOW(), NOW())
+		`, id, workflow)
+		require.NoError(t, err)
+	}
+
+	insertExec(t, "tag-1", orgID, envID, "wf-alpha", `{"env": "prod", "team": "backend"}`)
+	insertExec(t, "tag-2", orgID, envID, "wf-alpha", `{"env": "staging", "team": "backend"}`)
+
+	insertExec(t, "tag-3", orgID, envID, "wf-beta", `{"env": "dev", "owner": "alice"}`)
+
+	insertExec(t, "tag-4", orgID, envID, "wf-alpha", `{}`)     // empty object
+	insertExec(t, "tag-5", orgID, envID, "wf-alpha", `null`)   // jsonb NULL
+	insertExec(t, "tag-6", orgID, envID, "wf-alpha", `"text"`) // not an object
+
+	insertExec(t, "tag-other-org", "other-org", envID, "wf-alpha", `{"env": "leaked"}`)
+	insertExec(t, "tag-other-env", orgID, "other-env", "wf-alpha", `{"env": "leaked"}`)
+
+	var nullCount int
+	require.NoError(t, testDB.Pool.QueryRow(ctx, `
+		SELECT COUNT(*) FROM test_workflow_executions
+		WHERE organization_id = $1 AND environment_id = $2 AND workflow_name IS NULL
+	`, orgID, envID).Scan(&nullCount))
+	require.Equal(t, 0, nullCount, "trigger must populate workflow_name for all executions")
+
+	t.Run("empty workflow_name returns union of all tags in org/env", func(t *testing.T) {
+		tags, err := repo.GetExecutionTags(ctx, "")
+		require.NoError(t, err)
+
+		// Values are deduplicated and sorted by the query.
+		assert.Equal(t, map[string][]string{
+			"env":   {"dev", "prod", "staging"},
+			"team":  {"backend"},
+			"owner": {"alice"},
+		}, tags)
+	})
+
+	t.Run("non-empty workflow_name returns only that workflow's tags", func(t *testing.T) {
+		tags, err := repo.GetExecutionTags(ctx, "wf-alpha")
+		require.NoError(t, err)
+
+		assert.Equal(t, map[string][]string{
+			"env":  {"prod", "staging"},
+			"team": {"backend"},
+		}, tags)
+	})
+
+	t.Run("workflow_name with no executions returns empty result", func(t *testing.T) {
+		tags, err := repo.GetExecutionTags(ctx, "wf-does-not-exist")
+		require.NoError(t, err)
+		assert.Empty(t, tags)
+	})
+}


### PR DESCRIPTION
## Pull request description

Speeds up `GetTestWorkflowExecutionTags` by removing an unnecessary join and making the workflow filter index-friendly.

## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [x] tested locally
- [ ] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [x] added a test

## Breaking changes

-

## Changes

- Drop the `LEFT JOIN test_workflows w ON e.id = w.execution_id` and read `workflow_name` from the denormalized `test_workflow_executions.workflow_name` column (kept in sync by `trg_sync_execution_workflow_name`).
- Push the workflow filter inside the CTE `WHERE` and switch from `COALESCE(@workflow_name::text, '') = ''` to `sqlc.narg('workflow_name')::text IS NULL OR e.workflow_name = ...`, allowing the planner to use `idx_twe_org_env_wfname_sched`.
- Caller now passes `toPgText(testWorkflowName)` (empty string still maps to NULL → "all workflows", same behavior).

## Fixes

- `/test-workflow-with-executions/{id}/tags` query time on production-sized data: ~100ms → ~10–20ms warm, ~25× fewer buffer hits, far smaller cold-cache outliers.
- Removes ~22k PK probes into `test_workflows` per call.