### PR TITLE
feat: upload JMeter statistics reports

### DIFF
--- a/cmd/testworkflow-toolkit/artifacts/jmeter_statistics_post_processor.go
+++ b/cmd/testworkflow-toolkit/artifacts/jmeter_statistics_post_processor.go
@@ -1,0 +1,243 @@
+package artifacts
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"path/filepath"
+	"strings"
+
+	"github.com/pkg/errors"
+
+	"github.com/kubeshop/testkube/pkg/controlplaneclient"
+	"github.com/kubeshop/testkube/pkg/filesystem"
+	"github.com/kubeshop/testkube/pkg/ui"
+)
+
+const maxJMeterStatisticsProbeBytes int64 = 16 << 20
+
+// JMeterStatisticsPostProcessor checks JMeter dashboard statistics files and sends them to the cloud.
+type JMeterStatisticsPostProcessor struct {
+	fs            filesystem.FileSystem
+	client        controlplaneclient.ExecutionSelfClient
+	root          string
+	pathPrefix    string
+	environmentId string
+	executionId   string
+	workflowName  string
+	stepRef       string
+}
+
+func NewJMeterStatisticsPostProcessor(
+	fs filesystem.FileSystem,
+	client controlplaneclient.ExecutionSelfClient,
+	environmentId string,
+	executionId string,
+	workflowName string,
+	stepRef string,
+	root, pathPrefix string,
+) *JMeterStatisticsPostProcessor {
+	return &JMeterStatisticsPostProcessor{
+		fs:            fs,
+		client:        client,
+		environmentId: environmentId,
+		executionId:   executionId,
+		workflowName:  workflowName,
+		stepRef:       stepRef,
+		root:          root,
+		pathPrefix:    pathPrefix,
+	}
+}
+
+func (p *JMeterStatisticsPostProcessor) Start() error {
+	return nil
+}
+
+func (p *JMeterStatisticsPostProcessor) Add(path string) error {
+	if err := p.add(path); err != nil {
+		fmt.Printf("warn: jmeter statistics processing: %s: %s\n", path, err)
+	}
+	return nil
+}
+
+func (p *JMeterStatisticsPostProcessor) End() error {
+	return nil
+}
+
+func (p *JMeterStatisticsPostProcessor) add(path string) error {
+	uploadPath := path
+	if p.pathPrefix != "" {
+		uploadPath = filepath.Join(p.pathPrefix, uploadPath)
+	}
+	absPath := path
+	if !filepath.IsAbs(path) {
+		absPath = filepath.Join(p.root, absPath)
+	}
+	file, err := p.fs.OpenFileRO(absPath)
+	if err != nil {
+		return errors.Wrapf(err, "failed to open %s", path)
+	}
+	defer func() {
+		if file != nil {
+			_ = file.Close()
+		}
+	}()
+
+	stat, err := file.Stat()
+	if err != nil {
+		return errors.Wrapf(err, "failed to get file info for %s", path)
+	}
+	if !isJSONFile(stat) || !isJMeterStatisticsFilename(stat.Name()) {
+		return nil
+	}
+
+	if !hasJMeterStatisticsShape(file, maxJMeterStatisticsProbeBytes) {
+		return nil
+	}
+	if err := file.Close(); err != nil {
+		return errors.Wrapf(err, "failed to close %s", path)
+	}
+	file = nil
+	reportFile, err := p.fs.OpenFileRO(absPath)
+	if err != nil {
+		return errors.Wrapf(err, "failed to reopen %s", path)
+	}
+	defer func() { _ = reportFile.Close() }()
+
+	data, err := io.ReadAll(reportFile)
+	if err != nil {
+		return errors.Wrapf(err, "failed to read %s", path)
+	}
+	if !isJMeterStatisticsReport(data) {
+		return nil
+	}
+
+	fmt.Printf("Processing JMeter statistics report: %s\n", ui.LightCyan(path))
+	if err := p.client.AppendExecutionReport(context.Background(), p.environmentId, p.executionId, p.workflowName, p.stepRef, uploadPath, data); err != nil {
+		return errors.Wrapf(err, "failed to send JMeter statistics report %s", stat.Name())
+	}
+	return nil
+}
+
+func isJMeterStatisticsFilename(name string) bool {
+	return strings.EqualFold(name, "statistics.json")
+}
+
+func hasJMeterStatisticsShape(reader io.Reader, maxBytes int64) bool {
+	limited := &io.LimitedReader{R: reader, N: maxBytes}
+	decoder := json.NewDecoder(limited)
+
+	token, err := decoder.Token()
+	if err != nil {
+		return false
+	}
+	delim, ok := token.(json.Delim)
+	if !ok || delim != '{' {
+		return false
+	}
+
+	for decoder.More() {
+		keyToken, err := decoder.Token()
+		if err != nil {
+			return false
+		}
+		key, ok := keyToken.(string)
+		if !ok {
+			return false
+		}
+		if key == "Total" {
+			return jmeterStatisticsEntryHasMetricShape(decoder)
+		}
+		if err := skipJSONValue(decoder); err != nil {
+			return false
+		}
+	}
+	return false
+}
+
+func jmeterStatisticsEntryHasMetricShape(decoder *json.Decoder) bool {
+	token, err := decoder.Token()
+	if err != nil {
+		return false
+	}
+	delim, ok := token.(json.Delim)
+	if !ok || delim != '{' {
+		return false
+	}
+
+	hasTransaction := false
+	hasSampleCount := false
+	hasMetric := false
+	for decoder.More() {
+		keyToken, err := decoder.Token()
+		if err != nil {
+			return false
+		}
+		key, ok := keyToken.(string)
+		if !ok {
+			return false
+		}
+		switch key {
+		case "transaction":
+			var transaction string
+			if err := decoder.Decode(&transaction); err != nil {
+				return false
+			}
+			hasTransaction = transaction == "Total"
+		case "sampleCount":
+			hasSampleCount = jsonValueHasNumber(decoder)
+		case "errorCount", "errorPct", "meanResTime", "medianResTime", "minResTime", "maxResTime", "pct1ResTime", "pct2ResTime", "pct3ResTime", "throughput", "receivedKBytesPerSec", "sentKBytesPerSec":
+			hasMetric = jsonValueHasNumber(decoder)
+		default:
+			if err := skipJSONValue(decoder); err != nil {
+				return false
+			}
+		}
+	}
+	if _, err := decoder.Token(); err != nil {
+		return false
+	}
+	return hasTransaction && hasSampleCount && hasMetric
+}
+
+func isJMeterStatisticsReport(data []byte) bool {
+	var report map[string]jmeterStatisticsEntry
+	if err := json.Unmarshal(data, &report); err != nil {
+		return false
+	}
+	total, ok := report["Total"]
+	return ok && total.Transaction == "Total" && total.hasStatisticsMetrics()
+}
+
+type jmeterStatisticsEntry struct {
+	Transaction          string   `json:"transaction"`
+	SampleCount          *float64 `json:"sampleCount"`
+	ErrorCount           *float64 `json:"errorCount"`
+	ErrorPct             *float64 `json:"errorPct"`
+	MeanResTime          *float64 `json:"meanResTime"`
+	MedianResTime        *float64 `json:"medianResTime"`
+	MinResTime           *float64 `json:"minResTime"`
+	MaxResTime           *float64 `json:"maxResTime"`
+	Pct1ResTime          *float64 `json:"pct1ResTime"`
+	Pct2ResTime          *float64 `json:"pct2ResTime"`
+	Pct3ResTime          *float64 `json:"pct3ResTime"`
+	Throughput           *float64 `json:"throughput"`
+	ReceivedKBytesPerSec *float64 `json:"receivedKBytesPerSec"`
+	SentKBytesPerSec     *float64 `json:"sentKBytesPerSec"`
+}
+
+func (e jmeterStatisticsEntry) hasStatisticsMetrics() bool {
+	return e.SampleCount != nil && (e.ErrorCount != nil ||
+		e.ErrorPct != nil ||
+		e.MeanResTime != nil ||
+		e.MedianResTime != nil ||
+		e.MinResTime != nil ||
+		e.MaxResTime != nil ||
+		e.Pct1ResTime != nil ||
+		e.Pct2ResTime != nil ||
+		e.Pct3ResTime != nil ||
+		e.Throughput != nil ||
+		e.ReceivedKBytesPerSec != nil ||
+		e.SentKBytesPerSec != nil)
+}

--- a/cmd/testworkflow-toolkit/artifacts/jmeter_statistics_post_processor_test.go
+++ b/cmd/testworkflow-toolkit/artifacts/jmeter_statistics_post_processor_test.go
@@ -1,0 +1,157 @@
+package artifacts
+
+import (
+	"io/fs"
+	"strings"
+	"testing"
+
+	gomock "go.uber.org/mock/gomock"
+
+	"github.com/kubeshop/testkube/pkg/controlplaneclient"
+	"github.com/kubeshop/testkube/pkg/filesystem"
+)
+
+func TestIsJMeterStatisticsReport(t *testing.T) {
+	tests := []struct {
+		name string
+		data string
+		want bool
+	}{
+		{
+			name: "jmeter statistics report",
+			data: `{"Total":{"transaction":"Total","sampleCount":255,"errorCount":3,"errorPct":1.17,"meanResTime":235.4,"pct1ResTime":337,"pct2ResTime":339.2,"pct3ResTime":353,"throughput":4.23}}`,
+			want: true,
+		},
+		{
+			name: "jmeter statistics report with transaction entries",
+			data: `{"GET /api":{"transaction":"GET /api","sampleCount":10,"errorCount":0},"Total":{"transaction":"Total","sampleCount":10,"errorCount":0,"throughput":2.1}}`,
+			want: true,
+		},
+		{
+			name: "k6 summary is handled by dedicated processor",
+			data: `{"metrics":{"http_req_duration":{"values":{"p(95)":123}}}}`,
+			want: false,
+		},
+		{
+			name: "artillery report is handled by dedicated processor",
+			data: `{"aggregate":{"counters":{"http.requests":10}}}`,
+			want: false,
+		},
+		{
+			name: "statistics json without total transaction",
+			data: `{"Total":{"sampleCount":255,"errorCount":3}}`,
+			want: false,
+		},
+		{
+			name: "plain json",
+			data: `{"hello":"world"}`,
+			want: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isJMeterStatisticsReport([]byte(tc.data)); got != tc.want {
+				t.Fatalf("expected %t, got %t", tc.want, got)
+			}
+		})
+	}
+}
+
+func TestHasJMeterStatisticsShape(t *testing.T) {
+	tests := []struct {
+		name     string
+		data     string
+		maxBytes int64
+		want     bool
+	}{
+		{
+			name:     "jmeter statistics with total not first",
+			data:     `{"GET /api":{"transaction":"GET /api","sampleCount":10},"Total":{"transaction":"Total","sampleCount":10,"errorCount":0,"throughput":2.1}}`,
+			maxBytes: maxJMeterStatisticsProbeBytes,
+			want:     true,
+		},
+		{
+			name:     "statistics shaped json without numeric metrics",
+			data:     `{"Total":{"transaction":"Total","sampleCount":"10","errorCount":"0"}}`,
+			maxBytes: maxJMeterStatisticsProbeBytes,
+			want:     false,
+		},
+		{
+			name:     "bounded before total",
+			data:     `{"metadata":{"message":"` + strings.Repeat("a", 128) + `"},"Total":{"transaction":"Total","sampleCount":10,"errorCount":0}}`,
+			maxBytes: 64,
+			want:     false,
+		},
+		{
+			name:     "plain json",
+			data:     `{"hello":"world"}`,
+			maxBytes: maxJMeterStatisticsProbeBytes,
+			want:     false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := hasJMeterStatisticsShape(strings.NewReader(tc.data), tc.maxBytes); got != tc.want {
+				t.Fatalf("expected %t, got %t", tc.want, got)
+			}
+		})
+	}
+}
+
+func TestJMeterStatisticsPostProcessorAddUploadsReport(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	report := []byte(`{"Total":{"transaction":"Total","sampleCount":10,"errorCount":0,"throughput":2.1}}`)
+	mockFS := filesystem.NewMockFileSystem(mockCtrl)
+	mockFS.EXPECT().
+		OpenFileRO("/report/statistics.json").
+		Times(2).
+		DoAndReturn(func(string) (fs.File, error) {
+			return filesystem.NewMockFile("statistics.json", report), nil
+		})
+
+	mockClient := controlplaneclient.NewMockClient(mockCtrl)
+	mockClient.EXPECT().
+		AppendExecutionReport(gomock.Any(), "env123", "exec123", "workflow123", "step123", "report/statistics.json", report).
+		Return(nil)
+
+	pp := NewJMeterStatisticsPostProcessor(mockFS, mockClient, "env123", "exec123", "workflow123", "step123", "/", "")
+	if err := pp.add("report/statistics.json"); err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+}
+
+func TestJMeterStatisticsPostProcessorAddSkipsOtherJSONWithoutFullRead(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	mockFS := filesystem.NewMockFileSystem(mockCtrl)
+	mockFS.EXPECT().
+		OpenFileRO("/summary.json").
+		Return(newGuardedSingleReadFile("summary.json", []byte(`{"Total":{"transaction":"Total","sampleCount":10,"errorCount":0}}`)), nil)
+
+	mockClient := controlplaneclient.NewMockClient(mockCtrl)
+	pp := NewJMeterStatisticsPostProcessor(mockFS, mockClient, "env123", "exec123", "workflow123", "step123", "/", "")
+	if err := pp.add("summary.json"); err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+}
+
+func TestJMeterStatisticsPostProcessorAddSkipsNonReportStatisticsWithoutFullRead(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	mockFS := filesystem.NewMockFileSystem(mockCtrl)
+	mockFS.EXPECT().
+		OpenFileRO("/statistics.json").
+		Return(newGuardedSingleReadFile("statistics.json", []byte(`{"Total":{"transaction":"Total","sampleCount":"10","errorCount":"0"}}`)), nil)
+
+	mockClient := controlplaneclient.NewMockClient(mockCtrl)
+	pp := NewJMeterStatisticsPostProcessor(mockFS, mockClient, "env123", "exec123", "workflow123", "step123", "/", "")
+	if err := pp.add("statistics.json"); err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+}

--- a/cmd/testworkflow-toolkit/commands/artifacts.go
+++ b/cmd/testworkflow-toolkit/commands/artifacts.go
@@ -81,11 +81,12 @@ func NewArtifactsCmd() *cobra.Command {
 				ui.Failf("could not create cloud client: %v", err)
 			}
 
-			postProcessors := make([]artifacts.PostProcessor, 0, 3)
+			postProcessors := make([]artifacts.PostProcessor, 0, 4)
 			if env.HasJunitSupport() {
 				postProcessors = append(postProcessors, artifacts.NewJUnitPostProcessor(filesystem.NewOSFileSystem(), client, cfg.Execution.EnvironmentId, cfg.Execution.Id, cfg.Workflow.Name, config.Ref(), walker.Root(), cfg.Resource.FsPrefix))
 			}
 			postProcessors = append(postProcessors, artifacts.NewArtilleryReportPostProcessor(filesystem.NewOSFileSystem(), client, cfg.Execution.EnvironmentId, cfg.Execution.Id, cfg.Workflow.Name, config.Ref(), walker.Root(), cfg.Resource.FsPrefix))
+			postProcessors = append(postProcessors, artifacts.NewJMeterStatisticsPostProcessor(filesystem.NewOSFileSystem(), client, cfg.Execution.EnvironmentId, cfg.Execution.Id, cfg.Workflow.Name, config.Ref(), walker.Root(), cfg.Resource.FsPrefix))
 			postProcessors = append(postProcessors, artifacts.NewK6SummaryPostProcessor(filesystem.NewOSFileSystem(), client, cfg.Execution.EnvironmentId, cfg.Execution.Id, cfg.Workflow.Name, config.Ref(), walker.Root(), cfg.Resource.FsPrefix))
 			if len(postProcessors) == 1 {
 				handlerOpts = append(handlerOpts, artifacts.WithPostProcessor(postProcessors[0]))

--- a/test/jmeter/crd-workflow/smoke.yaml
+++ b/test/jmeter/crd-workflow/smoke.yaml
@@ -28,19 +28,7 @@ spec:
   - name: Run tests
     run:
       image: alpine/jmeter:5.6
-      command:
-      - jmeter
-      args:
-      - -n
-      - -t
-      - jmeter-executor-smoke.jmx
-      - -j
-      - /data/artifacts/jmeter.log
-      - -o
-      - /data/artifacts/report
-      - -l
-      - /data/artifacts/jtl-report.jtl
-      - -e
+      shell: mkdir -p /data/artifacts && jmeter -n -t jmeter-executor-smoke.jmx -j /data/artifacts/jmeter.log -o /data/artifacts/report -l /data/artifacts/jtl-report.jtl -e
     steps:
     - name: Save artifacts
       workingDir: /data/artifacts
@@ -78,19 +66,7 @@ spec:
   - name: Run tests
     run:
       image: justb4/jmeter:5.5
-      command:
-      - jmeter
-      args:
-      - -n
-      - -t
-      - jmeter-executor-smoke.jmx
-      - -j
-      - /data/artifacts/jmeter.log
-      - -o
-      - /data/artifacts/report
-      - -l
-      - /data/artifacts/jtl-report.jtl
-      - -e
+      shell: mkdir -p /data/artifacts && jmeter -n -t jmeter-executor-smoke.jmx -j /data/artifacts/jmeter.log -o /data/artifacts/report -l /data/artifacts/jtl-report.jtl -e
     steps:
     - name: Save artifacts
       workingDir: /data/artifacts
@@ -274,19 +250,7 @@ spec:
   - name: Run tests
     run:
       image: alpine/jmeter:latest
-      command:
-      - jmeter
-      args:
-      - -n
-      - -t
-      - jmeter-executor-smoke.jmx
-      - -j
-      - /data/artifacts/jmeter.log
-      - -o
-      - /data/artifacts/report
-      - -l
-      - /data/artifacts/jtl-report.jtl
-      - -e
+      shell: mkdir -p /data/artifacts && jmeter -n -t jmeter-executor-smoke.jmx -j /data/artifacts/jmeter.log -o /data/artifacts/report -l /data/artifacts/jtl-report.jtl -e
     steps:
     - name: Save artifacts
       workingDir: /data/artifacts
@@ -345,24 +309,7 @@ spec:
   - name: Run tests
     run:
       image: alpine/jmeter:5.6
-      command:
-      - jmeter
-      args:
-      - -n
-      - -X
-      - -Jserver.rmi.ssl.disable=true
-      - -Jclient.rmi.localport=7000
-      - -R
-      - '{{services.slave.*.ip}}'
-      - -t
-      - jmeter-executor-smoke.jmx
-      - -j
-      - /data/artifacts/jmeter.log
-      - -o
-      - /data/artifacts/report
-      - -l
-      - /data/artifacts/jtl-report.jtl
-      - -e
+      shell: mkdir -p /data/artifacts && jmeter -n -X -Jserver.rmi.ssl.disable=true -Jclient.rmi.localport=7000 -R {{services.slave.*.ip}} -t jmeter-executor-smoke.jmx -j /data/artifacts/jmeter.log -o /data/artifacts/report -l /data/artifacts/jtl-report.jtl -e
     steps:
     - name: Save artifacts
       workingDir: /data/artifacts

--- a/test/jmeter/crd-workflow/smoke.yaml
+++ b/test/jmeter/crd-workflow/smoke.yaml
@@ -6,6 +6,7 @@ metadata:
     core-tests: workflows
     tool: jmeter
     category: performance-testing
+    artifacts: "true"
   annotations:
     testkube.io/icon: jmeter
 spec:
@@ -33,6 +34,19 @@ spec:
       - -n
       - -t
       - jmeter-executor-smoke.jmx
+      - -j
+      - /data/artifacts/jmeter.log
+      - -o
+      - /data/artifacts/report
+      - -l
+      - /data/artifacts/jtl-report.jtl
+      - -e
+    steps:
+    - name: Save artifacts
+      workingDir: /data/artifacts
+      artifacts:
+        paths:
+        - '**/*'
 ---
 apiVersion: testworkflows.testkube.io/v1
 kind: TestWorkflow
@@ -41,6 +55,7 @@ metadata:
   labels:
     core-tests: workflows
     tool: jmeter
+    artifacts: "true"
     category: performance-testing
   annotations:
     testkube.io/icon: jmeter
@@ -69,6 +84,19 @@ spec:
       - -n
       - -t
       - jmeter-executor-smoke.jmx
+      - -j
+      - /data/artifacts/jmeter.log
+      - -o
+      - /data/artifacts/report
+      - -l
+      - /data/artifacts/jtl-report.jtl
+      - -e
+    steps:
+    - name: Save artifacts
+      workingDir: /data/artifacts
+      artifacts:
+        paths:
+        - '**/*'
 ---
 apiVersion: testworkflows.testkube.io/v1
 kind: TestWorkflow
@@ -252,6 +280,19 @@ spec:
       - -n
       - -t
       - jmeter-executor-smoke.jmx
+      - -j
+      - /data/artifacts/jmeter.log
+      - -o
+      - /data/artifacts/report
+      - -l
+      - /data/artifacts/jtl-report.jtl
+      - -e
+    steps:
+    - name: Save artifacts
+      workingDir: /data/artifacts
+      artifacts:
+        paths:
+        - '**/*'
 ---
 apiVersion: testworkflows.testkube.io/v1
 kind: TestWorkflow
@@ -260,6 +301,7 @@ metadata:
   labels:
     core-tests: workflows
     tool: jmeter
+    artifacts: "true"
     category: performance-testing
   annotations:
     testkube.io/icon: jmeter
@@ -314,6 +356,19 @@ spec:
       - '{{services.slave.*.ip}}'
       - -t
       - jmeter-executor-smoke.jmx
+      - -j
+      - /data/artifacts/jmeter.log
+      - -o
+      - /data/artifacts/report
+      - -l
+      - /data/artifacts/jtl-report.jtl
+      - -e
+    steps:
+    - name: Save artifacts
+      workingDir: /data/artifacts
+      artifacts:
+        paths:
+        - '**/*'
 ---
 apiVersion: testworkflows.testkube.io/v1
 kind: TestWorkflow

--- a/test/jmeter/crd-workflow/smoke.yaml
+++ b/test/jmeter/crd-workflow/smoke.yaml
@@ -28,7 +28,7 @@ spec:
   - name: Run tests
     run:
       image: alpine/jmeter:5.6
-      shell: mkdir -p /data/artifacts && jmeter -n -t jmeter-executor-smoke.jmx -j /data/artifacts/jmeter.log -o /data/artifacts/report -l /data/artifacts/jtl-report.jtl -e
+      shell: mkdir -p /data/artifacts && jmeter -n -t jmeter-executor-smoke.jmx -o /data/artifacts/report -l /data/artifacts/jtl-report.jtl -e
     steps:
     - name: Save artifacts
       workingDir: /data/artifacts
@@ -66,7 +66,7 @@ spec:
   - name: Run tests
     run:
       image: justb4/jmeter:5.5
-      shell: mkdir -p /data/artifacts && jmeter -n -t jmeter-executor-smoke.jmx -j /data/artifacts/jmeter.log -o /data/artifacts/report -l /data/artifacts/jtl-report.jtl -e
+      shell: mkdir -p /data/artifacts && jmeter -n -t jmeter-executor-smoke.jmx -o /data/artifacts/report -l /data/artifacts/jtl-report.jtl -e
     steps:
     - name: Save artifacts
       workingDir: /data/artifacts
@@ -102,7 +102,7 @@ spec:
     activeDeadlineSeconds: 300
   steps:
   - name: Run tests
-    shell: jmeter -n -t jmeter-executor-smoke.jmx -j /data/artifacts/jmeter.log -o /data/artifacts/report -l /data/artifacts/jtl-report.jtl -e
+    shell: jmeter -n -t jmeter-executor-smoke.jmx -o /data/artifacts/report -l /data/artifacts/jtl-report.jtl -e
     container:
       image: alpine/jmeter:5.6
     steps:
@@ -143,7 +143,7 @@ spec:
     template:
       name: official/jmeter/v2
       config:
-        run: "jmeter -n -t jmeter-executor-smoke.jmx -j /data/artifacts/jmeter.log -o /data/artifacts/report -l /data/artifacts/jtl-report.jtl -e"
+        run: "jmeter -n -t jmeter-executor-smoke.jmx -o /data/artifacts/report -l /data/artifacts/jtl-report.jtl -e"
     artifacts:
       paths:
       - '/data/artifacts/**/*'
@@ -178,7 +178,7 @@ spec:
     template:
       name: official/jmeter/v1
       config:
-        run: "jmeter -n -t jmeter-executor-smoke.jmx -j /data/artifacts/jmeter.log -o /data/artifacts/report -l /data/artifacts/jtl-report.jtl -e"
+        run: "jmeter -n -t jmeter-executor-smoke.jmx -o /data/artifacts/report -l /data/artifacts/jtl-report.jtl -e"
     artifacts:
       paths:
       - '/data/artifacts/**/*'
@@ -213,7 +213,7 @@ spec:
     template:
       name: official/jmeter/v2
       config:
-        run: "jmeter -n -t jmeter-executor-smoke.jmx -j /data/artifacts/jmeter.log -o /data/artifacts/report -l /data/artifacts/jtl-report.jtl -e"
+        run: "jmeter -n -t jmeter-executor-smoke.jmx -o /data/artifacts/report -l /data/artifacts/jtl-report.jtl -e"
     steps:
     - name: Save artifacts
       workingDir: /data/artifacts
@@ -250,7 +250,7 @@ spec:
   - name: Run tests
     run:
       image: alpine/jmeter:latest
-      shell: mkdir -p /data/artifacts && jmeter -n -t jmeter-executor-smoke.jmx -j /data/artifacts/jmeter.log -o /data/artifacts/report -l /data/artifacts/jtl-report.jtl -e
+      shell: mkdir -p /data/artifacts && jmeter -n -t jmeter-executor-smoke.jmx -o /data/artifacts/report -l /data/artifacts/jtl-report.jtl -e
     steps:
     - name: Save artifacts
       workingDir: /data/artifacts
@@ -309,7 +309,7 @@ spec:
   - name: Run tests
     run:
       image: alpine/jmeter:5.6
-      shell: mkdir -p /data/artifacts && jmeter -n -X -Jserver.rmi.ssl.disable=true -Jclient.rmi.localport=7000 -R {{services.slave.*.ip}} -t jmeter-executor-smoke.jmx -j /data/artifacts/jmeter.log -o /data/artifacts/report -l /data/artifacts/jtl-report.jtl -e
+      shell: mkdir -p /data/artifacts && jmeter -n -X -Jserver.rmi.ssl.disable=true -Jclient.rmi.localport=7000 -R {{services.slave.*.ip}} -t jmeter-executor-smoke.jmx -o /data/artifacts/report -l /data/artifacts/jtl-report.jtl -e
     steps:
     - name: Save artifacts
       workingDir: /data/artifacts
@@ -374,7 +374,7 @@ spec:
   - name: Run tests
     run:
       image: alpine/jmeter:5.6
-      shell: jmeter -n -X -Jserver.rmi.ssl.disable=true -Jclient.rmi.localport=7000 -R {{services.slave.*.ip}} -t jmeter-executor-smoke.jmx -j /data/artifacts/jmeter.log -o /data/artifacts/report -l /data/artifacts/jtl-report.jtl -e
+      shell: jmeter -n -X -Jserver.rmi.ssl.disable=true -Jclient.rmi.localport=7000 -R {{services.slave.*.ip}} -t jmeter-executor-smoke.jmx -o /data/artifacts/report -l /data/artifacts/jtl-report.jtl -e
     steps:
     - name: Save artifacts
       workingDir: /data/artifacts


### PR DESCRIPTION
## Summary
- detect JMeter dashboard `statistics.json` files during artifact upload
- upload detected statistics reports through the native execution report path
- add focused detector/upload tests
- update JMeter smoke workflows to export dashboard `report/statistics.json` through artifact upload

Linear: TKC-5776