### PR TITLE
fix(cli): correct dashboard telemetry events

### DIFF
--- a/cmd/kubectl-testkube/commands/dashboard.go
+++ b/cmd/kubectl-testkube/commands/dashboard.go
@@ -62,7 +62,7 @@ func openCloudDashboard(cfg config.Data) {
 	// open browser
 	uri := fmt.Sprintf("%s/organization/%s/environment/%s", cfg.CloudContext.UiUri, cfg.CloudContext.OrganizationId, cfg.CloudContext.EnvironmentId)
 	err := open.Run(uri)
-	ui.PrintOnError("openning dashboard", err)
+	ui.PrintOnError("opening dashboard", err)
 }
 
 func openOnPremDashboard(cmd *cobra.Command, cfg config.Data, verbose, skipBrowser bool, license string) {
@@ -93,7 +93,7 @@ func openOnPremDashboard(cmd *cobra.Command, cfg config.Data, verbose, skipBrows
 	ui.Debug("Port forwarding for minio", config.EnterpriseMinioName)
 	err = k8sclient.PortForward(ctx, cfg.Namespace, config.EnterpriseMinioName, config.EnterpriseMinioPort, config.EnterpriseMinioPortFrwardingPort, verbose)
 	if err != nil {
-		sendTelemetry(cmd, cfg, license, "port forwarding minio")
+		sendErrTelemetry(cmd, cfg, "port_forward", license, "port forwarding minio", err)
 	}
 	ui.ExitOnError("port forwarding minio", err)
 
@@ -106,7 +106,7 @@ func openOnPremDashboard(cmd *cobra.Command, cfg config.Data, verbose, skipBrows
 
 		ui.ExitOnError("opening dashboard in browser", err)
 
-		sendTelemetry(cmd, cfg, license, "dashbboard opened successfully")
+		sendTelemetry(cmd, cfg, license, "dashboard opened successfully")
 	}
 
 	c := make(chan os.Signal, 1)


### PR DESCRIPTION
## Pull request description

Tiny CLI dashboard cleanup. MinIO port-forward errors were going through success telemetry, so that signal was kinda off. also fixed two typo strings while in the same spot.

Repro:
`rg -n 'sendTelemetry\\(cmd, cfg, license, "port forwarding minio"\\)|dashbboard|openning' cmd/kubectl-testkube/commands/dashboard.go`

Before this PR it matched 3 lines. After the fix, no matches.

## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [x] tested locally
- [ ] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Breaking changes

- none

## Changes

- send MinIO port-forward failures through error telemetry, same as API/UI/Dex
- fix `openning` and `dashbboard` dashboard strings

## Fixes

- no linked issue found

Checks:
- `go test ./cmd/kubectl-testkube/commands`
- `go build ./...`
- `git diff --check`
- `make lint` currently hits pre-existing `SA1019` in `pkg/controller/testworkflowexecutionexecutor.go`, not touched here
