### PR TITLE
feat: support k6 summary report uploads

### DIFF
--- a/cmd/testworkflow-toolkit/artifacts/composite_post_processor.go
+++ b/cmd/testworkflow-toolkit/artifacts/composite_post_processor.go
@@ -1,0 +1,36 @@
+package artifacts
+
+type CompositePostProcessor struct {
+	processors []PostProcessor
+}
+
+func NewCompositePostProcessor(processors ...PostProcessor) *CompositePostProcessor {
+	return &CompositePostProcessor{processors: processors}
+}
+
+func (p *CompositePostProcessor) Start() error {
+	for _, processor := range p.processors {
+		if err := processor.Start(); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (p *CompositePostProcessor) Add(path string) error {
+	for _, processor := range p.processors {
+		if err := processor.Add(path); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (p *CompositePostProcessor) End() error {
+	for _, processor := range p.processors {
+		if err := processor.End(); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/cmd/testworkflow-toolkit/artifacts/k6_summary_post_processor.go
+++ b/cmd/testworkflow-toolkit/artifacts/k6_summary_post_processor.go
@@ -16,6 +16,8 @@ import (
 	"github.com/kubeshop/testkube/pkg/ui"
 )
 
+const maxK6SummaryProbeBytes int64 = 16 << 20
+
 // K6SummaryPostProcessor checks JSON files for k6 summary reports and sends them to the cloud.
 type K6SummaryPostProcessor struct {
 	fs            filesystem.FileSystem
@@ -77,7 +79,11 @@ func (p *K6SummaryPostProcessor) add(path string) error {
 	if err != nil {
 		return errors.Wrapf(err, "failed to open %s", path)
 	}
-	defer func() { _ = file.Close() }()
+	defer func() {
+		if file != nil {
+			_ = file.Close()
+		}
+	}()
 
 	stat, err := file.Stat()
 	if err != nil {
@@ -87,7 +93,20 @@ func (p *K6SummaryPostProcessor) add(path string) error {
 		return nil
 	}
 
-	data, err := io.ReadAll(file)
+	if !hasK6SummaryReportShape(file, maxK6SummaryProbeBytes) {
+		return nil
+	}
+	if err := file.Close(); err != nil {
+		return errors.Wrapf(err, "failed to close %s", path)
+	}
+	file = nil
+	reportFile, err := p.fs.OpenFileRO(absPath)
+	if err != nil {
+		return errors.Wrapf(err, "failed to reopen %s", path)
+	}
+	defer func() { _ = reportFile.Close() }()
+
+	data, err := io.ReadAll(reportFile)
 	if err != nil {
 		return errors.Wrapf(err, "failed to read %s", path)
 	}
@@ -130,6 +149,168 @@ func isK6SummaryReport(data []byte) bool {
 		}
 	}
 	return false
+}
+
+func hasK6SummaryReportShape(reader io.Reader, maxBytes int64) bool {
+	limited := &io.LimitedReader{R: reader, N: maxBytes}
+	decoder := json.NewDecoder(limited)
+
+	token, err := decoder.Token()
+	if err != nil {
+		return false
+	}
+	delim, ok := token.(json.Delim)
+	if !ok || delim != '{' {
+		return false
+	}
+
+	for decoder.More() {
+		keyToken, err := decoder.Token()
+		if err != nil {
+			return false
+		}
+		key, ok := keyToken.(string)
+		if !ok {
+			return false
+		}
+		if key == "metrics" {
+			return k6MetricsHaveNumericValues(decoder)
+		}
+		if err := skipJSONValue(decoder); err != nil {
+			return false
+		}
+	}
+	return false
+}
+
+func k6MetricsHaveNumericValues(decoder *json.Decoder) bool {
+	token, err := decoder.Token()
+	if err != nil {
+		return false
+	}
+	delim, ok := token.(json.Delim)
+	if !ok || delim != '{' {
+		return false
+	}
+
+	for decoder.More() {
+		if _, err := decoder.Token(); err != nil {
+			return false
+		}
+		if k6MetricHasNumericValue(decoder) {
+			return true
+		}
+	}
+	if _, err := decoder.Token(); err != nil {
+		return false
+	}
+	return false
+}
+
+func k6MetricHasNumericValue(decoder *json.Decoder) bool {
+	token, err := decoder.Token()
+	if err != nil {
+		return false
+	}
+	delim, ok := token.(json.Delim)
+	if !ok || delim != '{' {
+		return false
+	}
+
+	for decoder.More() {
+		keyToken, err := decoder.Token()
+		if err != nil {
+			return false
+		}
+		key, ok := keyToken.(string)
+		if !ok {
+			return false
+		}
+		if key == "type" || key == "contains" {
+			if err := skipJSONValue(decoder); err != nil {
+				return false
+			}
+			continue
+		}
+		if jsonValueHasNumber(decoder) {
+			return true
+		}
+	}
+	if _, err := decoder.Token(); err != nil {
+		return false
+	}
+	return false
+}
+
+func jsonValueHasNumber(decoder *json.Decoder) bool {
+	token, err := decoder.Token()
+	if err != nil {
+		return false
+	}
+	delim, ok := token.(json.Delim)
+	if !ok {
+		_, ok := token.(float64)
+		return ok
+	}
+
+	switch delim {
+	case '{':
+		for decoder.More() {
+			if _, err := decoder.Token(); err != nil {
+				return false
+			}
+			if jsonValueHasNumber(decoder) {
+				return true
+			}
+		}
+		_, err := decoder.Token()
+		return err == nil
+	case '[':
+		for decoder.More() {
+			if jsonValueHasNumber(decoder) {
+				return true
+			}
+		}
+		_, err := decoder.Token()
+		return err == nil
+	default:
+		return false
+	}
+}
+
+func skipJSONValue(decoder *json.Decoder) error {
+	token, err := decoder.Token()
+	if err != nil {
+		return err
+	}
+	delim, ok := token.(json.Delim)
+	if !ok {
+		return nil
+	}
+
+	switch delim {
+	case '{':
+		for decoder.More() {
+			if _, err := decoder.Token(); err != nil {
+				return err
+			}
+			if err := skipJSONValue(decoder); err != nil {
+				return err
+			}
+		}
+		_, err := decoder.Token()
+		return err
+	case '[':
+		for decoder.More() {
+			if err := skipJSONValue(decoder); err != nil {
+				return err
+			}
+		}
+		_, err := decoder.Token()
+		return err
+	default:
+		return nil
+	}
 }
 
 func hasNumericJSONValue(data []byte) bool {

--- a/cmd/testworkflow-toolkit/artifacts/k6_summary_post_processor.go
+++ b/cmd/testworkflow-toolkit/artifacts/k6_summary_post_processor.go
@@ -1,0 +1,150 @@
+package artifacts
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/fs"
+	"path/filepath"
+	"strings"
+
+	"github.com/pkg/errors"
+
+	"github.com/kubeshop/testkube/pkg/controlplaneclient"
+	"github.com/kubeshop/testkube/pkg/filesystem"
+	"github.com/kubeshop/testkube/pkg/ui"
+)
+
+// K6SummaryPostProcessor checks JSON files for k6 summary reports and sends them to the cloud.
+type K6SummaryPostProcessor struct {
+	fs            filesystem.FileSystem
+	client        controlplaneclient.ExecutionSelfClient
+	root          string
+	pathPrefix    string
+	environmentId string
+	executionId   string
+	workflowName  string
+	stepRef       string
+}
+
+func NewK6SummaryPostProcessor(
+	fs filesystem.FileSystem,
+	client controlplaneclient.ExecutionSelfClient,
+	environmentId string,
+	executionId string,
+	workflowName string,
+	stepRef string,
+	root, pathPrefix string,
+) *K6SummaryPostProcessor {
+	return &K6SummaryPostProcessor{
+		fs:            fs,
+		client:        client,
+		environmentId: environmentId,
+		executionId:   executionId,
+		workflowName:  workflowName,
+		stepRef:       stepRef,
+		root:          root,
+		pathPrefix:    pathPrefix,
+	}
+}
+
+func (p *K6SummaryPostProcessor) Start() error {
+	return nil
+}
+
+func (p *K6SummaryPostProcessor) Add(path string) error {
+	if err := p.add(path); err != nil {
+		fmt.Printf("warn: k6 summary processing: %s: %s\n", path, err)
+	}
+	return nil
+}
+
+func (p *K6SummaryPostProcessor) End() error {
+	return nil
+}
+
+func (p *K6SummaryPostProcessor) add(path string) error {
+	uploadPath := path
+	if p.pathPrefix != "" {
+		uploadPath = filepath.Join(p.pathPrefix, uploadPath)
+	}
+	absPath := path
+	if !filepath.IsAbs(path) {
+		absPath = filepath.Join(p.root, absPath)
+	}
+	file, err := p.fs.OpenFileRO(absPath)
+	if err != nil {
+		return errors.Wrapf(err, "failed to open %s", path)
+	}
+	defer func() { _ = file.Close() }()
+
+	stat, err := file.Stat()
+	if err != nil {
+		return errors.Wrapf(err, "failed to get file info for %s", path)
+	}
+	if !isJSONFile(stat) {
+		return nil
+	}
+
+	data, err := io.ReadAll(file)
+	if err != nil {
+		return errors.Wrapf(err, "failed to read %s", path)
+	}
+	if !isK6SummaryReport(data) {
+		return nil
+	}
+
+	fmt.Printf("Processing k6 summary report: %s\n", ui.LightCyan(path))
+	if err := p.client.AppendExecutionReport(context.Background(), p.environmentId, p.executionId, p.workflowName, p.stepRef, uploadPath, data); err != nil {
+		return errors.Wrapf(err, "failed to send k6 summary report %s", stat.Name())
+	}
+	return nil
+}
+
+func isJSONFile(stat fs.FileInfo) bool {
+	if stat.IsDir() || stat.Size() == 0 {
+		return false
+	}
+	return strings.HasSuffix(stat.Name(), ".json")
+}
+
+func isK6SummaryReport(data []byte) bool {
+	var report struct {
+		Metrics map[string]map[string]json.RawMessage `json:"metrics"`
+	}
+	if err := json.Unmarshal(data, &report); err != nil || len(report.Metrics) == 0 {
+		return false
+	}
+	for _, metric := range report.Metrics {
+		if values, ok := metric["values"]; ok && hasNumericJSONValue(values) {
+			return true
+		}
+		for key, value := range metric {
+			if key == "type" || key == "contains" || key == "values" {
+				continue
+			}
+			if hasNumericJSONValue(value) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func hasNumericJSONValue(data []byte) bool {
+	var nested map[string]json.RawMessage
+	if err := json.Unmarshal(data, &nested); err == nil && len(nested) > 0 {
+		for _, value := range nested {
+			if hasNumericJSONValue(value) {
+				return true
+			}
+		}
+		return false
+	}
+	if strings.TrimSpace(string(data)) == "null" {
+		return false
+	}
+	var value float64
+	return json.Unmarshal(data, &value) == nil
+}

--- a/cmd/testworkflow-toolkit/artifacts/k6_summary_post_processor_test.go
+++ b/cmd/testworkflow-toolkit/artifacts/k6_summary_post_processor_test.go
@@ -1,6 +1,16 @@
 package artifacts
 
-import "testing"
+import (
+	"errors"
+	"io/fs"
+	"strings"
+	"testing"
+
+	gomock "go.uber.org/mock/gomock"
+
+	"github.com/kubeshop/testkube/pkg/controlplaneclient"
+	"github.com/kubeshop/testkube/pkg/filesystem"
+)
 
 func TestIsK6SummaryReport(t *testing.T) {
 	tests := []struct {
@@ -42,4 +52,123 @@ func TestIsK6SummaryReport(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestHasK6SummaryReportShape(t *testing.T) {
+	tests := []struct {
+		name     string
+		data     string
+		maxBytes int64
+		want     bool
+	}{
+		{
+			name:     "k6 summary with root group before metrics",
+			data:     `{"root_group":{"name":"","groups":[]},"metrics":{"http_req_duration":{"type":"trend","contains":"time","values":{"p(95)":123}}}}`,
+			maxBytes: maxK6SummaryProbeBytes,
+			want:     true,
+		},
+		{
+			name:     "k6 summary export",
+			data:     `{"metrics":{"http_req_duration":{"avg":24.8,"p(95)":29.7},"http_reqs":{"rate":39.5,"count":1187}}}`,
+			maxBytes: maxK6SummaryProbeBytes,
+			want:     true,
+		},
+		{
+			name:     "k6 json output stream",
+			data:     `{"type":"Point","data":{"time":"2026-01-01T00:00:00Z","value":1,"metric":"http_reqs"}}` + "\n" + `{"type":"Point","data":{"value":2}}`,
+			maxBytes: maxK6SummaryProbeBytes,
+			want:     false,
+		},
+		{
+			name:     "bounded before metrics",
+			data:     `{"root_group":{"name":"` + strings.Repeat("a", 128) + `"},"metrics":{"http_req_duration":{"avg":24.8}}}`,
+			maxBytes: 64,
+			want:     false,
+		},
+		{
+			name:     "plain json",
+			data:     `{"hello":"world"}`,
+			maxBytes: maxK6SummaryProbeBytes,
+			want:     false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := hasK6SummaryReportShape(strings.NewReader(tc.data), tc.maxBytes); got != tc.want {
+				t.Fatalf("expected %t, got %t", tc.want, got)
+			}
+		})
+	}
+}
+
+func TestK6SummaryPostProcessorAddUploadsSummary(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	summary := []byte(`{"metrics":{"http_req_duration":{"avg":24.8,"p(95)":29.7}}}`)
+	mockFS := filesystem.NewMockFileSystem(mockCtrl)
+	mockFS.EXPECT().
+		OpenFileRO("/summary.json").
+		Times(2).
+		DoAndReturn(func(string) (fs.File, error) {
+			return filesystem.NewMockFile("summary.json", summary), nil
+		})
+
+	mockClient := controlplaneclient.NewMockClient(mockCtrl)
+	mockClient.EXPECT().
+		AppendExecutionReport(gomock.Any(), "env123", "exec123", "workflow123", "step123", "summary.json", summary).
+		Return(nil)
+
+	pp := NewK6SummaryPostProcessor(mockFS, mockClient, "env123", "exec123", "workflow123", "step123", "/", "")
+	if err := pp.add("summary.json"); err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+}
+
+func TestK6SummaryPostProcessorAddSkipsNonSummaryJSONWithoutFullRead(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	mockFS := filesystem.NewMockFileSystem(mockCtrl)
+	mockFS.EXPECT().
+		OpenFileRO("/k6-browser-result.json").
+		Return(newGuardedSingleReadFile("k6-browser-result.json", []byte(`{"type":"Point","data":{"metric":"http_reqs","value":1}}`)), nil)
+
+	mockClient := controlplaneclient.NewMockClient(mockCtrl)
+	pp := NewK6SummaryPostProcessor(mockFS, mockClient, "env123", "exec123", "workflow123", "step123", "/", "")
+	if err := pp.add("k6-browser-result.json"); err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+}
+
+var errUnexpectedFullRead = errors.New("unexpected full read")
+
+type guardedSingleReadFile struct {
+	name string
+	data []byte
+	read bool
+}
+
+func newGuardedSingleReadFile(name string, data []byte) *guardedSingleReadFile {
+	return &guardedSingleReadFile{name: name, data: data}
+}
+
+func (f *guardedSingleReadFile) Stat() (fs.FileInfo, error) {
+	return &filesystem.MockFileInfo{
+		FName: f.name,
+		FSize: int64(len(f.data)) + 1<<30,
+	}, nil
+}
+
+func (f *guardedSingleReadFile) Read(p []byte) (int, error) {
+	if f.read {
+		return 0, errUnexpectedFullRead
+	}
+	f.read = true
+	return copy(p, f.data), nil
+}
+
+func (f *guardedSingleReadFile) Close() error {
+	return nil
 }

--- a/cmd/testworkflow-toolkit/artifacts/k6_summary_post_processor_test.go
+++ b/cmd/testworkflow-toolkit/artifacts/k6_summary_post_processor_test.go
@@ -1,0 +1,45 @@
+package artifacts
+
+import "testing"
+
+func TestIsK6SummaryReport(t *testing.T) {
+	tests := []struct {
+		name string
+		data string
+		want bool
+	}{
+		{
+			name: "k6 summary with nested values",
+			data: `{"metrics":{"http_req_duration":{"values":{"p(95)":123}}}}`,
+			want: true,
+		},
+		{
+			name: "k6 summary export",
+			data: `{"metrics":{"http_req_duration":{"avg":24.8,"p(95)":29.7},"http_reqs":{"rate":39.5,"count":1187}}}`,
+			want: true,
+		},
+		{
+			name: "plain json",
+			data: `{"hello":"world"}`,
+			want: false,
+		},
+		{
+			name: "k6 summary without numeric values",
+			data: `{"metrics":{"http_req_duration":{"type":"trend","contains":"time","values":{}}}}`,
+			want: false,
+		},
+		{
+			name: "k6 summary null value",
+			data: `{"metrics":{"http_req_duration":{"avg":null}}}`,
+			want: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isK6SummaryReport([]byte(tc.data)); got != tc.want {
+				t.Fatalf("expected %t, got %t", tc.want, got)
+			}
+		})
+	}
+}

--- a/cmd/testworkflow-toolkit/commands/artifacts.go
+++ b/cmd/testworkflow-toolkit/commands/artifacts.go
@@ -83,7 +83,8 @@ func NewArtifactsCmd() *cobra.Command {
 
 			if env.HasJunitSupport() {
 				junitProcessor := artifacts.NewJUnitPostProcessor(filesystem.NewOSFileSystem(), client, cfg.Execution.EnvironmentId, cfg.Execution.Id, cfg.Workflow.Name, config.Ref(), walker.Root(), cfg.Resource.FsPrefix)
-				handlerOpts = append(handlerOpts, artifacts.WithPostProcessor(junitProcessor))
+				k6SummaryProcessor := artifacts.NewK6SummaryPostProcessor(filesystem.NewOSFileSystem(), client, cfg.Execution.EnvironmentId, cfg.Execution.Id, cfg.Workflow.Name, config.Ref(), walker.Root(), cfg.Resource.FsPrefix)
+				handlerOpts = append(handlerOpts, artifacts.WithPostProcessor(artifacts.NewCompositePostProcessor(junitProcessor, k6SummaryProcessor)))
 			}
 			if compress != "" {
 				processor = artifacts.NewTarCachedProcessor(compress, compressCachePath)

--- a/cmd/testworkflow-toolkit/commands/artifacts.go
+++ b/cmd/testworkflow-toolkit/commands/artifacts.go
@@ -81,10 +81,15 @@ func NewArtifactsCmd() *cobra.Command {
 				ui.Failf("could not create cloud client: %v", err)
 			}
 
+			postProcessors := make([]artifacts.PostProcessor, 0, 2)
 			if env.HasJunitSupport() {
-				junitProcessor := artifacts.NewJUnitPostProcessor(filesystem.NewOSFileSystem(), client, cfg.Execution.EnvironmentId, cfg.Execution.Id, cfg.Workflow.Name, config.Ref(), walker.Root(), cfg.Resource.FsPrefix)
-				k6SummaryProcessor := artifacts.NewK6SummaryPostProcessor(filesystem.NewOSFileSystem(), client, cfg.Execution.EnvironmentId, cfg.Execution.Id, cfg.Workflow.Name, config.Ref(), walker.Root(), cfg.Resource.FsPrefix)
-				handlerOpts = append(handlerOpts, artifacts.WithPostProcessor(artifacts.NewCompositePostProcessor(junitProcessor, k6SummaryProcessor)))
+				postProcessors = append(postProcessors, artifacts.NewJUnitPostProcessor(filesystem.NewOSFileSystem(), client, cfg.Execution.EnvironmentId, cfg.Execution.Id, cfg.Workflow.Name, config.Ref(), walker.Root(), cfg.Resource.FsPrefix))
+			}
+			postProcessors = append(postProcessors, artifacts.NewK6SummaryPostProcessor(filesystem.NewOSFileSystem(), client, cfg.Execution.EnvironmentId, cfg.Execution.Id, cfg.Workflow.Name, config.Ref(), walker.Root(), cfg.Resource.FsPrefix))
+			if len(postProcessors) == 1 {
+				handlerOpts = append(handlerOpts, artifacts.WithPostProcessor(postProcessors[0]))
+			} else {
+				handlerOpts = append(handlerOpts, artifacts.WithPostProcessor(artifacts.NewCompositePostProcessor(postProcessors...)))
 			}
 			if compress != "" {
 				processor = artifacts.NewTarCachedProcessor(compress, compressCachePath)

--- a/test/env/dev/dev-postgres/workflows/cloud-api-perf-smoke.yaml
+++ b/test/env/dev/dev-postgres/workflows/cloud-api-perf-smoke.yaml
@@ -48,7 +48,7 @@ spec:
   - name: create /data/artifacts
     shell: mkdir -p /data/artifacts
   - name: Run k6 load test
-    shell: k6 run -e TOKEN_BASIC_USER=$USER_TOKEN -e VUS={{ config.VUS }} -e DURATION={{ config.DURATION }} load-test.js --log-output=file=/data/artifacts/fails.log
+    shell: k6 run -e TOKEN_BASIC_USER=$USER_TOKEN -e VUS={{ config.VUS }} -e DURATION={{ config.DURATION }} load-test.js --log-output=file=/data/artifacts/fails.log --summary-export /data/artifacts/summary.json
     artifacts:
       paths:
       - /data/artifacts/**

--- a/test/examples/k6-perf/k6-crd.yaml
+++ b/test/examples/k6-perf/k6-crd.yaml
@@ -27,7 +27,7 @@ spec:
       image: grafana/k6:0.49.0
     steps:
     - run:
-        shell: mkdir /data/artifacts && k6 run k6-perf-test.js --vus {{ config.vus }} --duration {{ config.duration }}
+        shell: mkdir /data/artifacts && k6 run k6-perf-test.js --vus {{ config.vus }} --duration {{ config.duration }} --summary-export /data/artifacts/summary.json
         env:
         - name: K6_WEB_DASHBOARD
           value: "true"
@@ -69,7 +69,7 @@ spec:
       image: grafana/k6:0.49.0
     steps:
     - run:
-        shell: mkdir /data/artifacts && k6 run k6-perf-test-gcp.js --vus {{ config.vus }} --duration {{ config.duration }}
+        shell: mkdir /data/artifacts && k6 run k6-perf-test-gcp.js --vus {{ config.vus }} --duration {{ config.duration }} --summary-export /data/artifacts/summary.json
         env:
         - name: K6_WEB_DASHBOARD
           value: "true"
@@ -118,7 +118,7 @@ spec:
       run:
         image: grafana/k6:0.49.0
         workingDir: /data/repo/test/k6
-        shell: mkdir /data/artifacts && k6 run k6-perf-test.js --vus {{ config.vus }} --duration {{ config.duration }} --execution-segment '{{ index }}/{{ count }}:{{ index + 1 }}/{{ count }}'
+        shell: mkdir /data/artifacts && k6 run k6-perf-test.js --vus {{ config.vus }} --duration {{ config.duration }} --execution-segment '{{ index }}/{{ count }}:{{ index + 1 }}/{{ count }}' --summary-export /data/artifacts/summary-worker-{{ index + 1 }}.json
         env:
         - name: K6_WEB_DASHBOARD
           value: "true"
@@ -128,6 +128,7 @@ spec:
       workingDir: /data/artifacts
       paths:
       - '*.html'
+      - '*.json'
 ---
 apiVersion: testworkflows.testkube.io/v1
 kind: TestWorkflow
@@ -165,7 +166,7 @@ spec:
       run:
         image: grafana/k6:0.49.0
         workingDir: /data/repo/test/k6
-        shell: mkdir /data/artifacts && k6 run k6-perf-test-gcp.js --vus {{ config.vus }} --duration {{ config.duration }} --execution-segment '{{ index }}/{{ count }}:{{ index + 1 }}/{{ count }}'
+        shell: mkdir /data/artifacts && k6 run k6-perf-test-gcp.js --vus {{ config.vus }} --duration {{ config.duration }} --execution-segment '{{ index }}/{{ count }}:{{ index + 1 }}/{{ count }}' --summary-export /data/artifacts/summary-worker-{{ index + 1 }}.json
         env:
         - name: K6_WEB_DASHBOARD
           value: "true"
@@ -175,6 +176,7 @@ spec:
       workingDir: /data/artifacts
       paths:
       - '*.html'
+      - '*.json'
 ---
 apiVersion: testworkflows.testkube.io/v1
 kind: TestWorkflow
@@ -212,7 +214,7 @@ spec:
       run:
         image: grafana/k6:0.49.0
         workingDir: /data/repo/test/k6
-        shell: mkdir /data/artifacts && k6 run k6-perf-test-gcp-discard-response-bodies.js --vus {{ config.vus }} --duration {{ config.duration }} --execution-segment '{{ index }}/{{ count }}:{{ index + 1 }}/{{ count }}'
+        shell: mkdir /data/artifacts && k6 run k6-perf-test-gcp-discard-response-bodies.js --vus {{ config.vus }} --duration {{ config.duration }} --execution-segment '{{ index }}/{{ count }}:{{ index + 1 }}/{{ count }}' --summary-export /data/artifacts/summary-worker-{{ index + 1 }}.json
         env:
         - name: K6_WEB_DASHBOARD
           value: "true"
@@ -259,7 +261,7 @@ spec:
       run:
         image: grafana/k6:0.49.0
         workingDir: /data/repo/test/k6
-        shell: mkdir /data/artifacts && k6 run k6-perf-test.js -o experimental-prometheus-rw --vus {{ config.vus }} --duration {{ config.duration }} --execution-segment '{{ index }}/{{ count }}:{{ index + 1 }}/{{ count }}' --tag testid=worker-{{ index + 1}}
+        shell: mkdir /data/artifacts && k6 run k6-perf-test.js -o experimental-prometheus-rw --vus {{ config.vus }} --duration {{ config.duration }} --execution-segment '{{ index }}/{{ count }}:{{ index + 1 }}/{{ count }}' --tag testid=worker-{{ index + 1}} --summary-export /data/artifacts/summary-worker-{{ index + 1 }}.json
         env:
         - name: K6_WEB_DASHBOARD
           value: "true"
@@ -275,6 +277,7 @@ spec:
       workingDir: /data/artifacts
       paths:
       - '*.html'
+      - '*.json'
 ---
 apiVersion: testworkflows.testkube.io/v1
 kind: TestWorkflow
@@ -312,7 +315,7 @@ spec:
       run:
         image: grafana/k6:0.49.0
         workingDir: /data/repo/test/k6
-        shell: mkdir /data/artifacts && k6 run k6-perf-test-gcp.js -o experimental-prometheus-rw --vus {{ config.vus }} --duration {{ config.duration }} --execution-segment '{{ index }}/{{ count }}:{{ index + 1 }}/{{ count }}' --tag testid=worker-{{ index + 1}}
+        shell: mkdir /data/artifacts && k6 run k6-perf-test-gcp.js -o experimental-prometheus-rw --vus {{ config.vus }} --duration {{ config.duration }} --execution-segment '{{ index }}/{{ count }}:{{ index + 1 }}/{{ count }}' --tag testid=worker-{{ index + 1}} --summary-export /data/artifacts/summary-worker-{{ index + 1 }}.json
         env:
         - name: K6_WEB_DASHBOARD
           value: "true"
@@ -328,3 +331,4 @@ spec:
       workingDir: /data/artifacts
       paths:
       - '*.html'
+      - '*.json'

--- a/test/examples/k6-perf/k6-crd.yaml
+++ b/test/examples/k6-perf/k6-crd.yaml
@@ -224,6 +224,7 @@ spec:
       workingDir: /data/artifacts
       paths:
       - '*.html'
+      - '*.json'
 ---
 apiVersion: testworkflows.testkube.io/v1
 kind: TestWorkflow

--- a/test/k6/crd-workflow/smoke.yaml
+++ b/test/k6/crd-workflow/smoke.yaml
@@ -30,7 +30,7 @@ spec:
     steps:
     - shell: mkdir /data/artifacts
     - run:
-        shell: k6 run k6-smoke-test.js -e K6_ENV_FROM_PARAM=K6_ENV_FROM_PARAM_value --duration 30s
+        shell: k6 run k6-smoke-test.js -e K6_ENV_FROM_PARAM=K6_ENV_FROM_PARAM_value --duration 30s --summary-export /data/artifacts/summary.json
         env:
         - name: K6_SYSTEM_ENV
           value: K6_SYSTEM_ENV_value
@@ -156,10 +156,11 @@ spec:
             value: 'true'
           - name: K6_WEB_DASHBOARD_EXPORT
             value: k6-test-report.html
-        shell: k6 run k6-test.js --duration 30s
+        shell: k6 run k6-test.js --duration 30s --summary-export summary.json
       artifacts:
         paths:
           - k6-test-report.html
+          - summary.json
 ---
 apiVersion: testworkflows.testkube.io/v1
 kind: TestWorkflow


### PR DESCRIPTION
Linear: https://linear.app/kubeshop/issue/TKC-5753/support-native-k6-summaryjson-ingestion-for-granular-insights

## Summary
- detect native k6 `summary.json` exports in the toolkit artifact post-processor
- register k6 summaries as native report artifacts
- update k6 workflow examples to export `/data/artifacts/summary.json` so granular ingestion can consume them

## Validation
- `go test ./cmd/testworkflow-toolkit/artifacts ./cmd/testworkflow-toolkit/commands`
- `make lint && go build ./...`
- local Tilt run with `tilt up all -- --db postgres`; `k6-workflow-smoke` produced `summary.json` and the cloud-api PR ingested 74 k6 points for execution `6a0aaef4eaad8e623c5c0eed`

Companion PR: testkube-cloud-api parser branch `feat/tkc-5753-k6-summary-json-parser`.