### PR TITLE
feat(helm): add embedded SeaweedFS option for OSS chart

### DIFF
--- a/k8s/helm/testkube-api/templates/_helpers.tpl
+++ b/k8s/helm/testkube-api/templates/_helpers.tpl
@@ -310,14 +310,15 @@ Define API environment in standalone mode
 {{- end }}
 {{- end }}
 {{- $storageProvider := default "minio" .Values.global.storageProvider }}
+{{- $seaweedS3Port := default 8333 .Values.global.seaweedfsS3Port }}
 - name: "STORAGE_ENDPOINT"
   {{- if .Values.storage.endpoint }}
   value:  "{{ .Values.storage.endpoint }}"
   {{- else if eq $storageProvider "seaweedfs" }}
   {{- if .Values.executionNamespaces }}
-  value:  "{{ .Release.Name }}-seaweedfs-filer.{{ .Release.Namespace }}.svc.cluster.local:8333"
+  value:  "{{ .Release.Name }}-seaweedfs-filer.{{ .Release.Namespace }}.svc.cluster.local:{{ $seaweedS3Port }}"
   {{- else }}
-  value:  "{{ .Release.Name }}-seaweedfs-filer:8333"
+  value:  "{{ .Release.Name }}-seaweedfs-filer:{{ $seaweedS3Port }}"
   {{- end }}
   {{- else if .Values.executionNamespaces }}
   value:  "testkube-minio-service-{{ .Release.Namespace }}.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.storage.endpoint_port }}"

--- a/k8s/helm/testkube-api/templates/_helpers.tpl
+++ b/k8s/helm/testkube-api/templates/_helpers.tpl
@@ -309,9 +309,16 @@ Define API environment in standalone mode
   value: "{{ .Values.nats.tls.certSecret.baseMountPath }}/{{ .Values.nats.tls.certSecret.caFile }}"
 {{- end }}
 {{- end }}
+{{- $storageProvider := default "minio" .Values.global.storageProvider }}
 - name: "STORAGE_ENDPOINT"
   {{- if .Values.storage.endpoint }}
   value:  "{{ .Values.storage.endpoint }}"
+  {{- else if eq $storageProvider "seaweedfs" }}
+  {{- if .Values.executionNamespaces }}
+  value:  "{{ .Release.Name }}-seaweedfs-filer.{{ .Release.Namespace }}.svc.cluster.local:8333"
+  {{- else }}
+  value:  "{{ .Release.Name }}-seaweedfs-filer:8333"
+  {{- end }}
   {{- else if .Values.executionNamespaces }}
   value:  "testkube-minio-service-{{ .Release.Namespace }}.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.storage.endpoint_port }}"
   {{- else }}

--- a/k8s/helm/testkube-api/templates/minio.yaml
+++ b/k8s/helm/testkube-api/templates/minio.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.minio.enabled -}}
+{{- if and .Values.minio.enabled (ne (default "minio" .Values.global.storageProvider) "seaweedfs") -}}
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:

--- a/k8s/helm/testkube/Chart.lock
+++ b/k8s/helm/testkube/Chart.lock
@@ -17,6 +17,9 @@ dependencies:
 - name: nats
   repository: file://./charts/nats
   version: 1.2.6-4
+- name: seaweed
+  repository: oci://us-east1-docker.pkg.dev/testkube-cloud-372110/testkube
+  version: 4.23-0
 - name: testkube-api
   repository: file://../testkube-api
   version: 2.9.0-rc.0

--- a/k8s/helm/testkube/Chart.lock
+++ b/k8s/helm/testkube/Chart.lock
@@ -26,5 +26,5 @@ dependencies:
 - name: global
   repository: file://../global
   version: 0.1.3
-digest: sha256:c99d9e4731c48c49e95aa197edfca857c89ac74a0c056904a930576eb94bbfd2
-generated: "2026-05-15T21:42:24.913700328Z"
+digest: sha256:c878fd84045535eb41cef33fabd7c3f93038691b465d5c08ed9a103742de1f06
+generated: "2026-05-19T14:58:16.428168-04:00"

--- a/k8s/helm/testkube/Chart.yaml
+++ b/k8s/helm/testkube/Chart.yaml
@@ -29,6 +29,11 @@ dependencies:
     condition: testkube-api.nats.enabled
     version: 1.2.6-4
     repository: "file://./charts/nats"
+  - name: seaweed
+    alias: seaweedfs
+    condition: seaweedfs.enabled
+    version: 4.23-0
+    repository: oci://us-east1-docker.pkg.dev/testkube-cloud-372110/testkube
   - name: testkube-api
     version: 2.x.x-x
     repository: "file://../testkube-api"

--- a/k8s/helm/testkube/templates/seaweedfs-s3-config-secret.yaml
+++ b/k8s/helm/testkube/templates/seaweedfs-s3-config-secret.yaml
@@ -1,0 +1,34 @@
+{{- if and .Values.seaweedfs.enabled .Values.seaweedfs.filer.s3.enableAuth }}
+{{- $testkubeApi := index .Values "testkube-api" }}
+{{- $storage := index $testkubeApi "storage" }}
+{{- $accessKey := index $storage "accessKeyId" | default "testkube" }}
+{{- $secretKey := index $storage "accessKey" | default "t3stkub3-3nt3rpr1s3" }}
+{{- $configSecretName := .Values.seaweedfs.filer.s3.existingConfigSecret | default "testkube-seaweedfs-s3-config" }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ $configSecretName }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{ include "global.labels.standard" . | nindent 4 }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+    app.kubernetes.io/name: seaweedfs
+    app.kubernetes.io/instance: {{ .Release.Name }}
+type: Opaque
+stringData:
+  seaweedfs_s3_config: |
+    {
+      "identities": [
+        {
+          "name": "testkube-storage",
+          "credentials": [
+            {
+              "accessKey": "{{ $accessKey }}",
+              "secretKey": "{{ $secretKey }}"
+            }
+          ],
+          "actions": ["Admin", "Read", "Write", "List", "Tagging"]
+        }
+      ]
+    }
+{{- end }}

--- a/k8s/helm/testkube/templates/seaweedfs-s3-config-secret.yaml
+++ b/k8s/helm/testkube/templates/seaweedfs-s3-config-secret.yaml
@@ -3,6 +3,26 @@
 {{- $storage := index $testkubeApi "storage" }}
 {{- $accessKey := index $storage "accessKeyId" | default "testkube" }}
 {{- $secretKey := index $storage "accessKey" | default "t3stkub3-3nt3rpr1s3" }}
+{{- $accessRefName := index $storage "secretNameAccessKeyId" | default "" }}
+{{- $accessRefKey := index $storage "secretKeyAccessKeyId" | default "" }}
+{{- $secretRefName := index $storage "secretNameSecretAccessKey" | default "" }}
+{{- $secretRefKey := index $storage "secretKeySecretAccessKey" | default "" }}
+{{- $accessKeyFromSecret := "" }}
+{{- if and $accessRefName $accessRefKey }}
+  {{- $accessSecret := lookup "v1" "Secret" .Release.Namespace $accessRefName }}
+  {{- if and $accessSecret (hasKey $accessSecret.data $accessRefKey) }}
+    {{- $accessKeyFromSecret = (index $accessSecret.data $accessRefKey | b64dec) }}
+  {{- end }}
+{{- end }}
+{{- $secretKeyFromSecret := "" }}
+{{- if and $secretRefName $secretRefKey }}
+  {{- $secretSecret := lookup "v1" "Secret" .Release.Namespace $secretRefName }}
+  {{- if and $secretSecret (hasKey $secretSecret.data $secretRefKey) }}
+    {{- $secretKeyFromSecret = (index $secretSecret.data $secretRefKey | b64dec) }}
+  {{- end }}
+{{- end }}
+{{- $accessKey = default $accessKey $accessKeyFromSecret }}
+{{- $secretKey = default $secretKey $secretKeyFromSecret }}
 {{- $configSecretName := .Values.seaweedfs.filer.s3.existingConfigSecret | default "testkube-seaweedfs-s3-config" }}
 apiVersion: v1
 kind: Secret

--- a/k8s/helm/testkube/values.yaml
+++ b/k8s/helm/testkube/values.yaml
@@ -35,6 +35,8 @@ global:
     ## scraper - scrape logs from testkube scraper container
     # -- Comma-separated array of containers which should get scraped for logs
     whitelistedContainers: init,logs,scraper
+  # -- Embedded object storage provider used by API fallback endpoint resolution (`minio` or `seaweedfs`).
+  storageProvider: minio
   ## Global TLS settings
   tls:
     # -- Toggle whether to globally skip certificate verification
@@ -530,6 +532,36 @@ testkube-logs:
     # -- (int/percentage) Number or percentage of pods that can be unavailable.
     maxUnavailable: ""
 
+# SeaweedFS chart parameters (embedded S3-compatible storage alternative to MinIO)
+seaweedfs:
+  # -- Toggle whether to install embedded SeaweedFS.
+  enabled: false
+  global:
+    seaweedfs:
+      image:
+        # -- SeaweedFS image name.
+        name: kubeshop/testkube-seaweedfs
+  master:
+    # -- Number of SeaweedFS master replicas.
+    replicas: 1
+  volume:
+    # -- Number of SeaweedFS volume replicas.
+    replicas: 1
+  filer:
+    # -- Number of SeaweedFS filer replicas.
+    replicas: 1
+    s3:
+      # -- Toggle whether to expose S3 API through filer.
+      enabled: true
+      # -- S3 API port for filer mode.
+      port: 8333
+      # -- Toggle whether to require access credentials for S3.
+      enableAuth: true
+      # -- Name of secret containing `seaweedfs_s3_config`.
+      existingConfigSecret: testkube-seaweedfs-s3-config
+      # -- Disable bucket creation hook by default.
+      createBuckets: []
+
 # Testkube API parameters
 testkube-api:
   # -- Testkube API full name override
@@ -880,7 +912,7 @@ testkube-api:
 
   # MinIO parameters
   minio:
-    # -- Toggle whether to install MinIO
+    # -- Toggle whether to install MinIO. If `global.storageProvider=seaweedfs`, MinIO deployment is skipped automatically.
     enabled: true
     # -- Minio extra vars
     extraEnvVars: []
@@ -1016,15 +1048,15 @@ testkube-api:
       #     - testkube.example.com
     #   secretName: testkube-cert-secret
 
-  # Storage for Testkube API using MinIO
+  # Storage for Testkube API using S3-compatible backend (MinIO or SeaweedFS)
   storage:
-    # -- MinIO endpoint
+    # -- S3 endpoint. If empty, chart resolves default from `global.storageProvider`.
     endpoint: ""
-    # -- MinIO endpoint port
+    # -- S3 endpoint port (used by MinIO fallback endpoint).
     endpoint_port: "9000"
-    # -- MinIO Access Key ID
+    # -- S3 Access Key ID
     accessKeyId: "minio"
-    # -- MinIO Secret Access Key
+    # -- S3 Secret Access Key
     accessKey: "minio123"
     # -- k8s Secret name for storage accessKeyId
     secretNameAccessKeyId: ""
@@ -1034,15 +1066,15 @@ testkube-api:
     secretNameSecretAccessKey: ""
     # -- Key for storage secretAccessKeyId taken from k8s secret
     secretKeySecretAccessKey: ""
-    # -- MinIO Region
+    # -- S3 Region
     region: ""
-    # -- MinIO Token
+    # -- S3 Token
     token: ""
-    # -- MinIO Bucket
+    # -- S3 Bucket
     bucket: "testkube-artifacts"
-    # -- MinIO Expiration period in days
+    # -- Artifact expiration period in days
     expiration: 0
-    # -- MinIO Use SSL
+    # -- Toggle whether to use TLS in the storage client
     SSL: false
     # -- Toggle whether to verify TLS certificates
     skipVerify: false

--- a/k8s/helm/testkube/values.yaml
+++ b/k8s/helm/testkube/values.yaml
@@ -37,6 +37,8 @@ global:
     whitelistedContainers: init,logs,scraper
   # -- Embedded object storage provider used by API fallback endpoint resolution (`minio` or `seaweedfs`).
   storageProvider: minio
+  # -- Default SeaweedFS S3 port used by API endpoint fallback when `global.storageProvider=seaweedfs`.
+  seaweedfsS3Port: 8333
   ## Global TLS settings
   tls:
     # -- Toggle whether to globally skip certificate verification


### PR DESCRIPTION
## Summary
- add `seaweed` (aliased as `seaweedfs`) as an optional OCI dependency in OSS `testkube` chart and expose a new `seaweedfs` values block
- add `global.storageProvider` switch and route API storage endpoint fallback to SeaweedFS when selected
- gate embedded MinIO deployment when SeaweedFS provider is selected and create a Seaweed S3 auth config secret from API storage credentials

## Test plan
- [x] `helm dependency update k8s/helm/testkube`
- [x] `helm lint k8s/helm/testkube`
- [x] `helm template tk-default k8s/helm/testkube` (default/minio path)
- [x] `helm template tk-seaweed k8s/helm/testkube --set seaweedfs.enabled=true --set global.storageProvider=seaweedfs`
- [x] verify rendered output includes `tk-seaweed-seaweedfs-*` resources and `STORAGE_ENDPOINT=tk-seaweed-seaweedfs-filer:8333`
- [x] verify seaweed mode render excludes MinIO resources


Made with [Cursor](https://cursor.com)