### PR TITLE
fix(cli): prevent crash when displaying incomplete test workflow exec…

### DIFF
--- a/cmd/kubectl-testkube/commands/testworkflows/renderer/testworkflowexecution_obj.go
+++ b/cmd/kubectl-testkube/commands/testworkflows/renderer/testworkflowexecution_obj.go
@@ -50,7 +50,15 @@ func TestWorkflowExecutionRenderer(client client.Client, ui *ui.UI, obj interfac
 
 func printPrettyOutput(ui *ui.UI, execution testkube.TestWorkflowExecution) {
 	ui.Info("Test Workflow Execution:")
-	ui.Warn("Name:                ", execution.Workflow.Name)
+
+	if execution.Workflow != nil {
+		ui.Warn("Name:                ", execution.Workflow.Name)
+	} else {
+		ui.NL()
+		ui.Err(errors.New("incomplete execution data received from API: missing Workflow field"))
+		ui.Warn("Hint: check your API endpoint configuration (HTTP vs HTTPS) and API server accessibility")
+	}
+
 	if execution.Id != "" {
 		ui.Warn("Execution ID:        ", execution.Id)
 		ui.Warn("Execution name:      ", execution.Name)

--- a/cmd/kubectl-testkube/commands/testworkflows/renderer/testworkflowexecution_obj.go
+++ b/cmd/kubectl-testkube/commands/testworkflows/renderer/testworkflowexecution_obj.go
@@ -56,7 +56,7 @@ func printPrettyOutput(ui *ui.UI, execution testkube.TestWorkflowExecution) {
 	} else {
 		ui.NL()
 		ui.Err(errors.New("incomplete execution data received from API: missing Workflow field"))
-		ui.Warn("Hint: check your API endpoint configuration (HTTP vs HTTPS) and API server accessibility")
+		ui.Hint("check your API endpoint configuration (HTTP vs HTTPS) and API server accessibility")
 	}
 
 	if execution.Id != "" {

--- a/cmd/kubectl-testkube/commands/testworkflows/renderer/testworkflowexecution_obj_test.go
+++ b/cmd/kubectl-testkube/commands/testworkflows/renderer/testworkflowexecution_obj_test.go
@@ -1,0 +1,84 @@
+package renderer
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/kubeshop/testkube/pkg/api/v1/testkube"
+	"github.com/kubeshop/testkube/pkg/ui"
+)
+
+func TestPrintPrettyOutput_NilWorkflow(t *testing.T) {
+	var buf bytes.Buffer
+	testUI := ui.NewUI(false, &buf)
+
+	execution := testkube.TestWorkflowExecution{
+		Id:        "test-id",
+		Name:      "test-name",
+		Namespace: "test-namespace",
+		Workflow:  nil,
+	}
+
+	require.NotPanics(t, func() {
+		printPrettyOutput(testUI, execution)
+	})
+
+	output := buf.String()
+	assert.Contains(t, output, "incomplete execution data received from API")
+	assert.Contains(t, output, "missing Workflow field")
+	assert.Contains(t, output, "Hint:")
+	assert.Contains(t, output, "test-id")
+	assert.Contains(t, output, "test-name")
+}
+
+func TestPrintPrettyOutput_NilWorkflowWithInitError(t *testing.T) {
+	var buf bytes.Buffer
+	testUI := ui.NewUI(false, &buf)
+
+	initErrorMsg := "connection refused: failed to connect to API server"
+	execution := testkube.TestWorkflowExecution{
+		Id:        "test-id",
+		Name:      "test-name",
+		Namespace: "test-namespace",
+		Workflow:  nil,
+		Result: &testkube.TestWorkflowResult{
+			Initialization: &testkube.TestWorkflowStepResult{
+				ErrorMessage: initErrorMsg,
+			},
+		},
+	}
+
+	require.NotPanics(t, func() {
+		printPrettyOutput(testUI, execution)
+	})
+
+	output := buf.String()
+	assert.Contains(t, output, "incomplete execution data received from API")
+	assert.Contains(t, output, initErrorMsg)
+}
+
+func TestPrintPrettyOutput_ValidWorkflow(t *testing.T) {
+	var buf bytes.Buffer
+	testUI := ui.NewUI(false, &buf)
+
+	execution := testkube.TestWorkflowExecution{
+		Id:        "test-id",
+		Name:      "test-name",
+		Namespace: "test-namespace",
+		Workflow: &testkube.TestWorkflow{
+			Name: "test-workflow",
+		},
+	}
+
+	require.NotPanics(t, func() {
+		printPrettyOutput(testUI, execution)
+	})
+
+	output := buf.String()
+	assert.Contains(t, output, "test-workflow")
+	assert.Contains(t, output, "Test Workflow Execution:")
+	assert.NotContains(t, output, "incomplete execution data")
+}

--- a/cmd/kubectl-testkube/commands/testworkflows/renderer/testworkflowexecution_obj_test.go
+++ b/cmd/kubectl-testkube/commands/testworkflows/renderer/testworkflowexecution_obj_test.go
@@ -29,7 +29,7 @@ func TestPrintPrettyOutput_NilWorkflow(t *testing.T) {
 	output := buf.String()
 	assert.Contains(t, output, "incomplete execution data received from API")
 	assert.Contains(t, output, "missing Workflow field")
-	assert.Contains(t, output, "Hint:")
+	assert.Contains(t, output, "check your API endpoint configuration")
 	assert.Contains(t, output, "test-id")
 	assert.Contains(t, output, "test-name")
 }


### PR DESCRIPTION
Finalizing of [zucchinidev](https://github.com/zucchinidev/testkube/tree/fix/cli-nil-workflow-panic) contribution pr

When API connectivity issues cause incomplete execution data to be received, the CLI would crash with an unhelpful nil pointer error, preventing users from diagnosing the underlying problem.

This change ensures graceful degradation by detecting missing workflow references and displaying a clear error message with actionable guidance about common causes such as API endpoint misconfiguration.

Users can now view available execution details even when workflow metadata is incomplete, significantly improving the troubleshooting experience.

Closes #6891

## Pull request description 



## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [x] tested locally
- [x] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [x] added a test

## Breaking changes

-

## Changes

-

## Fixes

-