### PR TITLE
fix: [TKC-5412] add insecure kubelet log backend option

### DIFF
--- a/cmd/api-server/services/executionworker.go
+++ b/cmd/api-server/services/executionworker.go
@@ -55,11 +55,12 @@ func CreateExecutionWorker(
 			// TODO: Prepare ControlPlane interface for OSS, so we may unify the communication
 			LocalApiUrl: fmt.Sprintf("http://%s:%d", cfg.APIServerFullname, cfg.APIServerPort),
 		},
-		FeatureFlags:           featureFlags,
-		RunnerId:               runnerId,
-		CommonEnvVariables:     commonEnvVariables,
-		LogAbortedDetails:      logAbortedDetails,
-		AllowLowSecurityFields: cfg.AllowLowSecurityFields,
+		FeatureFlags:                             featureFlags,
+		RunnerId:                                 runnerId,
+		CommonEnvVariables:                       commonEnvVariables,
+		LogAbortedDetails:                        logAbortedDetails,
+		AllowLowSecurityFields:                   cfg.AllowLowSecurityFields,
+		WorkflowLogsInsecureSkipTLSVerifyBackend: cfg.WorkflowLogsInsecureSkipTLSVerifyBackend,
 		// Automatically disable resource metrics collection in standalone mode (no API key and no agent registration token configured),
 		// as the gRPC control plane connection from execution pods may not be available.
 		DisableResourceMetrics: cfg.TestkubeProAPIKey == "" && cfg.TestkubeProAgentRegToken == "",

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -235,11 +235,12 @@ type Config struct {
 	DisableOfficialTemplates        bool     `envconfig:"DISABLE_OFFICIAL_TEMPLATES" default:"false"`
 	TerminationLogPath              string   `envconfig:"TERMINATION_LOG_PATH" default:"/dev/termination-log"`
 
-	ExportArchiveMaxSize           int  `envconfig:"EXPORT_ARCHIVE_MAX_SIZE" default:"104857600"`
-	FeatureCloudStorage            bool `envconfig:"FEATURE_CLOUD_STORAGE" default:"false"`
-	TestWorkflowLogArchiveRequired bool `envconfig:"TESTWORKFLOW_LOG_ARCHIVE_REQUIRED" default:"true"`
-	TestTriggerControlPlane        bool `envconfig:"TEST_TRIGGER_CONTROL_PLANE" default:"false"`
-	ForceSuperAgentMode            bool `envconfig:"WARNING_UNSAFE_FORCE_SUPERAGENT_MODE" default:"false"`
+	ExportArchiveMaxSize                     int  `envconfig:"EXPORT_ARCHIVE_MAX_SIZE" default:"104857600"`
+	FeatureCloudStorage                      bool `envconfig:"FEATURE_CLOUD_STORAGE" default:"false"`
+	TestWorkflowLogArchiveRequired           bool `envconfig:"TESTWORKFLOW_LOG_ARCHIVE_REQUIRED" default:"true"`
+	WorkflowLogsInsecureSkipTLSVerifyBackend bool `envconfig:"TESTKUBE_WORKFLOW_LOGS_INSECURE_SKIP_TLS_VERIFY_BACKEND" default:"false"`
+	TestTriggerControlPlane                  bool `envconfig:"TEST_TRIGGER_CONTROL_PLANE" default:"false"`
+	ForceSuperAgentMode                      bool `envconfig:"WARNING_UNSAFE_FORCE_SUPERAGENT_MODE" default:"false"`
 }
 
 type DeprecatedConfig struct {

--- a/pkg/testworkflows/executionworker/controller/controller.go
+++ b/pkg/testworkflows/executionworker/controller/controller.go
@@ -28,8 +28,9 @@ var (
 )
 
 type ControllerOptions struct {
-	Signature []stage.Signature
-	RunnerId  string
+	Signature                                []stage.Signature
+	RunnerId                                 string
+	WorkflowLogsInsecureSkipTLSVerifyBackend bool
 }
 
 type LightweightNotification struct {
@@ -63,12 +64,16 @@ type Controller interface {
 func New(parentCtx context.Context, clientSet kubernetes.Interface, namespace, id string, scheduledAt time.Time, opts ...ControllerOptions) (Controller, error) {
 	var signature []stage.Signature
 	var expectedRunnerId string
+	var workflowLogsInsecureSkipTLSVerifyBackend bool
 	for _, opt := range opts {
 		if opt.Signature != nil {
 			signature = opt.Signature
 		}
 		if opt.RunnerId != "" {
 			expectedRunnerId = opt.RunnerId
+		}
+		if opt.WorkflowLogsInsecureSkipTLSVerifyBackend {
+			workflowLogsInsecureSkipTLSVerifyBackend = true
 		}
 	}
 
@@ -115,26 +120,28 @@ func New(parentCtx context.Context, clientSet kubernetes.Interface, namespace, i
 
 	// Build accessible controller
 	return &controller{
-		id:          id,
-		namespace:   namespace,
-		scheduledAt: scheduledAt,
-		signature:   sig,
-		clientSet:   clientSet,
-		ctx:         ctx,
-		ctxCancel:   ctxCancel,
-		watcher:     watcher,
+		id:                                       id,
+		namespace:                                namespace,
+		scheduledAt:                              scheduledAt,
+		signature:                                sig,
+		clientSet:                                clientSet,
+		ctx:                                      ctx,
+		ctxCancel:                                ctxCancel,
+		watcher:                                  watcher,
+		workflowLogsInsecureSkipTLSVerifyBackend: workflowLogsInsecureSkipTLSVerifyBackend,
 	}, nil
 }
 
 type controller struct {
-	id          string
-	namespace   string
-	scheduledAt time.Time
-	signature   []stage.Signature
-	clientSet   kubernetes.Interface
-	ctx         context.Context
-	ctxCancel   context.CancelFunc
-	watcher     watchers.ExecutionWatcher
+	id                                       string
+	namespace                                string
+	scheduledAt                              time.Time
+	signature                                []stage.Signature
+	clientSet                                kubernetes.Interface
+	ctx                                      context.Context
+	ctxCancel                                context.CancelFunc
+	watcher                                  watchers.ExecutionWatcher
+	workflowLogsInsecureSkipTLSVerifyBackend bool
 }
 
 func (c *controller) Signature() []stage.Signature {
@@ -232,6 +239,9 @@ func (c *controller) Watch(parentCtx context.Context, disableFollow bool, logAbo
 	ch, err := WatchInstrumentedPod(parentCtx, c.clientSet, c.signature, c.scheduledAt, c.watcher, WatchInstrumentedPodOptions{
 		DisableFollow:     disableFollow,
 		LogAbortedDetails: logAbortedDetails,
+		ContainerLogOptions: ContainerLogOptions{
+			InsecureSkipTLSVerifyBackend: c.workflowLogsInsecureSkipTLSVerifyBackend,
+		},
 	})
 	if err != nil {
 		v := make(chan ChannelMessage[Notification], 1)
@@ -249,6 +259,9 @@ func (c *controller) Logs(parentCtx context.Context, follow bool) io.Reader {
 		ref := ""
 		ch, err := WatchInstrumentedPod(parentCtx, c.clientSet, c.signature, c.scheduledAt, c.watcher, WatchInstrumentedPodOptions{
 			DisableFollow: !follow,
+			ContainerLogOptions: ContainerLogOptions{
+				InsecureSkipTLSVerifyBackend: c.workflowLogsInsecureSkipTLSVerifyBackend,
+			},
 		})
 		if err != nil {
 			return

--- a/pkg/testworkflows/executionworker/controller/logs.go
+++ b/pkg/testworkflows/executionworker/controller/logs.go
@@ -67,28 +67,36 @@ func (c *ContainerLog) Type() ContainerLogType {
 	return ContainerLogTypeLog
 }
 
-// getContainerLogsStream is getting logs stream, and tries to reinitialize the stream on EOF.
-// EOF may happen not only on the actual container end, but also in case of the log rotation.
-// @see {@link https://stackoverflow.com/a/68673451}
-func getContainerLogsStream(ctx context.Context, clientSet kubernetes.Interface, namespace, podName, containerName string, isDone func() bool, since *time.Time) (io.Reader, error) {
-	// Fail immediately if the context is finished
-	if ctx.Err() != nil {
-		return nil, ctx.Err()
-	}
+type ContainerLogOptions struct {
+	InsecureSkipTLSVerifyBackend bool
+}
 
-	// Build Kubernetes structure for time
+func buildPodLogOptions(containerName string, isDone func() bool, since *time.Time, opts ContainerLogOptions) *corev1.PodLogOptions {
 	var sinceTime *metav1.Time
 	if since != nil {
 		sinceTime = &metav1.Time{Time: *since}
 	}
 
+	return &corev1.PodLogOptions{
+		Container:                    containerName,
+		Follow:                       !isDone(),
+		Timestamps:                   true,
+		SinceTime:                    sinceTime,
+		InsecureSkipTLSVerifyBackend: opts.InsecureSkipTLSVerifyBackend,
+	}
+}
+
+// getContainerLogsStream is getting logs stream, and tries to reinitialize the stream on EOF.
+// EOF may happen not only on the actual container end, but also in case of the log rotation.
+// @see {@link https://stackoverflow.com/a/68673451}
+func getContainerLogsStream(ctx context.Context, clientSet kubernetes.Interface, namespace, podName, containerName string, isDone func() bool, since *time.Time, opts ContainerLogOptions) (io.Reader, error) {
+	// Fail immediately if the context is finished
+	if ctx.Err() != nil {
+		return nil, ctx.Err()
+	}
+
 	// Create logs stream request
-	req := clientSet.CoreV1().Pods(namespace).GetLogs(podName, &corev1.PodLogOptions{
-		Container:  containerName,
-		Follow:     !isDone(),
-		Timestamps: true,
-		SinceTime:  sinceTime,
-	})
+	req := clientSet.CoreV1().Pods(namespace).GetLogs(podName, buildPodLogOptions(containerName, isDone, since, opts))
 	var err error
 	var stream io.ReadCloser
 	retries := 0
@@ -114,7 +122,14 @@ func getContainerLogsStream(ctx context.Context, clientSet kubernetes.Interface,
 				return nil, err
 			}
 			delay = LogRetryOnConnectionLostDelay
-			log.DefaultLogger.Errorw("cluster's TLS error (likely CSR signing delay) while loading container logs, retrying", "pod", podName, "attempt", retries, "error", err)
+			log.DefaultLogger.Errorw(
+				"kubelet TLS error while loading container logs, retrying",
+				"pod", podName,
+				"container", containerName,
+				"attempt", retries,
+				"insecureSkipTLSVerifyBackend", opts.InsecureSkipTLSVerifyBackend,
+				"error", err,
+			)
 		case strings.Contains(errMsg, "proxy error"):
 			retries++
 			if retries > LogRetryMaxAttempts {
@@ -144,8 +159,21 @@ func getContainerLogsStream(ctx context.Context, clientSet kubernetes.Interface,
 
 type logStreamOpener func(ctx context.Context, clientSet kubernetes.Interface, namespace, podName, containerName string, isDone func() bool, since *time.Time) (io.Reader, error)
 
-func WatchContainerLogs(parentCtx context.Context, clientSet kubernetes.Interface, namespace, podName, containerName string, bufferSize int, isDone func() bool, isLastHint func(*instructions.Instruction) bool) <-chan ChannelMessage[ContainerLog] {
-	return watchContainerLogsWithStream(parentCtx, getContainerLogsStream, clientSet, namespace, podName, containerName, bufferSize, isDone, isLastHint, LogStreamIdleTimeout)
+func WatchContainerLogs(parentCtx context.Context, clientSet kubernetes.Interface, namespace, podName, containerName string, bufferSize int, isDone func() bool, isLastHint func(*instructions.Instruction) bool, opts ContainerLogOptions) <-chan ChannelMessage[ContainerLog] {
+	return watchContainerLogsWithStream(
+		parentCtx,
+		func(ctx context.Context, clientSet kubernetes.Interface, namespace, podName, containerName string, isDone func() bool, since *time.Time) (io.Reader, error) {
+			return getContainerLogsStream(ctx, clientSet, namespace, podName, containerName, isDone, since, opts)
+		},
+		clientSet,
+		namespace,
+		podName,
+		containerName,
+		bufferSize,
+		isDone,
+		isLastHint,
+		LogStreamIdleTimeout,
+	)
 }
 
 func watchContainerLogsWithStream(parentCtx context.Context, opener logStreamOpener, clientSet kubernetes.Interface, namespace, podName, containerName string, bufferSize int, isDone func() bool, isLastHint func(*instructions.Instruction) bool, idleTimeout time.Duration) <-chan ChannelMessage[ContainerLog] {

--- a/pkg/testworkflows/executionworker/controller/logs_test.go
+++ b/pkg/testworkflows/executionworker/controller/logs_test.go
@@ -82,6 +82,34 @@ func Test_ReadTimestamp_NonUTC_Recurring(t *testing.T) {
 	assert.Equal(t, time.Date(2024, 6, 7, 12, 41, 49, 37275300, time.UTC), reader.ts)
 }
 
+func TestBuildPodLogOptionsDefaultsToVerifiedKubeletBackend(t *testing.T) {
+	t.Parallel()
+
+	opts := buildPodLogOptions("container", func() bool { return false }, nil, ContainerLogOptions{})
+
+	assert.Equal(t, "container", opts.Container)
+	assert.True(t, opts.Follow)
+	assert.True(t, opts.Timestamps)
+	assert.Nil(t, opts.SinceTime)
+	assert.False(t, opts.InsecureSkipTLSVerifyBackend)
+}
+
+func TestBuildPodLogOptionsCanSkipKubeletBackendTLSVerification(t *testing.T) {
+	t.Parallel()
+
+	since := time.Date(2026, 4, 27, 12, 30, 0, 0, time.UTC)
+	opts := buildPodLogOptions("container", func() bool { return true }, &since, ContainerLogOptions{
+		InsecureSkipTLSVerifyBackend: true,
+	})
+
+	assert.Equal(t, "container", opts.Container)
+	assert.False(t, opts.Follow)
+	assert.True(t, opts.Timestamps)
+	assert.NotNil(t, opts.SinceTime)
+	assert.True(t, since.Equal(opts.SinceTime.Time))
+	assert.True(t, opts.InsecureSkipTLSVerifyBackend)
+}
+
 type blockingReader struct {
 	ctx context.Context
 }

--- a/pkg/testworkflows/executionworker/controller/watchinstrumentedpod.go
+++ b/pkg/testworkflows/executionworker/controller/watchinstrumentedpod.go
@@ -21,8 +21,9 @@ const (
 )
 
 type WatchInstrumentedPodOptions struct {
-	DisableFollow     bool
-	LogAbortedDetails bool
+	DisableFollow       bool
+	LogAbortedDetails   bool
+	ContainerLogOptions ContainerLogOptions
 }
 
 func WatchInstrumentedPod(parentCtx context.Context, clientSet kubernetes.Interface, signature []stage.Signature, scheduledAt time.Time, watcher watchers2.ExecutionWatcher, opts WatchInstrumentedPodOptions) (<-chan ChannelMessage[Notification], error) {
@@ -188,7 +189,7 @@ func WatchInstrumentedPod(parentCtx context.Context, clientSet kubernetes.Interf
 			isDone := func() bool {
 				return opts.DisableFollow || watcher.State().ContainerFinished(container) || watcher.State().Completed()
 			}
-			logsCh := WatchContainerLogs(ctx, clientSet, watcher.State().Namespace(), watcher.State().PodName(), container, 10, isDone, isLastHint)
+			logsCh := WatchContainerLogs(ctx, clientSet, watcher.State().Namespace(), watcher.State().PodName(), container, 10, isDone, isLastHint, opts.ContainerLogOptions)
 			containersReady = watcher.State().ContainersReady()
 		logs:
 			for {

--- a/pkg/testworkflows/executionworker/kubernetesworker/interface.go
+++ b/pkg/testworkflows/executionworker/kubernetesworker/interface.go
@@ -27,13 +27,14 @@ type ImageInspectorConfig struct {
 }
 
 type Config struct {
-	Cluster                ClusterConfig
-	ImageInspector         ImageInspectorConfig
-	Connection             testworkflowconfig.WorkerConnectionConfig
-	FeatureFlags           map[string]string
-	RunnerId               string
-	CommonEnvVariables     []corev1.EnvVar
-	LogAbortedDetails      bool
-	AllowLowSecurityFields bool
-	DisableResourceMetrics bool
+	Cluster                                  ClusterConfig
+	ImageInspector                           ImageInspectorConfig
+	Connection                               testworkflowconfig.WorkerConnectionConfig
+	FeatureFlags                             map[string]string
+	RunnerId                                 string
+	CommonEnvVariables                       []corev1.EnvVar
+	LogAbortedDetails                        bool
+	AllowLowSecurityFields                   bool
+	WorkflowLogsInsecureSkipTLSVerifyBackend bool
+	DisableResourceMetrics                   bool
 }

--- a/pkg/testworkflows/executionworker/kubernetesworker/worker.go
+++ b/pkg/testworkflows/executionworker/kubernetesworker/worker.go
@@ -56,7 +56,9 @@ func NewWorker(clientSet kubernetes.Interface, processor testworkflowprocessor.P
 		clientSet: clientSet,
 		processor: processor,
 		config:    config,
-		registry:  registry.NewControllersRegistry(clientSet, namespaces, config.RunnerId, 50),
+		registry: registry.NewControllersRegistry(clientSet, namespaces, config.RunnerId, 50, controller.ControllerOptions{
+			WorkflowLogsInsecureSkipTLSVerifyBackend: config.WorkflowLogsInsecureSkipTLSVerifyBackend,
+		}),
 		baseWorkerConfig: testworkflowconfig.WorkerConfig{
 			Namespace:                         config.Cluster.DefaultNamespace,
 			DefaultRegistry:                   config.Cluster.DefaultRegistry,

--- a/pkg/testworkflows/executionworker/registry/controllers.go
+++ b/pkg/testworkflows/executionworker/registry/controllers.go
@@ -24,6 +24,7 @@ type controllersRegistry struct {
 	namespaces             NamespacesRegistry
 	runnerId               string
 	ips                    PodIpsRegistry
+	controllerOptions      controller.ControllerOptions
 	controllers            map[string]controller.Controller
 	controllerReservations map[string]int
 	mu                     sync.RWMutex
@@ -39,11 +40,18 @@ type ControllersRegistry interface {
 	RegisterPodIP(id, podIp string)
 }
 
-func NewControllersRegistry(clientSet kubernetes.Interface, namespaces NamespacesRegistry, runnerId string, podIpCacheSize int) ControllersRegistry {
+func NewControllersRegistry(clientSet kubernetes.Interface, namespaces NamespacesRegistry, runnerId string, podIpCacheSize int, opts ...controller.ControllerOptions) ControllersRegistry {
+	var controllerOptions controller.ControllerOptions
+	for _, opt := range opts {
+		if opt.WorkflowLogsInsecureSkipTLSVerifyBackend {
+			controllerOptions.WorkflowLogsInsecureSkipTLSVerifyBackend = true
+		}
+	}
 	r := &controllersRegistry{
 		clientSet:              clientSet,
 		namespaces:             namespaces,
 		runnerId:               runnerId,
+		controllerOptions:      controllerOptions,
 		controllers:            make(map[string]controller.Controller),
 		controllerReservations: make(map[string]int),
 	}
@@ -125,8 +133,9 @@ func (r *controllersRegistry) Connect(ctx context.Context, id string, hints exec
 				}
 				scheduledAt := common.ResolvePtr(hints.ScheduledAt, time.Time{}) // TODO: consider caching or making it optional
 				nextCtrl, err := controller.New(ctx, r.clientSet, namespace, id, scheduledAt, controller.ControllerOptions{
-					Signature: signature,
-					RunnerId:  r.runnerId,
+					Signature:                                signature,
+					RunnerId:                                 r.runnerId,
+					WorkflowLogsInsecureSkipTLSVerifyBackend: r.controllerOptions.WorkflowLogsInsecureSkipTLSVerifyBackend,
 				})
 				if err != nil {
 					return nil, err


### PR DESCRIPTION
## Summary
- add a default-off TESTKUBE_WORKFLOW_LOGS_INSECURE_SKIP_TLS_VERIFY_BACKEND setting
- thread the option into TestWorkflow pod log reads and set Kubernetes PodLogOptions.InsecureSkipTLSVerifyBackend
- add focused tests for secure default and opt-in pod log options

## Notes
This is equivalent to Kubernetes `kubectl logs --insecure-skip-tls-verify-backend` for TestWorkflow pod log reads. It only affects the apiserver-to-kubelet pod log backend TLS verification path and should be treated as a temporary workaround while kubelet serving certificate/CSR issues are fixed.

## Testing
Not run in this session.