### PR TITLE
fix: preserve HTTP/2 for workflow log SSE

### DIFF
--- a/pkg/http/client.go
+++ b/pkg/http/client.go
@@ -38,7 +38,6 @@ func NewClient(insecure ...bool) *http.Client {
 // NewSSEClient is HTTP client with long timeout to be able to read SSE endpoints
 func NewSSEClient(insecure ...bool) *http.Client {
 	netTransport := http.DefaultTransport.(*http.Transport).Clone()
-	netTransport.ForceAttemptHTTP2 = false
 	if len(insecure) == 1 && insecure[0] {
 		netTransport.TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
 	}

--- a/pkg/http/client_test.go
+++ b/pkg/http/client_test.go
@@ -26,6 +26,6 @@ func TestNewClient(t *testing.T) {
 
 		// then
 		assert.Equal(t, time.Hour, c.Timeout)
-		assert.False(t, transport.ForceAttemptHTTP2)
+		assert.True(t, transport.ForceAttemptHTTP2)
 	})
 }


### PR DESCRIPTION
## Summary
- preserve the default Go transport HTTP/2 behavior for the CLI SSE client
- update the SSE client unit test so it asserts HTTP/2 remains enabled

## Issue
`NewSSEClient` cloned `http.DefaultTransport` and then set `ForceAttemptHTTP2 = false`. That forced the workflow log-follow SSE request onto an HTTP/1.x transport even when the cloud endpoint/proxy path served HTTP/2 frames. In that state the Go client failed before parsing the SSE stream with a malformed HTTP response that started with HTTP/2 frame bytes (`\x00\x00\x12\x04...`).

The log watcher does not surface that stream setup failure to the user-facing command; it keeps polling execution status and shows `Waiting for workflow logs (...)` until the workflow finishes. The workflow itself is assigned and running, pod logs exist, and the cloud SSE endpoint streams live events. The stuck spinner is caused by the CLI SSE transport configuration.