### PR TITLE
fix: [TKC-5587] keep quiet workflow log streams alive

### DIFF
--- a/internal/app/api/v1/testworkflowexecutions.go
+++ b/internal/app/api/v1/testworkflowexecutions.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"net/url"
 	"strconv"
+	"time"
 
 	"github.com/gofiber/fiber/v2"
 	"github.com/gofiber/websocket/v2"
@@ -23,6 +24,8 @@ import (
 	testworkflow2 "github.com/kubeshop/testkube/pkg/repository/testworkflow"
 	"github.com/kubeshop/testkube/pkg/testworkflows/executionworker/executionworkertypes"
 )
+
+const workflowNotificationHeartbeatInterval = 20 * time.Second
 
 func parseResumeAfterSeqNo(c *fiber.Ctx) (uint32, error) {
 	value := c.Query("resumeAfterSeqNo", "")
@@ -59,29 +62,69 @@ func workflowNotificationResumable(notification testkube.TestWorkflowExecutionNo
 }
 
 func streamableWorkflowNotifications(source <-chan *testkube.TestWorkflowExecutionNotification, resumeAfterSeqNo uint32) <-chan testkube.TestWorkflowExecutionNotification {
+	return streamableWorkflowNotificationsWithHeartbeat(nil, source, resumeAfterSeqNo, workflowNotificationHeartbeatInterval)
+}
+
+func streamableWorkflowNotificationsWithHeartbeat(done <-chan struct{}, source <-chan *testkube.TestWorkflowExecutionNotification, resumeAfterSeqNo uint32, heartbeatInterval time.Duration) <-chan testkube.TestWorkflowExecutionNotification {
 	notifications := make(chan testkube.TestWorkflowExecutionNotification)
 	go func() {
 		defer close(notifications)
 
 		var seqNo uint32
-		for notification := range source {
-			if notification == nil {
-				continue
+		var heartbeat <-chan time.Time
+		var heartbeatTicker *time.Ticker
+		if heartbeatInterval > 0 {
+			heartbeatTicker = time.NewTicker(heartbeatInterval)
+			heartbeat = heartbeatTicker.C
+			defer heartbeatTicker.Stop()
+		}
+		send := func(notification testkube.TestWorkflowExecutionNotification) bool {
+			select {
+			case notifications <- notification:
+				return true
+			case <-done:
+				return false
 			}
+		}
 
-			streamNotification := *notification
-			if streamNotification.EventType == "" {
-				streamNotification.EventType = workflowNotificationEventType(streamNotification)
-			}
-			if workflowNotificationResumable(streamNotification) {
-				seqNo++
-				streamNotification.SeqNo = int32(seqNo)
-				if seqNo <= resumeAfterSeqNo {
+		for {
+			select {
+			case <-done:
+				return
+			case notification, ok := <-source:
+				if !ok {
+					return
+				}
+				if notification == nil {
 					continue
 				}
-			}
 
-			notifications <- streamNotification
+				streamNotification := *notification
+				if streamNotification.EventType == "" {
+					streamNotification.EventType = workflowNotificationEventType(streamNotification)
+				}
+				if workflowNotificationResumable(streamNotification) {
+					seqNo++
+					streamNotification.SeqNo = int32(seqNo)
+					if seqNo <= resumeAfterSeqNo {
+						continue
+					}
+				}
+
+				if !send(streamNotification) {
+					return
+				}
+			case <-heartbeat:
+				heartbeatNotification := testkube.TestWorkflowExecutionNotification{
+					EventType: "heartbeat",
+				}
+				if seqNo > 0 {
+					heartbeatNotification.SeqNo = int32(seqNo)
+				}
+				if !send(heartbeatNotification) {
+					return
+				}
+			}
 		}
 	}()
 	return notifications
@@ -103,7 +146,7 @@ func (s *TestkubeAPI) streamNotifications(ctx *fasthttp.RequestCtx, id string, n
 
 		enc := json.NewEncoder(w)
 
-		for n := range streamableWorkflowNotifications(notifications.Channel(), resumeAfterSeqNo) {
+		for n := range streamableWorkflowNotificationsWithHeartbeat(ctx.Done(), notifications.Channel(), resumeAfterSeqNo, workflowNotificationHeartbeatInterval) {
 			if n.SeqNo > 0 {
 				_, err = fmt.Fprintf(w, "id: %d\n", n.SeqNo)
 				if err != nil {

--- a/internal/app/api/v1/testworkflowexecutions_notifications_test.go
+++ b/internal/app/api/v1/testworkflowexecutions_notifications_test.go
@@ -36,6 +36,59 @@ func TestStreamableWorkflowNotificationsAppliesResumeCursorAndSequencing(t *test
 	require.NotNil(t, notifications[1].Result)
 }
 
+func TestStreamableWorkflowNotificationsSendsHeartbeatWhileQuiet(t *testing.T) {
+	done := make(chan struct{})
+	defer close(done)
+	source := make(chan *testkube.TestWorkflowExecutionNotification)
+
+	notifications := streamableWorkflowNotificationsWithHeartbeat(done, source, 0, 5*time.Millisecond)
+
+	select {
+	case notification := <-notifications:
+		assert.Equal(t, "heartbeat", notification.EventType)
+		assert.Zero(t, notification.SeqNo)
+		assert.Empty(t, notification.Log)
+		assert.Nil(t, notification.Output)
+		assert.Nil(t, notification.Result)
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("expected heartbeat while workflow notification stream is quiet")
+	}
+}
+
+func TestStreamableWorkflowNotificationsHeartbeatDoesNotAdvanceSeqNo(t *testing.T) {
+	done := make(chan struct{})
+	defer close(done)
+	source := make(chan *testkube.TestWorkflowExecutionNotification, 1)
+
+	notifications := streamableWorkflowNotificationsWithHeartbeat(done, source, 0, 5*time.Millisecond)
+
+	select {
+	case notification := <-notifications:
+		require.Equal(t, "heartbeat", notification.EventType)
+		assert.Zero(t, notification.SeqNo)
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("expected initial heartbeat")
+	}
+
+	source <- &testkube.TestWorkflowExecutionNotification{Log: "after quiet period"}
+
+	timeout := time.After(100 * time.Millisecond)
+	for {
+		select {
+		case notification := <-notifications:
+			if notification.EventType == "heartbeat" {
+				continue
+			}
+			assert.Equal(t, "log", notification.EventType)
+			assert.Equal(t, int32(1), notification.SeqNo)
+			assert.Equal(t, "after quiet period", notification.Log)
+			return
+		case <-timeout:
+			t.Fatal("expected durable log notification after heartbeat")
+		}
+	}
+}
+
 func TestWorkflowNotificationEventType(t *testing.T) {
 	assert.Equal(t, "log", workflowNotificationEventType(testkube.TestWorkflowExecutionNotification{Log: "hello"}))
 	assert.Equal(t, "result", workflowNotificationEventType(testkube.TestWorkflowExecutionNotification{Result: &testkube.TestWorkflowResult{}}))

--- a/pkg/api/v1/client/common.go
+++ b/pkg/api/v1/client/common.go
@@ -3,7 +3,9 @@ package client
 import (
 	"bufio"
 	"bytes"
+	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 
@@ -23,7 +25,7 @@ func StreamToTestWorkflowExecutionNotificationsChannel(resp io.Reader, notificat
 	for {
 		b, err := utils.ReadLongLine(reader)
 		if err != nil {
-			if err != io.EOF {
+			if !isExpectedStreamCloseError(err) {
 				fmt.Printf("Read long line error: %+v' \n", err)
 			}
 
@@ -45,6 +47,10 @@ func StreamToTestWorkflowExecutionNotificationsChannel(resp io.Reader, notificat
 
 		notifications <- out
 	}
+}
+
+func isExpectedStreamCloseError(err error) bool {
+	return errors.Is(err, io.EOF) || errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded)
 }
 
 // trimDataChunk remove data: and newlines from incoming SSE data line

--- a/pkg/api/v1/client/common_test.go
+++ b/pkg/api/v1/client/common_test.go
@@ -1,6 +1,9 @@
 package client
 
 import (
+	"context"
+	"errors"
+	"io"
 	"strings"
 	"testing"
 
@@ -66,4 +69,12 @@ func TestStreamToTestWorkflowExecutionNotificationsChannel_HandlesSSEEventFields
 	assert.Equal(t, int32(8), received[1].SeqNo)
 	assert.Equal(t, "log", received[1].EventType)
 	assert.Equal(t, "hello", received[1].Log)
+}
+
+func TestIsExpectedStreamCloseError(t *testing.T) {
+	assert.True(t, isExpectedStreamCloseError(io.EOF))
+	assert.True(t, isExpectedStreamCloseError(context.Canceled))
+	assert.True(t, isExpectedStreamCloseError(context.DeadlineExceeded))
+	assert.True(t, isExpectedStreamCloseError(errors.Join(errors.New("read failed"), context.Canceled)))
+	assert.False(t, isExpectedStreamCloseError(errors.New("connection reset by peer")))
 }


### PR DESCRIPTION
## Summary

- emit protocol heartbeat notifications from the direct/proxy workflow notification SSE path while a stream is otherwise quiet
- keep durable workflow notification sequencing unchanged so heartbeats do not advance resume cursors
- stop printing expected SSE reader shutdown errors for `io.EOF`, `context.Canceled`, and `context.DeadlineExceeded`