### PR TITLE
feat: enhance CLI update check and telemetry integration

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,11 +45,20 @@
 - When adding support for a new cluster type, add detection entries to the appropriate layer(s) in `cluster_type.go` and add corresponding test cases in `cluster_type_test.go`.
 - `cmd/api-server/services/telemetry.go` drives the heartbeat loop that sends `testkube_api_heartbeat` events hourly, including the detected cluster type and agent capabilities.
 - `cmd/api-server/services/capabilities.go` extracts agent capability tags (persona, mode, feature flags) from the runtime config for inclusion in telemetry events. When adding new agent features/toggles that should be tracked, add them here and in `capabilities_test.go`.
+- `pkg/cliruntime/context.go` is a leaf package containing the CLI runtime-context helpers (`IsRunningInDocker`, `DockerContext`, `CliRunContext`). `pkg/telemetry` and `cmd/kubectl-testkube/commands/common` both depend on it; placing it in its own package avoids an import cycle between common and telemetry.
+
+## CLI update check
+
+- `cmd/kubectl-testkube/commands/common/update_check.go` implements `MaybeNotifyNewerRelease` (per-command post-run hint) and `CheckComponentsStatus` (richer per-component report rendered by `testkube version`). Both consult `pkg/cliruntime` to skip in CI/Docker/Kubernetes contexts and honor the `--output` flag and `TESTKUBE_DISABLE_UPDATE_CHECK` env opt-out.
+- `cmd/kubectl-testkube/commands/common/install_source.go` classifies how the running CLI binary was installed (Homebrew, Chocolatey, APT, install.sh, Docker, `go install`, unknown) by inspecting the resolved `os.Executable` path and the Docker context. The classification drives the install-source-specific upgrade command surfaced in the hint.
+- Adding a new install channel: extend `DetectInstallSource` and add a test case to `install_source_test.go` that exercises the new path under the relevant `goos`.
+- Adding a new CI/runtime detection: extend `pkg/cliruntime/context.go` so both telemetry and the update-check feature stay in sync.
 
 ## Configuration references
 
 - Agent behavior is driven by env vars defined in `internal/config/config.go` (scan for `envconfig:"..."` tags when researching a toggle).
 - Helm chart values are the source of deployment defaults; `build/_local/values.dev.yaml` (shaped by the `values.dev.tpl.yaml` template) shows the local overrides used by `tk-dev` if you need a concrete reference.
+- CLI update-check toggle: set `TESTKUBE_DISABLE_UPDATE_CHECK=1` to suppress both the per-command hint and the `testkube version` status block. The CLI persists `lastUpdateCheckAt` and `latestKnownVersion` in `~/.testkube/config.json` to throttle the per-command hint to once per day.
 
 ## Architecture reference
 

--- a/cmd/kubectl-testkube/commands/common/helper.go
+++ b/cmd/kubectl-testkube/commands/common/helper.go
@@ -1458,8 +1458,18 @@ type releaseMetadata struct {
 	TagName string `json:"tag_name"`
 }
 
+// GetLatestVersion fetches the latest Testkube release tag from GitHub using
+// a background context. It is kept for backwards-compatible callers that do
+// not need to bound the call. Prefer GetLatestVersionWithContext for new code.
 func GetLatestVersion() (string, error) {
-	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, latestReleaseUrl, nil)
+	return GetLatestVersionWithContext(context.Background())
+}
+
+// GetLatestVersionWithContext fetches the latest Testkube release tag from
+// GitHub honoring the provided context. The returned version has the leading
+// "v" prefix stripped.
+func GetLatestVersionWithContext(ctx context.Context) (string, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, latestReleaseUrl, nil)
 	if err != nil {
 		return "", err
 	}

--- a/cmd/kubectl-testkube/commands/common/install_source.go
+++ b/cmd/kubectl-testkube/commands/common/install_source.go
@@ -1,0 +1,169 @@
+package common
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+
+	"github.com/kubeshop/testkube/pkg/cliruntime"
+)
+
+// InstallSource is a discrete classification of how the running CLI binary was
+// installed. It is used to surface the appropriate package-manager or
+// installer-specific upgrade command in the update-check hint.
+type InstallSource string
+
+const (
+	InstallSourceHomebrew      InstallSource = "homebrew"
+	InstallSourceChocolatey    InstallSource = "chocolatey"
+	InstallSourceApt           InstallSource = "apt"
+	InstallSourceInstallScript InstallSource = "install-script"
+	InstallSourceDocker        InstallSource = "docker"
+	InstallSourceGoInstall     InstallSource = "go-install"
+	InstallSourceUnknown       InstallSource = "unknown"
+)
+
+// InstallInfo describes the detected origin of the running CLI binary.
+type InstallInfo struct {
+	Source InstallSource
+	// UpgradeCmd is the command a user can run to upgrade this CLI. Empty for
+	// InstallSourceUnknown; callers should fall back to a "download from
+	// releases page" message in that case.
+	UpgradeCmd string
+	// ResolvedPath is the filesystem path the executable resolves to after
+	// following symlinks. Surfaced only via verbose/debug output for
+	// diagnostics; empty when the path could not be resolved.
+	ResolvedPath string
+}
+
+// These package-private seams keep DetectInstallSource fully unit-testable
+// without requiring real binaries on disk or platform-specific runners.
+var (
+	execPath            = os.Executable
+	goos                = runtime.GOOS
+	isRunningInDocker   = cliruntime.IsRunningInDocker
+	evalSymlinks        = filepath.EvalSymlinks
+	lookupEnv           = os.LookupEnv
+	userHomeDir         = os.UserHomeDir
+	releasesPageURL     = "https://github.com/kubeshop/testkube/releases/latest"
+	homebrewUpgradeCmd  = "brew upgrade testkube"
+	chocoUpgradeCmd     = "choco upgrade testkube"
+	aptUpgradeCmd       = "sudo apt-get update && sudo apt-get install --only-upgrade testkube"
+	scriptUpgradeCmd    = "curl -sSLf https://get.testkube.io | sh"
+	dockerUpgradeCmd    = "docker pull kubeshop/testkube-cli:latest"
+	goInstallUpgradeCmd = "go install github.com/kubeshop/testkube/cmd/kubectl-testkube@latest"
+)
+
+// DetectInstallSource attempts to classify how the running CLI binary was
+// installed. The classification is best-effort and falls back to
+// InstallSourceUnknown when no heuristic matches. The returned UpgradeCmd is
+// always safe to display verbatim to the user.
+func DetectInstallSource() InstallInfo {
+	if isRunningInDocker() {
+		return InstallInfo{Source: InstallSourceDocker, UpgradeCmd: dockerUpgradeCmd}
+	}
+
+	exe, err := execPath()
+	if err != nil || exe == "" {
+		return InstallInfo{Source: InstallSourceUnknown}
+	}
+
+	resolved, err := evalSymlinks(exe)
+	if err != nil || resolved == "" {
+		resolved = exe
+	}
+
+	switch goos {
+	case "windows":
+		if matched := classifyWindows(resolved); matched.Source != "" {
+			matched.ResolvedPath = resolved
+			return matched
+		}
+	default:
+		if matched := classifyUnix(resolved); matched.Source != "" {
+			matched.ResolvedPath = resolved
+			return matched
+		}
+	}
+
+	if matched := classifyGoInstall(resolved); matched.Source != "" {
+		matched.ResolvedPath = resolved
+		return matched
+	}
+
+	return InstallInfo{Source: InstallSourceUnknown, ResolvedPath: resolved}
+}
+
+func classifyWindows(resolved string) InstallInfo {
+	lower := strings.ToLower(resolved)
+	if strings.Contains(lower, `\chocolatey\`) || strings.Contains(lower, `/chocolatey/`) {
+		return InstallInfo{Source: InstallSourceChocolatey, UpgradeCmd: chocoUpgradeCmd}
+	}
+	if chocoRoot, ok := lookupEnv("ChocolateyInstall"); ok && chocoRoot != "" {
+		if strings.HasPrefix(lower, strings.ToLower(chocoRoot)) {
+			return InstallInfo{Source: InstallSourceChocolatey, UpgradeCmd: chocoUpgradeCmd}
+		}
+	}
+	return InstallInfo{}
+}
+
+func classifyUnix(resolved string) InstallInfo {
+	// Homebrew binaries always resolve under a Cellar directory regardless of
+	// the user-facing prefix, so the Cellar check covers Intel Macs,
+	// Apple-silicon Macs, and Linuxbrew installs equally well.
+	if strings.Contains(resolved, "/Cellar/") {
+		return InstallInfo{Source: InstallSourceHomebrew, UpgradeCmd: homebrewUpgradeCmd}
+	}
+	homebrewPrefixes := []string{
+		"/opt/homebrew/",
+		"/usr/local/Homebrew/",
+		"/home/linuxbrew/.linuxbrew/",
+	}
+	if prefix, ok := lookupEnv("HOMEBREW_PREFIX"); ok && prefix != "" {
+		homebrewPrefixes = append(homebrewPrefixes, strings.TrimRight(prefix, "/")+"/")
+	}
+	for _, prefix := range homebrewPrefixes {
+		if strings.HasPrefix(resolved, prefix) {
+			return InstallInfo{Source: InstallSourceHomebrew, UpgradeCmd: homebrewUpgradeCmd}
+		}
+	}
+
+	// The install.sh script always drops the binary in /usr/local/bin (see
+	// install.sh:119) while the deb package puts it in /usr/bin. We classify
+	// in that order because /usr/local/bin matches both Linux and macOS, but
+	// /usr/bin only makes sense as "installed via apt" on Linux.
+	if resolved == "/usr/local/bin/kubectl-testkube" {
+		return InstallInfo{Source: InstallSourceInstallScript, UpgradeCmd: scriptUpgradeCmd}
+	}
+	if goos == "linux" && strings.HasPrefix(resolved, "/usr/bin/") {
+		return InstallInfo{Source: InstallSourceApt, UpgradeCmd: aptUpgradeCmd}
+	}
+
+	return InstallInfo{}
+}
+
+func classifyGoInstall(resolved string) InstallInfo {
+	if strings.Contains(resolved, "/go/bin/") || strings.Contains(resolved, `\go\bin\`) {
+		return InstallInfo{Source: InstallSourceGoInstall, UpgradeCmd: goInstallUpgradeCmd}
+	}
+	if gopath, ok := lookupEnv("GOPATH"); ok && gopath != "" {
+		binDir := filepath.Join(gopath, "bin")
+		if strings.HasPrefix(resolved, binDir+string(filepath.Separator)) {
+			return InstallInfo{Source: InstallSourceGoInstall, UpgradeCmd: goInstallUpgradeCmd}
+		}
+	}
+	if home, err := userHomeDir(); err == nil && home != "" {
+		binDir := filepath.Join(home, "go", "bin")
+		if strings.HasPrefix(resolved, binDir+string(filepath.Separator)) {
+			return InstallInfo{Source: InstallSourceGoInstall, UpgradeCmd: goInstallUpgradeCmd}
+		}
+	}
+	return InstallInfo{}
+}
+
+// ReleasesPageURL returns the canonical "latest releases" URL used as the
+// fallback hint when the install source cannot be determined.
+func ReleasesPageURL() string {
+	return releasesPageURL
+}

--- a/cmd/kubectl-testkube/commands/common/install_source_test.go
+++ b/cmd/kubectl-testkube/commands/common/install_source_test.go
@@ -1,0 +1,205 @@
+package common
+
+import (
+	"errors"
+	"path/filepath"
+	"testing"
+)
+
+// withSeams swaps the package-private detection seams (execPath, goos,
+// isRunningInDocker, evalSymlinks, lookupEnv, userHomeDir) for the duration of
+// the test and restores them via t.Cleanup. Pass nil for any field that should
+// retain its default.
+type detectStub struct {
+	resolved   string
+	resolveErr error
+	goos       string
+	inDocker   bool
+	env        map[string]string
+	homeDir    string
+}
+
+func withSeams(t *testing.T, stub detectStub) {
+	t.Helper()
+
+	originalExecPath := execPath
+	originalGoos := goos
+	originalIsRunningInDocker := isRunningInDocker
+	originalEvalSymlinks := evalSymlinks
+	originalLookupEnv := lookupEnv
+	originalUserHomeDir := userHomeDir
+
+	execPath = func() (string, error) {
+		if stub.resolved == "" {
+			return "", errors.New("no executable configured")
+		}
+		return stub.resolved, nil
+	}
+	evalSymlinks = func(path string) (string, error) {
+		if stub.resolveErr != nil {
+			return "", stub.resolveErr
+		}
+		return path, nil
+	}
+	goos = stub.goos
+	isRunningInDocker = func() bool { return stub.inDocker }
+	lookupEnv = func(key string) (string, bool) {
+		if stub.env != nil {
+			if v, ok := stub.env[key]; ok {
+				return v, true
+			}
+		}
+		return "", false
+	}
+	userHomeDir = func() (string, error) {
+		if stub.homeDir == "" {
+			return "", errors.New("no home dir")
+		}
+		return stub.homeDir, nil
+	}
+
+	t.Cleanup(func() {
+		execPath = originalExecPath
+		goos = originalGoos
+		isRunningInDocker = originalIsRunningInDocker
+		evalSymlinks = originalEvalSymlinks
+		lookupEnv = originalLookupEnv
+		userHomeDir = originalUserHomeDir
+	})
+}
+
+func TestDetectInstallSource_Docker(t *testing.T) {
+	withSeams(t, detectStub{inDocker: true, resolved: "/usr/local/bin/kubectl-testkube", goos: "linux"})
+	info := DetectInstallSource()
+	if info.Source != InstallSourceDocker {
+		t.Fatalf("expected Docker, got %q", info.Source)
+	}
+	if info.UpgradeCmd == "" {
+		t.Fatal("expected non-empty docker upgrade command")
+	}
+}
+
+func TestDetectInstallSource_Homebrew_macOSAppleSilicon(t *testing.T) {
+	withSeams(t, detectStub{
+		resolved: "/opt/homebrew/Cellar/testkube/2.1.140/bin/kubectl-testkube",
+		goos:     "darwin",
+	})
+	info := DetectInstallSource()
+	if info.Source != InstallSourceHomebrew {
+		t.Fatalf("expected Homebrew, got %q", info.Source)
+	}
+	if info.UpgradeCmd != "brew upgrade testkube" {
+		t.Fatalf("unexpected upgrade command: %q", info.UpgradeCmd)
+	}
+}
+
+func TestDetectInstallSource_Homebrew_Linuxbrew(t *testing.T) {
+	withSeams(t, detectStub{
+		resolved: "/home/linuxbrew/.linuxbrew/bin/kubectl-testkube",
+		goos:     "linux",
+	})
+	info := DetectInstallSource()
+	if info.Source != InstallSourceHomebrew {
+		t.Fatalf("expected Homebrew, got %q", info.Source)
+	}
+}
+
+func TestDetectInstallSource_Chocolatey(t *testing.T) {
+	withSeams(t, detectStub{
+		resolved: `C:\ProgramData\chocolatey\bin\kubectl-testkube.exe`,
+		goos:     "windows",
+	})
+	info := DetectInstallSource()
+	if info.Source != InstallSourceChocolatey {
+		t.Fatalf("expected Chocolatey, got %q", info.Source)
+	}
+	if info.UpgradeCmd != "choco upgrade testkube" {
+		t.Fatalf("unexpected upgrade command: %q", info.UpgradeCmd)
+	}
+}
+
+func TestDetectInstallSource_Chocolatey_FromEnv(t *testing.T) {
+	withSeams(t, detectStub{
+		resolved: `C:\tools\choco\bin\kubectl-testkube.exe`,
+		goos:     "windows",
+		env:      map[string]string{"ChocolateyInstall": `C:\tools\choco`},
+	})
+	info := DetectInstallSource()
+	if info.Source != InstallSourceChocolatey {
+		t.Fatalf("expected Chocolatey (via env), got %q", info.Source)
+	}
+}
+
+func TestDetectInstallSource_Apt(t *testing.T) {
+	withSeams(t, detectStub{
+		resolved: "/usr/bin/kubectl-testkube",
+		goos:     "linux",
+	})
+	info := DetectInstallSource()
+	if info.Source != InstallSourceApt {
+		t.Fatalf("expected Apt, got %q", info.Source)
+	}
+	if info.UpgradeCmd == "" {
+		t.Fatal("expected non-empty apt upgrade command")
+	}
+}
+
+func TestDetectInstallSource_AptOnlyOnLinux(t *testing.T) {
+	withSeams(t, detectStub{
+		resolved: "/usr/bin/kubectl-testkube",
+		goos:     "darwin",
+	})
+	info := DetectInstallSource()
+	if info.Source == InstallSourceApt {
+		t.Fatal("apt classification must not apply on darwin")
+	}
+}
+
+func TestDetectInstallSource_InstallScript(t *testing.T) {
+	withSeams(t, detectStub{
+		resolved: "/usr/local/bin/kubectl-testkube",
+		goos:     "linux",
+	})
+	info := DetectInstallSource()
+	if info.Source != InstallSourceInstallScript {
+		t.Fatalf("expected InstallScript, got %q", info.Source)
+	}
+}
+
+func TestDetectInstallSource_GoInstall_GoBinPath(t *testing.T) {
+	withSeams(t, detectStub{
+		resolved: "/Users/dev/go/bin/kubectl-testkube",
+		goos:     "darwin",
+		homeDir:  "/Users/dev",
+	})
+	info := DetectInstallSource()
+	if info.Source != InstallSourceGoInstall {
+		t.Fatalf("expected GoInstall, got %q", info.Source)
+	}
+}
+
+func TestDetectInstallSource_GoInstall_FromGOPATH(t *testing.T) {
+	withSeams(t, detectStub{
+		resolved: filepath.Join("/srv/gopath/bin", "kubectl-testkube"),
+		goos:     "linux",
+		env:      map[string]string{"GOPATH": "/srv/gopath"},
+	})
+	info := DetectInstallSource()
+	if info.Source != InstallSourceGoInstall {
+		t.Fatalf("expected GoInstall, got %q", info.Source)
+	}
+}
+
+func TestDetectInstallSource_Unknown(t *testing.T) {
+	withSeams(t, detectStub{
+		resolved: "/opt/custom/kubectl-testkube",
+		goos:     "linux",
+	})
+	info := DetectInstallSource()
+	if info.Source != InstallSourceUnknown {
+		t.Fatalf("expected Unknown, got %q", info.Source)
+	}
+	if info.UpgradeCmd != "" {
+		t.Fatalf("expected empty upgrade command, got %q", info.UpgradeCmd)
+	}
+}

--- a/cmd/kubectl-testkube/commands/common/update_check.go
+++ b/cmd/kubectl-testkube/commands/common/update_check.go
@@ -1,0 +1,269 @@
+package common
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/Masterminds/semver"
+	"github.com/spf13/cobra"
+
+	"github.com/kubeshop/testkube/cmd/kubectl-testkube/config"
+	"github.com/kubeshop/testkube/pkg/cliruntime"
+	"github.com/kubeshop/testkube/pkg/ui"
+)
+
+// outputPrettyValue mirrors render.OutputPretty without importing the render
+// package (which imports common, so a direct dependency would create an import
+// cycle). Kept in sync with cmd/kubectl-testkube/commands/common/render.
+const outputPrettyValue = "pretty"
+
+const (
+	// updateCheckInterval is the minimum time between successive GitHub release
+	// lookups for the per-command hint path. The user-explicit `testkube
+	// version` path ignores this cache.
+	updateCheckInterval = 24 * time.Hour
+	// updateCheckTimeout caps every GitHub request issued by the update-check
+	// feature so a slow or unreachable network never delays the CLI.
+	updateCheckTimeout = 1500 * time.Millisecond
+	// updateCheckEnvDisable, when set to any non-empty value, suppresses both
+	// the per-command hint and the version-command status block.
+	updateCheckEnvDisable = "TESTKUBE_DISABLE_UPDATE_CHECK"
+)
+
+// fetchLatestVersion is the indirection used by MaybeNotifyNewerRelease and
+// CheckComponentsStatus so unit tests can substitute a stub fetcher.
+var fetchLatestVersion = func(ctx context.Context) (string, error) {
+	return GetLatestVersionWithContext(ctx)
+}
+
+// detectCliRunContext is the indirection used by MaybeNotifyNewerRelease so
+// unit tests can simulate a "local" execution context regardless of the host
+// environment. Production callers always hit cliruntime.CliRunContext.
+var detectCliRunContext = cliruntime.CliRunContext
+
+// MaybeNotifyNewerRelease optionally prints a one-line hint when a newer
+// Testkube CLI release is available. It is designed to be called from
+// PersistentPostRun on every command and short-circuits in any automated
+// context (CI, Docker, Kubernetes pods, etc.) and for the `version` command
+// (which renders its own richer report). The returned bool indicates whether
+// cfg was mutated and should be persisted by the caller.
+func MaybeNotifyNewerRelease(cmd *cobra.Command, cfg *config.Data) bool {
+	if cmd != nil && cmd.Name() == "version" {
+		return false
+	}
+	if !updateCheckEnabled(cmd) {
+		return false
+	}
+	if detectCliRunContext() != cliruntime.CliRunContextLocal {
+		return false
+	}
+
+	currentVersion, ok := parseSemverLoose(Version)
+	if !ok {
+		return false
+	}
+
+	latest, dirty := latestVersionForHint(cfg)
+	if latest == "" {
+		return false
+	}
+
+	latestVersion, ok := parseSemverLoose(latest)
+	if !ok {
+		return false
+	}
+
+	if !currentVersion.LessThan(latestVersion) {
+		return dirty
+	}
+
+	printCliUpgradeHint(latest, Version)
+	return dirty
+}
+
+// CheckComponentsStatus prints a per-component update status block for the
+// `testkube version` command. Unlike MaybeNotifyNewerRelease it always runs an
+// online lookup (subject to the env opt-out and output-format gates) because
+// the user explicitly asked for version information. It returns true when cfg
+// was mutated so the caller can persist the refreshed cache. ContextType drives
+// whether the server block is rendered.
+func CheckComponentsStatus(cmd *cobra.Command, cfg *config.Data, cliVersion, serverVersion string) bool {
+	if !updateCheckEnabled(cmd) {
+		return false
+	}
+
+	ui.NL()
+	ui.H1("Update Status")
+
+	ctx, cancel := context.WithTimeout(context.Background(), updateCheckTimeout)
+	defer cancel()
+
+	latest, err := fetchLatestVersion(ctx)
+	dirty := false
+	if err != nil {
+		ui.Debug("update check: failed to fetch latest release", err.Error())
+	} else if latest != "" && cfg != nil {
+		cfg.LatestKnownVersion = latest
+		cfg.LastUpdateCheckAt = time.Now()
+		dirty = true
+	}
+
+	printCliStatus(cliVersion, latest)
+	printServerStatus(cfg, serverVersion, latest)
+	return dirty
+}
+
+// printCliUpgradeHint emits the install-source-aware "new release available"
+// message used by both MaybeNotifyNewerRelease and CheckComponentsStatus.
+func printCliUpgradeHint(latest, current string) {
+	info := DetectInstallSource()
+	ui.NL()
+	ui.Info("A new Testkube CLI release is available", latest,
+		fmt.Sprintf("(you are running %s)", current))
+	if info.UpgradeCmd != "" {
+		ui.Hint(fmt.Sprintf("Upgrade with: %s", info.UpgradeCmd))
+	} else {
+		ui.Hint(fmt.Sprintf("Download the latest binary from %s", ReleasesPageURL()))
+	}
+	if ui.IsVerbose() && info.ResolvedPath != "" {
+		ui.Debug("Detected install source", string(info.Source), info.ResolvedPath)
+	}
+}
+
+func printCliStatus(cliVersion, latest string) {
+	current, ok := parseSemverLoose(cliVersion)
+	if !ok {
+		// Dev/local builds: report the raw version we have without comparing.
+		ui.Info("Testkube CLI", fallback(cliVersion, "unknown"))
+		return
+	}
+	if latest == "" {
+		ui.Info("Testkube CLI", cliVersion, "(latest: unknown)")
+		return
+	}
+	latestVersion, ok := parseSemverLoose(latest)
+	if !ok {
+		ui.Info("Testkube CLI", cliVersion, "(latest: unknown)")
+		return
+	}
+	if current.LessThan(latestVersion) {
+		printCliUpgradeHint(latest, cliVersion)
+		return
+	}
+	ui.Info("Testkube CLI", cliVersion, "(up to date)")
+}
+
+func printServerStatus(cfg *config.Data, serverVersion, latest string) {
+	if cfg == nil || serverVersion == "" {
+		if cfg != nil && cfg.ContextType == config.ContextTypeKubeconfig {
+			ui.Debug("update check: Testkube server is not reachable, skipping server status")
+		}
+		return
+	}
+
+	if cfg.ContextType == config.ContextTypeCloud {
+		ui.Info("Testkube Server", serverVersion, "(managed by Testkube Cloud)")
+		return
+	}
+
+	if cfg.ContextType != config.ContextTypeKubeconfig {
+		return
+	}
+
+	current, ok := parseSemverLoose(serverVersion)
+	if !ok {
+		ui.Info("Testkube Server", serverVersion)
+		return
+	}
+	if latest == "" {
+		ui.Info("Testkube Server", serverVersion, "(latest: unknown)")
+		return
+	}
+	latestVersion, ok := parseSemverLoose(latest)
+	if !ok {
+		ui.Info("Testkube Server", serverVersion, "(latest: unknown)")
+		return
+	}
+	if current.LessThan(latestVersion) {
+		ui.NL()
+		ui.Info("Testkube Server", serverVersion, fmt.Sprintf("(latest: %s)", latest))
+		ui.Hint("Upgrade the cluster install with: testkube upgrade")
+		return
+	}
+	ui.Info("Testkube Server", serverVersion, "(up to date)")
+}
+
+// updateCheckEnabled checks the universal preconditions shared by both
+// MaybeNotifyNewerRelease and CheckComponentsStatus: pretty output is required
+// (so we never break -o json/yaml) and the env opt-out must not be set.
+func updateCheckEnabled(cmd *cobra.Command) bool {
+	if v, _ := os.LookupEnv(updateCheckEnvDisable); v != "" {
+		return false
+	}
+	return outputIsPretty(cmd)
+}
+
+func outputIsPretty(cmd *cobra.Command) bool {
+	if cmd == nil {
+		return true
+	}
+	outputFlag := cmd.Flag("output")
+	if outputFlag == nil {
+		return true
+	}
+	value := outputFlag.Value.String()
+	if value == "" {
+		return true
+	}
+	return value == outputPrettyValue
+}
+
+// latestVersionForHint returns the latest known release version for the
+// per-command hint path, honouring the 24h cache. It only performs a network
+// call when the cache is stale or empty. The second return value indicates
+// whether cfg was refreshed with new data.
+func latestVersionForHint(cfg *config.Data) (string, bool) {
+	if cfg != nil && cfg.LatestKnownVersion != "" &&
+		time.Since(cfg.LastUpdateCheckAt) < updateCheckInterval {
+		return cfg.LatestKnownVersion, false
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), updateCheckTimeout)
+	defer cancel()
+
+	latest, err := fetchLatestVersion(ctx)
+	if err != nil || latest == "" {
+		if err != nil {
+			ui.Debug("update check: failed to fetch latest release", err.Error())
+		}
+		return "", false
+	}
+	if cfg != nil {
+		cfg.LatestKnownVersion = latest
+		cfg.LastUpdateCheckAt = time.Now()
+	}
+	return latest, cfg != nil
+}
+
+// parseSemverLoose accepts both bare ("1.2.3") and "v"-prefixed inputs and
+// returns the parsed value plus an "ok" flag. Empty input returns ok=false so
+// callers can use it as a single combined "is comparable" guard.
+func parseSemverLoose(input string) (*semver.Version, bool) {
+	if input == "" {
+		return nil, false
+	}
+	v, err := semver.NewVersion(input)
+	if err != nil {
+		return nil, false
+	}
+	return v, true
+}
+
+func fallback(value, def string) string {
+	if value == "" {
+		return def
+	}
+	return value
+}

--- a/cmd/kubectl-testkube/commands/common/update_check_test.go
+++ b/cmd/kubectl-testkube/commands/common/update_check_test.go
@@ -1,0 +1,351 @@
+package common
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/kubeshop/testkube/cmd/kubectl-testkube/config"
+	"github.com/kubeshop/testkube/pkg/cliruntime"
+)
+
+// withStubFetcher swaps the package-private fetchLatestVersion seam used by
+// MaybeNotifyNewerRelease and CheckComponentsStatus. The stub captures whether
+// it was called so tests can assert the cache short-circuit path.
+type fetcherStub struct {
+	value  string
+	err    error
+	called int
+}
+
+func (s *fetcherStub) fetch(_ context.Context) (string, error) {
+	s.called++
+	return s.value, s.err
+}
+
+func withFetcher(t *testing.T, stub *fetcherStub) {
+	t.Helper()
+	original := fetchLatestVersion
+	fetchLatestVersion = stub.fetch
+	t.Cleanup(func() { fetchLatestVersion = original })
+}
+
+// withVersion temporarily overrides the build-injected CLI version for tests
+// that exercise the semver-parse branches of MaybeNotifyNewerRelease.
+func withVersion(t *testing.T, version string) {
+	t.Helper()
+	original := Version
+	Version = version
+	t.Cleanup(func() { Version = original })
+}
+
+// withRunContext swaps the cliContext detection seam so each test can simulate
+// a specific runtime (local, CI system, container) regardless of the host
+// environment. Also clears the env opt-out so tests start from a known state.
+func withRunContext(t *testing.T, ctx string) {
+	t.Helper()
+	t.Setenv("TESTKUBE_DISABLE_UPDATE_CHECK", "")
+	original := detectCliRunContext
+	detectCliRunContext = func() string { return ctx }
+	t.Cleanup(func() { detectCliRunContext = original })
+}
+
+// withLocalRunContext is the common case for the per-command hint tests: the
+// CLI is on a developer machine. Use withRunContext to simulate CI/Docker.
+func withLocalRunContext(t *testing.T) {
+	t.Helper()
+	withRunContext(t, cliruntime.CliRunContextLocal)
+}
+
+// newCmdWithOutputFlag returns a minimal cobra.Command with an --output flag
+// preset to the requested value. It is sufficient for tests that only need
+// the output gate to behave correctly.
+func newCmdWithOutputFlag(name, output string) *cobra.Command {
+	cmd := &cobra.Command{Use: name}
+	cmd.Flags().StringP("output", "o", output, "")
+	return cmd
+}
+
+func TestMaybeNotifyNewerRelease_SkipsVersionCommand(t *testing.T) {
+	withLocalRunContext(t)
+	stub := &fetcherStub{value: "2.1.140"}
+	withFetcher(t, stub)
+	withVersion(t, "2.1.130")
+
+	cmd := newCmdWithOutputFlag("version", "pretty")
+	cfg := &config.Data{}
+
+	if dirty := MaybeNotifyNewerRelease(cmd, cfg); dirty {
+		t.Fatal("expected dirty=false for version command")
+	}
+	if stub.called != 0 {
+		t.Fatalf("fetcher should not be called for version command, got %d calls", stub.called)
+	}
+}
+
+func TestMaybeNotifyNewerRelease_SkipsEnvOptOut(t *testing.T) {
+	withLocalRunContext(t)
+	t.Setenv("TESTKUBE_DISABLE_UPDATE_CHECK", "1")
+	stub := &fetcherStub{value: "2.1.140"}
+	withFetcher(t, stub)
+	withVersion(t, "2.1.130")
+
+	cmd := newCmdWithOutputFlag("get", "pretty")
+	cfg := &config.Data{}
+
+	if dirty := MaybeNotifyNewerRelease(cmd, cfg); dirty {
+		t.Fatal("expected dirty=false when env opt-out is set")
+	}
+	if stub.called != 0 {
+		t.Fatalf("fetcher should not be called when opt-out is set, got %d calls", stub.called)
+	}
+}
+
+func TestMaybeNotifyNewerRelease_SkipsNonPrettyOutput(t *testing.T) {
+	withLocalRunContext(t)
+	stub := &fetcherStub{value: "2.1.140"}
+	withFetcher(t, stub)
+	withVersion(t, "2.1.130")
+
+	cmd := newCmdWithOutputFlag("get", "json")
+	cfg := &config.Data{}
+
+	if dirty := MaybeNotifyNewerRelease(cmd, cfg); dirty {
+		t.Fatal("expected dirty=false for non-pretty output")
+	}
+	if stub.called != 0 {
+		t.Fatalf("fetcher should not be called for non-pretty output, got %d calls", stub.called)
+	}
+}
+
+func TestMaybeNotifyNewerRelease_SkipsCIContext(t *testing.T) {
+	withRunContext(t, "github-actions")
+	stub := &fetcherStub{value: "2.1.140"}
+	withFetcher(t, stub)
+	withVersion(t, "2.1.130")
+
+	cmd := newCmdWithOutputFlag("get", "pretty")
+	cfg := &config.Data{}
+
+	if dirty := MaybeNotifyNewerRelease(cmd, cfg); dirty {
+		t.Fatal("expected dirty=false in CI context")
+	}
+	if stub.called != 0 {
+		t.Fatalf("fetcher should not be called in CI context, got %d calls", stub.called)
+	}
+}
+
+func TestMaybeNotifyNewerRelease_SkipsUnparseableClientVersion(t *testing.T) {
+	withLocalRunContext(t)
+	stub := &fetcherStub{value: "2.1.140"}
+	withFetcher(t, stub)
+	withVersion(t, "dev")
+
+	cmd := newCmdWithOutputFlag("get", "pretty")
+	cfg := &config.Data{}
+
+	if dirty := MaybeNotifyNewerRelease(cmd, cfg); dirty {
+		t.Fatal("expected dirty=false when client version is not semver")
+	}
+	if stub.called != 0 {
+		t.Fatalf("fetcher should not be called for unparseable version, got %d calls", stub.called)
+	}
+}
+
+func TestMaybeNotifyNewerRelease_UsesFreshCache(t *testing.T) {
+	withLocalRunContext(t)
+	stub := &fetcherStub{value: "2.1.140"}
+	withFetcher(t, stub)
+	withVersion(t, "2.1.130")
+
+	cmd := newCmdWithOutputFlag("get", "pretty")
+	cfg := &config.Data{
+		LastUpdateCheckAt:  time.Now().Add(-1 * time.Hour),
+		LatestKnownVersion: "2.1.135",
+	}
+
+	dirty := MaybeNotifyNewerRelease(cmd, cfg)
+	if dirty {
+		t.Fatal("expected dirty=false when reading from fresh cache")
+	}
+	if stub.called != 0 {
+		t.Fatalf("fetcher should not be called when cache is fresh, got %d calls", stub.called)
+	}
+}
+
+func TestMaybeNotifyNewerRelease_RefreshesStaleCache(t *testing.T) {
+	withLocalRunContext(t)
+	stub := &fetcherStub{value: "2.1.140"}
+	withFetcher(t, stub)
+	withVersion(t, "2.1.130")
+
+	cmd := newCmdWithOutputFlag("get", "pretty")
+	cfg := &config.Data{
+		LastUpdateCheckAt:  time.Now().Add(-48 * time.Hour),
+		LatestKnownVersion: "2.1.135",
+	}
+
+	dirty := MaybeNotifyNewerRelease(cmd, cfg)
+	if !dirty {
+		t.Fatal("expected dirty=true after refreshing stale cache")
+	}
+	if stub.called != 1 {
+		t.Fatalf("fetcher should be called exactly once, got %d", stub.called)
+	}
+	if cfg.LatestKnownVersion != "2.1.140" {
+		t.Fatalf("expected LatestKnownVersion=2.1.140, got %q", cfg.LatestKnownVersion)
+	}
+}
+
+func TestMaybeNotifyNewerRelease_NoOpWhenUpToDate(t *testing.T) {
+	withLocalRunContext(t)
+	stub := &fetcherStub{value: "2.1.140"}
+	withFetcher(t, stub)
+	withVersion(t, "2.1.140")
+
+	cmd := newCmdWithOutputFlag("get", "pretty")
+	cfg := &config.Data{
+		LastUpdateCheckAt:  time.Now().Add(-1 * time.Hour),
+		LatestKnownVersion: "2.1.140",
+	}
+
+	dirty := MaybeNotifyNewerRelease(cmd, cfg)
+	if dirty {
+		t.Fatal("expected dirty=false when versions match and cache is fresh")
+	}
+}
+
+func TestMaybeNotifyNewerRelease_HTTPFailureIsSilent(t *testing.T) {
+	withLocalRunContext(t)
+	stub := &fetcherStub{err: errors.New("network down")}
+	withFetcher(t, stub)
+	withVersion(t, "2.1.130")
+
+	cmd := newCmdWithOutputFlag("get", "pretty")
+	cfg := &config.Data{}
+
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("HTTP failure caused panic: %v", r)
+		}
+	}()
+	if dirty := MaybeNotifyNewerRelease(cmd, cfg); dirty {
+		t.Fatal("expected dirty=false on fetch error")
+	}
+}
+
+func TestCheckComponentsStatus_SkipsNonPrettyOutput(t *testing.T) {
+	stub := &fetcherStub{value: "2.1.140"}
+	withFetcher(t, stub)
+
+	cmd := newCmdWithOutputFlag("version", "yaml")
+	cfg := &config.Data{}
+
+	if dirty := CheckComponentsStatus(cmd, cfg, "2.1.130", "2.1.125"); dirty {
+		t.Fatal("expected dirty=false for non-pretty output")
+	}
+	if stub.called != 0 {
+		t.Fatalf("fetcher should not be called for non-pretty output, got %d calls", stub.called)
+	}
+}
+
+func TestCheckComponentsStatus_SkipsEnvOptOut(t *testing.T) {
+	t.Setenv("TESTKUBE_DISABLE_UPDATE_CHECK", "1")
+	stub := &fetcherStub{value: "2.1.140"}
+	withFetcher(t, stub)
+
+	cmd := newCmdWithOutputFlag("version", "pretty")
+	cfg := &config.Data{}
+
+	if dirty := CheckComponentsStatus(cmd, cfg, "2.1.130", "2.1.125"); dirty {
+		t.Fatal("expected dirty=false when env opt-out is set")
+	}
+	if stub.called != 0 {
+		t.Fatalf("fetcher should not be called when opt-out is set, got %d calls", stub.called)
+	}
+}
+
+func TestCheckComponentsStatus_RunsInCIContext(t *testing.T) {
+	// Unlike MaybeNotifyNewerRelease this entry point is explicit and must
+	// run even when cliContext is something other than the local sentinel.
+	t.Setenv("GITHUB_ACTIONS", "true")
+	t.Setenv("TESTKUBE_DISABLE_UPDATE_CHECK", "")
+	stub := &fetcherStub{value: "2.1.140"}
+	withFetcher(t, stub)
+
+	cmd := newCmdWithOutputFlag("version", "pretty")
+	cfg := &config.Data{}
+
+	if dirty := CheckComponentsStatus(cmd, cfg, "2.1.130", "2.1.125"); !dirty {
+		t.Fatal("expected dirty=true after successful fetch")
+	}
+	if stub.called != 1 {
+		t.Fatalf("fetcher should be called even in CI, got %d", stub.called)
+	}
+}
+
+func TestCheckComponentsStatus_CachesFreshValue(t *testing.T) {
+	stub := &fetcherStub{value: "2.1.140"}
+	withFetcher(t, stub)
+
+	cmd := newCmdWithOutputFlag("version", "pretty")
+	cfg := &config.Data{}
+
+	if dirty := CheckComponentsStatus(cmd, cfg, "2.1.130", "2.1.125"); !dirty {
+		t.Fatal("expected dirty=true so the caller can persist the new cache")
+	}
+	if cfg.LatestKnownVersion != "2.1.140" {
+		t.Fatalf("expected LatestKnownVersion=2.1.140, got %q", cfg.LatestKnownVersion)
+	}
+	if cfg.LastUpdateCheckAt.IsZero() {
+		t.Fatal("expected LastUpdateCheckAt to be set")
+	}
+}
+
+func TestCheckComponentsStatus_FetchFailureIsRecoverable(t *testing.T) {
+	stub := &fetcherStub{err: errors.New("network down")}
+	withFetcher(t, stub)
+
+	cmd := newCmdWithOutputFlag("version", "pretty")
+	cfg := &config.Data{ContextType: config.ContextTypeKubeconfig}
+
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("fetch failure caused panic: %v", r)
+		}
+	}()
+	dirty := CheckComponentsStatus(cmd, cfg, "2.1.130", "2.1.125")
+	if dirty {
+		t.Fatal("expected dirty=false when fetch fails")
+	}
+	if stub.called != 1 {
+		t.Fatalf("fetcher should be invoked exactly once, got %d", stub.called)
+	}
+}
+
+func TestCheckComponentsStatus_DisconnectedServerSkipsServerBlock(t *testing.T) {
+	stub := &fetcherStub{value: "2.1.140"}
+	withFetcher(t, stub)
+
+	cmd := newCmdWithOutputFlag("version", "pretty")
+	cfg := &config.Data{ContextType: config.ContextTypeKubeconfig}
+
+	if dirty := CheckComponentsStatus(cmd, cfg, "2.1.130", ""); !dirty {
+		t.Fatal("expected dirty=true so the CLI block still updates the cache")
+	}
+}
+
+func TestCheckComponentsStatus_CloudContextSuppressesServerHint(t *testing.T) {
+	stub := &fetcherStub{value: "2.1.140"}
+	withFetcher(t, stub)
+
+	cmd := newCmdWithOutputFlag("version", "pretty")
+	cfg := &config.Data{ContextType: config.ContextTypeCloud}
+
+	if dirty := CheckComponentsStatus(cmd, cfg, "2.1.140", "2.1.125"); !dirty {
+		t.Fatal("expected dirty=true after successful fetch")
+	}
+}

--- a/cmd/kubectl-testkube/commands/root.go
+++ b/cmd/kubectl-testkube/commands/root.go
@@ -118,6 +118,7 @@ var RootCmd = &cobra.Command{
 
 		// We ignore this check for cloud, since agent can be offline, and config API won't work
 		// but other commands should work.
+		cfgDirty := false
 		if clientCfg.ContextType != config.ContextTypeCloud {
 			serverCfg, err := client.GetConfig()
 			if ui.Verbose && err != nil {
@@ -132,14 +133,24 @@ var RootCmd = &cobra.Command{
 					clientCfg.DisableAnalytics()
 					ui.Debug("Sync telemetry on CLI with API", "disabled")
 				}
-
-				err = config.Save(clientCfg)
-				ui.WarnOnError("syncing config", err)
+				cfgDirty = true
 			}
 		}
 
 		if !isPreRunTelemetry(cmd) {
 			handleTelemetry(cmd, &clientCfg, false)
+		}
+
+		// Update-check hint - silent in CI/Docker/Kubernetes, skipped for the
+		// version command (which renders its own richer status block).
+		if common.MaybeNotifyNewerRelease(cmd, &clientCfg) {
+			cfgDirty = true
+		}
+
+		if cfgDirty {
+			if err := config.Save(clientCfg); err != nil {
+				ui.WarnOnError("syncing config", err)
+			}
 		}
 	},
 

--- a/cmd/kubectl-testkube/commands/version.go
+++ b/cmd/kubectl-testkube/commands/version.go
@@ -20,8 +20,14 @@ func NewVersionCmd() *cobra.Command {
 			ui.ExitOnError("getting client", err)
 
 			info, err := client.GetServerInfo()
+			// Track the actual server version separately from the displayed
+			// string so we can compare semantic versions even when the API
+			// call failed. info.Version is reused as the display field and may
+			// include an error suffix below.
+			serverVersion := info.Version
 			if err != nil {
 				info.Version = info.Version + " " + err.Error()
+				serverVersion = ""
 			}
 
 			ui.Logo()
@@ -39,6 +45,16 @@ func NewVersionCmd() *cobra.Command {
 				ui.Info("Build date", common.Date)
 			}
 
+			cfg, err := config.Load()
+			if err != nil {
+				ui.WarnOnError("loading config for update check", err)
+				return
+			}
+			if common.CheckComponentsStatus(cmd, &cfg, common.Version, serverVersion) {
+				if err := config.Save(cfg); err != nil {
+					ui.WarnOnError("saving update-check cache", err)
+				}
+			}
 		},
 		PersistentPreRun: func(cmd *cobra.Command, args []string) {
 			cfg, err := config.Load()

--- a/cmd/kubectl-testkube/commands/version_test.go
+++ b/cmd/kubectl-testkube/commands/version_test.go
@@ -1,0 +1,37 @@
+package commands
+
+import (
+	"testing"
+)
+
+// TestVersionCmdShape is a smoke test ensuring NewVersionCmd returns a
+// well-formed cobra command with the expected metadata. The bulk of the
+// update-awareness behavior is exercised by the common package tests for
+// CheckComponentsStatus and MaybeNotifyNewerRelease; this test just guards
+// against accidental regressions in the command wiring.
+func TestVersionCmdShape(t *testing.T) {
+	cmd := NewVersionCmd()
+	if cmd == nil {
+		t.Fatal("NewVersionCmd returned nil")
+	}
+	if cmd.Use != "version" {
+		t.Fatalf("expected Use=version, got %q", cmd.Use)
+	}
+	if cmd.Run == nil {
+		t.Fatal("expected version command to define a Run function")
+	}
+	if cmd.PersistentPreRun == nil {
+		t.Fatal("expected version command to define a PersistentPreRun function")
+	}
+
+	foundAlias := false
+	for _, alias := range cmd.Aliases {
+		if alias == "v" {
+			foundAlias = true
+			break
+		}
+	}
+	if !foundAlias {
+		t.Fatalf("expected 'v' alias on version command, got %v", cmd.Aliases)
+	}
+}

--- a/cmd/kubectl-testkube/config/data.go
+++ b/cmd/kubectl-testkube/config/data.go
@@ -1,5 +1,7 @@
 package config
 
+import "time"
+
 type ContextType string
 
 const (
@@ -63,6 +65,14 @@ type Data struct {
 	ContextType  ContextType  `json:"contextType,omitempty"`
 	CloudContext CloudContext `json:"cloudContext,omitempty"`
 	Master       Master       `json:"master,omitempty"`
+
+	// LastUpdateCheckAt is the timestamp of the most recent successful GitHub
+	// release lookup performed by the CLI update-check feature. Used together
+	// with LatestKnownVersion to throttle the per-command hint to once per day.
+	LastUpdateCheckAt time.Time `json:"lastUpdateCheckAt,omitempty"`
+	// LatestKnownVersion caches the latest GitHub release tag (without the "v"
+	// prefix) observed during the last successful check.
+	LatestKnownVersion string `json:"latestKnownVersion,omitempty"`
 }
 
 func (c *Data) EnableAnalytics() {

--- a/pkg/cliruntime/context.go
+++ b/pkg/cliruntime/context.go
@@ -17,6 +17,15 @@ const CliRunContextLocal = "others|local"
 
 // IsRunningInDocker detects whether the current process is running inside a
 // Docker (or compatible OCI) container.
+//
+// The detection deliberately ignores Docker *client* configuration variables
+// (DOCKER_HOST, DOCKER_TLS_VERIFY, DOCKER_CERT_PATH, DOCKER_MACHINE_NAME,
+// DOCKER_BUILDKIT) because those are commonly exported on developer
+// workstations talking to a remote or alternative daemon (docker-machine,
+// Colima, lima, etc.) and do not imply the current process itself is
+// containerized. We rely instead on filesystem/cgroup markers that only exist
+// inside a container, plus env vars that are conventionally set *by* a
+// container image rather than by the local shell.
 func IsRunningInDocker() bool {
 	// /.dockerenv is the canonical marker for Docker; other runtimes (podman,
 	// containerd-via-Docker-API) typically replicate it.
@@ -24,17 +33,11 @@ func IsRunningInDocker() bool {
 		return true
 	}
 
-	for _, envVar := range []string{
-		"DOCKER_CONTAINER",
-		"DOCKER_BUILDKIT",
-		"DOCKER_HOST",
-		"DOCKER_TLS_VERIFY",
-		"DOCKER_CERT_PATH",
-		"DOCKER_MACHINE_NAME",
-	} {
-		if _, exists := os.LookupEnv(envVar); exists {
-			return true
-		}
+	// DOCKER_CONTAINER is conventionally set by container images themselves
+	// (e.g. via ENV in a Dockerfile) to signal in-container execution to
+	// child processes. It is not a Docker client variable.
+	if _, exists := os.LookupEnv("DOCKER_CONTAINER"); exists {
+		return true
 	}
 
 	if runtime.GOOS == "linux" {
@@ -71,9 +74,6 @@ func DockerContext() string {
 			return "kubernetes:" + namespace
 		}
 		return "kubernetes"
-	}
-	if _, ok := os.LookupEnv("DOCKER_BUILDKIT"); ok {
-		return "docker-buildkit"
 	}
 	if _, ok := os.LookupEnv("DOCKER_DESKTOP"); ok {
 		return "docker-desktop"

--- a/pkg/cliruntime/context.go
+++ b/pkg/cliruntime/context.go
@@ -1,0 +1,180 @@
+// Package cliruntime exposes lightweight runtime-context detection helpers
+// (Docker, CI, interactive local). It is intentionally dependency-free so it
+// can be imported by both the telemetry package and the CLI commands packages
+// without creating an import cycle.
+package cliruntime
+
+import (
+	"os"
+	"runtime"
+	"strings"
+)
+
+// CliRunContextLocal is the value returned by CliRunContext when the CLI is
+// running interactively on a developer machine (i.e. not inside a known CI
+// system, Docker container, or Kubernetes pod).
+const CliRunContextLocal = "others|local"
+
+// IsRunningInDocker detects whether the current process is running inside a
+// Docker (or compatible OCI) container.
+func IsRunningInDocker() bool {
+	// /.dockerenv is the canonical marker for Docker; other runtimes (podman,
+	// containerd-via-Docker-API) typically replicate it.
+	if _, err := os.Stat("/.dockerenv"); err == nil {
+		return true
+	}
+
+	for _, envVar := range []string{
+		"DOCKER_CONTAINER",
+		"DOCKER_BUILDKIT",
+		"DOCKER_HOST",
+		"DOCKER_TLS_VERIFY",
+		"DOCKER_CERT_PATH",
+		"DOCKER_MACHINE_NAME",
+	} {
+		if _, exists := os.LookupEnv(envVar); exists {
+			return true
+		}
+	}
+
+	if runtime.GOOS == "linux" {
+		if cgroupData, err := os.ReadFile("/proc/1/cgroup"); err == nil {
+			content := string(cgroupData)
+			if strings.Contains(content, "docker") || strings.Contains(content, "containerd") {
+				return true
+			}
+		}
+	}
+
+	return false
+}
+
+// DockerContext returns a non-empty descriptor when the CLI is running inside
+// a known containerized environment (Docker Compose, Kubernetes pod, etc.).
+// Returns an empty string when not inside a container.
+func DockerContext() string {
+	if !IsRunningInDocker() {
+		return ""
+	}
+
+	if _, ok := os.LookupEnv("COMPOSE_PROJECT_NAME"); ok {
+		if projectName := os.Getenv("COMPOSE_PROJECT_NAME"); projectName != "" {
+			return "docker-compose:" + projectName
+		}
+		return "docker-compose"
+	}
+	if _, ok := os.LookupEnv("DOCKER_SWARM"); ok {
+		return "docker-swarm"
+	}
+	if _, ok := os.LookupEnv("KUBERNETES_SERVICE_HOST"); ok {
+		if namespace := os.Getenv("POD_NAMESPACE"); namespace != "" {
+			return "kubernetes:" + namespace
+		}
+		return "kubernetes"
+	}
+	if _, ok := os.LookupEnv("DOCKER_BUILDKIT"); ok {
+		return "docker-buildkit"
+	}
+	if _, ok := os.LookupEnv("DOCKER_DESKTOP"); ok {
+		return "docker-desktop"
+	}
+
+	if runtime.GOOS == "linux" {
+		if cgroupData, err := os.ReadFile("/proc/1/cgroup"); err == nil {
+			content := string(cgroupData)
+			if strings.Contains(content, "containerd") {
+				return "containerd"
+			}
+			if strings.Contains(content, "crio") {
+				return "cri-o"
+			}
+		}
+	}
+
+	if version, ok := os.LookupEnv("TESTKUBE_DOCKER_IMAGE_VERSION"); ok {
+		return "docker:testkube:" + version
+	}
+
+	if _, ok := os.LookupEnv("GITHUB_ACTIONS"); ok {
+		return "docker:github-actions"
+	}
+	if _, ok := os.LookupEnv("CIRCLECI"); ok {
+		return "docker:circleci"
+	}
+	if _, ok := os.LookupEnv("GITLAB_CI"); ok {
+		return "docker:gitlab-ci"
+	}
+	if _, ok := os.LookupEnv("BUILDKITE"); ok {
+		return "docker:buildkite"
+	}
+
+	if _, ok := os.LookupEnv("AWS_EXECUTION_ENV"); ok {
+		return "docker:aws"
+	}
+	if _, ok := os.LookupEnv("GOOGLE_CLOUD_PROJECT"); ok {
+		return "docker:gcp"
+	}
+	if _, ok := os.LookupEnv("AZURE_CONTAINER_REGISTRY"); ok {
+		return "docker:azure"
+	}
+
+	return "docker"
+}
+
+// CliRunContext returns a stable identifier describing where the CLI is
+// running: a Docker-derived string when inside a container, a CI system name
+// when run from a known CI, or CliRunContextLocal otherwise. Callers can use
+// the CliRunContextLocal sentinel to decide whether to emit interactive-only
+// output (e.g. update-check hints).
+func CliRunContext() string {
+	if dockerContext := DockerContext(); dockerContext != "" {
+		return dockerContext
+	}
+
+	if value, ok := os.LookupEnv("GITHUB_ACTIONS"); ok {
+		if value == "true" {
+			return "github-actions"
+		}
+	}
+	if _, ok := os.LookupEnv("TF_BUILD"); ok {
+		return "azure-pipelines"
+	}
+	if _, ok := os.LookupEnv("JENKINS_URL"); ok {
+		return "jenkins"
+	}
+	if _, ok := os.LookupEnv("JENKINS_HOME"); ok {
+		return "jenkins"
+	}
+	if _, ok := os.LookupEnv("CIRCLECI"); ok {
+		return "circleci"
+	}
+	if _, ok := os.LookupEnv("GITLAB_CI"); ok {
+		return "gitlab-ci"
+	}
+	if _, ok := os.LookupEnv("BUILDKITE"); ok {
+		return "buildkite"
+	}
+	if _, ok := os.LookupEnv("TRAVIS"); ok {
+		return "travis-ci"
+	}
+	if _, ok := os.LookupEnv("AIRFLOW_HOME"); ok {
+		return "airflow"
+	}
+	if _, ok := os.LookupEnv("TEAMCITY_VERSION"); ok {
+		return "teamcity"
+	}
+	if _, ok := os.LookupEnv("GO_PIPELINE_NAME"); ok {
+		return "gocd"
+	}
+	if _, ok := os.LookupEnv("SEMAPHORE"); ok {
+		return "semaphore-ci"
+	}
+	if _, ok := os.LookupEnv("BITBUCKET_BUILD_NUMBER"); ok {
+		return "bitbucket-pipelines"
+	}
+	if _, ok := os.LookupEnv("DRONE"); ok {
+		return "drone"
+	}
+
+	return CliRunContextLocal
+}

--- a/pkg/telemetry/telemetry.go
+++ b/pkg/telemetry/telemetry.go
@@ -2,7 +2,6 @@ package telemetry
 
 import (
 	"net/http"
-	"os"
 	"runtime"
 	"strings"
 	"sync"
@@ -11,6 +10,7 @@ import (
 
 	"github.com/kubeshop/testkube/cmd/kubectl-testkube/commands/common"
 	"github.com/kubeshop/testkube/cmd/kubectl-testkube/config"
+	"github.com/kubeshop/testkube/pkg/cliruntime"
 	httpclient "github.com/kubeshop/testkube/pkg/http"
 	"github.com/kubeshop/testkube/pkg/log"
 	"github.com/kubeshop/testkube/pkg/utils/text"
@@ -255,192 +255,22 @@ func getUserID(cmd *cobra.Command) string {
 	return data.CloudContext.EnvironmentId
 }
 
-// IsRunningInDocker detects if the CLI is running inside a Docker container
+// IsRunningInDocker detects if the CLI is running inside a Docker container.
+//
+// Kept as a thin wrapper around cliruntime.IsRunningInDocker so external
+// callers (this package's tests, existing telemetry consumers) keep working.
 func IsRunningInDocker() bool {
-	// Method 1: Check for .dockerenv file
-	if _, err := os.Stat("/.dockerenv"); err == nil {
-		return true
-	}
-
-	// Method 2: Check Docker-specific environment variables
-	dockerEnvVars := []string{
-		"DOCKER_CONTAINER",
-		"DOCKER_BUILDKIT",
-		"DOCKER_HOST",
-		"DOCKER_TLS_VERIFY",
-		"DOCKER_CERT_PATH",
-		"DOCKER_MACHINE_NAME",
-	}
-
-	for _, envVar := range dockerEnvVars {
-		if _, exists := os.LookupEnv(envVar); exists {
-			return true
-		}
-	}
-
-	// Method 3: Check cgroup for Docker/containerd (Linux only)
-	if runtime.GOOS == "linux" {
-		if cgroupData, err := os.ReadFile("/proc/1/cgroup"); err == nil {
-			cgroupContent := string(cgroupData)
-			if strings.Contains(cgroupContent, "docker") ||
-				strings.Contains(cgroupContent, "containerd") {
-				return true
-			}
-		}
-	}
-
-	return false
+	return cliruntime.IsRunningInDocker()
 }
 
-// GetDockerContext detects how the Docker container is being run
+// GetDockerContext returns a descriptor of the container environment when
+// running inside Docker/Kubernetes, or "" otherwise.
 func GetDockerContext() string {
-	if !IsRunningInDocker() {
-		return ""
-	}
-
-	// Check for Docker Compose
-	if _, ok := os.LookupEnv("COMPOSE_PROJECT_NAME"); ok {
-		projectName := os.Getenv("COMPOSE_PROJECT_NAME")
-		if projectName != "" {
-			return "docker-compose:" + projectName
-		}
-		return "docker-compose"
-	}
-
-	// Check for Docker Swarm
-	if _, ok := os.LookupEnv("DOCKER_SWARM"); ok {
-		return "docker-swarm"
-	}
-
-	// Check for Kubernetes (running in a pod)
-	if _, ok := os.LookupEnv("KUBERNETES_SERVICE_HOST"); ok {
-		namespace := os.Getenv("POD_NAMESPACE")
-		if namespace != "" {
-			return "kubernetes:" + namespace
-		}
-		return "kubernetes"
-	}
-
-	// Check for Docker BuildKit (during build)
-	if _, ok := os.LookupEnv("DOCKER_BUILDKIT"); ok {
-		return "docker-buildkit"
-	}
-
-	// Check for Docker Desktop
-	if _, ok := os.LookupEnv("DOCKER_DESKTOP"); ok {
-		return "docker-desktop"
-	}
-
-	// Check for specific container runtime
-	if runtime.GOOS == "linux" {
-		if cgroupData, err := os.ReadFile("/proc/1/cgroup"); err == nil {
-			cgroupContent := string(cgroupData)
-			if strings.Contains(cgroupContent, "containerd") {
-				return "containerd"
-			}
-			if strings.Contains(cgroupContent, "crio") {
-				return "cri-o"
-			}
-		}
-	}
-
-	// Check for custom Testkube Docker image version
-	if version, ok := os.LookupEnv("TESTKUBE_DOCKER_IMAGE_VERSION"); ok {
-		return "docker:testkube:" + version
-	}
-
-	// Check for CI/CD environments that might be using Docker
-	if _, ok := os.LookupEnv("GITHUB_ACTIONS"); ok {
-		return "docker:github-actions"
-	}
-	if _, ok := os.LookupEnv("CIRCLECI"); ok {
-		return "docker:circleci"
-	}
-	if _, ok := os.LookupEnv("GITLAB_CI"); ok {
-		return "docker:gitlab-ci"
-	}
-	if _, ok := os.LookupEnv("BUILDKITE"); ok {
-		return "docker:buildkite"
-	}
-
-	// Check for container orchestration platforms
-	if _, ok := os.LookupEnv("AWS_EXECUTION_ENV"); ok {
-		return "docker:aws"
-	}
-	if _, ok := os.LookupEnv("GOOGLE_CLOUD_PROJECT"); ok {
-		return "docker:gcp"
-	}
-	if _, ok := os.LookupEnv("AZURE_CONTAINER_REGISTRY"); ok {
-		return "docker:azure"
-	}
-
-	// Default Docker context
-	return "docker"
+	return cliruntime.DockerContext()
 }
 
+// GetCliRunContext returns the CLI runtime context identifier (CI system,
+// container runtime, or the local sentinel).
 func GetCliRunContext() string {
-	// Check for Docker first with detailed context
-	if dockerContext := GetDockerContext(); dockerContext != "" {
-		return dockerContext
-	}
-
-	if value, ok := os.LookupEnv("GITHUB_ACTIONS"); ok {
-		if value == "true" {
-			return "github-actions"
-		}
-	}
-
-	if _, ok := os.LookupEnv("TF_BUILD"); ok {
-		return "azure-pipelines"
-	}
-
-	if _, ok := os.LookupEnv("JENKINS_URL"); ok {
-		return "jenkins"
-	}
-
-	if _, ok := os.LookupEnv("JENKINS_HOME"); ok {
-		return "jenkins"
-	}
-
-	if _, ok := os.LookupEnv("CIRCLECI"); ok {
-		return "circleci"
-	}
-
-	if _, ok := os.LookupEnv("GITLAB_CI"); ok {
-		return "gitlab-ci"
-	}
-
-	if _, ok := os.LookupEnv("BUILDKITE"); ok {
-		return "buildkite"
-	}
-
-	if _, ok := os.LookupEnv("TRAVIS"); ok {
-		return "travis-ci"
-	}
-
-	if _, ok := os.LookupEnv("AIRFLOW_HOME"); ok {
-		return "airflow"
-	}
-
-	if _, ok := os.LookupEnv("TEAMCITY_VERSION"); ok {
-		return "teamcity"
-	}
-
-	if _, ok := os.LookupEnv("GO_PIPELINE_NAME"); ok {
-		return "gocd"
-	}
-
-	if _, ok := os.LookupEnv("SEMAPHORE"); ok {
-		return "semaphore-ci"
-	}
-
-	if _, ok := os.LookupEnv("BITBUCKET_BUILD_NUMBER"); ok {
-		return "bitbucket-pipelines"
-	}
-
-	if _, ok := os.LookupEnv("DRONE"); ok {
-		return "drone"
-	}
-
-	return "others|local"
+	return cliruntime.CliRunContext()
 }


### PR DESCRIPTION
This PR adds an update check to the CLI - so users can get notified if a new version is available. It uses the GitHub Releases page as its source.


- Implemented `MaybeNotifyNewerRelease` and `CheckComponentsStatus` for richer update notifications in the CLI.
- Added support for classifying CLI installation sources and extended `DetectInstallSource` with new test cases.
- Introduced `LastUpdateCheckAt` and `LatestKnownVersion` fields in the configuration to manage update check throttling.
- Refactored Docker context detection to utilize `pkg/cliruntime` for improved modularity and to prevent import cycles.
- Updated telemetry to sync with CLI runtime context and added a toggle to suppress update checks.

## Pull request description 



## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [ ] tested locally
- [ ] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Breaking changes

-

## Changes

-

## Fixes

-