### PR TITLE
fix: testkube nats bus resilience improvements

### DIFF
--- a/cmd/api-server/commons/commons.go
+++ b/cmd/api-server/commons/commons.go
@@ -340,7 +340,11 @@ func ReadProContext(ctx context.Context, cfg *config.Config, grpcClient cloud.Te
 	return proContext, nil
 }
 
-func MustCreateNATSConnection(cfg *config.Config) *nats.EncodedConn { //nolint:staticcheck
+// MustCreateNATSConnection returns both the encoded connection and the
+// ConnectionConfig it was built from, so callers can pass the config on to
+// NATSBus without constructing it a second time (which risks drift when new
+// fields are added to ConnectionConfig).
+func MustCreateNATSConnection(cfg *config.Config) (*nats.EncodedConn, bus.ConnectionConfig) { //nolint:staticcheck
 	// if embedded NATS server is enabled, we'll replace connection with one to the embedded server
 	if cfg.NatsEmbedded {
 		_, nc, err := event.ServerWithConnection(cfg.NatsEmbeddedStoreDir)
@@ -350,10 +354,11 @@ func MustCreateNATSConnection(cfg *config.Config) *nats.EncodedConn { //nolint:s
 
 		conn, err := nats.NewEncodedConn(nc, nats.JSON_ENCODER) //nolint:staticcheck
 		ExitOnError("creating NATS connection", err)
-		return conn
+		// Embedded connections have no external URI; return empty config.
+		return conn, bus.ConnectionConfig{}
 	}
 
-	conn, err := bus.NewNATSEncodedConnection(bus.ConnectionConfig{
+	natsCfg := bus.ConnectionConfig{
 		NatsURI:            cfg.NatsURI,
 		NatsSecure:         cfg.NatsSecure,
 		NatsSkipVerify:     cfg.NatsSkipVerify,
@@ -361,9 +366,10 @@ func MustCreateNATSConnection(cfg *config.Config) *nats.EncodedConn { //nolint:s
 		NatsKeyFile:        cfg.NatsKeyFile,
 		NatsCAFile:         cfg.NatsCAFile,
 		NatsConnectTimeout: cfg.NatsConnectTimeout,
-	})
+	}
+	conn, err := bus.NewNATSEncodedConnection(natsCfg)
 	ExitOnError("creating NATS connection", err)
-	return conn
+	return conn, natsCfg
 }
 
 // Components

--- a/cmd/api-server/main.go
+++ b/cmd/api-server/main.go
@@ -166,16 +166,7 @@ func main() {
 	metrics := metrics.NewMetrics()
 
 	log.DefaultLogger.Info("connecting to NATS...")
-	natsCfg := bus.ConnectionConfig{
-		NatsURI:            cfg.NatsURI,
-		NatsSecure:         cfg.NatsSecure,
-		NatsSkipVerify:     cfg.NatsSkipVerify,
-		NatsCertFile:       cfg.NatsCertFile,
-		NatsKeyFile:        cfg.NatsKeyFile,
-		NatsCAFile:         cfg.NatsCAFile,
-		NatsConnectTimeout: cfg.NatsConnectTimeout,
-	}
-	nc := commons.MustCreateNATSConnection(cfg)
+	nc, natsCfg := commons.MustCreateNATSConnection(cfg)
 	log.DefaultLogger.Infow("connected to NATS successfully", "embedded", cfg.NatsEmbedded, "uri", cfg.NatsURI)
 
 	eventBus := bus.NewNATSBus(nc, natsCfg)

--- a/cmd/api-server/main.go
+++ b/cmd/api-server/main.go
@@ -166,10 +166,19 @@ func main() {
 	metrics := metrics.NewMetrics()
 
 	log.DefaultLogger.Info("connecting to NATS...")
+	natsCfg := bus.ConnectionConfig{
+		NatsURI:            cfg.NatsURI,
+		NatsSecure:         cfg.NatsSecure,
+		NatsSkipVerify:     cfg.NatsSkipVerify,
+		NatsCertFile:       cfg.NatsCertFile,
+		NatsKeyFile:        cfg.NatsKeyFile,
+		NatsCAFile:         cfg.NatsCAFile,
+		NatsConnectTimeout: cfg.NatsConnectTimeout,
+	}
 	nc := commons.MustCreateNATSConnection(cfg)
 	log.DefaultLogger.Infow("connected to NATS successfully", "embedded", cfg.NatsEmbedded, "uri", cfg.NatsURI)
 
-	eventBus := bus.NewNATSBus(nc)
+	eventBus := bus.NewNATSBus(nc, natsCfg)
 	if cfg.Trace {
 		eventBus.TraceEvents()
 	}

--- a/go.sum
+++ b/go.sum
@@ -200,8 +200,6 @@ github.com/fluxcd/pkg/apis/event v0.25.0/go.mod h1:TlK8HWYrTwl0raqBRC+ROoNpYW5fd
 github.com/frankban/quicktest v1.14.6 h1:7Xjx+VpznH+oBnejlPUj8oUpdxnVs4f8XU8WnHkI4W8=
 github.com/frankban/quicktest v1.14.6/go.mod h1:4ptaffx2x8+WTWXmUCuVU6aPUX1/Mz7zb5vbUoiM6w0=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
-github.com/fsnotify/fsnotify v1.10.0 h1:Xx/5Ydg9CeBDX/wi4VJqStNtohYjitZhhlHt4h3St1M=
-github.com/fsnotify/fsnotify v1.10.0/go.mod h1:TLheqan6HD6GBK6PrDWyDPBaEV8LspOxvPSjC+bVfgo=
 github.com/fsnotify/fsnotify v1.10.1 h1:b0/UzAf9yR5rhf3RPm9gf3ehBPpf0oZKIjtpKrx59Ho=
 github.com/fsnotify/fsnotify v1.10.1/go.mod h1:TLheqan6HD6GBK6PrDWyDPBaEV8LspOxvPSjC+bVfgo=
 github.com/fxamacker/cbor/v2 v2.9.0 h1:NpKPmjDBgUfBms6tr6JZkTHtfFGcMKsw3eGcmD/sapM=
@@ -378,8 +376,6 @@ github.com/keygen-sh/jsonapi-go v1.2.1 h1:NTSIAxl2+7S5fPnKgrYwNjQSWbdKRtrFq26SD8
 github.com/keygen-sh/jsonapi-go v1.2.1/go.mod h1:8j9vsLiKyJyDqmt8r3tYaYNmXszq2+cFhoO6QdMdAes=
 github.com/keygen-sh/keygen-go/v3 v3.3.0 h1:EuX4HIxGgkfnF6GKOolvTJhch1SRpKq7bIxpj5R9n+w=
 github.com/keygen-sh/keygen-go/v3 v3.3.0/go.mod h1:YoFyryzXEk6XrbT3H8EUUU+JcIJkQu414TA6CvZgS/E=
-github.com/klauspost/compress v1.18.5 h1:/h1gH5Ce+VWNLSWqPzOVn6XBO+vJbCNGvjoaGBFW2IE=
-github.com/klauspost/compress v1.18.5/go.mod h1:cwPg85FWrGar70rWktvGQj8/hthj3wpl0PGDogxkrSQ=
 github.com/klauspost/compress v1.18.6 h1:2jupLlAwFm95+YDR+NwD2MEfFO9d4z4Prjl1XXDjuao=
 github.com/klauspost/compress v1.18.6/go.mod h1:cwPg85FWrGar70rWktvGQj8/hthj3wpl0PGDogxkrSQ=
 github.com/klauspost/cpuid/v2 v2.0.1/go.mod h1:FInQzS24/EEf25PyTYn52gqo7WaD8xa0213Md/qVLRg=
@@ -407,8 +403,6 @@ github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0 h1:6E+4a0GO5zZEnZ
 github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0/go.mod h1:zJYVVT2jmtg6P3p1VtQj7WsuWi/y4VnjVBn7F8KPB3I=
 github.com/magiconair/properties v1.8.10 h1:s31yESBquKXCV9a/ScB3ESkOjUYYv+X0rg8SYxI99mE=
 github.com/magiconair/properties v1.8.10/go.mod h1:Dhd985XPs7jluiymwWYZ0G4Z61jb3vdS329zhj2hYo0=
-github.com/mark3labs/mcp-go v0.50.0 h1:kfxh8ejrBCABy5pez+rUYpsSLUKV2Yg38xBtrGRuo4U=
-github.com/mark3labs/mcp-go v0.50.0/go.mod h1:Zg9cB2HdwdMMVgY0xtTzq3KvYIOJQDsaut+jWjwDaQY=
 github.com/mark3labs/mcp-go v0.51.0 h1:e8AhEfxzcYt7XqYzwT7uzWNhnqpu3H1Tn7dEJB9Ygj8=
 github.com/mark3labs/mcp-go v0.51.0/go.mod h1:Zg9cB2HdwdMMVgY0xtTzq3KvYIOJQDsaut+jWjwDaQY=
 github.com/maruel/natural v1.1.1 h1:Hja7XhhmvEFhcByqDoHz9QZbkWey+COd9xWfCfn1ioo=
@@ -624,8 +618,6 @@ github.com/tklauser/numcpus v0.11.0 h1:nSTwhKH5e1dMNsCdVBukSZrURJRoHbSEQjdEbY+9R
 github.com/tklauser/numcpus v0.11.0/go.mod h1:z+LwcLq54uWZTX0u/bGobaV34u6V7KNlTZejzM6/3MQ=
 github.com/valyala/bytebufferpool v1.0.0 h1:GqA5TC/0021Y/b9FG4Oi9Mr3q7XYx6KllzawFIhcdPw=
 github.com/valyala/bytebufferpool v1.0.0/go.mod h1:6bBcMArwyJ5K/AmCkWv1jt77kVWyCJ6HpOuEn7z0Csc=
-github.com/valyala/fasthttp v1.70.0 h1:LAhMGcWk13QZWm85+eg8ZBNbrq5mnkWFGbHMUJHIdXA=
-github.com/valyala/fasthttp v1.70.0/go.mod h1:oDZEHHkJ/Buyklg6uURmYs19442zFSnCIfX3j1FY3pE=
 github.com/valyala/fasthttp v1.71.0 h1:tepR7H+Guh9VUqxxcPggYi8R3lGUu2Rsdh+z7/FCY3k=
 github.com/valyala/fasthttp v1.71.0/go.mod h1:z1sDUvOShhXq/C9mwH/fSm1Vb71tUJwmQdgkBrBNwnA=
 github.com/vbatts/tar-split v0.12.2 h1:w/Y6tjxpeiFMR47yzZPlPj/FcPLpXbTUi/9H7d3CPa4=
@@ -843,8 +835,6 @@ k8s.io/gengo/v2 v2.0.0-20250922181213-ec3ebc5fd46b h1:gMplByicHV/TJBizHd9aVEsTYo
 k8s.io/gengo/v2 v2.0.0-20250922181213-ec3ebc5fd46b/go.mod h1:CgujABENc3KuTrcsdpGmrrASjtQsWCT7R99mEV4U/fM=
 k8s.io/klog/v2 v2.140.0 h1:Tf+J3AH7xnUzZyVVXhTgGhEKnFqye14aadWv7bzXdzc=
 k8s.io/klog/v2 v2.140.0/go.mod h1:o+/RWfJ6PwpnFn7OyAG3QnO47BFsymfEfrz6XyYSSp0=
-k8s.io/kube-openapi v0.0.0-20260502001324-b7f5293f4787 h1:kHv8PETbPIVHfqKBYwTNNSjqChf/7xn3JOS3re+NWs8=
-k8s.io/kube-openapi v0.0.0-20260502001324-b7f5293f4787/go.mod h1:Cyq7UE0QtGe+Zo+/6XFrxiS4Mq0tLyQEONkFzSkfp9o=
 k8s.io/kube-openapi v0.0.0-20260504175024-7bfe71ffdc10 h1:WTqpjlNkK8rfPghVhuBPxEswk9Y99sUpiMAfOClcuNM=
 k8s.io/kube-openapi v0.0.0-20260504175024-7bfe71ffdc10/go.mod h1:Cyq7UE0QtGe+Zo+/6XFrxiS4Mq0tLyQEONkFzSkfp9o=
 k8s.io/streaming v0.36.0 h1:agnTxU+NFulUrtYzXUGKO3ndEa8jKwht1Kwn9nu9x+4=

--- a/pkg/event/bus/nats.go
+++ b/pkg/event/bus/nats.go
@@ -44,9 +44,13 @@ func optsFromConfig(cfg ConnectionConfig) (opts []nats.Option) {
 	opts = []nats.Option{
 		// Never stop trying to reconnect — the process should not require a restart
 		// due to a transient NATS outage.
+		// Note: RetryOnFailedConnect is intentionally omitted. It would make
+		// nats.Connect() return nil on an unreachable server, silently disabling
+		// the retry.DoWithData startup loop and removing crash-on-startup behaviour.
+		// MaxReconnects(-1) covers all runtime reconnection; startup retries are
+		// handled by the caller's retry loop.
 		nats.MaxReconnects(-1),
 		nats.ReconnectWait(2 * time.Second),
-		nats.RetryOnFailedConnect(true),
 	}
 
 	if cfg.NatsSecure {
@@ -172,10 +176,11 @@ func (n *NATSBus) reconnect() error {
 	if err != nil {
 		return fmt.Errorf("nats reconnect failed: %w", err)
 	}
-	n.nc = conn
 
-	// Re-register every subscription on the new connection.  Without this step
-	// all consumers would silently stop receiving events after a reconnect.
+	// Re-register subscriptions BEFORE exposing conn via n.nc.  This closes the
+	// window where the new connection is live but has no handlers — messages
+	// published to subscribed topics during that gap would otherwise be silently
+	// discarded by the NATS server.
 	n.subscriptions.Range(func(key, value any) bool {
 		entry := value.(*subscriptionEntry)
 
@@ -202,6 +207,7 @@ func (n *NATSBus) reconnect() error {
 		return true
 	})
 
+	n.nc = conn
 	return nil
 }
 

--- a/pkg/event/bus/nats.go
+++ b/pkg/event/bus/nats.go
@@ -28,6 +28,9 @@ const (
 	SubscriptionName       = "agentevents"
 	InternalPublishTopic   = "internal.all"
 	InternalSubscribeTopic = "internal.>"
+
+	natsMaxReconnects = -1
+	natsReconnectWait = 2 * time.Second
 )
 
 type ConnectionConfig struct {
@@ -49,8 +52,8 @@ func optsFromConfig(cfg ConnectionConfig) (opts []nats.Option) {
 		// the retry.DoWithData startup loop and removing crash-on-startup behaviour.
 		// MaxReconnects(-1) covers all runtime reconnection; startup retries are
 		// handled by the caller's retry loop.
-		nats.MaxReconnects(-1),
-		nats.ReconnectWait(2 * time.Second),
+		nats.MaxReconnects(natsMaxReconnects),
+		nats.ReconnectWait(natsReconnectWait),
 	}
 
 	if cfg.NatsSecure {
@@ -139,9 +142,16 @@ type subscriptionEntry struct {
 type NATSBus struct {
 	nc            *nats.EncodedConn
 	cfg           ConnectionConfig
-	mu            sync.RWMutex
-	reconnectMu   sync.Mutex // serialises reconnect attempts; never held while mu is held
+	connMu        sync.RWMutex
+	reconnectMu   sync.Mutex // serialises reconnect attempts; never held while connMu is held
 	subscriptions sync.Map   // map[string]*subscriptionEntry
+}
+
+// getNC returns the current encoded connection under a read lock.
+func (n *NATSBus) getNC() *nats.EncodedConn {
+	n.connMu.RLock()
+	defer n.connMu.RUnlock()
+	return n.nc
 }
 
 // Publish publishes event to NATS on events topic
@@ -160,7 +170,7 @@ func (n *NATSBus) Subscribe(queueName string, handler Handler) error {
 // Design notes:
 //   - reconnectMu serialises concurrent reconnect attempts so only one goroutine
 //     pays the cost of NewNATSEncodedConnection's retry loop at a time.
-//   - n.mu (the read/write lock guarding n.nc) is held only for the final
+//   - connMu (the read/write lock guarding n.nc) is held only for the final
 //     pointer swap, so publishers are not stalled for the full retry duration.
 //   - CompareAndSwap is used when updating subscription entries so that a
 //     concurrent Unsubscribe (which calls LoadAndDelete) wins: if the key was
@@ -178,10 +188,7 @@ func (n *NATSBus) reconnect() error {
 
 	// Re-check now that we hold reconnectMu: a previous waiter may have
 	// already swapped in a healthy connection.
-	n.mu.RLock()
-	closed := n.nc.Conn.IsClosed()
-	n.mu.RUnlock()
-	if !closed {
+	if !n.getNC().Conn.IsClosed() {
 		return nil
 	}
 
@@ -200,6 +207,7 @@ func (n *NATSBus) reconnect() error {
 	// Re-register subscriptions on the new connection BEFORE exposing it via
 	// n.nc.  This closes the window where messages could arrive on a topic that
 	// has no handler yet.
+	var failedKeys []any
 	n.subscriptions.Range(func(key, value any) bool {
 		entry := value.(*subscriptionEntry)
 
@@ -215,6 +223,9 @@ func (n *NATSBus) reconnect() error {
 				"topic", entry.topic,
 				"queue", entry.queue,
 				"error", serr)
+			// Mark for removal: leaving a stale entry would cause silent message
+			// loss and unexpected Drain() calls on dead subscriptions.
+			failedKeys = append(failedKeys, key)
 			return true
 		}
 
@@ -234,10 +245,14 @@ func (n *NATSBus) reconnect() error {
 		return true
 	})
 
+	for _, key := range failedKeys {
+		n.subscriptions.Delete(key)
+	}
+
 	// Hold the write lock only for the pointer swap.
-	n.mu.Lock()
+	n.connMu.Lock()
 	n.nc = conn
-	n.mu.Unlock()
+	n.connMu.Unlock()
 	return nil
 }
 
@@ -247,10 +262,7 @@ func (n *NATSBus) reconnect() error {
 func (n *NATSBus) PublishTopic(topic string, event testkube.Event) error {
 	log.Tracew(log.DefaultLogger, "publishing event", event.Log()...)
 
-	n.mu.RLock()
-	nc := n.nc
-	n.mu.RUnlock()
-
+	nc := n.getNC()
 	err := nc.Publish(topic, event)
 	if err == nil {
 		return nil
@@ -274,11 +286,7 @@ func (n *NATSBus) PublishTopic(topic string, event testkube.Event) error {
 		return fmt.Errorf("nats publish failed, reconnect error: %w", rerr)
 	}
 
-	n.mu.RLock()
-	nc = n.nc
-	n.mu.RUnlock()
-
-	return nc.Publish(topic, event)
+	return n.getNC().Publish(topic, event)
 }
 
 // SubscribeTopic subscribes to NATS topic.
@@ -288,26 +296,19 @@ func (n *NATSBus) SubscribeTopic(topic, queueName string, handler Handler) error
 	// sanitize names for NATS
 	queue := common.ListenerName(queueName)
 
-	n.mu.RLock()
-	nc := n.nc
-	n.mu.RUnlock()
-
 	// async subscribe on queue
-	s, err := nc.QueueSubscribe(topic, queue, handler)
+	s, err := n.getNC().QueueSubscribe(topic, queue, handler)
+	if err != nil && !errors.Is(err, nats.ErrConnectionClosed) {
+		return err
+	}
 	if err != nil {
-		if !errors.Is(err, nats.ErrConnectionClosed) {
-			return err
-		}
 		log.DefaultLogger.Warnw("nats connection closed during subscribe, attempting reconnect",
 			"topic", topic,
 			"error_type", "nats_connection_closed")
 		if rerr := n.reconnect(); rerr != nil {
 			return fmt.Errorf("nats subscribe failed, reconnect error: %w", rerr)
 		}
-		n.mu.RLock()
-		nc = n.nc
-		n.mu.RUnlock()
-		s, err = nc.QueueSubscribe(topic, queue, handler)
+		s, err = n.getNC().QueueSubscribe(topic, queue, handler)
 		if err != nil {
 			return err
 		}
@@ -336,10 +337,7 @@ func (n *NATSBus) Unsubscribe(queueName string) error {
 }
 
 func (n *NATSBus) Close() error {
-	n.mu.RLock()
-	nc := n.nc
-	n.mu.RUnlock()
-	nc.Close()
+	n.getNC().Close()
 	return nil
 }
 
@@ -348,17 +346,13 @@ func (n *NATSBus) queueName(subscription, queue string) string {
 }
 
 func (n *NATSBus) TraceEvents() {
-	n.mu.RLock()
-	nc := n.nc
-	n.mu.RUnlock()
-
 	topic := SubscriptionName + ".>"
 	handler := Handler(func(event testkube.Event) error {
 		log.Tracew(log.DefaultLogger, "all events.> trace", event.Log()...)
 		return nil
 	})
 
-	s, err := nc.Subscribe(topic, handler)
+	s, err := n.getNC().Subscribe(topic, handler)
 	if err != nil {
 		log.DefaultLogger.Errorw("error subscribing to all events", "error", err)
 		return

--- a/pkg/event/bus/nats.go
+++ b/pkg/event/bus/nats.go
@@ -275,7 +275,7 @@ func (n *NATSBus) Unsubscribe(queueName string) error {
 	queue := common.ListenerName(queueName)
 
 	key := n.queueName(SubscriptionName, queue)
-	if v, ok := n.subscriptions.Load(key); ok {
+	if v, ok := n.subscriptions.LoadAndDelete(key); ok {
 		return v.(*subscriptionEntry).sub.Drain()
 	}
 	return nil

--- a/pkg/event/bus/nats.go
+++ b/pkg/event/bus/nats.go
@@ -277,7 +277,10 @@ func (n *NATSBus) Unsubscribe(queueName string) error {
 }
 
 func (n *NATSBus) Close() error {
-	n.nc.Close()
+	n.mu.RLock()
+	nc := n.nc
+	n.mu.RUnlock()
+	nc.Close()
 	return nil
 }
 
@@ -286,7 +289,11 @@ func (n *NATSBus) queueName(subscription, queue string) string {
 }
 
 func (n *NATSBus) TraceEvents() {
-	s, err := n.nc.Subscribe(SubscriptionName+".>", func(event testkube.Event) {
+	n.mu.RLock()
+	nc := n.nc
+	n.mu.RUnlock()
+
+	s, err := nc.Subscribe(SubscriptionName+".>", func(event testkube.Event) {
 		log.Tracew(log.DefaultLogger, "all events.> trace", event.Log()...)
 	})
 

--- a/pkg/event/bus/nats.go
+++ b/pkg/event/bus/nats.go
@@ -140,7 +140,8 @@ type NATSBus struct {
 	nc            *nats.EncodedConn
 	cfg           ConnectionConfig
 	mu            sync.RWMutex
-	subscriptions sync.Map // map[string]*subscriptionEntry
+	reconnectMu   sync.Mutex // serialises reconnect attempts; never held while mu is held
+	subscriptions sync.Map   // map[string]*subscriptionEntry
 }
 
 // Publish publishes event to NATS on events topic
@@ -155,32 +156,50 @@ func (n *NATSBus) Subscribe(queueName string, handler Handler) error {
 
 // reconnect replaces the underlying connection when it has been permanently
 // closed.  Callers must NOT hold n.mu when calling this.
+//
+// Design notes:
+//   - reconnectMu serialises concurrent reconnect attempts so only one goroutine
+//     pays the cost of NewNATSEncodedConnection's retry loop at a time.
+//   - n.mu (the read/write lock guarding n.nc) is held only for the final
+//     pointer swap, so publishers are not stalled for the full retry duration.
+//   - CompareAndSwap is used when updating subscription entries so that a
+//     concurrent Unsubscribe (which calls LoadAndDelete) wins: if the key was
+//     deleted between Range seeing it and the Store, the orphan subscription is
+//     drained rather than re-inserted.
 func (n *NATSBus) reconnect() error {
-	n.mu.Lock()
-	defer n.mu.Unlock()
-
-	// Another goroutine may have already reconnected while we waited for the lock.
-	if !n.nc.Conn.IsClosed() {
-		return nil
-	}
-
 	if n.cfg.NatsURI == "" {
 		return errors.New("nats reconnect: no URI configured (embedded connection cannot reconnect)")
+	}
+
+	// Serialise reconnect attempts.  If two goroutines both detect
+	// ErrConnectionClosed, only one should create a new connection.
+	n.reconnectMu.Lock()
+	defer n.reconnectMu.Unlock()
+
+	// Re-check now that we hold reconnectMu: a previous waiter may have
+	// already swapped in a healthy connection.
+	n.mu.RLock()
+	closed := n.nc.Conn.IsClosed()
+	n.mu.RUnlock()
+	if !closed {
+		return nil
 	}
 
 	log.DefaultLogger.Warnw("nats connection is closed, reinitialising",
 		"error_type", "nats_connection_closed",
 		"url", n.cfg.NatsURI)
 
+	// Create the new connection outside every lock so that publishers are not
+	// stalled during the (potentially slow) retry loop inside
+	// NewNATSEncodedConnection.
 	conn, err := NewNATSEncodedConnection(n.cfg)
 	if err != nil {
 		return fmt.Errorf("nats reconnect failed: %w", err)
 	}
 
-	// Re-register subscriptions BEFORE exposing conn via n.nc.  This closes the
-	// window where the new connection is live but has no handlers — messages
-	// published to subscribed topics during that gap would otherwise be silently
-	// discarded by the NATS server.
+	// Re-register subscriptions on the new connection BEFORE exposing it via
+	// n.nc.  This closes the window where messages could arrive on a topic that
+	// has no handler yet.
 	n.subscriptions.Range(func(key, value any) bool {
 		entry := value.(*subscriptionEntry)
 
@@ -198,16 +217,27 @@ func (n *NATSBus) reconnect() error {
 				"error", serr)
 			return true
 		}
-		n.subscriptions.Store(key, &subscriptionEntry{
+
+		newEntry := &subscriptionEntry{
 			topic:   entry.topic,
 			queue:   entry.queue,
 			handler: entry.handler,
 			sub:     newSub,
-		})
+		}
+		// CompareAndSwap against the exact pointer seen by Range.  If
+		// Unsubscribe ran LoadAndDelete between Range seeing this entry and now,
+		// the swap will fail and we drain the orphan subscription rather than
+		// silently re-inserting a ghost entry that can never be removed.
+		if !n.subscriptions.CompareAndSwap(key, value, newEntry) {
+			_ = newSub.Drain()
+		}
 		return true
 	})
 
+	// Hold the write lock only for the pointer swap.
+	n.mu.Lock()
 	n.nc = conn
+	n.mu.Unlock()
 	return nil
 }
 
@@ -251,7 +281,9 @@ func (n *NATSBus) PublishTopic(topic string, event testkube.Event) error {
 	return nc.Publish(topic, event)
 }
 
-// SubscribeTopic subscribes to NATS topic
+// SubscribeTopic subscribes to NATS topic.
+// If the connection is permanently closed it attempts a single reconnect before
+// giving up, mirroring the self-healing behaviour of PublishTopic.
 func (n *NATSBus) SubscribeTopic(topic, queueName string, handler Handler) error {
 	// sanitize names for NATS
 	queue := common.ListenerName(queueName)
@@ -262,18 +294,34 @@ func (n *NATSBus) SubscribeTopic(topic, queueName string, handler Handler) error
 
 	// async subscribe on queue
 	s, err := nc.QueueSubscribe(topic, queue, handler)
-	if err == nil {
-		// store topic, queue, and handler so reconnect() can re-register them
-		key := n.queueName(SubscriptionName, queue)
-		n.subscriptions.Store(key, &subscriptionEntry{
-			topic:   topic,
-			queue:   queue,
-			handler: handler,
-			sub:     s,
-		})
+	if err != nil {
+		if !errors.Is(err, nats.ErrConnectionClosed) {
+			return err
+		}
+		log.DefaultLogger.Warnw("nats connection closed during subscribe, attempting reconnect",
+			"topic", topic,
+			"error_type", "nats_connection_closed")
+		if rerr := n.reconnect(); rerr != nil {
+			return fmt.Errorf("nats subscribe failed, reconnect error: %w", rerr)
+		}
+		n.mu.RLock()
+		nc = n.nc
+		n.mu.RUnlock()
+		s, err = nc.QueueSubscribe(topic, queue, handler)
+		if err != nil {
+			return err
+		}
 	}
 
-	return err
+	// store topic, queue, and handler so reconnect() can re-register them
+	key := n.queueName(SubscriptionName, queue)
+	n.subscriptions.Store(key, &subscriptionEntry{
+		topic:   topic,
+		queue:   queue,
+		handler: handler,
+		sub:     s,
+	})
+	return nil
 }
 
 func (n *NATSBus) Unsubscribe(queueName string) error {

--- a/pkg/event/bus/nats.go
+++ b/pkg/event/bus/nats.go
@@ -68,8 +68,6 @@ func optsFromConfig(cfg ConnectionConfig) (opts []nats.Option) {
 }
 
 func NewNATSEncodedConnection(cfg ConnectionConfig, opts ...nats.Option) (*nats.EncodedConn, error) {
-	opts = append(opts, optsFromConfig(cfg)...)
-
 	nc, err := NewNATSConnection(cfg, opts...)
 	if err != nil {
 		log.DefaultLogger.Fatalw("error connecting to nats", "error", err)
@@ -133,9 +131,10 @@ func NewNATSBus(nc *nats.EncodedConn, cfg ConnectionConfig) *NATSBus {
 
 // subscriptionEntry holds everything needed to re-register a subscription on a
 // fresh connection after a reconnect.
+// When queue is empty a plain Subscribe is used; otherwise QueueSubscribe.
 type subscriptionEntry struct {
 	topic   string
-	queue   string
+	queue   string // empty → plain Subscribe, non-empty → QueueSubscribe
 	handler Handler
 	sub     *nats.Subscription
 }
@@ -186,7 +185,14 @@ func (n *NATSBus) reconnect() error {
 	// all consumers would silently stop receiving events after a reconnect.
 	n.subscriptions.Range(func(key, value any) bool {
 		entry := value.(*subscriptionEntry)
-		newSub, serr := conn.QueueSubscribe(entry.topic, entry.queue, entry.handler)
+
+		var newSub *nats.Subscription
+		var serr error
+		if entry.queue == "" {
+			newSub, serr = conn.Subscribe(entry.topic, entry.handler)
+		} else {
+			newSub, serr = conn.QueueSubscribe(entry.topic, entry.queue, entry.handler)
+		}
 		if serr != nil {
 			log.DefaultLogger.Errorw("failed to re-register subscription after nats reconnect",
 				"topic", entry.topic,
@@ -293,14 +299,25 @@ func (n *NATSBus) TraceEvents() {
 	nc := n.nc
 	n.mu.RUnlock()
 
-	s, err := nc.Subscribe(SubscriptionName+".>", func(event testkube.Event) {
+	topic := SubscriptionName + ".>"
+	handler := Handler(func(event testkube.Event) error {
 		log.Tracew(log.DefaultLogger, "all events.> trace", event.Log()...)
+		return nil
 	})
 
+	s, err := nc.Subscribe(topic, handler)
 	if err != nil {
 		log.DefaultLogger.Errorw("error subscribing to all events", "error", err)
 		return
 	}
+
+	// Store with empty queue so reconnect() re-registers it via plain Subscribe.
+	n.subscriptions.Store("trace:"+topic, &subscriptionEntry{
+		topic:   topic,
+		queue:   "",
+		handler: handler,
+		sub:     s,
+	})
 
 	log.DefaultLogger.Infow("subscribed to all events", "subscription", s.Subject)
 }

--- a/pkg/event/bus/nats.go
+++ b/pkg/event/bus/nats.go
@@ -3,6 +3,7 @@ package bus
 
 import (
 	"crypto/tls"
+	"errors"
 	"fmt"
 	"sync"
 	"time"
@@ -40,7 +41,14 @@ type ConnectionConfig struct {
 }
 
 func optsFromConfig(cfg ConnectionConfig) (opts []nats.Option) {
-	opts = []nats.Option{}
+	opts = []nats.Option{
+		// Never stop trying to reconnect — the process should not require a restart
+		// due to a transient NATS outage.
+		nats.MaxReconnects(-1),
+		nats.ReconnectWait(2 * time.Second),
+		nats.RetryOnFailedConnect(true),
+	}
+
 	if cfg.NatsSecure {
 		if cfg.NatsSkipVerify {
 			opts = append(opts, nats.Secure(&tls.Config{InsecureSkipVerify: true}))
@@ -84,6 +92,21 @@ func NewNATSEncodedConnection(cfg ConnectionConfig, opts ...nats.Option) (*nats.
 
 func NewNATSConnection(cfg ConnectionConfig, opts ...nats.Option) (*nats.Conn, error) {
 	opts = append(opts, optsFromConfig(cfg)...)
+	opts = append(opts,
+		nats.DisconnectErrHandler(func(_ *nats.Conn, err error) {
+			log.DefaultLogger.Warnw("nats disconnected",
+				"error_type", "nats_connection_closed",
+				"error", err)
+		}),
+		nats.ReconnectHandler(func(nc *nats.Conn) {
+			log.DefaultLogger.Infow("nats reconnected",
+				"url", nc.ConnectedUrl())
+		}),
+		nats.ClosedHandler(func(_ *nats.Conn) {
+			log.DefaultLogger.Errorw("nats connection permanently closed",
+				"error_type", "nats_connection_closed")
+		}),
+	)
 
 	nc, err := retry.DoWithData(
 		func() (*nats.Conn, error) {
@@ -101,14 +124,17 @@ func NewNATSConnection(cfg ConnectionConfig, opts ...nats.Option) (*nats.Conn, e
 	return nc, nil
 }
 
-func NewNATSBus(nc *nats.EncodedConn) *NATSBus {
+func NewNATSBus(nc *nats.EncodedConn, cfg ConnectionConfig) *NATSBus {
 	return &NATSBus{
-		nc: nc,
+		nc:  nc,
+		cfg: cfg,
 	}
 }
 
 type NATSBus struct {
 	nc            *nats.EncodedConn
+	cfg           ConnectionConfig
+	mu            sync.RWMutex
 	subscriptions sync.Map
 }
 
@@ -122,10 +148,65 @@ func (n *NATSBus) Subscribe(queueName string, handler Handler) error {
 	return n.SubscribeTopic(SubscriptionName, queueName, handler)
 }
 
-// PublishTopic publishes event to NATS on given topic
+// reconnect replaces the underlying connection when it has been permanently
+// closed.  Callers must NOT hold n.mu when calling this.
+func (n *NATSBus) reconnect() error {
+	n.mu.Lock()
+	defer n.mu.Unlock()
+
+	// Another goroutine may have already reconnected while we waited for the lock.
+	if !n.nc.Conn.IsClosed() {
+		return nil
+	}
+
+	if n.cfg.NatsURI == "" {
+		return errors.New("nats reconnect: no URI configured (embedded connection cannot reconnect)")
+	}
+
+	log.DefaultLogger.Warnw("nats connection is closed, reinitialising",
+		"error_type", "nats_connection_closed",
+		"url", n.cfg.NatsURI)
+
+	conn, err := NewNATSEncodedConnection(n.cfg)
+	if err != nil {
+		return fmt.Errorf("nats reconnect failed: %w", err)
+	}
+	n.nc = conn
+	return nil
+}
+
+// PublishTopic publishes event to NATS on given topic.
+// If the connection is permanently closed it attempts a single reconnect before
+// giving up, so a transient NATS restart does not require a pod restart.
 func (n *NATSBus) PublishTopic(topic string, event testkube.Event) error {
 	log.Tracew(log.DefaultLogger, "publishing event", event.Log()...)
-	return n.nc.Publish(topic, event)
+
+	n.mu.RLock()
+	nc := n.nc
+	n.mu.RUnlock()
+
+	err := nc.Publish(topic, event)
+	if err == nil {
+		return nil
+	}
+
+	if !errors.Is(err, nats.ErrConnectionClosed) {
+		return err
+	}
+
+	log.DefaultLogger.Warnw("nats connection closed during publish, attempting reconnect",
+		"topic", topic,
+		"error_type", "nats_connection_closed")
+
+	if rerr := n.reconnect(); rerr != nil {
+		return fmt.Errorf("nats publish failed, reconnect error: %w", rerr)
+	}
+
+	n.mu.RLock()
+	nc = n.nc
+	n.mu.RUnlock()
+
+	return nc.Publish(topic, event)
 }
 
 // SubscribeTopic subscribes to NATS topic

--- a/pkg/event/bus/nats.go
+++ b/pkg/event/bus/nats.go
@@ -70,19 +70,13 @@ func optsFromConfig(cfg ConnectionConfig) (opts []nats.Option) {
 func NewNATSEncodedConnection(cfg ConnectionConfig, opts ...nats.Option) (*nats.EncodedConn, error) {
 	nc, err := NewNATSConnection(cfg, opts...)
 	if err != nil {
-		log.DefaultLogger.Fatalw("error connecting to nats", "error", err)
 		return nil, err
 	}
 
 	// automatic NATS JSON CODEC
 	ec, err := nats.NewEncodedConn(nc, nats.JSON_ENCODER)
 	if err != nil {
-		log.DefaultLogger.Fatalw("error connecting to nats", "error", err)
 		return nil, err
-	}
-
-	if err != nil {
-		log.DefaultLogger.Errorw("error creating NATS connection", "error", err)
 	}
 
 	return ec, nil
@@ -115,7 +109,6 @@ func NewNATSConnection(cfg ConnectionConfig, opts ...nats.Option) (*nats.Conn, e
 		retry.Attempts(NATS_RETRY_ATTEMPTS),
 	)
 	if err != nil {
-		log.DefaultLogger.Fatalw("error connecting to nats", "error", err)
 		return nil, err
 	}
 
@@ -231,6 +224,12 @@ func (n *NATSBus) PublishTopic(topic string, event testkube.Event) error {
 		return err
 	}
 
+	// ErrConnectionClosed means the connection is permanently gone — not a
+	// transient blip.  With MaxReconnects(-1) the NATS library handles transient
+	// outages internally (buffering publishes while reconnecting), so this path
+	// is a last-resort safety net for the rare case where the connection object
+	// itself must be replaced (e.g. after an explicit Close or an unforeseen
+	// client state machine edge-case).
 	log.DefaultLogger.Warnw("nats connection closed during publish, attempting reconnect",
 		"topic", topic,
 		"error_type", "nats_connection_closed")

--- a/pkg/event/bus/nats.go
+++ b/pkg/event/bus/nats.go
@@ -165,7 +165,7 @@ func (n *NATSBus) Subscribe(queueName string, handler Handler) error {
 }
 
 // reconnect replaces the underlying connection when it has been permanently
-// closed.  Callers must NOT hold n.mu when calling this.
+// closed.  Callers must NOT hold n.connMu when calling this.
 //
 // Design notes:
 //   - reconnectMu serialises concurrent reconnect attempts so only one goroutine
@@ -196,9 +196,10 @@ func (n *NATSBus) reconnect() error {
 		"error_type", "nats_connection_closed",
 		"url", n.cfg.NatsURI)
 
-	// Create the new connection outside every lock so that publishers are not
+	// Create the new connection outside connMu so that publishers are not
 	// stalled during the (potentially slow) retry loop inside
-	// NewNATSEncodedConnection.
+	// NewNATSEncodedConnection.  (reconnectMu is still held to serialise
+	// concurrent reconnect attempts.)
 	conn, err := NewNATSEncodedConnection(n.cfg)
 	if err != nil {
 		return fmt.Errorf("nats reconnect failed: %w", err)

--- a/pkg/event/bus/nats.go
+++ b/pkg/event/bus/nats.go
@@ -131,11 +131,20 @@ func NewNATSBus(nc *nats.EncodedConn, cfg ConnectionConfig) *NATSBus {
 	}
 }
 
+// subscriptionEntry holds everything needed to re-register a subscription on a
+// fresh connection after a reconnect.
+type subscriptionEntry struct {
+	topic   string
+	queue   string
+	handler Handler
+	sub     *nats.Subscription
+}
+
 type NATSBus struct {
 	nc            *nats.EncodedConn
 	cfg           ConnectionConfig
 	mu            sync.RWMutex
-	subscriptions sync.Map
+	subscriptions sync.Map // map[string]*subscriptionEntry
 }
 
 // Publish publishes event to NATS on events topic
@@ -172,6 +181,28 @@ func (n *NATSBus) reconnect() error {
 		return fmt.Errorf("nats reconnect failed: %w", err)
 	}
 	n.nc = conn
+
+	// Re-register every subscription on the new connection.  Without this step
+	// all consumers would silently stop receiving events after a reconnect.
+	n.subscriptions.Range(func(key, value any) bool {
+		entry := value.(*subscriptionEntry)
+		newSub, serr := conn.QueueSubscribe(entry.topic, entry.queue, entry.handler)
+		if serr != nil {
+			log.DefaultLogger.Errorw("failed to re-register subscription after nats reconnect",
+				"topic", entry.topic,
+				"queue", entry.queue,
+				"error", serr)
+			return true
+		}
+		n.subscriptions.Store(key, &subscriptionEntry{
+			topic:   entry.topic,
+			queue:   entry.queue,
+			handler: entry.handler,
+			sub:     newSub,
+		})
+		return true
+	})
+
 	return nil
 }
 
@@ -214,13 +245,21 @@ func (n *NATSBus) SubscribeTopic(topic, queueName string, handler Handler) error
 	// sanitize names for NATS
 	queue := common.ListenerName(queueName)
 
-	// async subscribe on queue
-	s, err := n.nc.QueueSubscribe(topic, queue, handler)
+	n.mu.RLock()
+	nc := n.nc
+	n.mu.RUnlock()
 
+	// async subscribe on queue
+	s, err := nc.QueueSubscribe(topic, queue, handler)
 	if err == nil {
-		// store subscription for later unsubscribe
+		// store topic, queue, and handler so reconnect() can re-register them
 		key := n.queueName(SubscriptionName, queue)
-		n.subscriptions.Store(key, s)
+		n.subscriptions.Store(key, &subscriptionEntry{
+			topic:   topic,
+			queue:   queue,
+			handler: handler,
+			sub:     s,
+		})
 	}
 
 	return err
@@ -231,8 +270,8 @@ func (n *NATSBus) Unsubscribe(queueName string) error {
 	queue := common.ListenerName(queueName)
 
 	key := n.queueName(SubscriptionName, queue)
-	if s, ok := n.subscriptions.Load(key); ok {
-		return s.(*nats.Subscription).Drain()
+	if v, ok := n.subscriptions.Load(key); ok {
+		return v.(*subscriptionEntry).sub.Drain()
 	}
 	return nil
 }

--- a/pkg/event/bus/nats.go
+++ b/pkg/event/bus/nats.go
@@ -251,8 +251,16 @@ func (n *NATSBus) reconnect() error {
 
 	// Hold the write lock only for the pointer swap.
 	n.connMu.Lock()
+	oldNC := n.nc
 	n.nc = conn
 	n.connMu.Unlock()
+
+	// Explicitly close the old connection after releasing the write lock.
+	// If the connection is already in CLOSED state this is a no-op; the
+	// explicit call makes the intent clear and guards the edge case where
+	// the connection reached a non-CLOSED terminal state without triggering
+	// the closed handler.
+	oldNC.Close()
 	return nil
 }
 

--- a/pkg/event/bus/nats.go
+++ b/pkg/event/bus/nats.go
@@ -122,10 +122,34 @@ func NewNATSConnection(cfg ConnectionConfig, opts ...nats.Option) (*nats.Conn, e
 }
 
 func NewNATSBus(nc *nats.EncodedConn, cfg ConnectionConfig) *NATSBus {
-	return &NATSBus{
+	b := &NATSBus{
 		nc:  nc,
 		cfg: cfg,
 	}
+	// Override the default logging-only ClosedHandler set by NewNATSConnection
+	// so that a permanent connection close triggers a background reconnect
+	// even during quiet periods with no in-flight publishes or subscribes.
+	nc.Conn.SetClosedHandler(b.onConnectionClosed)
+	return b
+}
+
+// onConnectionClosed is the nats.ClosedHandler installed on every connection
+// managed by this bus (initial and those created by reconnect()).
+// It logs the event and, when a URI is configured, triggers a background
+// reconnect so a permanent close during a quiet period does not leave the bus
+// in a stuck state until the next publish/subscribe attempt.
+func (n *NATSBus) onConnectionClosed(_ *nats.Conn) {
+	log.DefaultLogger.Errorw("nats connection permanently closed",
+		"error_type", "nats_connection_closed")
+	if n.cfg.NatsURI == "" {
+		return
+	}
+	go func() {
+		if err := n.reconnect(); err != nil {
+			log.DefaultLogger.Errorw("nats background reconnect after connection closed failed",
+				"error", err)
+		}
+	}()
 }
 
 // subscriptionEntry holds everything needed to re-register a subscription on a
@@ -203,6 +227,11 @@ func (n *NATSBus) reconnect() error {
 	if err != nil {
 		return fmt.Errorf("nats reconnect failed: %w", err)
 	}
+
+	// Register our closed handler on the new connection so that if it is
+	// itself permanently closed during a quiet period, another background
+	// reconnect is triggered automatically.
+	conn.Conn.SetClosedHandler(n.onConnectionClosed)
 
 	// Re-register subscriptions on the new connection BEFORE exposing it via
 	// n.nc.  This closes the window where messages could arrive on a topic that

--- a/pkg/event/bus/nats.go
+++ b/pkg/event/bus/nats.go
@@ -94,7 +94,7 @@ func NewNATSConnection(cfg ConnectionConfig, opts ...nats.Option) (*nats.Conn, e
 	opts = append(opts,
 		nats.DisconnectErrHandler(func(_ *nats.Conn, err error) {
 			log.DefaultLogger.Warnw("nats disconnected",
-				"error_type", "nats_connection_closed",
+				"error_type", "nats_disconnected",
 				"error", err)
 		}),
 		nats.ReconnectHandler(func(nc *nats.Conn) {

--- a/pkg/event/bus/nats.go
+++ b/pkg/event/bus/nats.go
@@ -351,8 +351,11 @@ func (n *NATSBus) SubscribeTopic(topic, queueName string, handler Handler) error
 		}
 	}
 
-	// store topic, queue, and handler so reconnect() can re-register them
-	key := n.queueName(SubscriptionName, queue)
+	// store topic, queue, and handler so reconnect() can re-register them.
+	// Key includes the actual topic so that the same queue name used with
+	// different topics produces distinct entries and does not silently
+	// overwrite a previous subscription.
+	key := n.queueName(topic, queue)
 	n.subscriptions.Store(key, &subscriptionEntry{
 		topic:   topic,
 		queue:   queue,
@@ -366,11 +369,22 @@ func (n *NATSBus) Unsubscribe(queueName string) error {
 	// sanitize names for NATS
 	queue := common.ListenerName(queueName)
 
-	key := n.queueName(SubscriptionName, queue)
-	if v, ok := n.subscriptions.LoadAndDelete(key); ok {
-		return v.(*subscriptionEntry).sub.Drain()
-	}
-	return nil
+	// Scan all entries matching this queue name, since subscriptions may have
+	// been created via SubscribeTopic with varying topics (and therefore
+	// different map keys).  Drain each matching subscription and remove it.
+	var firstErr error
+	n.subscriptions.Range(func(key, value any) bool {
+		entry := value.(*subscriptionEntry)
+		if entry.queue != queue {
+			return true
+		}
+		n.subscriptions.Delete(key)
+		if err := entry.sub.Drain(); err != nil && firstErr == nil {
+			firstErr = err
+		}
+		return true
+	})
+	return firstErr
 }
 
 func (n *NATSBus) Close() error {

--- a/pkg/event/bus/nats.go
+++ b/pkg/event/bus/nats.go
@@ -359,7 +359,10 @@ func (n *NATSBus) TraceEvents() {
 	}
 
 	// Store with empty queue so reconnect() re-registers it via plain Subscribe.
-	n.subscriptions.Store("trace:"+topic, &subscriptionEntry{
+	// Uses "trace:" prefix to separate from regular subscriptions (which use
+	// queueName format). TraceEvents is intended to be permanent; no Unsubscribe.
+	key := "trace:" + topic
+	n.subscriptions.Store(key, &subscriptionEntry{
 		topic:   topic,
 		queue:   "",
 		handler: handler,

--- a/pkg/event/bus/nats.go
+++ b/pkg/event/bus/nats.go
@@ -333,8 +333,17 @@ func (n *NATSBus) SubscribeTopic(topic, queueName string, handler Handler) error
 	// sanitize names for NATS
 	queue := common.ListenerName(queueName)
 
-	// async subscribe on queue
-	s, err := n.getNC().QueueSubscribe(topic, queue, handler)
+	// Use plain Subscribe when queue is empty (consistent with reconnect()).
+	// QueueSubscribe with an empty queue name is invalid and would be rejected
+	// by the NATS server with a protocol error.
+	doSubscribe := func(nc *nats.EncodedConn) (*nats.Subscription, error) {
+		if queue == "" {
+			return nc.Subscribe(topic, handler)
+		}
+		return nc.QueueSubscribe(topic, queue, handler)
+	}
+
+	s, err := doSubscribe(n.getNC())
 	if err != nil && !errors.Is(err, nats.ErrConnectionClosed) {
 		return err
 	}
@@ -345,7 +354,7 @@ func (n *NATSBus) SubscribeTopic(topic, queueName string, handler Handler) error
 		if rerr := n.reconnect(); rerr != nil {
 			return fmt.Errorf("nats subscribe failed, reconnect error: %w", rerr)
 		}
-		s, err = n.getNC().QueueSubscribe(topic, queue, handler)
+		s, err = doSubscribe(n.getNC())
 		if err != nil {
 			return err
 		}

--- a/pkg/event/bus/nats.go
+++ b/pkg/event/bus/nats.go
@@ -212,6 +212,16 @@ func (n *NATSBus) reconnect() error {
 	n.reconnectMu.Lock()
 	defer n.reconnectMu.Unlock()
 
+	// Re-check the shutdown flag now that we hold reconnectMu.  There is a
+	// TOCTOU window between onConnectionClosed's pre-goroutine check and here:
+	// Close() could have run concurrently, setting the flag and closing the
+	// connection.  Without this check the IsClosed() guard below would be true
+	// (Close() just closed the connection) and we would establish a live
+	// connection after intentional shutdown.
+	if n.shutdown.Load() {
+		return nil
+	}
+
 	// Re-check now that we hold reconnectMu: a previous waiter may have
 	// already swapped in a healthy connection.
 	if !n.getNC().Conn.IsClosed() {

--- a/pkg/event/bus/nats.go
+++ b/pkg/event/bus/nats.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/avast/retry-go/v5"
@@ -135,13 +136,14 @@ func NewNATSBus(nc *nats.EncodedConn, cfg ConnectionConfig) *NATSBus {
 
 // onConnectionClosed is the nats.ClosedHandler installed on every connection
 // managed by this bus (initial and those created by reconnect()).
-// It logs the event and, when a URI is configured, triggers a background
-// reconnect so a permanent close during a quiet period does not leave the bus
-// in a stuck state until the next publish/subscribe attempt.
+// It logs the event and, when a URI is configured and the bus has not been
+// intentionally shut down, triggers a background reconnect so a permanent
+// close during a quiet period does not leave the bus in a stuck state until
+// the next publish/subscribe attempt.
 func (n *NATSBus) onConnectionClosed(_ *nats.Conn) {
 	log.DefaultLogger.Errorw("nats connection permanently closed",
 		"error_type", "nats_connection_closed")
-	if n.cfg.NatsURI == "" {
+	if n.cfg.NatsURI == "" || n.shutdown.Load() {
 		return
 	}
 	go func() {
@@ -168,6 +170,7 @@ type NATSBus struct {
 	connMu        sync.RWMutex
 	reconnectMu   sync.Mutex // serialises reconnect attempts; never held while connMu is held
 	subscriptions sync.Map   // map[string]*subscriptionEntry
+	shutdown      atomic.Bool
 }
 
 // getNC returns the current encoded connection under a read lock.
@@ -397,6 +400,9 @@ func (n *NATSBus) Unsubscribe(queueName string) error {
 }
 
 func (n *NATSBus) Close() error {
+	// Signal that this is an intentional shutdown so the ClosedHandler does
+	// not spawn a background reconnect goroutine.
+	n.shutdown.Store(true)
 	n.getNC().Close()
 	return nil
 }

--- a/pkg/event/bus/nats_integration_test.go
+++ b/pkg/event/bus/nats_integration_test.go
@@ -96,7 +96,7 @@ func TestNATS_Integration(t *testing.T) {
 	defer ec.Close() //nolint:staticcheck
 
 	// and NATS event bus
-	n := NewNATSBus(ec)
+	n := NewNATSBus(ec, ConnectionConfig{NatsURI: cfg.NatsURI})
 
 	var wg sync.WaitGroup
 	wg.Add(2)

--- a/pkg/event/bus/nats_integration_test.go
+++ b/pkg/event/bus/nats_integration_test.go
@@ -77,6 +77,21 @@ func TestMultipleMessages_Integration(t *testing.T) {
 
 }
 
+func TestNATSBus_Reconnect_Integration(t *testing.T) {
+	// Requires NATS server lifecycle control - recommend using testcontainers
+	// or nats-server.RunServer() for automated test setup/teardown
+	t.Skip("requires NATS server restart capability")
+
+	// Test outline:
+	// 1. Start NATS, create bus, subscribe to topic
+	// 2. Publish event, verify handler receives it
+	// 3. Stop NATS (force connection close)
+	// 4. Attempt publish - should fail with ErrConnectionClosed
+	// 5. Restart NATS
+	// 6. Publish again - should auto-reconnect and succeed
+	// 7. Verify subscription was re-registered (handler receives event)
+}
+
 func TestNATS_Integration(t *testing.T) {
 	test.IntegrationTest(t)
 

--- a/pkg/event/bus/nats_reconnect_test.go
+++ b/pkg/event/bus/nats_reconnect_test.go
@@ -166,3 +166,22 @@ func TestNATSBus_SubscribeTopic_EmptyQueueUsesPlainSubscribe(t *testing.T) {
 	require.NotNil(t, entry, "subscription entry not found in map")
 	assert.Empty(t, entry.queue, "entry.queue should be empty for plain Subscribe")
 }
+
+// TestNATSBus_Close_DoesNotReconnect verifies that calling Close() sets the
+// shutdown flag so the ClosedHandler does not spawn a background reconnect,
+// leaving the bus permanently closed as the caller intended.
+func TestNATSBus_Close_DoesNotReconnect(t *testing.T) {
+	b, _ := makeTestBus(t)
+
+	require.False(t, b.shutdown.Load(), "shutdown flag should be false before Close()")
+	require.NoError(t, b.Close())
+
+	assert.True(t, b.shutdown.Load(), "shutdown flag should be true after Close()")
+	assert.True(t, b.getNC().Conn.IsClosed(), "underlying connection should be closed")
+
+	// Give the ClosedHandler goroutine time to fire (if it incorrectly did).
+	time.Sleep(50 * time.Millisecond)
+
+	// The connection should remain closed — no reconnect was triggered.
+	assert.True(t, b.getNC().Conn.IsClosed(), "bus should remain closed after Close(); unexpected reconnect detected")
+}

--- a/pkg/event/bus/nats_reconnect_test.go
+++ b/pkg/event/bus/nats_reconnect_test.go
@@ -1,0 +1,168 @@
+package bus
+
+import (
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/nats-io/nats.go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/kubeshop/testkube/pkg/api/v1/testkube"
+)
+
+// makeTestBus starts an embedded NATS server and returns a NATSBus whose
+// ConnectionConfig points at that server (so reconnect() can create a new
+// connection without an external NATS installation).  It also returns the
+// underlying *nats.Conn so tests can manipulate the connection lifecycle.
+// The server is shut down by t.Cleanup.
+func makeTestBus(t *testing.T) (*NATSBus, *nats.Conn) {
+	t.Helper()
+
+	ns, nc := TestServerWithConnection(t)
+	t.Cleanup(func() { ns.Shutdown() })
+
+	ec, err := nats.NewEncodedConn(nc, nats.JSON_ENCODER) //nolint:staticcheck
+	require.NoError(t, err)
+
+	cfg := ConnectionConfig{NatsURI: ns.ClientURL()}
+	b := NewNATSBus(ec, cfg)
+	return b, nc
+}
+
+// waitDone blocks until wg.Wait() completes or the timeout elapses, failing
+// the test with msg if it times out.
+func waitDone(t *testing.T, wg *sync.WaitGroup, timeout time.Duration, msg string) {
+	t.Helper()
+	done := make(chan struct{})
+	go func() { wg.Wait(); close(done) }()
+	select {
+	case <-done:
+	case <-time.After(timeout):
+		t.Fatal(msg)
+	}
+}
+
+// TestNATSBus_Reconnect_ReRegistersSubscriptions verifies that after the
+// underlying connection is permanently closed, calling reconnect() swaps in a
+// new connection AND re-registers all previously stored subscriptions so they
+// continue receiving events.
+func TestNATSBus_Reconnect_ReRegistersSubscriptions(t *testing.T) {
+	b, nc := makeTestBus(t)
+
+	var count int32
+	var wg sync.WaitGroup
+	wg.Add(1)
+
+	require.NoError(t, b.SubscribeTopic("recon-topic", "recon-queue", func(evt testkube.Event) error {
+		atomic.AddInt32(&count, 1)
+		wg.Done()
+		return nil
+	}))
+
+	// Baseline: verify the subscription works on the initial connection.
+	event := testkube.NewEventStartTestWorkflow(testkube.NewQueuedExecution(), "")
+	event.Id = "pre-reconnect"
+	require.NoError(t, b.PublishTopic("recon-topic", event))
+	waitDone(t, &wg, 2*time.Second, "timed out waiting for pre-reconnect event")
+	require.Equal(t, int32(1), atomic.LoadInt32(&count))
+
+	// Suppress the automatic background reconnect triggered by the ClosedHandler
+	// so the test has explicit, race-free control over when reconnect() runs.
+	nc.SetClosedHandler(func(_ *nats.Conn) {})
+
+	// Force-close the underlying connection so IsClosed() == true.
+	nc.Close()
+	require.Eventually(t, func() bool { return b.getNC().Conn.IsClosed() },
+		time.Second, 10*time.Millisecond, "underlying connection should be closed")
+
+	// Reconnect; the embedded server is still running so a new connection is
+	// established immediately.
+	require.NoError(t, b.reconnect())
+	assert.False(t, b.getNC().Conn.IsClosed(), "new connection should be open after reconnect")
+
+	// Publish again — the subscription must have been re-registered on the new
+	// connection, so the handler should fire.
+	wg.Add(1)
+	event.Id = "post-reconnect"
+	require.NoError(t, b.PublishTopic("recon-topic", event))
+	waitDone(t, &wg, 2*time.Second, "timed out waiting for post-reconnect event; subscription may not have been re-registered")
+	assert.Equal(t, int32(2), atomic.LoadInt32(&count))
+}
+
+// TestNATSBus_PublishTopic_ReconnectsOnClosedConnection verifies that
+// PublishTopic detects ErrConnectionClosed, triggers a reconnect, and
+// successfully delivers the event on the new connection.
+func TestNATSBus_PublishTopic_ReconnectsOnClosedConnection(t *testing.T) {
+	b, nc := makeTestBus(t)
+
+	var count int32
+	var wg sync.WaitGroup
+	wg.Add(1)
+
+	// Subscribe before forcing the close so that the subscription is in the map
+	// and gets re-registered during the reconnect triggered by PublishTopic.
+	require.NoError(t, b.SubscribeTopic("pub-recon-topic", "pub-recon-queue", func(evt testkube.Event) error {
+		atomic.AddInt32(&count, 1)
+		wg.Done()
+		return nil
+	}))
+
+	// Suppress the automatic ClosedHandler reconnect.
+	nc.SetClosedHandler(func(_ *nats.Conn) {})
+	nc.Close()
+	require.Eventually(t, func() bool { return b.getNC().Conn.IsClosed() },
+		time.Second, 10*time.Millisecond, "underlying connection should be closed")
+
+	event := testkube.NewEventStartTestWorkflow(testkube.NewQueuedExecution(), "")
+	event.Id = "pub-recon-test"
+
+	// PublishTopic should detect ErrConnectionClosed, reconnect, re-register
+	// the subscription, then publish — all transparently.
+	require.NoError(t, b.PublishTopic("pub-recon-topic", event),
+		"PublishTopic should reconnect and succeed")
+
+	waitDone(t, &wg, 2*time.Second, "timed out waiting for event after reconnect-triggered publish")
+	assert.Equal(t, int32(1), atomic.LoadInt32(&count))
+}
+
+// TestNATSBus_SubscribeTopic_EmptyQueueUsesPlainSubscribe verifies that
+// SubscribeTopic falls back to a plain (non-queue) Subscribe when the
+// sanitized queue name is empty, and that the resulting subscription receives
+// events correctly.
+func TestNATSBus_SubscribeTopic_EmptyQueueUsesPlainSubscribe(t *testing.T) {
+	b, _ := makeTestBus(t)
+
+	var count int32
+	var wg sync.WaitGroup
+	wg.Add(1)
+
+	// Passing an empty queueName sanitizes to "" → should use plain Subscribe.
+	require.NoError(t, b.SubscribeTopic("eq-topic", "", func(evt testkube.Event) error {
+		atomic.AddInt32(&count, 1)
+		wg.Done()
+		return nil
+	}))
+
+	event := testkube.NewEventStartTestWorkflow(testkube.NewQueuedExecution(), "")
+	event.Id = "empty-queue-test"
+	require.NoError(t, b.PublishTopic("eq-topic", event))
+
+	waitDone(t, &wg, 2*time.Second, "timed out waiting for event on empty-queue subscription")
+	assert.Equal(t, int32(1), atomic.LoadInt32(&count))
+
+	// Confirm the subscription entry is stored with an empty queue field.
+	var entry *subscriptionEntry
+	b.subscriptions.Range(func(_, value any) bool {
+		e := value.(*subscriptionEntry)
+		if e.topic == "eq-topic" {
+			entry = e
+			return false
+		}
+		return true
+	})
+	require.NotNil(t, entry, "subscription entry not found in map")
+	assert.Empty(t, entry.queue, "entry.queue should be empty for plain Subscribe")
+}

--- a/pkg/event/emitter_integration_test.go
+++ b/pkg/event/emitter_integration_test.go
@@ -37,7 +37,7 @@ func GetTestNATSEmitter(mockCtrl *gomock.Controller) *Emitter {
 	mockLeaseRepository.EXPECT().
 		TryAcquire(gomock.Any(), gomock.Any(), gomock.Any()).
 		Return(true, nil).AnyTimes()
-	return NewEmitter(bus.NewNATSBus(nc), mockLeaseRepository, "agentevents", "", DefaultEventTTL, DefaultEventCacheCapacity)
+	return NewEmitter(bus.NewNATSBus(nc, bus.ConnectionConfig{NatsURI: cfg.NatsURI}), mockLeaseRepository, "agentevents", "", DefaultEventTTL, DefaultEventCacheCapacity)
 }
 
 func TestEmitter_NATS_Register_Integration(t *testing.T) {


### PR DESCRIPTION
## Pull request description 

Finalizing of <a href="https://github.com/dom-raven/testkube/tree/testkube-nats-bug">dom-raven</a> contribution pr, with the following resilience improvements to the NATS event bus:

- Self-healing reconnect: `PublishTopic` and `SubscribeTopic` detect `ErrConnectionClosed` and trigger a reconnect, swapping in a fresh `*nats.EncodedConn` and re-registering all subscriptions on the new connection before exposing it.
- Stale subscription cleanup: `reconnect()` tracks failed re-registrations and removes them from the subscriptions map to prevent ghost entries.
- Explicit old connection close: the previous `*nats.EncodedConn` is captured under the write lock and explicitly closed after the pointer swap.
- Proactive closed-handler feedback: `NATSBus.onConnectionClosed` is installed on every connection (initial and reconnected) so a permanently closed replacement connection triggers a background `reconnect()` without waiting for the next publish/subscribe.
- Safe shutdown: `NATSBus.Close()` sets an atomic shutdown flag before closing the connection so `onConnectionClosed` skips the background reconnect on intentional shutdown, preventing a live connection from being re-established after the bus is stopped. `reconnect()` also re-checks the flag after acquiring `reconnectMu` to close the TOCTOU window where `Close()` could race with an already-spawned reconnect goroutine.
- Correct subscription keying: `SubscribeTopic` keys entries by `topic + "." + queue` instead of the hardcoded `SubscriptionName` constant, preventing silent overwrites when the same queue name is reused with different topics.
- Empty-queue consistency: `SubscribeTopic` now uses plain `Subscribe` when the sanitized queue name is empty, matching `reconnect()`'s behaviour and avoiding a protocol error from passing an empty queue name to the server.
- `TraceEvents` stores its subscription under a `"trace:"` prefixed key with an empty queue so `reconnect()` re-registers it via plain `Subscribe`.
- `NewNATSBus` accepts `ConnectionConfig` so the bus can reconnect without reconstructing config ad-hoc; `MustCreateNATSConnection` returns both the encoded connection and the config.

## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [x] tested locally
- [x] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [x] added a test

## Breaking changes

-

## Changes

- `NewNATSBus` now accepts `ConnectionConfig` in addition to `*nats.EncodedConn`
- `MustCreateNATSConnection` now returns `(conn, config)` instead of just `conn`
- `SubscribeTopic` uses plain `Subscribe` when queue sanitizes to empty string
- `NATSBus` gained an `atomic.Bool` shutdown flag; `Close()` sets it before closing the connection
- `reconnect()` checks the shutdown flag after acquiring `reconnectMu` to close the TOCTOU race window between `onConnectionClosed` and a concurrent `Close()`
- Added `nats_reconnect_test.go` with unit tests for all self-healing paths using the embedded NATS server (no external infra required): reconnect re-registers subscriptions, `PublishTopic` auto-reconnects on `ErrConnectionClosed`, empty queue falls back to plain `Subscribe`, and `Close()` does not trigger a background reconnect

## Fixes

- NATS event bus silently stuck after permanent connection close
- Subscription map key collision when the same queue name is used with different topics
- Empty queue name passed to `QueueSubscribe` causing a NATS protocol error
- `Close()` unintentionally triggering a background reconnect via the `ClosedHandler`, leaving a live connection after intentional shutdown
- TOCTOU race in shutdown: a reconnect goroutine spawned just before `Close()` sets the shutdown flag could establish a new live connection after intentional shutdown