### PR TITLE
fix: [TKC-5587] wait for runner before workflow log follow

### DIFF
--- a/cmd/kubectl-testkube/commands/testworkflows/run.go
+++ b/cmd/kubectl-testkube/commands/testworkflows/run.go
@@ -628,6 +628,13 @@ type Options struct {
 	Prefix string
 }
 
+func isExecutionReadyForLogFollow(execution testkube.TestWorkflowExecution) bool {
+	if execution.Result != nil && execution.Result.IsFinished() {
+		return true
+	}
+	return execution.RunnerId != ""
+}
+
 // uiWatch waits for execution assignment, streams logs, and returns exit code
 func uiWatch(
 	execution testkube.TestWorkflowExecution,
@@ -648,7 +655,7 @@ func uiWatch(
 	// Wait until the execution will be assigned to some runner
 	iteration := 0
 	executionId := execution.Id // Store ID before potential error
-	for !execution.Assigned() {
+	for !isExecutionReadyForLogFollow(execution) {
 		var err error
 		iteration++
 		time.Sleep(getIterationDelay(iteration))
@@ -659,7 +666,7 @@ func uiWatch(
 	}
 
 	// Print final logs in case execution is already finished
-	if execution.Result.IsFinished() {
+	if execution.Result != nil && execution.Result.IsFinished() {
 		ui.Info("Getting logs for test workflow execution", execution.Id)
 
 		logs, err := client.GetTestWorkflowExecutionLogs(execution.Id)

--- a/cmd/kubectl-testkube/commands/testworkflows/run_test.go
+++ b/cmd/kubectl-testkube/commands/testworkflows/run_test.go
@@ -82,6 +82,56 @@ func TestGetIterationDelay(t *testing.T) {
 		})
 	}
 }
+
+func TestIsExecutionReadyForLogFollowWaitsForRunnerID(t *testing.T) {
+	runningResult := newWorkflowResult(testkube.RUNNING_TestWorkflowStatus, false)
+	finishedResult := newWorkflowResult(testkube.PASSED_TestWorkflowStatus, true)
+
+	tests := []struct {
+		name      string
+		execution testkube.TestWorkflowExecution
+		expected  bool
+	}{
+		{
+			name: "not ready when signature exists without runner assignment",
+			execution: testkube.TestWorkflowExecution{
+				Result: runningResult,
+				Signature: []testkube.TestWorkflowSignature{
+					{Ref: "step-1"},
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "ready when runner assigned",
+			execution: testkube.TestWorkflowExecution{
+				Result: runningResult,
+				Signature: []testkube.TestWorkflowSignature{
+					{Ref: "step-1"},
+				},
+				RunnerId: "runner-1",
+			},
+			expected: true,
+		},
+		{
+			name: "ready when already finished",
+			execution: testkube.TestWorkflowExecution{
+				Result: finishedResult,
+				Signature: []testkube.TestWorkflowSignature{
+					{Ref: "step-1"},
+				},
+			},
+			expected: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, isExecutionReadyForLogFollow(tt.execution))
+		})
+	}
+}
+
 func TestParseConfig(t *testing.T) {
 	tests := []struct {
 		name     string


### PR DESCRIPTION
## Summary

following logs can get stuck when execution is still queued, and the CLI immediately opened the notification stream, before runner assignment. 

- wait for a concrete `RunnerId` before opening workflow log follow streams
- keep the already-finished execution path so final logs still print without a runner wait
- add regression coverage for the case where `Signature` exists before runner assignment