### PR TITLE
fix: correct 'succesfully' typos in CLI output strings

### DIFF
--- a/cmd/kubectl-testkube/cloudlogin/login.go
+++ b/cmd/kubectl-testkube/cloudlogin/login.go
@@ -71,7 +71,7 @@ func CloudLogin(ctx context.Context, providerURL, connectorID string, port int) 
 		if code != "" {
 			ch <- code
 			fmt.Fprintln(w, "<script>window.close()</script>")
-			fmt.Fprintln(w, "Your testkube CLI is now succesfully authenticated. Go back to the terminal to continue.")
+			fmt.Fprintln(w, "Your testkube CLI is now successfully authenticated. Go back to the terminal to continue.")
 		} else {
 			fmt.Fprintln(w, "Authorization failed.")
 		}

--- a/cmd/kubectl-testkube/commands/testworkflows/abort.go
+++ b/cmd/kubectl-testkube/commands/testworkflows/abort.go
@@ -30,7 +30,7 @@ func NewAbortTestWorkflowExecutionCmd() *cobra.Command {
 			err = client.AbortTestWorkflowExecution(execution.Workflow.Name, execution.Id, false)
 			ui.ExitOnError(fmt.Sprintf("aborting testworkflow execution %s", executionID), err)
 
-			ui.SuccessAndExit("Succesfully aborted test workflow execution", executionID)
+			ui.SuccessAndExit("Successfully aborted test workflow execution", executionID)
 		},
 	}
 }

--- a/cmd/kubectl-testkube/commands/testworkflows/cancel.go
+++ b/cmd/kubectl-testkube/commands/testworkflows/cancel.go
@@ -32,7 +32,7 @@ func NewCancelTestWorkflowExecutionCmd() *cobra.Command {
 			err = client.AbortTestWorkflowExecution(execution.Workflow.Name, execution.Id, force)
 			ui.ExitOnError(fmt.Sprintf("canceling testworkflow execution %s", executionID), err)
 
-			ui.SuccessAndExit("Succesfully canceled test workflow execution", executionID)
+			ui.SuccessAndExit("Successfully canceled test workflow execution", executionID)
 		},
 	}
 

--- a/cmd/kubectl-testkube/commands/webhooks/delete.go
+++ b/cmd/kubectl-testkube/commands/webhooks/delete.go
@@ -34,7 +34,7 @@ func NewDeleteWebhookCmd() *cobra.Command {
 					ui.SuccessAndExit("Operation completed")
 				}
 				ui.ExitOnError("deleting webhook: "+name, err)
-				ui.SuccessAndExit("Succesfully deleted webhook", name)
+				ui.SuccessAndExit("Successfully deleted webhook", name)
 			}
 
 			if len(selectors) != 0 {
@@ -45,7 +45,7 @@ func NewDeleteWebhookCmd() *cobra.Command {
 					ui.SuccessAndExit("Operation completed")
 				}
 				ui.ExitOnError("deleting webhooks by labels: "+selector, err)
-				ui.SuccessAndExit("Succesfully deleted webhooks by labels", selector)
+				ui.SuccessAndExit("Successfully deleted webhooks by labels", selector)
 			}
 
 			ui.Failf("Pass Webhook name or labels to delete by labels")

--- a/cmd/kubectl-testkube/commands/webhooktemplates/delete.go
+++ b/cmd/kubectl-testkube/commands/webhooktemplates/delete.go
@@ -34,7 +34,7 @@ func NewDeleteWebhookTemplateCmd() *cobra.Command {
 					ui.SuccessAndExit("Operation completed")
 				}
 				ui.ExitOnError("deleting webhook template: "+name, err)
-				ui.SuccessAndExit("Succesfully deleted webhook template", name)
+				ui.SuccessAndExit("Successfully deleted webhook template", name)
 			}
 
 			if len(selectors) != 0 {
@@ -45,7 +45,7 @@ func NewDeleteWebhookTemplateCmd() *cobra.Command {
 					ui.SuccessAndExit("Operation completed")
 				}
 				ui.ExitOnError("deleting webhook templates by labels: "+selector, err)
-				ui.SuccessAndExit("Succesfully deleted webhook templates by labels", selector)
+				ui.SuccessAndExit("Successfully deleted webhook templates by labels", selector)
 			}
 
 			ui.Failf("Pass Webhook Template name or labels to delete by labels")


### PR DESCRIPTION
Fixes 'Succesfully'/'succesfully' to 'Successfully'/'successfully' across five CLI commands (webhooks/webhooktemplates delete, testworkflows abort/cancel, cloudlogin).