### PR TITLE
fix: correct 'occured' typo in mock validator error details

### DIFF
--- a/pkg/diagnostics/validators/mock/invalid_multi.go
+++ b/pkg/diagnostics/validators/mock/invalid_multi.go
@@ -9,7 +9,7 @@ type AlwaysInvalidMultiValidator struct {
 func (val AlwaysInvalidMultiValidator) Validate(subject any) v.ValidationResult {
 	return v.NewResult().
 		WithValidator("Always invalid " + val.Name).
-		WithError(v.Err("err1", v.ErrorKindCustom).WithDetails("some error occured")).
-		WithError(v.Err("err2", v.ErrorKindCustom).WithDetails("some error occured")).
+		WithError(v.Err("err1", v.ErrorKindCustom).WithDetails("some error occurred")).
+		WithError(v.Err("err2", v.ErrorKindCustom).WithDetails("some error occurred")).
 		WithError(v.Err("err3", v.ErrorKindCustom).WithDocsURI("https://docs.testkube.io/"))
 }


### PR DESCRIPTION
Fixes two instances of 'occured' to 'occurred' in mock validator error details under pkg/diagnostics/validators/mock/invalid_multi.go.