### PR TITLE
fix(cli): gate UIShell hints on TTY so -o json output stays parseable

### DIFF
--- a/cmd/kubectl-testkube/commands/common/uihints.go
+++ b/cmd/kubectl-testkube/commands/common/uihints.go
@@ -1,29 +1,36 @@
 package common
 
 import (
+	"os"
+
+	"github.com/mattn/go-isatty"
+
 	"github.com/kubeshop/testkube/pkg/ui"
 )
 
-// UIShellGetExecution prints the testkube command to get test workflow execution details.
+// Gate hints on a TTY so non-interactive stdout (e.g. `-o json | jq`) stays parseable.
+// Var (not func) so tests can override.
+var hintsEnabled = func() bool {
+	fd := os.Stdout.Fd()
+	return isatty.IsTerminal(fd) || isatty.IsCygwinTerminal(fd)
+}
+
+func shellHint(hint, cmd string) {
+	if !hintsEnabled() {
+		return
+	}
+	ui.Hint(hint)
+	ui.ShellCommand(cmd)
+}
+
 func UIShellGetExecution(id string) {
-	ui.Hint("Get the TestWorkflow execution details:")
-	ui.ShellCommand(
-		"testkube get twe " + id,
-	)
+	shellHint("Get the TestWorkflow execution details:", "testkube get twe "+id)
 }
 
-// UIShellViewExecution prints the testkube command to view a test workflow execution in the browser.
 func UIShellViewExecution(id string) {
-	ui.Hint("View the TestWorkflow execution details in your browser:")
-	ui.ShellCommand(
-		"testkube view " + id,
-	)
+	shellHint("View the TestWorkflow execution details in your browser:", "testkube view "+id)
 }
 
-// UIShellWatchExecution prints the testkube command to watch a test workflow execution until complete.
 func UIShellWatchExecution(id string) {
-	ui.Hint("Watch the TestWorkflow execution until complete:")
-	ui.ShellCommand(
-		"testkube watch twe " + id,
-	)
+	shellHint("Watch the TestWorkflow execution until complete:", "testkube watch twe "+id)
 }

--- a/cmd/kubectl-testkube/commands/common/uihints_test.go
+++ b/cmd/kubectl-testkube/commands/common/uihints_test.go
@@ -1,0 +1,51 @@
+package common
+
+import (
+	"io"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestUIShell_SuppressedWhenStdoutNotTTY(t *testing.T) {
+	cases := []struct {
+		name string
+		fn   func()
+	}{
+		{"GetExecution", func() { UIShellGetExecution("test-id") }},
+		{"ViewExecution", func() { UIShellViewExecution("test-id") }},
+		{"WatchExecution", func() { UIShellWatchExecution("test-id") }},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			out := captureStdout(t, tc.fn)
+			require.Empty(t, out, "hint must not be written when stdout is not a TTY")
+		})
+	}
+}
+
+// captureStdout swaps os.Stdout for an os.Pipe (non-tty fd) so hintsEnabled() returns false.
+func captureStdout(t *testing.T, fn func()) string {
+	t.Helper()
+
+	r, w, err := os.Pipe()
+	require.NoError(t, err)
+
+	saved := os.Stdout
+	os.Stdout = w
+	t.Cleanup(func() {
+		os.Stdout = saved
+		_ = r.Close()
+	})
+
+	done := make(chan string, 1)
+	go func() {
+		b, _ := io.ReadAll(r)
+		done <- string(b)
+	}()
+
+	fn()
+	require.NoError(t, w.Close())
+	return <-done
+}


### PR DESCRIPTION
## Summary

The `UIShell*` helpers (`UIShellGetExecution`, `UIShellViewExecution`, `UIShellWatchExecution`) write decorative prose to stdout via `ui.Hint` + `ui.ShellCommand`. When stdout is piped or redirected, the prose lands in the parser's input.

Concretely, the OSS workflow tests run:

```sh
exec_name=$(testkube get tw <name> --namespace ... -o json \
  | awk '/^{/ {i++} i==2' \
  | jq -r '.name')
```

After the helpers fire on the second JSON block (`LatestExecution`), `awk` keeps streaming the trailing `💡 ...` / `$ ...` lines into `jq`, which fails with `parse error: Invalid numeric literal`. With `set -o pipefail`, the whole `$(...)` fails, the OSS tests abort.

This PR keeps the hints exactly as #7517 designed them for interactive users, and silences them when stdout isn't a TTY (pipes, redirects, in-cluster steps, CI).

## Approach

A single `hintsEnabled` gate in `cmd/kubectl-testkube/commands/common/uihints.go` short-circuits all three helpers. Behavior unchanged in a real terminal; suppressed everywhere a parser is reading.

Picked TTY-gating over "send hints to stderr" because TTY-gating cleanly covers the case where CI captures both streams (`2>&1`), which is common.

## Reproduction

```sh
$ go run ./test-repro.go | awk '/^{/ {i++} i==2' | jq -r '.name'
jq: parse error: Invalid numeric literal at line 2, column 5
junit5-workflow-smoke-1
$ echo "exit: $?"
exit: 5
```

After the fix, same pipeline exits 0 with clean JSON.
