### PR TITLE
fix(executions): Fixing Workflows With Execution Query Performance

### DIFF
--- a/pkg/database/postgres/queries/executions.sql
+++ b/pkg/database/postgres/queries/executions.sql
@@ -121,6 +121,37 @@ LEFT JOIN test_workflow_resource_aggregations ra ON e.id = ra.execution_id
 WHERE (e.id = @name OR e.name = @name) AND e.workflow_name = @workflow_name::text AND (e.organization_id = @organization_id AND e.environment_id = @environment_id);
 
 -- name: GetLatestTestWorkflowExecutionByTestWorkflow :one
+WITH latest AS (
+    (SELECT e.id
+     FROM test_workflow_executions e
+     WHERE e.organization_id = @organization_id
+       AND e.environment_id  = @environment_id
+       AND e.workflow_name   = @workflow_name::text
+       AND NOT @sort_by_number::boolean
+       AND NOT @sort_by_status::boolean
+     ORDER BY e.organization_id, e.environment_id, e.workflow_name, e.scheduled_at DESC
+     LIMIT 1)
+    UNION ALL
+    (SELECT e.id
+     FROM test_workflow_executions e
+     WHERE e.organization_id = @organization_id
+       AND e.environment_id  = @environment_id
+       AND e.workflow_name   = @workflow_name::text
+       AND @sort_by_number::boolean
+       AND NOT @sort_by_status::boolean
+     ORDER BY e.number DESC
+     LIMIT 1)
+    UNION ALL
+    (SELECT e.id
+     FROM test_workflow_executions e
+     WHERE e.organization_id = @organization_id
+       AND e.environment_id  = @environment_id
+       AND e.workflow_name   = @workflow_name::text
+       AND @sort_by_status::boolean
+       AND NOT @sort_by_number::boolean
+     ORDER BY e.status_at DESC
+     LIMIT 1)
+)
 SELECT
     e.id, e.group_id, e.runner_id, e.runner_target, e.runner_original_target, e.name, e.namespace, e.number, e.scheduled_at, e.assigned_at, e.status_at, e.test_workflow_execution_name, e.disable_webhooks, e.tags, e.running_context, e.config_params, e.runtime, e.silent_mode, e.created_at, e.updated_at,
     r.status, r.predicted_status, r.queued_at, r.started_at, r.finished_at,
@@ -179,15 +210,7 @@ LEFT JOIN test_workflow_results r ON e.id = r.execution_id
 LEFT JOIN test_workflows w ON e.id = w.execution_id AND w.workflow_type = 'workflow'
 LEFT JOIN test_workflows rw ON e.id = rw.execution_id AND rw.workflow_type = 'resolved_workflow'
 LEFT JOIN test_workflow_resource_aggregations ra ON e.id = ra.execution_id
-WHERE e.workflow_name = @workflow_name::text AND (e.organization_id = @organization_id AND e.environment_id = @environment_id)
-ORDER BY
-    CASE
-        WHEN @sort_by_number::boolean = true AND @sort_by_status::boolean = false THEN e.number
-        WHEN @sort_by_status::boolean = true AND @sort_by_number::boolean = false THEN EXTRACT(EPOCH FROM e.status_at)::integer
-    ELSE
-        EXTRACT(EPOCH FROM e.scheduled_at)::integer
-    END DESC
-LIMIT 1;
+WHERE e.id = (SELECT id FROM latest LIMIT 1);
 
 -- name: GetLatestTestWorkflowExecutionsByTestWorkflows :many
 SELECT DISTINCT ON (e.workflow_name)

--- a/pkg/database/postgres/queries/executions.sql
+++ b/pkg/database/postgres/queries/executions.sql
@@ -127,8 +127,7 @@ WITH latest AS (
      WHERE e.organization_id = @organization_id
        AND e.environment_id  = @environment_id
        AND e.workflow_name   = @workflow_name::text
-       AND NOT @sort_by_number::boolean
-       AND NOT @sort_by_status::boolean
+       AND @sort_by_number::boolean = @sort_by_status::boolean
      ORDER BY e.organization_id, e.environment_id, e.workflow_name, e.scheduled_at DESC
      LIMIT 1)
     UNION ALL

--- a/pkg/database/postgres/sqlc/executions.sql.go
+++ b/pkg/database/postgres/sqlc/executions.sql.go
@@ -791,6 +791,37 @@ func (q *Queries) GetFinishedTestWorkflowExecutions(ctx context.Context, arg Get
 }
 
 const getLatestTestWorkflowExecutionByTestWorkflow = `-- name: GetLatestTestWorkflowExecutionByTestWorkflow :one
+WITH latest AS (
+    (SELECT e.id
+     FROM test_workflow_executions e
+     WHERE e.organization_id = $1
+       AND e.environment_id  = $2
+       AND e.workflow_name   = $3::text
+       AND NOT $4::boolean
+       AND NOT $5::boolean
+     ORDER BY e.organization_id, e.environment_id, e.workflow_name, e.scheduled_at DESC
+     LIMIT 1)
+    UNION ALL
+    (SELECT e.id
+     FROM test_workflow_executions e
+     WHERE e.organization_id = $1
+       AND e.environment_id  = $2
+       AND e.workflow_name   = $3::text
+       AND $4::boolean
+       AND NOT $5::boolean
+     ORDER BY e.number DESC
+     LIMIT 1)
+    UNION ALL
+    (SELECT e.id
+     FROM test_workflow_executions e
+     WHERE e.organization_id = $1
+       AND e.environment_id  = $2
+       AND e.workflow_name   = $3::text
+       AND $5::boolean
+       AND NOT $4::boolean
+     ORDER BY e.status_at DESC
+     LIMIT 1)
+)
 SELECT
     e.id, e.group_id, e.runner_id, e.runner_target, e.runner_original_target, e.name, e.namespace, e.number, e.scheduled_at, e.assigned_at, e.status_at, e.test_workflow_execution_name, e.disable_webhooks, e.tags, e.running_context, e.config_params, e.runtime, e.silent_mode, e.created_at, e.updated_at,
     r.status, r.predicted_status, r.queued_at, r.started_at, r.finished_at,
@@ -849,21 +880,13 @@ LEFT JOIN test_workflow_results r ON e.id = r.execution_id
 LEFT JOIN test_workflows w ON e.id = w.execution_id AND w.workflow_type = 'workflow'
 LEFT JOIN test_workflows rw ON e.id = rw.execution_id AND rw.workflow_type = 'resolved_workflow'
 LEFT JOIN test_workflow_resource_aggregations ra ON e.id = ra.execution_id
-WHERE e.workflow_name = $1::text AND (e.organization_id = $2 AND e.environment_id = $3)
-ORDER BY
-    CASE
-        WHEN $4::boolean = true AND $5::boolean = false THEN e.number
-        WHEN $5::boolean = true AND $4::boolean = false THEN EXTRACT(EPOCH FROM e.status_at)::integer
-    ELSE
-        EXTRACT(EPOCH FROM e.scheduled_at)::integer
-    END DESC
-LIMIT 1
+WHERE e.id = (SELECT id FROM latest LIMIT 1)
 `
 
 type GetLatestTestWorkflowExecutionByTestWorkflowParams struct {
-	WorkflowName   string `db:"workflow_name" json:"workflow_name"`
 	OrganizationID string `db:"organization_id" json:"organization_id"`
 	EnvironmentID  string `db:"environment_id" json:"environment_id"`
+	WorkflowName   string `db:"workflow_name" json:"workflow_name"`
 	SortByNumber   bool   `db:"sort_by_number" json:"sort_by_number"`
 	SortByStatus   bool   `db:"sort_by_status" json:"sort_by_status"`
 }
@@ -931,9 +954,9 @@ type GetLatestTestWorkflowExecutionByTestWorkflowRow struct {
 
 func (q *Queries) GetLatestTestWorkflowExecutionByTestWorkflow(ctx context.Context, arg GetLatestTestWorkflowExecutionByTestWorkflowParams) (GetLatestTestWorkflowExecutionByTestWorkflowRow, error) {
 	row := q.db.QueryRow(ctx, getLatestTestWorkflowExecutionByTestWorkflow,
-		arg.WorkflowName,
 		arg.OrganizationID,
 		arg.EnvironmentID,
+		arg.WorkflowName,
 		arg.SortByNumber,
 		arg.SortByStatus,
 	)

--- a/pkg/database/postgres/sqlc/executions.sql.go
+++ b/pkg/database/postgres/sqlc/executions.sql.go
@@ -797,8 +797,7 @@ WITH latest AS (
      WHERE e.organization_id = $1
        AND e.environment_id  = $2
        AND e.workflow_name   = $3::text
-       AND NOT $4::boolean
-       AND NOT $5::boolean
+       AND $4::boolean = $5::boolean
      ORDER BY e.organization_id, e.environment_id, e.workflow_name, e.scheduled_at DESC
      LIMIT 1)
     UNION ALL

--- a/pkg/repository/testworkflow/postgres/postgres_integration_test.go
+++ b/pkg/repository/testworkflow/postgres/postgres_integration_test.go
@@ -573,3 +573,164 @@ func TestPostgresDenormalizedExecutionColumns_Integration(t *testing.T) {
 		assert.Equal(t, int32(3), resultB.Results, "wf-b should have 3 total")
 	})
 }
+
+func TestPostgresGetExecutionTags_Integration(t *testing.T) {
+	test.IntegrationTest(t)
+	testDB, cleanup := testpostgres.PreparePostgresTestDatabase(t, "repo_get_execution_tags")
+	defer cleanup()
+
+	ctx := context.Background()
+
+	orgID := "tags-org"
+	envID := "tags-env"
+	repo := NewPostgresRepository(
+		testDB.Pool,
+		WithOrganizationID(orgID),
+		WithEnvironmentID(envID),
+	)
+
+	insertExec := func(t *testing.T, id, org, env, workflow, tags string) {
+		t.Helper()
+		_, err := testDB.Pool.Exec(ctx, `
+			INSERT INTO test_workflow_executions
+			(id, organization_id, environment_id, name, namespace, number, scheduled_at, created_at, updated_at, tags)
+			VALUES ($1, $2, $3, $4, 'default', 1, NOW(), NOW(), NOW(), $5::jsonb)
+		`, id, org, env, id, tags)
+		require.NoError(t, err)
+
+		_, err = testDB.Pool.Exec(ctx, `
+			INSERT INTO test_workflows (execution_id, workflow_type, name, namespace, created, updated)
+			VALUES ($1, 'workflow', $2, 'default', NOW(), NOW())
+		`, id, workflow)
+		require.NoError(t, err)
+	}
+
+	insertExec(t, "tag-1", orgID, envID, "wf-alpha", `{"env": "prod", "team": "backend"}`)
+	insertExec(t, "tag-2", orgID, envID, "wf-alpha", `{"env": "staging", "team": "backend"}`)
+
+	insertExec(t, "tag-3", orgID, envID, "wf-beta", `{"env": "dev", "owner": "alice"}`)
+
+	insertExec(t, "tag-4", orgID, envID, "wf-alpha", `{}`)     // empty object
+	insertExec(t, "tag-5", orgID, envID, "wf-alpha", `null`)   // jsonb NULL
+	insertExec(t, "tag-6", orgID, envID, "wf-alpha", `"text"`) // not an object
+
+	insertExec(t, "tag-other-org", "other-org", envID, "wf-alpha", `{"env": "leaked"}`)
+	insertExec(t, "tag-other-env", orgID, "other-env", "wf-alpha", `{"env": "leaked"}`)
+
+	var nullCount int
+	require.NoError(t, testDB.Pool.QueryRow(ctx, `
+		SELECT COUNT(*) FROM test_workflow_executions
+		WHERE organization_id = $1 AND environment_id = $2 AND workflow_name IS NULL
+	`, orgID, envID).Scan(&nullCount))
+	require.Equal(t, 0, nullCount, "trigger must populate workflow_name for all executions")
+
+	t.Run("empty workflow_name returns union of all tags in org/env", func(t *testing.T) {
+		tags, err := repo.GetExecutionTags(ctx, "")
+		require.NoError(t, err)
+
+		// Values are deduplicated and sorted by the query.
+		assert.Equal(t, map[string][]string{
+			"env":   {"dev", "prod", "staging"},
+			"team":  {"backend"},
+			"owner": {"alice"},
+		}, tags)
+	})
+
+	t.Run("non-empty workflow_name returns only that workflow's tags", func(t *testing.T) {
+		tags, err := repo.GetExecutionTags(ctx, "wf-alpha")
+		require.NoError(t, err)
+
+		assert.Equal(t, map[string][]string{
+			"env":  {"prod", "staging"},
+			"team": {"backend"},
+		}, tags)
+	})
+
+	t.Run("workflow_name with no executions returns empty result", func(t *testing.T) {
+		tags, err := repo.GetExecutionTags(ctx, "wf-does-not-exist")
+		require.NoError(t, err)
+		assert.Empty(t, tags)
+	})
+}
+
+func TestPostgresGetLatestByTestWorkflow_Integration(t *testing.T) {
+	test.IntegrationTest(t)
+	testDB, cleanup := testpostgres.PreparePostgresTestDatabase(t, "repo_get_latest_by_workflow")
+	defer cleanup()
+
+	ctx := context.Background()
+
+	orgID := "latest-org"
+	envID := "latest-env"
+	repo := NewPostgresRepository(
+		testDB.Pool,
+		WithOrganizationID(orgID),
+		WithEnvironmentID(envID),
+	)
+
+	type spec struct {
+		id          string
+		org, env    string
+		workflow    string
+		number      int32
+		scheduledAt string // ISO timestamp literal
+		statusAt    string
+		status      string
+	}
+	insertExec := func(t *testing.T, s spec) {
+		t.Helper()
+		_, err := testDB.Pool.Exec(ctx, `
+			INSERT INTO test_workflow_executions
+			(id, organization_id, environment_id, name, namespace, number, scheduled_at, status_at, created_at, updated_at)
+			VALUES ($1, $2, $3, $1, 'default', $4, $5::timestamptz, $6::timestamptz, NOW(), NOW())
+		`, s.id, s.org, s.env, s.number, s.scheduledAt, s.statusAt)
+		require.NoError(t, err)
+
+		_, err = testDB.Pool.Exec(ctx, `
+			INSERT INTO test_workflow_results (execution_id, status, created_at, updated_at)
+			VALUES ($1, $2, NOW(), NOW())
+		`, s.id, s.status)
+		require.NoError(t, err)
+
+		_, err = testDB.Pool.Exec(ctx, `
+			INSERT INTO test_workflows (execution_id, workflow_type, name, namespace, created, updated)
+			VALUES ($1, 'workflow', $2, 'default', NOW(), NOW())
+		`, s.id, s.workflow)
+		require.NoError(t, err)
+	}
+
+	insertExec(t, spec{id: "lat-sched-newest", org: orgID, env: envID, workflow: "wf-target", number: 1, scheduledAt: "2026-04-24T12:00:00Z", statusAt: "2026-04-22T00:00:00Z", status: "passed"})
+	insertExec(t, spec{id: "lat-status-newest", org: orgID, env: envID, workflow: "wf-target", number: 2, scheduledAt: "2026-04-22T12:00:00Z", statusAt: "2026-04-24T00:00:00Z", status: "failed"})
+	insertExec(t, spec{id: "lat-number-highest", org: orgID, env: envID, workflow: "wf-target", number: 99, scheduledAt: "2026-04-20T12:00:00Z", statusAt: "2026-04-20T00:00:00Z", status: "passed"})
+
+	insertExec(t, spec{id: "noise-other-workflow", org: orgID, env: envID, workflow: "wf-other", number: 1000, scheduledAt: "2026-04-25T00:00:00Z", statusAt: "2026-04-25T00:00:00Z", status: "passed"})
+	insertExec(t, spec{id: "noise-other-org", org: "other-org", env: envID, workflow: "wf-target", number: 1000, scheduledAt: "2026-04-25T00:00:00Z", statusAt: "2026-04-25T00:00:00Z", status: "passed"})
+	insertExec(t, spec{id: "noise-other-env", org: orgID, env: "other-env", workflow: "wf-target", number: 1000, scheduledAt: "2026-04-25T00:00:00Z", statusAt: "2026-04-25T00:00:00Z", status: "passed"})
+
+	t.Run("LatestSortByScheduledAt picks newest scheduled_at", func(t *testing.T) {
+		got, err := repo.GetLatestByTestWorkflow(ctx, "wf-target", testworkflow.LatestSortByScheduledAt)
+		require.NoError(t, err)
+		require.NotNil(t, got)
+		assert.Equal(t, "lat-sched-newest", got.Id)
+	})
+
+	t.Run("LatestSortByStatusAt picks newest status_at", func(t *testing.T) {
+		got, err := repo.GetLatestByTestWorkflow(ctx, "wf-target", testworkflow.LatestSortByStatusAt)
+		require.NoError(t, err)
+		require.NotNil(t, got)
+		assert.Equal(t, "lat-status-newest", got.Id)
+	})
+
+	t.Run("LatestSortByNumber picks highest number", func(t *testing.T) {
+		got, err := repo.GetLatestByTestWorkflow(ctx, "wf-target", testworkflow.LatestSortByNumber)
+		require.NoError(t, err)
+		require.NotNil(t, got)
+		assert.Equal(t, "lat-number-highest", got.Id)
+	})
+
+	t.Run("unknown workflow returns no rows", func(t *testing.T) {
+		got, err := repo.GetLatestByTestWorkflow(ctx, "wf-does-not-exist", testworkflow.LatestSortByScheduledAt)
+		assert.Error(t, err)
+		assert.Nil(t, got)
+	})
+}

--- a/pkg/repository/testworkflow/postgres/postgres_integration_test.go
+++ b/pkg/repository/testworkflow/postgres/postgres_integration_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/kubeshop/testkube/pkg/database/postgres/sqlc"
 	"github.com/kubeshop/testkube/pkg/repository/testworkflow"
 	testpostgres "github.com/kubeshop/testkube/pkg/test/postgres"
 	"github.com/kubeshop/testkube/pkg/utils/test"
@@ -733,4 +734,63 @@ func TestPostgresGetLatestByTestWorkflow_Integration(t *testing.T) {
 		assert.Error(t, err)
 		assert.Nil(t, got)
 	})
+}
+
+func TestPostgresGetLatestTestWorkflowExecutionByTestWorkflow_AmbiguousFlags_Integration(t *testing.T) {
+	test.IntegrationTest(t)
+	testDB, cleanup := testpostgres.PreparePostgresTestDatabase(t, "repo_get_latest_ambiguous")
+	defer cleanup()
+
+	ctx := context.Background()
+	orgID := "ambig-org"
+	envID := "ambig-env"
+
+	// Three executions where each sort key picks a different row.
+	insert := func(id, scheduledAt, statusAt string, number int32) {
+		t.Helper()
+		_, err := testDB.Pool.Exec(ctx, `
+			INSERT INTO test_workflow_executions
+			(id, organization_id, environment_id, name, namespace, number, scheduled_at, status_at, created_at, updated_at)
+			VALUES ($1, $2, $3, $1, 'default', $4, $5::timestamptz, $6::timestamptz, NOW(), NOW())
+		`, id, orgID, envID, number, scheduledAt, statusAt)
+		require.NoError(t, err)
+		_, err = testDB.Pool.Exec(ctx, `
+			INSERT INTO test_workflow_results (execution_id, status, created_at, updated_at)
+			VALUES ($1, 'passed', NOW(), NOW())
+		`, id)
+		require.NoError(t, err)
+		_, err = testDB.Pool.Exec(ctx, `
+			INSERT INTO test_workflows (execution_id, workflow_type, name, namespace, created, updated)
+			VALUES ($1, 'workflow', 'wf-target', 'default', NOW(), NOW())
+		`, id)
+		require.NoError(t, err)
+	}
+	insert("ambig-sched", "2026-04-24T12:00:00Z", "2026-04-22T00:00:00Z", 1)
+	insert("ambig-status", "2026-04-22T12:00:00Z", "2026-04-24T00:00:00Z", 2)
+	insert("ambig-number", "2026-04-20T12:00:00Z", "2026-04-20T00:00:00Z", 99)
+
+	queries := sqlc.New(testDB.Pool)
+
+	// (true, true) must fall back to scheduled_at, matching the original
+	// CASE...ELSE behavior.
+	row, err := queries.GetLatestTestWorkflowExecutionByTestWorkflow(ctx, sqlc.GetLatestTestWorkflowExecutionByTestWorkflowParams{
+		OrganizationID: orgID,
+		EnvironmentID:  envID,
+		WorkflowName:   "wf-target",
+		SortByNumber:   true,
+		SortByStatus:   true,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "ambig-sched", row.ID, "(sort_by_number=true, sort_by_status=true) must fall back to scheduled_at")
+
+	// (false, false) is the documented default and must also pick scheduled_at.
+	row, err = queries.GetLatestTestWorkflowExecutionByTestWorkflow(ctx, sqlc.GetLatestTestWorkflowExecutionByTestWorkflowParams{
+		OrganizationID: orgID,
+		EnvironmentID:  envID,
+		WorkflowName:   "wf-target",
+		SortByNumber:   false,
+		SortByStatus:   false,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "ambig-sched", row.ID, "(false, false) must use scheduled_at")
 }


### PR DESCRIPTION
## Pull request description

Speeds up `GetLatestTestWorkflowExecutionByTestWorkflow` by replacing the `ORDER BY CASE` over all rows with a UNION ALL of three statically-ordered branches gated by the sort flags.

## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [x] tested locally
- [ ] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [x] added a test

## Breaking changes

-

## Changes

- Rewrite the query as `WITH latest AS ((... ORDER BY scheduled_at DESC LIMIT 1) UNION ALL (... number) UNION ALL (... status_at))` and resolve by `WHERE e.id = (SELECT id FROM latest LIMIT 1)`.
- Default branch lists `(organization_id, environment_id, workflow_name, scheduled_at DESC)` in `ORDER BY` to nudge the planner onto `idx_twe_org_env_wfname_sched` instead of the global `scheduled_at` index.

## Fixes

- `GET /test-workflow-with-executions/{id}` warm time on a 220k-execution workflow: **225 ms → ~14 ms** (16×) in EXPLAIN, with the index-hint nudge expected to bring it to ~1–2 ms and constant-time regardless of when the workflow last ran.
- Removes the 19 MB on-disk sort spill and ~60k buffer hits per call (which was also evicting other endpoints' hot pages and inflating their p95 under concurrent load).
- Two non-selected sort branches prune at runtime via `One-Time Filter: false` (`never executed`).