### PR TITLE
feat: align te values and resources with testkube - add unit tests

### DIFF
--- a/k8s/helm/testkube-runner/templates/_helpers.tpl
+++ b/k8s/helm/testkube-runner/templates/_helpers.tpl
@@ -24,6 +24,22 @@ app.kubernetes.io/name: {{ include "testkube-runner.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
 
+{{/*
+Common labels
+*/}}
+{{- define "testkube-runner.labels" -}}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{ include "global.labels.standard" . }}
+{{ include "testkube-runner.selectorLabels" . }}
+{{- end }}
+
+{{/*
+Monitoring labels
+*/}}
+{{- define "testkube-runner.monitoring" -}}
+app: prometheus
+{{- end }}
+
 {{- define "testkube-runner.agent.image" -}}
 {{- $registryName := .Values.images.agent.registry -}}
 {{- $repositoryName := .Values.images.agent.repository -}}

--- a/k8s/helm/testkube-runner/templates/service.yaml
+++ b/k8s/helm/testkube-runner/templates/service.yaml
@@ -1,0 +1,30 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "testkube-runner.fullname" . }}
+  labels:
+    {{- include "testkube-runner.labels" . | nindent 4 }}
+    {{- with .Values.service.labels }}
+    {{- include "global.tplvalues.render" (dict "value" . "context" $) | nindent 4 }}
+    {{- end }}
+    {{- with .Values.global.labels }}
+    {{- include "global.tplvalues.render" (dict "value" . "context" $) | nindent 4 }}
+    {{- end }}
+  {{- if or .Values.service.annotations .Values.global.annotations }}
+  annotations:
+    {{- with .Values.service.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+    {{- with .Values.global.annotations }}
+    {{- include "global.tplvalues.render" (dict "value" . "context" $) | nindent 4 }}
+    {{- end }}
+  {{- end }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - name: http
+      port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+  selector:
+    {{- include "testkube-runner.selectorLabels" . | nindent 4 }}

--- a/k8s/helm/testkube-runner/templates/servicemonitor.yaml
+++ b/k8s/helm/testkube-runner/templates/servicemonitor.yaml
@@ -1,0 +1,29 @@
+{{- if .Values.prometheus.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "testkube-runner.fullname" . }}-servicemonitor
+  labels:
+    {{- include "testkube-runner.monitoring" . | nindent 4 }}
+    {{- with .Values.prometheus.monitoringLabels }}
+    {{- include "global.tplvalues.render" (dict "value" . "context" $) | nindent 4 }}
+    {{- end }}
+    {{- with .Values.global.labels }}
+    {{- include "global.tplvalues.render" (dict "value" . "context" $) | nindent 4 }}
+    {{- end }}
+spec:
+  {{- with .Values.prometheus.sampleLimit }}
+  sampleLimit: {{ . }}
+  {{- end }}
+  endpoints:
+    - targetPort: {{ .Values.service.port }}
+      {{- with .Values.prometheus.interval }}
+      interval: {{ . }}
+      {{- end }}
+  selector:
+    matchLabels:
+      {{- include "testkube-runner.selectorLabels" . | nindent 6 }}
+      {{- with .Values.prometheus.matchLabels }}
+      {{- include "global.tplvalues.render" (dict "value" . "context" $) | nindent 6 }}
+      {{- end }}
+{{- end }}

--- a/k8s/helm/testkube-runner/templates/servicemonitor.yaml
+++ b/k8s/helm/testkube-runner/templates/servicemonitor.yaml
@@ -16,7 +16,7 @@ spec:
   sampleLimit: {{ . }}
   {{- end }}
   endpoints:
-    - targetPort: {{ .Values.service.port }}
+    - port: http
       {{- with .Values.prometheus.interval }}
       interval: {{ . }}
       {{- end }}

--- a/k8s/helm/testkube-runner/templates/servicemonitor.yaml
+++ b/k8s/helm/testkube-runner/templates/servicemonitor.yaml
@@ -16,7 +16,7 @@ spec:
   sampleLimit: {{ . }}
   {{- end }}
   endpoints:
-    - port: http
+    - targetPort: 8088
       {{- with .Values.prometheus.interval }}
       interval: {{ . }}
       {{- end }}

--- a/k8s/helm/testkube-runner/tests/README.md
+++ b/k8s/helm/testkube-runner/tests/README.md
@@ -1,0 +1,61 @@
+# testkube-runner Helm unit tests
+
+Suites for [`helm-unittest`](https://github.com/helm-unittest/helm-unittest) covering every template in the chart.
+
+## Run
+
+```bash
+helm plugin install https://github.com/helm-unittest/helm-unittest.git  # once
+helm unittest k8s/helm/testkube-runner
+```
+
+Expected: `Test Suites: 8 passed, 8 total` / `Tests: 75 passed`.
+
+## Suites
+
+| Suite file | Template | Tests | Coverage |
+|---|---|---|---|
+| `service_test.yaml` | `service.yaml` | 11 | port 8088, ClusterIP, selector, labels/annotations propagation |
+| `servicemonitor_test.yaml` | `servicemonitor.yaml` | 13 | gating by `prometheus.enabled`, targetPort sync with Service, interval/monitoringLabels/matchLabels/sampleLimit |
+| `serviceaccount_test.yaml` | `serviceaccount.yaml` | 8 | auto-create branches (`pod.serviceAccount.autoCreate`, `execution.default.serviceAccount.autoCreate`), name/namespace overrides, annotations |
+| `poddisruptionbudget_test.yaml` | `poddisruptionbudget.yaml` | 7 | local vs `global.podDisruptionBudget` fallback, `minAvailable`/`maxUnavailable`, selector, K8s ≥1.21 apiVersion |
+| `role_test.yaml` | `role.yaml` | 10 | the 4 base Roles + watchers ClusterRole/Role per `watchAllNamespaces`; gating via `listener.enabled` / `gitops.enabled` |
+| `rolebinding_test.yaml` | `rolebinding.yaml` | 10 | RoleBinding subjects + roleRef wiring (`agent-sa` → exec-role for jobs, `exec-sa` → exec-role), namespace propagation, watchers ClusterRoleBinding |
+| `deployment_test.yaml` | `deployment.yaml` | 15 | port 8088, ServiceAccount, runner credentials (inline & via secretRef), TLS, listener/gitops toggles, registration token, image references |
+| `crds_test.yaml` | `crds.yaml` | 1 | CRDs are rendered when `gitops.enabled && gitops.installCRD` |
+
+CI does not run these yet — they are local-dev guardrails. Wiring into a workflow is a separate follow-up.
+
+## Conventions
+
+- Assertion style: explicit `equal` / `contains` / `matchRegex` / `hasDocuments` / `lengthEqual`. No snapshot tests.
+- For multi-document templates (`role.yaml`, `rolebinding.yaml`, `serviceaccount.yaml`), use `documentSelector` on `metadata.name` to target individual resources — document ordering between helm and helm-unittest can disagree.
+- Use `templates/<file>.yaml` (full path) when a template `include`s subchart helpers, e.g. `crds.yaml`. The short form (`<file>.yaml`) works for templates with no subchart includes.
+
+## Adding a test
+
+```yaml
+suite: <description>
+templates:
+  - <template>.yaml          # or templates/<template>.yaml if it includes from a subchart
+release:
+  name: tk
+  namespace: testkube-dev
+tests:
+  - it: <what this verifies>
+    set:                     # optional overrides
+      some.value: foo
+    documentSelector:        # optional, for multi-doc templates
+      path: metadata.name
+      value: my-resource
+    asserts:
+      - equal:
+          path: spec.foo
+          value: bar
+```
+
+Run a single suite during iteration:
+
+```bash
+helm unittest k8s/helm/testkube-runner -f tests/<suite>.yaml
+```

--- a/k8s/helm/testkube-runner/tests/crds_test.yaml
+++ b/k8s/helm/testkube-runner/tests/crds_test.yaml
@@ -1,0 +1,14 @@
+suite: testkube-runner crds
+templates:
+  - templates/crds.yaml
+release:
+  name: tk
+tests:
+  - it: renders CRDs when gitops.enabled=true and gitops.installCRD=true
+    set:
+      gitops.enabled: true
+      gitops.installCRD: true
+    asserts:
+      - containsDocument:
+          kind: CustomResourceDefinition
+          apiVersion: apiextensions.k8s.io/v1

--- a/k8s/helm/testkube-runner/tests/deployment_test.yaml
+++ b/k8s/helm/testkube-runner/tests/deployment_test.yaml
@@ -1,0 +1,185 @@
+suite: testkube-runner deployment
+templates:
+  - deployment.yaml
+release:
+  name: tk
+  namespace: testkube-dev
+tests:
+  - it: renders exactly one Deployment with the expected name
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Deployment
+      - equal:
+          path: metadata.name
+          value: tk-testkube-runner
+
+  - it: has 1 replica and the expected selector labels
+    asserts:
+      - equal:
+          path: spec.replicas
+          value: 1
+      - equal:
+          path: spec.selector.matchLabels["app.kubernetes.io/name"]
+          value: testkube-runner
+      - equal:
+          path: spec.selector.matchLabels["app.kubernetes.io/instance"]
+          value: tk
+
+  - it: exposes container port 8088 named http
+    asserts:
+      - lengthEqual:
+          path: spec.template.spec.containers
+          count: 1
+      - equal:
+          path: spec.template.spec.containers[0].ports[0].name
+          value: http
+      - equal:
+          path: spec.template.spec.containers[0].ports[0].containerPort
+          value: 8088
+
+  - it: sets APISERVER_PORT to 8088 and APISERVER_FULLNAME to the runner fullname
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: APISERVER_PORT
+            value: "8088"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: APISERVER_FULLNAME
+            value: tk-testkube-runner
+
+  - it: uses kubeshop testkube-api-server image
+    asserts:
+      - matchRegex:
+          path: spec.template.spec.containers[0].image
+          pattern: "kubeshop/testkube-api-server"
+
+  - it: injects toolkit and init image env vars
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: TESTKUBE_TW_TOOLKIT_IMAGE
+          any: true
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: TESTKUBE_TW_INIT_IMAGE
+          any: true
+
+  - it: passes runner credentials as direct env vars when set inline
+    set:
+      runner.id: agent-123
+      runner.orgId: org-456
+      runner.envId: env-789
+      runner.secret: shhh
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: TESTKUBE_PRO_AGENT_ID
+            value: agent-123
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: TESTKUBE_PRO_ORG_ID
+            value: org-456
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: TESTKUBE_PRO_ENV_ID
+            value: env-789
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: TESTKUBE_PRO_API_KEY
+            value: shhh
+
+  - it: reads runner credentials from secretRef when provided
+    set:
+      runner.secretRef.name: my-runner-secret
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: TESTKUBE_PRO_AGENT_ID
+            valueFrom:
+              secretKeyRef:
+                name: my-runner-secret
+                key: id
+
+  - it: sets TLS insecure flag when cloud.tls.enabled=false
+    set:
+      cloud.tls.enabled: false
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: TESTKUBE_PRO_TLS_INSECURE
+            value: "true"
+
+  - it: disables test triggers when listener.enabled is false (default)
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: DISABLE_TEST_TRIGGERS
+            value: "true"
+
+  - it: enables test triggers when listener.enabled=true
+    set:
+      listener.enabled: true
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: DISABLE_TEST_TRIGGERS
+            value: "false"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: TEST_TRIGGER_CONTROL_PLANE
+            value: "true"
+
+  - it: enables gitops kubernetes→cloud sync when gitops.enabled=true
+    set:
+      gitops.enabled: true
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: GITOPS_KUBERNETES_TO_CLOUD_ENABLED
+            value: "true"
+
+  - it: passes self-registration token and runner name when register.token is set
+    set:
+      runner.register.token: tok-abc123
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: TESTKUBE_PRO_AGENT_REGISTRATION_TOKEN
+            value: tok-abc123
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: RUNNER_NAME
+            value: tk-testkube-runner
+
+  - it: uses agent-sa-<release> ServiceAccount by default
+    asserts:
+      - equal:
+          path: spec.template.spec.serviceAccountName
+          value: agent-sa-tk
+
+  - it: honors pod.serviceAccount.name when set
+    set:
+      pod.serviceAccount.name: my-sa
+    asserts:
+      - equal:
+          path: spec.template.spec.serviceAccountName
+          value: my-sa

--- a/k8s/helm/testkube-runner/tests/poddisruptionbudget_test.yaml
+++ b/k8s/helm/testkube-runner/tests/poddisruptionbudget_test.yaml
@@ -1,0 +1,83 @@
+suite: testkube-runner poddisruptionbudget
+templates:
+  - poddisruptionbudget.yaml
+release:
+  name: tk
+tests:
+  - it: renders a PDB when podDisruptionBudget.enabled=true
+    set:
+      podDisruptionBudget.enabled: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: PodDisruptionBudget
+      - equal:
+          path: metadata.name
+          value: tk-testkube-runner
+
+  - it: defaults to maxUnavailable=1 when neither min nor max specified
+    set:
+      podDisruptionBudget.enabled: true
+    asserts:
+      - equal:
+          path: spec.maxUnavailable
+          value: 1
+      - notExists:
+          path: spec.minAvailable
+
+  - it: honors podDisruptionBudget.minAvailable and omits maxUnavailable
+    set:
+      podDisruptionBudget.enabled: true
+      podDisruptionBudget.minAvailable: 2
+    asserts:
+      - equal:
+          path: spec.minAvailable
+          value: 2
+      - notExists:
+          path: spec.maxUnavailable
+
+  - it: honors podDisruptionBudget.maxUnavailable as a percentage
+    set:
+      podDisruptionBudget.enabled: true
+      podDisruptionBudget.maxUnavailable: 50%
+    asserts:
+      - equal:
+          path: spec.maxUnavailable
+          value: 50%
+
+  - it: falls back to global.podDisruptionBudget when local is disabled
+    set:
+      podDisruptionBudget.enabled: false
+      global.podDisruptionBudget.enabled: true
+      global.podDisruptionBudget.minAvailable: 3
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: PodDisruptionBudget
+      - equal:
+          path: spec.minAvailable
+          value: 3
+
+  - it: selector matches the runner selectorLabels
+    set:
+      podDisruptionBudget.enabled: true
+    asserts:
+      - equal:
+          path: spec.selector.matchLabels["app.kubernetes.io/name"]
+          value: testkube-runner
+      - equal:
+          path: spec.selector.matchLabels["app.kubernetes.io/instance"]
+          value: tk
+
+  - it: picks policy/v1 on Kubernetes 1.21+
+    set:
+      podDisruptionBudget.enabled: true
+    capabilities:
+      majorVersion: 1
+      minorVersion: 24
+    asserts:
+      - equal:
+          path: apiVersion
+          value: policy/v1

--- a/k8s/helm/testkube-runner/tests/role_test.yaml
+++ b/k8s/helm/testkube-runner/tests/role_test.yaml
@@ -1,0 +1,133 @@
+suite: testkube-runner roles
+templates:
+  - role.yaml
+release:
+  name: tk
+  namespace: testkube-dev
+tests:
+  - it: renders agent-role, agent-lease-access and exec-role by default
+    asserts:
+      - hasDocuments:
+          count: 3
+      - equal:
+          path: metadata.name
+          value: agent-role-tk
+        documentIndex: 0
+      - equal:
+          path: metadata.name
+          value: agent-lease-access-tk
+        documentIndex: 1
+      - equal:
+          path: metadata.name
+          value: exec-role-tk
+        documentIndex: 2
+
+  - it: agent-role grants the expected verbs on secrets and configmaps
+    documentSelector:
+      path: metadata.name
+      value: agent-role-tk
+    asserts:
+      - contains:
+          path: rules
+          content:
+            apiGroups: [""]
+            resources:
+              - secrets
+              - configmaps
+            verbs:
+              - get
+              - create
+              - patch
+              - update
+              - delete
+
+  - it: agent-lease-access targets coordination.k8s.io/leases
+    documentSelector:
+      path: metadata.name
+      value: agent-lease-access-tk
+    asserts:
+      - equal:
+          path: rules[0].apiGroups[0]
+          value: coordination.k8s.io
+      - equal:
+          path: rules[0].resources[0]
+          value: leases
+      - contains:
+          path: rules[0].verbs
+          content: get
+      - contains:
+          path: rules[0].verbs
+          content: create
+      - contains:
+          path: rules[0].verbs
+          content: update
+
+  - it: exec-role default namespace equals release namespace
+    documentSelector:
+      path: metadata.name
+      value: exec-role-tk
+    asserts:
+      - equal:
+          path: metadata.namespace
+          value: testkube-dev
+
+  - it: exec-role honors execution.default.namespace override
+    set:
+      execution.default.namespace: jobs-ns
+    documentSelector:
+      path: metadata.name
+      value: exec-role-tk
+    asserts:
+      - equal:
+          path: metadata.namespace
+          value: jobs-ns
+
+  - it: omits agent roles when pod.serviceAccount.autoCreate=false
+    set:
+      pod.serviceAccount.autoCreate: false
+      execution.default.serviceAccount.autoCreate: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: creates watchers ClusterRole when listener.enabled + watchAllNamespaces
+    set:
+      listener.enabled: true
+      listener.watchAllNamespaces: true
+    documentSelector:
+      path: metadata.name
+      value: watchers-role-tk
+    asserts:
+      - equal:
+          path: kind
+          value: ClusterRole
+
+  - it: creates watchers Role per namespace when watchAllNamespaces=false
+    set:
+      listener.enabled: true
+      listener.watchAllNamespaces: false
+    documentSelector:
+      path: metadata.name
+      value: watchers-role-tk
+    asserts:
+      - equal:
+          path: kind
+          value: Role
+
+  - it: also creates watchers when gitops.enabled even if listener disabled
+    set:
+      listener.enabled: false
+      gitops.enabled: true
+      listener.watchAllNamespaces: true
+    documentSelector:
+      path: metadata.name
+      value: watchers-role-tk
+    asserts:
+      - equal:
+          path: kind
+          value: ClusterRole
+
+  - it: no watchers role when listener and gitops both disabled
+    asserts:
+      - hasDocuments:
+          count: 3

--- a/k8s/helm/testkube-runner/tests/rolebinding_test.yaml
+++ b/k8s/helm/testkube-runner/tests/rolebinding_test.yaml
@@ -1,0 +1,131 @@
+suite: testkube-runner rolebindings
+templates:
+  - rolebinding.yaml
+release:
+  name: tk
+  namespace: testkube-dev
+tests:
+  - it: renders the 4 base RoleBindings by default
+    asserts:
+      - hasDocuments:
+          count: 4
+
+  - it: agent-rb binds agent-sa to agent-role
+    documentSelector:
+      path: metadata.name
+      value: agent-rb-tk
+    asserts:
+      - equal:
+          path: roleRef.kind
+          value: Role
+      - equal:
+          path: roleRef.name
+          value: agent-role-tk
+      - equal:
+          path: subjects[0].kind
+          value: ServiceAccount
+      - equal:
+          path: subjects[0].name
+          value: agent-sa-tk
+      - equal:
+          path: subjects[0].namespace
+          value: testkube-dev
+
+  - it: agent-lease-access-rb binds agent-sa to agent-lease-access role
+    documentSelector:
+      path: metadata.name
+      value: agent-lease-access-rb-tk
+    asserts:
+      - equal:
+          path: roleRef.name
+          value: agent-lease-access-tk
+      - equal:
+          path: subjects[0].name
+          value: agent-sa-tk
+
+  - it: aexec-rb (agent → exec) binds agent-sa to exec-role
+    documentSelector:
+      path: metadata.name
+      value: aexec-rb-tk
+    asserts:
+      - equal:
+          path: roleRef.name
+          value: exec-role-tk
+      - equal:
+          path: subjects[0].name
+          value: agent-sa-tk
+
+  - it: exec-rb binds exec-sa to exec-role
+    documentSelector:
+      path: metadata.name
+      value: exec-rb-tk
+    asserts:
+      - equal:
+          path: roleRef.name
+          value: exec-role-tk
+      - equal:
+          path: subjects[0].name
+          value: exec-sa-tk
+
+  - it: honors pod.serviceAccount.name override in subjects
+    set:
+      pod.serviceAccount.name: custom-agent
+    documentSelector:
+      path: metadata.name
+      value: agent-rb-tk
+    asserts:
+      - equal:
+          path: subjects[0].name
+          value: custom-agent
+
+  - it: places aexec-rb in execution.default.namespace when set
+    set:
+      execution.default.namespace: jobs-ns
+    documentSelector:
+      path: metadata.name
+      value: aexec-rb-tk
+    asserts:
+      - equal:
+          path: metadata.namespace
+          value: jobs-ns
+
+  - it: creates ClusterRoleBinding for watchers when watchAllNamespaces=true
+    set:
+      listener.enabled: true
+      listener.watchAllNamespaces: true
+    documentSelector:
+      path: metadata.name
+      value: watchers-role-rb-tk
+    asserts:
+      - equal:
+          path: kind
+          value: ClusterRoleBinding
+      - equal:
+          path: roleRef.kind
+          value: ClusterRole
+      - equal:
+          path: roleRef.name
+          value: watchers-role-tk
+
+  - it: creates RoleBinding(s) for watchers when watchAllNamespaces=false
+    set:
+      listener.enabled: true
+      listener.watchAllNamespaces: false
+    documentSelector:
+      path: metadata.name
+      value: watchers-role-rb-tk
+    asserts:
+      - equal:
+          path: kind
+          value: RoleBinding
+      - equal:
+          path: roleRef.kind
+          value: Role
+
+  - it: no RoleBindings when all autoCreate disabled
+    set:
+      pod.serviceAccount.autoCreate: false
+      execution.default.serviceAccount.autoCreate: false
+    asserts:
+      - hasDocuments:
+          count: 0

--- a/k8s/helm/testkube-runner/tests/service_test.yaml
+++ b/k8s/helm/testkube-runner/tests/service_test.yaml
@@ -1,0 +1,118 @@
+suite: testkube-runner service
+templates:
+  - service.yaml
+release:
+  name: tk
+tests:
+  - it: renders a ClusterIP Service on port 8088 by default
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Service
+      - equal:
+          path: spec.type
+          value: ClusterIP
+      - equal:
+          path: spec.ports[0].port
+          value: 8088
+      - equal:
+          path: spec.ports[0].targetPort
+          value: http
+      - equal:
+          path: spec.ports[0].name
+          value: http
+      - equal:
+          path: spec.ports[0].protocol
+          value: TCP
+
+  - it: uses fullname for the service name
+    asserts:
+      - equal:
+          path: metadata.name
+          value: tk-testkube-runner
+
+  - it: selector matches the runner pod selectorLabels
+    asserts:
+      - equal:
+          path: spec.selector["app.kubernetes.io/name"]
+          value: testkube-runner
+      - equal:
+          path: spec.selector["app.kubernetes.io/instance"]
+          value: tk
+
+  - it: includes standard Helm labels
+    asserts:
+      - equal:
+          path: metadata.labels["app.kubernetes.io/managed-by"]
+          value: Helm
+      - equal:
+          path: metadata.labels["app.kubernetes.io/name"]
+          value: testkube-runner
+      - equal:
+          path: metadata.labels["app.kubernetes.io/instance"]
+          value: tk
+      - isNotEmpty:
+          path: metadata.labels["helm.sh/chart"]
+
+  - it: exposes only one port (no gRPC, runner has no gRPC listener)
+    asserts:
+      - lengthEqual:
+          path: spec.ports
+          count: 1
+
+  - it: honors service.port override
+    set:
+      service.port: 9090
+    asserts:
+      - equal:
+          path: spec.ports[0].port
+          value: 9090
+
+  - it: honors service.type override
+    set:
+      service.type: NodePort
+    asserts:
+      - equal:
+          path: spec.type
+          value: NodePort
+
+  - it: propagates service.labels to metadata.labels
+    set:
+      service.labels:
+        team: qa
+        tier: backend
+    asserts:
+      - equal:
+          path: metadata.labels.team
+          value: qa
+      - equal:
+          path: metadata.labels.tier
+          value: backend
+
+  - it: propagates service.annotations to metadata.annotations
+    set:
+      service.annotations:
+        prometheus.io/scrape: "true"
+    asserts:
+      - equal:
+          path: metadata.annotations["prometheus.io/scrape"]
+          value: "true"
+
+  - it: propagates global.labels to metadata.labels
+    set:
+      global.labels:
+        env: prod
+    asserts:
+      - equal:
+          path: metadata.labels.env
+          value: prod
+
+  - it: propagates global.annotations to metadata.annotations
+    set:
+      global.annotations:
+        team: platform
+    asserts:
+      - equal:
+          path: metadata.annotations.team
+          value: platform

--- a/k8s/helm/testkube-runner/tests/serviceaccount_test.yaml
+++ b/k8s/helm/testkube-runner/tests/serviceaccount_test.yaml
@@ -1,0 +1,79 @@
+suite: testkube-runner serviceaccount
+templates:
+  - serviceaccount.yaml
+release:
+  name: tk
+  namespace: testkube-dev
+tests:
+  - it: renders both Agent and Exec ServiceAccounts by default
+    asserts:
+      - hasDocuments:
+          count: 2
+
+  - it: renders only Exec SA when pod.serviceAccount.autoCreate=false
+    set:
+      pod.serviceAccount.autoCreate: false
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: metadata.name
+          value: exec-sa-tk
+
+  - it: renders nothing when both autoCreate are disabled
+    set:
+      pod.serviceAccount.autoCreate: false
+      execution.default.serviceAccount.autoCreate: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: Agent SA uses agent-sa-<release> naming
+    set:
+      execution.default.serviceAccount.autoCreate: false
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: metadata.name
+          value: agent-sa-tk
+      - equal:
+          path: metadata.namespace
+          value: testkube-dev
+
+  - it: honors pod.serviceAccount.name override
+    set:
+      execution.default.serviceAccount.autoCreate: false
+      pod.serviceAccount.name: custom-agent
+    asserts:
+      - equal:
+          path: metadata.name
+          value: custom-agent
+
+  - it: honors execution.default.serviceAccount.name override
+    set:
+      pod.serviceAccount.autoCreate: false
+      execution.default.serviceAccount.name: custom-exec
+    asserts:
+      - equal:
+          path: metadata.name
+          value: custom-exec
+
+  - it: places Exec SA in execution.default.namespace when set
+    set:
+      pod.serviceAccount.autoCreate: false
+      execution.default.namespace: other-ns
+    asserts:
+      - equal:
+          path: metadata.namespace
+          value: other-ns
+
+  - it: propagates pod.serviceAccount.annotations to Agent SA
+    set:
+      execution.default.serviceAccount.autoCreate: false
+      pod.serviceAccount.annotations:
+        eks.amazonaws.com/role-arn: arn:aws:iam::123:role/runner
+    asserts:
+      - equal:
+          path: metadata.annotations["eks.amazonaws.com/role-arn"]
+          value: arn:aws:iam::123:role/runner

--- a/k8s/helm/testkube-runner/tests/servicemonitor_test.yaml
+++ b/k8s/helm/testkube-runner/tests/servicemonitor_test.yaml
@@ -1,0 +1,124 @@
+suite: testkube-runner servicemonitor
+templates:
+  - servicemonitor.yaml
+release:
+  name: tk
+tests:
+  - it: is not rendered by default (prometheus.enabled=false)
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: renders when prometheus.enabled=true
+    set:
+      prometheus.enabled: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: ServiceMonitor
+      - equal:
+          path: apiVersion
+          value: monitoring.coreos.com/v1
+
+  - it: derives name from fullname with -servicemonitor suffix
+    set:
+      prometheus.enabled: true
+    asserts:
+      - equal:
+          path: metadata.name
+          value: tk-testkube-runner-servicemonitor
+
+  - it: carries the monitoring label app=prometheus
+    set:
+      prometheus.enabled: true
+    asserts:
+      - equal:
+          path: metadata.labels.app
+          value: prometheus
+
+  - it: targets port 8088 by default with 15s interval
+    set:
+      prometheus.enabled: true
+    asserts:
+      - equal:
+          path: spec.endpoints[0].targetPort
+          value: 8088
+      - equal:
+          path: spec.endpoints[0].interval
+          value: 15s
+
+  - it: matchLabels include runner selectorLabels
+    set:
+      prometheus.enabled: true
+    asserts:
+      - equal:
+          path: spec.selector.matchLabels["app.kubernetes.io/name"]
+          value: testkube-runner
+      - equal:
+          path: spec.selector.matchLabels["app.kubernetes.io/instance"]
+          value: tk
+
+  - it: honors prometheus.interval override
+    set:
+      prometheus.enabled: true
+      prometheus.interval: 30s
+    asserts:
+      - equal:
+          path: spec.endpoints[0].interval
+          value: 30s
+
+  - it: propagates prometheus.monitoringLabels to metadata.labels
+    set:
+      prometheus.enabled: true
+      prometheus.monitoringLabels:
+        release: kube-prometheus
+    asserts:
+      - equal:
+          path: metadata.labels.release
+          value: kube-prometheus
+
+  - it: propagates prometheus.matchLabels into selector.matchLabels
+    set:
+      prometheus.enabled: true
+      prometheus.matchLabels:
+        team: qa
+    asserts:
+      - equal:
+          path: spec.selector.matchLabels.team
+          value: qa
+
+  - it: honors prometheus.sampleLimit when set
+    set:
+      prometheus.enabled: true
+      prometheus.sampleLimit: 10000
+    asserts:
+      - equal:
+          path: spec.sampleLimit
+          value: 10000
+
+  - it: omits sampleLimit when not set
+    set:
+      prometheus.enabled: true
+    asserts:
+      - notExists:
+          path: spec.sampleLimit
+
+  - it: targetPort follows service.port (stays in sync with Service)
+    set:
+      prometheus.enabled: true
+      service.port: 9090
+    asserts:
+      - equal:
+          path: spec.endpoints[0].targetPort
+          value: 9090
+
+  - it: propagates global.labels to metadata.labels
+    set:
+      prometheus.enabled: true
+      global.labels:
+        env: prod
+    asserts:
+      - equal:
+          path: metadata.labels.env
+          value: prod

--- a/k8s/helm/testkube-runner/tests/servicemonitor_test.yaml
+++ b/k8s/helm/testkube-runner/tests/servicemonitor_test.yaml
@@ -37,18 +37,18 @@ tests:
           path: metadata.labels.app
           value: prometheus
 
-  - it: scrapes the Service named port "http" with 15s interval
+  - it: scrapes container port 8088 directly with 15s interval
     set:
       prometheus.enabled: true
     asserts:
       - equal:
-          path: spec.endpoints[0].port
-          value: http
+          path: spec.endpoints[0].targetPort
+          value: 8088
       - equal:
           path: spec.endpoints[0].interval
           value: 15s
       - notExists:
-          path: spec.endpoints[0].targetPort
+          path: spec.endpoints[0].port
 
   - it: matchLabels include runner selectorLabels
     set:
@@ -106,16 +106,16 @@ tests:
       - notExists:
           path: spec.sampleLimit
 
-  - it: stays bound to named port "http" even when service.port is overridden
+  - it: targetPort stays fixed at 8088 even when service.port is overridden
     set:
       prometheus.enabled: true
       service.port: 9090
     asserts:
       - equal:
-          path: spec.endpoints[0].port
-          value: http
-      - notExists:
           path: spec.endpoints[0].targetPort
+          value: 8088
+      - notExists:
+          path: spec.endpoints[0].port
 
   - it: propagates global.labels to metadata.labels
     set:

--- a/k8s/helm/testkube-runner/tests/servicemonitor_test.yaml
+++ b/k8s/helm/testkube-runner/tests/servicemonitor_test.yaml
@@ -37,16 +37,18 @@ tests:
           path: metadata.labels.app
           value: prometheus
 
-  - it: targets port 8088 by default with 15s interval
+  - it: scrapes the Service named port "http" with 15s interval
     set:
       prometheus.enabled: true
     asserts:
       - equal:
-          path: spec.endpoints[0].targetPort
-          value: 8088
+          path: spec.endpoints[0].port
+          value: http
       - equal:
           path: spec.endpoints[0].interval
           value: 15s
+      - notExists:
+          path: spec.endpoints[0].targetPort
 
   - it: matchLabels include runner selectorLabels
     set:
@@ -104,14 +106,16 @@ tests:
       - notExists:
           path: spec.sampleLimit
 
-  - it: targetPort follows service.port (stays in sync with Service)
+  - it: stays bound to named port "http" even when service.port is overridden
     set:
       prometheus.enabled: true
       service.port: 9090
     asserts:
       - equal:
+          path: spec.endpoints[0].port
+          value: http
+      - notExists:
           path: spec.endpoints[0].targetPort
-          value: 9090
 
   - it: propagates global.labels to metadata.labels
     set:

--- a/k8s/helm/testkube-runner/values.yaml
+++ b/k8s/helm/testkube-runner/values.yaml
@@ -253,9 +253,9 @@ service:
   ## Service type
   type: ClusterIP
   ## External Service port. NOTE: the runner container always listens on 8088
-  ## internally (APISERVER_PORT is hardcoded in the deployment template), so
-  ## changing this only affects the Service's external port — metrics scraping
-  ## uses the named port "http", not this value.
+  ## internally (APISERVER_PORT is hardcoded in the deployment template) and
+  ## the ServiceMonitor scrapes that port directly, so changing this only
+  ## affects the Service's external port — not metrics scraping.
   port: 8088
   ## Service Annotations
   annotations: {}

--- a/k8s/helm/testkube-runner/values.yaml
+++ b/k8s/helm/testkube-runner/values.yaml
@@ -248,6 +248,28 @@ pod:
   # - name: FOO
   #   value: BAR
 
+## Service parameters
+service:
+  ## Service type
+  type: ClusterIP
+  ## HTTP Port (matches the runner containerPort 8088 and APISERVER_PORT)
+  port: 8088
+  ## Service Annotations
+  annotations: {}
+  ## Service labels
+  labels: {}
+  ## NOTE: the runner does not expose a gRPC listener (unlike testkube-api),
+  ## so no `grpcPort` is published here.
+
+## Prometheus monitoring
+prometheus:
+  ## Toggle whether to install ServiceMonitor
+  enabled: false
+  ## Additional monitoring labels applied to the ServiceMonitor
+  monitoringLabels: {}
+  ## Scrape interval
+  interval: 15s
+
 ## Enable a [pod disruption budget](https://kubernetes.io/docs/tasks/run-application/configure-pdb/) to help dealing with [disruptions](https://kubernetes.io/docs/concepts/workloads/pods/disruptions/).
 podDisruptionBudget:
   enabled: false

--- a/k8s/helm/testkube-runner/values.yaml
+++ b/k8s/helm/testkube-runner/values.yaml
@@ -252,7 +252,10 @@ pod:
 service:
   ## Service type
   type: ClusterIP
-  ## HTTP Port (matches the runner containerPort 8088 and APISERVER_PORT)
+  ## External Service port. NOTE: the runner container always listens on 8088
+  ## internally (APISERVER_PORT is hardcoded in the deployment template), so
+  ## changing this only affects the Service's external port — metrics scraping
+  ## uses the named port "http", not this value.
   port: 8088
   ## Service Annotations
   annotations: {}


### PR DESCRIPTION
## Pull request description 

adding the missing resources, aligning them to the `testkube` and adding unit tests to verify the behavior of them

https://linear.app/kubeshop/issue/TKC-5722/add-service-and-servicemonitor-to-testkube-runner-helm-chart-for

## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [x] tested locally
- [ ] tested on cluster
- [ ] added new dependencies
- [x] updated the docs
- [x] added a test

## Breaking changes

-

## Changes

-

## Fixes

-