### PR TITLE
fix: [TKC-5587] clear lint failures

### DIFF
--- a/pkg/controller/testworkflowexecutionexecutor.go
+++ b/pkg/controller/testworkflowexecutionexecutor.go
@@ -106,7 +106,7 @@ func testWorkflowExecutionExecutor(client client.Client, recorder events.EventRe
 			if updateErr := client.Status().Update(ctx, &statusTWE); updateErr != nil {
 				return ctrl.Result{}, fmt.Errorf("updating error status for execution %q: %w (original error: %w)", twe.Name, updateErr, execErr)
 			}
-			recorder.Eventf(&statusTWE, nil, corev1.EventTypeWarning, "ExecutionNotScheduled", "ScheduleExecution", err.Error())
+			recorder.Eventf(&statusTWE, nil, corev1.EventTypeWarning, "ExecutionNotScheduled", "ScheduleExecution", "%s", err.Error())
 			return ctrl.Result{}, nil
 		}
 

--- a/pkg/controller/testworkflowexecutionexecutor_test.go
+++ b/pkg/controller/testworkflowexecutionexecutor_test.go
@@ -11,7 +11,6 @@ import (
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -36,6 +35,18 @@ var scheduleCmpOpts = []cmp.Option{
 type fakeTestWorkflowExecutor struct {
 	req *cloud.ScheduleRequest
 	err error
+}
+
+type fakeEventRecorder struct {
+	Events chan string
+}
+
+func newFakeEventRecorder(buffer int) *fakeEventRecorder {
+	return &fakeEventRecorder{Events: make(chan string, buffer)}
+}
+
+func (r *fakeEventRecorder) Eventf(_ runtime.Object, _ runtime.Object, eventtype, reason, _ string, note string, args ...any) {
+	r.Events <- fmt.Sprintf("%s %s %s", eventtype, reason, fmt.Sprintf(note, args...))
 }
 
 func (f *fakeTestWorkflowExecutor) Execute(_ context.Context, request *cloud.ScheduleRequest) ([]testkubev1.TestWorkflowExecution, error) {
@@ -274,7 +285,7 @@ func TestWorkflowExecutionExecutorController(t *testing.T) {
 				t.Fatalf("failed to add testworkflowsv1 to scheme: %v", err)
 			}
 			k8sClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(test.objs...).WithStatusSubresource(&testworkflowsv1.TestWorkflowExecution{}).Build()
-			recorder := record.NewFakeRecorder(10)
+			recorder := newFakeEventRecorder(10)
 			reconciler := testWorkflowExecutionExecutor(k8sClient, recorder, exec)
 
 			_, err := reconciler.Reconcile(context.Background(), test.request)


### PR DESCRIPTION
## Summary
- replace deprecated controller-runtime `GetEventRecorderFor` usage with the new events recorder API
- update the controller unit test to use a small fake for the new recorder interface
- avoid CI govet inline failures by replacing `x/exp/slices` helpers and deprecated `reflect.Ptr` aliases

