### PR TITLE
feat: [TKC-5772] upload artillery reports

### DIFF
--- a/cmd/testworkflow-toolkit/artifacts/artillery_report_post_processor.go
+++ b/cmd/testworkflow-toolkit/artifacts/artillery_report_post_processor.go
@@ -1,0 +1,125 @@
+package artifacts
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"path/filepath"
+
+	"github.com/pkg/errors"
+
+	"github.com/kubeshop/testkube/pkg/controlplaneclient"
+	"github.com/kubeshop/testkube/pkg/filesystem"
+	"github.com/kubeshop/testkube/pkg/ui"
+)
+
+// ArtilleryReportPostProcessor checks JSON files for Artillery reports and sends them to the cloud.
+type ArtilleryReportPostProcessor struct {
+	fs            filesystem.FileSystem
+	client        controlplaneclient.ExecutionSelfClient
+	root          string
+	pathPrefix    string
+	environmentId string
+	executionId   string
+	workflowName  string
+	stepRef       string
+}
+
+func NewArtilleryReportPostProcessor(
+	fs filesystem.FileSystem,
+	client controlplaneclient.ExecutionSelfClient,
+	environmentId string,
+	executionId string,
+	workflowName string,
+	stepRef string,
+	root, pathPrefix string,
+) *ArtilleryReportPostProcessor {
+	return &ArtilleryReportPostProcessor{
+		fs:            fs,
+		client:        client,
+		environmentId: environmentId,
+		executionId:   executionId,
+		workflowName:  workflowName,
+		stepRef:       stepRef,
+		root:          root,
+		pathPrefix:    pathPrefix,
+	}
+}
+
+func (p *ArtilleryReportPostProcessor) Start() error {
+	return nil
+}
+
+func (p *ArtilleryReportPostProcessor) Add(path string) error {
+	if err := p.add(path); err != nil {
+		fmt.Printf("warn: artillery report processing: %s: %s\n", path, err)
+	}
+	return nil
+}
+
+func (p *ArtilleryReportPostProcessor) End() error {
+	return nil
+}
+
+func (p *ArtilleryReportPostProcessor) add(path string) error {
+	uploadPath := path
+	if p.pathPrefix != "" {
+		uploadPath = filepath.Join(p.pathPrefix, uploadPath)
+	}
+	absPath := path
+	if !filepath.IsAbs(path) {
+		absPath = filepath.Join(p.root, absPath)
+	}
+	file, err := p.fs.OpenFileRO(absPath)
+	if err != nil {
+		return errors.Wrapf(err, "failed to open %s", path)
+	}
+	defer func() { _ = file.Close() }()
+
+	stat, err := file.Stat()
+	if err != nil {
+		return errors.Wrapf(err, "failed to get file info for %s", path)
+	}
+	if !isJSONFile(stat) {
+		return nil
+	}
+
+	data, err := io.ReadAll(file)
+	if err != nil {
+		return errors.Wrapf(err, "failed to read %s", path)
+	}
+	if !isArtilleryReport(data) {
+		return nil
+	}
+
+	fmt.Printf("Processing Artillery report: %s\n", ui.LightCyan(path))
+	if err := p.client.AppendExecutionReport(context.Background(), p.environmentId, p.executionId, p.workflowName, p.stepRef, uploadPath, data); err != nil {
+		return errors.Wrapf(err, "failed to send Artillery report %s", stat.Name())
+	}
+	return nil
+}
+
+func isArtilleryReport(data []byte) bool {
+	var report struct {
+		Aggregate artilleryAggregate `json:"aggregate"`
+	}
+	if err := json.Unmarshal(data, &report); err != nil {
+		return false
+	}
+	return artilleryAggregateHasMetrics(report.Aggregate)
+}
+
+type artilleryAggregate struct {
+	Counters   map[string]float64            `json:"counters"`
+	Rates      map[string]float64            `json:"rates"`
+	Summaries  map[string]map[string]float64 `json:"summaries"`
+	Histograms map[string]map[string]float64 `json:"histograms"`
+}
+
+func artilleryAggregateHasMetrics(aggregate artilleryAggregate) bool {
+	return len(aggregate.Counters) > 0 ||
+		len(aggregate.Rates) > 0 ||
+		len(aggregate.Summaries) > 0 ||
+		len(aggregate.Histograms) > 0
+}

--- a/cmd/testworkflow-toolkit/artifacts/artillery_report_post_processor.go
+++ b/cmd/testworkflow-toolkit/artifacts/artillery_report_post_processor.go
@@ -14,6 +14,8 @@ import (
 	"github.com/kubeshop/testkube/pkg/ui"
 )
 
+const maxArtilleryReportProbeBytes int64 = 16 << 20
+
 // ArtilleryReportPostProcessor checks JSON files for Artillery reports and sends them to the cloud.
 type ArtilleryReportPostProcessor struct {
 	fs            filesystem.FileSystem
@@ -75,7 +77,11 @@ func (p *ArtilleryReportPostProcessor) add(path string) error {
 	if err != nil {
 		return errors.Wrapf(err, "failed to open %s", path)
 	}
-	defer func() { _ = file.Close() }()
+	defer func() {
+		if file != nil {
+			_ = file.Close()
+		}
+	}()
 
 	stat, err := file.Stat()
 	if err != nil {
@@ -85,7 +91,20 @@ func (p *ArtilleryReportPostProcessor) add(path string) error {
 		return nil
 	}
 
-	data, err := io.ReadAll(file)
+	if !hasArtilleryReportShape(file, maxArtilleryReportProbeBytes) {
+		return nil
+	}
+	if err := file.Close(); err != nil {
+		return errors.Wrapf(err, "failed to close %s", path)
+	}
+	file = nil
+	reportFile, err := p.fs.OpenFileRO(absPath)
+	if err != nil {
+		return errors.Wrapf(err, "failed to reopen %s", path)
+	}
+	defer func() { _ = reportFile.Close() }()
+
+	data, err := io.ReadAll(reportFile)
 	if err != nil {
 		return errors.Wrapf(err, "failed to read %s", path)
 	}
@@ -98,6 +117,73 @@ func (p *ArtilleryReportPostProcessor) add(path string) error {
 		return errors.Wrapf(err, "failed to send Artillery report %s", stat.Name())
 	}
 	return nil
+}
+
+func hasArtilleryReportShape(reader io.Reader, maxBytes int64) bool {
+	limited := &io.LimitedReader{R: reader, N: maxBytes}
+	decoder := json.NewDecoder(limited)
+
+	token, err := decoder.Token()
+	if err != nil {
+		return false
+	}
+	delim, ok := token.(json.Delim)
+	if !ok || delim != '{' {
+		return false
+	}
+
+	for decoder.More() {
+		keyToken, err := decoder.Token()
+		if err != nil {
+			return false
+		}
+		key, ok := keyToken.(string)
+		if !ok {
+			return false
+		}
+		if key == "aggregate" {
+			return artilleryAggregateHasMetricShape(decoder)
+		}
+		if err := skipJSONValue(decoder); err != nil {
+			return false
+		}
+	}
+	return false
+}
+
+func artilleryAggregateHasMetricShape(decoder *json.Decoder) bool {
+	token, err := decoder.Token()
+	if err != nil {
+		return false
+	}
+	delim, ok := token.(json.Delim)
+	if !ok || delim != '{' {
+		return false
+	}
+
+	for decoder.More() {
+		keyToken, err := decoder.Token()
+		if err != nil {
+			return false
+		}
+		key, ok := keyToken.(string)
+		if !ok {
+			return false
+		}
+		if key == "counters" || key == "rates" || key == "summaries" || key == "histograms" {
+			if jsonValueHasNumber(decoder) {
+				return true
+			}
+			continue
+		}
+		if err := skipJSONValue(decoder); err != nil {
+			return false
+		}
+	}
+	if _, err := decoder.Token(); err != nil {
+		return false
+	}
+	return false
 }
 
 func isArtilleryReport(data []byte) bool {

--- a/cmd/testworkflow-toolkit/artifacts/artillery_report_post_processor_test.go
+++ b/cmd/testworkflow-toolkit/artifacts/artillery_report_post_processor_test.go
@@ -1,6 +1,15 @@
 package artifacts
 
-import "testing"
+import (
+	"io/fs"
+	"strings"
+	"testing"
+
+	gomock "go.uber.org/mock/gomock"
+
+	"github.com/kubeshop/testkube/pkg/controlplaneclient"
+	"github.com/kubeshop/testkube/pkg/filesystem"
+)
 
 func TestIsArtilleryReport(t *testing.T) {
 	tests := []struct {
@@ -46,5 +55,93 @@ func TestIsArtilleryReport(t *testing.T) {
 				t.Fatalf("expected %t, got %t", tc.want, got)
 			}
 		})
+	}
+}
+
+func TestHasArtilleryReportShape(t *testing.T) {
+	tests := []struct {
+		name     string
+		data     string
+		maxBytes int64
+		want     bool
+	}{
+		{
+			name:     "artillery report with metadata before aggregate",
+			data:     `{"intermediate":{"latencies":[1,2,3]},"aggregate":{"counters":{"http.requests":10}}}`,
+			maxBytes: maxArtilleryReportProbeBytes,
+			want:     true,
+		},
+		{
+			name:     "artillery report with summaries",
+			data:     `{"aggregate":{"summaries":{"http.response_time":{"p95":123.4}}}}`,
+			maxBytes: maxArtilleryReportProbeBytes,
+			want:     true,
+		},
+		{
+			name:     "k6 summary export",
+			data:     `{"metrics":{"http_req_duration":{"avg":24.8,"p(95)":29.7},"http_reqs":{"rate":39.5,"count":1187}}}`,
+			maxBytes: maxArtilleryReportProbeBytes,
+			want:     false,
+		},
+		{
+			name:     "bounded before aggregate",
+			data:     `{"intermediate":{"message":"` + strings.Repeat("a", 128) + `"},"aggregate":{"counters":{"http.requests":10}}}`,
+			maxBytes: 64,
+			want:     false,
+		},
+		{
+			name:     "plain json",
+			data:     `{"hello":"world"}`,
+			maxBytes: maxArtilleryReportProbeBytes,
+			want:     false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := hasArtilleryReportShape(strings.NewReader(tc.data), tc.maxBytes); got != tc.want {
+				t.Fatalf("expected %t, got %t", tc.want, got)
+			}
+		})
+	}
+}
+
+func TestArtilleryReportPostProcessorAddUploadsReport(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	report := []byte(`{"aggregate":{"counters":{"http.requests":10}}}`)
+	mockFS := filesystem.NewMockFileSystem(mockCtrl)
+	mockFS.EXPECT().
+		OpenFileRO("/artillery-report.json").
+		Times(2).
+		DoAndReturn(func(string) (fs.File, error) {
+			return filesystem.NewMockFile("artillery-report.json", report), nil
+		})
+
+	mockClient := controlplaneclient.NewMockClient(mockCtrl)
+	mockClient.EXPECT().
+		AppendExecutionReport(gomock.Any(), "env123", "exec123", "workflow123", "step123", "artillery-report.json", report).
+		Return(nil)
+
+	pp := NewArtilleryReportPostProcessor(mockFS, mockClient, "env123", "exec123", "workflow123", "step123", "/", "")
+	if err := pp.add("artillery-report.json"); err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+}
+
+func TestArtilleryReportPostProcessorAddSkipsNonReportJSONWithoutFullRead(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	mockFS := filesystem.NewMockFileSystem(mockCtrl)
+	mockFS.EXPECT().
+		OpenFileRO("/browser-trace.json").
+		Return(newGuardedSingleReadFile("browser-trace.json", []byte(`{"type":"trace","events":[{"name":"navigation"}]}`)), nil)
+
+	mockClient := controlplaneclient.NewMockClient(mockCtrl)
+	pp := NewArtilleryReportPostProcessor(mockFS, mockClient, "env123", "exec123", "workflow123", "step123", "/", "")
+	if err := pp.add("browser-trace.json"); err != nil {
+		t.Fatalf("expected no error, got %v", err)
 	}
 }

--- a/cmd/testworkflow-toolkit/artifacts/artillery_report_post_processor_test.go
+++ b/cmd/testworkflow-toolkit/artifacts/artillery_report_post_processor_test.go
@@ -1,0 +1,50 @@
+package artifacts
+
+import "testing"
+
+func TestIsArtilleryReport(t *testing.T) {
+	tests := []struct {
+		name string
+		data string
+		want bool
+	}{
+		{
+			name: "k6 summary with nested values is handled by dedicated processor",
+			data: `{"metrics":{"http_req_duration":{"values":{"p(95)":123}}}}`,
+			want: false,
+		},
+		{
+			name: "k6 summary export is handled by dedicated processor",
+			data: `{"metrics":{"http_req_duration":{"avg":24.8,"p(95)":29.7},"http_reqs":{"rate":39.5,"count":1187}}}`,
+			want: false,
+		},
+		{
+			name: "artillery report",
+			data: `{"aggregate":{"counters":{"http.requests":10}}}`,
+			want: true,
+		},
+		{
+			name: "playwright json is not in this processor scope",
+			data: `{"suites":[{"specs":[{"tests":[{"results":[{"status":"passed"}]}]}]}]}`,
+			want: false,
+		},
+		{
+			name: "cypress json is not in this processor scope",
+			data: `{"stats":{"tests":1},"tests":[{"title":"works","state":"passed"}]}`,
+			want: false,
+		},
+		{
+			name: "plain json",
+			data: `{"hello":"world"}`,
+			want: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isArtilleryReport([]byte(tc.data)); got != tc.want {
+				t.Fatalf("expected %t, got %t", tc.want, got)
+			}
+		})
+	}
+}

--- a/cmd/testworkflow-toolkit/artifacts/artillery_report_post_processor_test.go
+++ b/cmd/testworkflow-toolkit/artifacts/artillery_report_post_processor_test.go
@@ -78,6 +78,12 @@ func TestHasArtilleryReportShape(t *testing.T) {
 			want:     true,
 		},
 		{
+			name:     "aggregate shaped json without numeric metrics",
+			data:     `{"aggregate":{"counters":{"status":"ok"},"rates":{},"summaries":{"http.response_time":{"p95":"123.4"}}}}`,
+			maxBytes: maxArtilleryReportProbeBytes,
+			want:     false,
+		},
+		{
 			name:     "k6 summary export",
 			data:     `{"metrics":{"http_req_duration":{"avg":24.8,"p(95)":29.7},"http_reqs":{"rate":39.5,"count":1187}}}`,
 			maxBytes: maxArtilleryReportProbeBytes,
@@ -142,6 +148,22 @@ func TestArtilleryReportPostProcessorAddSkipsNonReportJSONWithoutFullRead(t *tes
 	mockClient := controlplaneclient.NewMockClient(mockCtrl)
 	pp := NewArtilleryReportPostProcessor(mockFS, mockClient, "env123", "exec123", "workflow123", "step123", "/", "")
 	if err := pp.add("browser-trace.json"); err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+}
+
+func TestArtilleryReportPostProcessorAddSkipsAggregateShapedJSONWithoutFullRead(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	mockFS := filesystem.NewMockFileSystem(mockCtrl)
+	mockFS.EXPECT().
+		OpenFileRO("/aggregate-dump.json").
+		Return(newGuardedSingleReadFile("aggregate-dump.json", []byte(`{"aggregate":{"counters":{"status":"ok"}}}`)), nil)
+
+	mockClient := controlplaneclient.NewMockClient(mockCtrl)
+	pp := NewArtilleryReportPostProcessor(mockFS, mockClient, "env123", "exec123", "workflow123", "step123", "/", "")
+	if err := pp.add("aggregate-dump.json"); err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
 }

--- a/cmd/testworkflow-toolkit/artifacts/k6_summary_post_processor.go
+++ b/cmd/testworkflow-toolkit/artifacts/k6_summary_post_processor.go
@@ -263,16 +263,20 @@ func jsonValueHasNumber(decoder *json.Decoder) bool {
 				return true
 			}
 		}
-		_, err := decoder.Token()
-		return err == nil
+		if _, err := decoder.Token(); err != nil {
+			return false
+		}
+		return false
 	case '[':
 		for decoder.More() {
 			if jsonValueHasNumber(decoder) {
 				return true
 			}
 		}
-		_, err := decoder.Token()
-		return err == nil
+		if _, err := decoder.Token(); err != nil {
+			return false
+		}
+		return false
 	default:
 		return false
 	}

--- a/cmd/testworkflow-toolkit/artifacts/k6_summary_post_processor_test.go
+++ b/cmd/testworkflow-toolkit/artifacts/k6_summary_post_processor_test.go
@@ -74,6 +74,12 @@ func TestHasK6SummaryReportShape(t *testing.T) {
 			want:     true,
 		},
 		{
+			name:     "k6 summary without numeric values",
+			data:     `{"metrics":{"http_req_duration":{"type":"trend","contains":"time","values":{},"status":"ok"}}}`,
+			maxBytes: maxK6SummaryProbeBytes,
+			want:     false,
+		},
+		{
 			name:     "k6 json output stream",
 			data:     `{"type":"Point","data":{"time":"2026-01-01T00:00:00Z","value":1,"metric":"http_reqs"}}` + "\n" + `{"type":"Point","data":{"value":2}}`,
 			maxBytes: maxK6SummaryProbeBytes,

--- a/cmd/testworkflow-toolkit/commands/artifacts.go
+++ b/cmd/testworkflow-toolkit/commands/artifacts.go
@@ -81,10 +81,11 @@ func NewArtifactsCmd() *cobra.Command {
 				ui.Failf("could not create cloud client: %v", err)
 			}
 
-			postProcessors := make([]artifacts.PostProcessor, 0, 2)
+			postProcessors := make([]artifacts.PostProcessor, 0, 3)
 			if env.HasJunitSupport() {
 				postProcessors = append(postProcessors, artifacts.NewJUnitPostProcessor(filesystem.NewOSFileSystem(), client, cfg.Execution.EnvironmentId, cfg.Execution.Id, cfg.Workflow.Name, config.Ref(), walker.Root(), cfg.Resource.FsPrefix))
 			}
+			postProcessors = append(postProcessors, artifacts.NewArtilleryReportPostProcessor(filesystem.NewOSFileSystem(), client, cfg.Execution.EnvironmentId, cfg.Execution.Id, cfg.Workflow.Name, config.Ref(), walker.Root(), cfg.Resource.FsPrefix))
 			postProcessors = append(postProcessors, artifacts.NewK6SummaryPostProcessor(filesystem.NewOSFileSystem(), client, cfg.Execution.EnvironmentId, cfg.Execution.Id, cfg.Workflow.Name, config.Ref(), walker.Root(), cfg.Resource.FsPrefix))
 			if len(postProcessors) == 1 {
 				handlerOpts = append(handlerOpts, artifacts.WithPostProcessor(postProcessors[0]))

--- a/test/artillery/crd-workflow/smoke.yaml
+++ b/test/artillery/crd-workflow/smoke.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     core-tests: workflows
     tool: artillery
+    artifacts: "true"
     category: performance-testing
   annotations:
     testkube.io/icon: artillery
@@ -26,7 +27,13 @@ spec:
     activeDeadlineSeconds: 300
   steps:
   - name: Run test
-    shell: /home/node/artillery/bin/run run artillery-smoke-test.yaml
+    shell: |
+      mkdir -p /data/artifacts
+      /home/node/artillery/bin/run run artillery-smoke-test.yaml -o /data/artifacts/artillery-report.json
+    artifacts:
+      workingDir: /data/artifacts
+      paths:
+      - '*'
 ---
 apiVersion: testworkflows.testkube.io/v1
 kind: TestWorkflow


### PR DESCRIPTION
## Linear
- https://linear.app/kubeshop/issue/TKC-5772/support-native-artillery-report-ingestion-for-granular-insights

## Summary
- add a toolkit post-processor for native Artillery aggregate JSON reports
- detect Artillery aggregate JSON artifacts and append them as execution reports
- wire the new processor into artifact upload alongside JUnit and k6 summary handling
- update `test/artillery/crd-workflow/smoke.yaml` so `artillery-workflow-smoke` exports `artillery-report.json` as an artifact