### PR TITLE
fix(postgres): create missing DB on API startup

### DIFF
--- a/cmd/api-server/commons/commons.go
+++ b/cmd/api-server/commons/commons.go
@@ -30,6 +30,7 @@ import (
 	"github.com/kubeshop/testkube/pkg/capabilities"
 	"github.com/kubeshop/testkube/pkg/cloud"
 	"github.com/kubeshop/testkube/pkg/configmap"
+	postgresdb "github.com/kubeshop/testkube/pkg/database/postgres"
 	postgresmigrations "github.com/kubeshop/testkube/pkg/database/postgres/migrations"
 	"github.com/kubeshop/testkube/pkg/dbmigrator"
 	"github.com/kubeshop/testkube/pkg/event"
@@ -201,6 +202,11 @@ func getMongoSSLConfig(cfg *config.Config, secretClient secret.Interface) *stora
 }
 
 func MustGetPostgresDatabase(ctx context.Context, cfg *config.Config, migrate bool) *pgxpool.Pool {
+	if migrate {
+		err := postgresdb.CreateDatabaseIfNotExists(ctx, cfg.APIPostgresDSN)
+		ExitOnError("Creating Postgres database if needed", err)
+	}
+
 	// Connect to PostgreSQL
 	pool, err := pgxpool.New(ctx, cfg.APIPostgresDSN)
 	ExitOnError("Getting Postgres database", err)

--- a/pkg/database/postgres/database.go
+++ b/pkg/database/postgres/database.go
@@ -2,16 +2,55 @@ package database
 
 import (
 	"context"
+	"errors"
 
 	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/jackc/pgx/v5/pgxpool"
 
 	sqlc "github.com/kubeshop/testkube/pkg/controlplane/scheduling/sqlc"
+	"github.com/kubeshop/testkube/pkg/log"
 )
 
 type DB struct {
 	Pool *pgxpool.Pool
 	*sqlc.Queries
+}
+
+func CreateDatabaseIfNotExists(ctx context.Context, connectionString string) error {
+	connConfig, err := pgx.ParseConfig(connectionString)
+	if err != nil {
+		return err
+	}
+	log.DefaultLogger.Infof("Attempting to create database %q on host %s", connConfig.Database, connConfig.Host)
+
+	if connConfig.Database == "" {
+		log.DefaultLogger.Info("No database in connection string")
+		return nil
+	}
+
+	dbName := connConfig.Database
+	connConfig.Database = ""
+
+	conn, err := pgx.ConnectConfig(ctx, connConfig)
+	if err != nil {
+		return err
+	}
+	defer conn.Close(ctx)
+
+	_, err = conn.Exec(ctx, "CREATE DATABASE "+pgx.Identifier{dbName}.Sanitize())
+	if err != nil {
+		var pgErr *pgconn.PgError
+		if errors.As(err, &pgErr) && pgErr.Code == "42P04" {
+			log.DefaultLogger.Infof("Database %s already exists", dbName)
+		} else {
+			return err
+		}
+	} else {
+		log.DefaultLogger.Infof("Database %s created successfully", dbName)
+	}
+
+	return nil
 }
 
 func NewForScheduler(pool *pgxpool.Pool) (*DB, error) {

--- a/pkg/database/postgres/database.go
+++ b/pkg/database/postgres/database.go
@@ -30,7 +30,7 @@ func CreateDatabaseIfNotExists(ctx context.Context, connectionString string) err
 	}
 
 	dbName := connConfig.Database
-	connConfig.Database = ""
+	connConfig.Database = "postgres"
 
 	conn, err := pgx.ConnectConfig(ctx, connConfig)
 	if err != nil {


### PR DESCRIPTION
## Summary
- replicate the cloud-api/Wim pattern in Testkube API startup for PostgreSQL
- add `CreateDatabaseIfNotExists` in the postgres DB package using DSN parsing and idempotent `CREATE DATABASE`
- invoke this step before opening the pool and applying migrations when postgres migrations are enabled

## Test plan
- [x] `go test ./cmd/api-server/commons ./pkg/database/postgres/...`
- [x] local kind reproduction previously showed missing `backend` DB; this change targets that startup path in API
- [ ] validate end-to-end on release/2-9 chart deployment with PostgreSQL enabled


Made with [Cursor](https://cursor.com)