### PR TITLE
fix: preserve HTTP/2 for workflow log SSE

### DIFF
--- a/pkg/http/client.go
+++ b/pkg/http/client.go
@@ -38,7 +38,6 @@ func NewClient(insecure ...bool) *http.Client {
 // NewSSEClient is HTTP client with long timeout to be able to read SSE endpoints
 func NewSSEClient(insecure ...bool) *http.Client {
 	netTransport := http.DefaultTransport.(*http.Transport).Clone()
-	netTransport.ForceAttemptHTTP2 = false
 	if len(insecure) == 1 && insecure[0] {
 		netTransport.TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
 	}

--- a/pkg/http/client_test.go
+++ b/pkg/http/client_test.go
@@ -26,6 +26,6 @@ func TestNewClient(t *testing.T) {
 
 		// then
 		assert.Equal(t, time.Hour, c.Timeout)
-		assert.False(t, transport.ForceAttemptHTTP2)
+		assert.True(t, transport.ForceAttemptHTTP2)
 	})
 }


### PR DESCRIPTION
## Summary
- backport #7684 to `release/2-9`
- preserve the default Go transport HTTP/2 behavior for the CLI SSE client
- update the SSE client unit test so it asserts HTTP/2 remains enabled

## Issue
`NewSSEClient` cloned `http.DefaultTransport` and then set `ForceAttemptHTTP2 = false`. That forced the workflow log-follow SSE request onto an HTTP/1.x transport even when the cloud endpoint/proxy path served HTTP/2 frames. In that state the Go client failed before parsing the SSE stream with a malformed HTTP response that started with HTTP/2 frame bytes (`\x00\x00\x12\x04...`).

The log watcher keeps polling execution status, so the CLI looked stuck on `Waiting for workflow logs (...)` until the workflow finished. The workflow itself was assigned and running, pod logs existed, and the cloud SSE endpoint streamed live events. The stuck spinner was caused by the CLI SSE transport configuration.

## Validation
- `go test ./pkg/http`
- `rm -f bin/app/testkube && make build-testkube-cli`
- `go build ./...`

## Note
- `make lint` currently fails on `release/2-9` because of an unrelated pre-existing staticcheck issue in `pkg/controller/testworkflowexecutionexecutor.go`: `SA1019: mgr.GetEventRecorderFor is deprecated`.