### PR TITLE
fix: [TKC-5787] return not found for missing agent resources

### DIFF
--- a/internal/app/api/v1/testtriggers.go
+++ b/internal/app/api/v1/testtriggers.go
@@ -278,6 +278,9 @@ func (s *TestkubeAPI) GetTestTriggerHandler() fiber.Handler {
 
 		apiTestTrigger, err := s.TestTriggersClient.Get(c.Context(), s.getEnvironmentId(), name, namespace)
 		if err != nil {
+			if apiutils.IsNotFound(err) {
+				return s.Error(c, http.StatusNotFound, fmt.Errorf("%s: test trigger not found: %w", errPrefix, err))
+			}
 			return s.Error(c, http.StatusBadGateway, fmt.Errorf("%s: client could not get test trigger: %w", errPrefix, err))
 		}
 

--- a/internal/app/api/v1/testtriggers_test.go
+++ b/internal/app/api/v1/testtriggers_test.go
@@ -13,6 +13,8 @@ import (
 	"github.com/gofiber/fiber/v2"
 	"github.com/stretchr/testify/assert"
 	gomock "go.uber.org/mock/gomock"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 
 	testtriggersv1 "github.com/kubeshop/testkube/api/testtriggers/v1"
 	"github.com/kubeshop/testkube/internal/config"
@@ -1108,6 +1110,23 @@ func TestGetTestTriggerHandler(t *testing.T) {
 		// then
 		assert.NoError(t, err)
 		assert.Equal(t, http.StatusBadGateway, resp.StatusCode)
+	})
+
+	t.Run("should return not found when test trigger does not exist", func(t *testing.T) {
+		// given
+		mockClient.EXPECT().
+			Get(gomock.Any(), "test-env", "missing-trigger", "default").
+			Return(nil, status.Error(codes.NotFound, "test trigger not found")).
+			Times(1)
+
+		req := httptest.NewRequestWithContext(context.Background(), "GET", "/test-triggers/missing-trigger", nil)
+
+		// when
+		resp, err := app.Test(req)
+
+		// then
+		assert.NoError(t, err)
+		assert.Equal(t, http.StatusNotFound, resp.StatusCode)
 	})
 }
 

--- a/internal/app/api/v1/webhook.go
+++ b/internal/app/api/v1/webhook.go
@@ -6,7 +6,6 @@ import (
 	"net/http"
 
 	"github.com/gofiber/fiber/v2"
-	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/util/yaml"
 
 	executorv1 "github.com/kubeshop/testkube/api/executor/v1"
@@ -81,7 +80,7 @@ func (s *TestkubeAPI) UpdateWebhookHandler() fiber.Handler {
 		// we need to get resource first and load its metadata.ResourceVersion
 		webhook, err := s.WebhooksClient.Get(name)
 		if err != nil {
-			if errors.IsNotFound(err) {
+			if apiutils.IsNotFound(err) {
 				return s.Error(c, http.StatusNotFound, fmt.Errorf("%s: client found no webhook: %w", errPrefix, err))
 			}
 
@@ -135,7 +134,7 @@ func (s *TestkubeAPI) GetWebhookHandler() fiber.Handler {
 
 		item, err := s.WebhooksClient.Get(name)
 		if err != nil {
-			if errors.IsNotFound(err) {
+			if apiutils.IsNotFound(err) {
 				return s.Error(c, http.StatusNotFound, fmt.Errorf("%s: webhook not found: %w", errPrefix, err))
 			}
 			return s.Error(c, http.StatusBadGateway, fmt.Errorf("%s: client could not get webhook: %w", errPrefix, err))
@@ -159,7 +158,7 @@ func (s *TestkubeAPI) DeleteWebhookHandler() fiber.Handler {
 
 		err := s.WebhooksClient.Delete(name)
 		if err != nil {
-			if errors.IsNotFound(err) {
+			if apiutils.IsNotFound(err) {
 				return s.Error(c, http.StatusNotFound, fmt.Errorf("%s: webhook not found: %w", errPrefix, err))
 			}
 			return s.Error(c, http.StatusBadGateway, fmt.Errorf("%s: client could not delete webhook: %w", errPrefix, err))

--- a/internal/app/api/v1/webhook_test.go
+++ b/internal/app/api/v1/webhook_test.go
@@ -1,0 +1,104 @@
+package v1
+
+import (
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gofiber/fiber/v2"
+	"github.com/stretchr/testify/assert"
+	gomock "go.uber.org/mock/gomock"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	executorsclientv1 "github.com/kubeshop/testkube/pkg/operator/client/executors/v1"
+)
+
+func TestGetWebhookHandler_NotFound(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockClient := executorsclientv1.NewMockWebhooksInterface(ctrl)
+	testAPI := &TestkubeAPI{WebhooksClient: mockClient}
+
+	app := fiber.New()
+	app.Get("/webhooks/:name", testAPI.GetWebhookHandler())
+
+	mockClient.EXPECT().
+		Get("missing-webhook").
+		Return(nil, status.Error(codes.NotFound, "webhook not found")).
+		Times(1)
+
+	req := httptest.NewRequest("GET", "/webhooks/missing-webhook", nil)
+	resp, err := app.Test(req)
+
+	assert.NoError(t, err)
+	assert.Equal(t, http.StatusNotFound, resp.StatusCode)
+}
+
+func TestGetWebhookHandler_ClientError(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockClient := executorsclientv1.NewMockWebhooksInterface(ctrl)
+	testAPI := &TestkubeAPI{WebhooksClient: mockClient}
+
+	app := fiber.New()
+	app.Get("/webhooks/:name", testAPI.GetWebhookHandler())
+
+	mockClient.EXPECT().
+		Get("broken-webhook").
+		Return(nil, errors.New("client failed")).
+		Times(1)
+
+	req := httptest.NewRequest("GET", "/webhooks/broken-webhook", nil)
+	resp, err := app.Test(req)
+
+	assert.NoError(t, err)
+	assert.Equal(t, http.StatusBadGateway, resp.StatusCode)
+}
+
+func TestDeleteWebhookHandler_NotFound(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockClient := executorsclientv1.NewMockWebhooksInterface(ctrl)
+	testAPI := &TestkubeAPI{WebhooksClient: mockClient}
+
+	app := fiber.New()
+	app.Delete("/webhooks/:name", testAPI.DeleteWebhookHandler())
+
+	mockClient.EXPECT().
+		Delete("missing-webhook").
+		Return(status.Error(codes.NotFound, "webhook not found")).
+		Times(1)
+
+	req := httptest.NewRequest("DELETE", "/webhooks/missing-webhook", nil)
+	resp, err := app.Test(req)
+
+	assert.NoError(t, err)
+	assert.Equal(t, http.StatusNotFound, resp.StatusCode)
+}
+
+func TestDeleteWebhookHandler_ClientError(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockClient := executorsclientv1.NewMockWebhooksInterface(ctrl)
+	testAPI := &TestkubeAPI{WebhooksClient: mockClient}
+
+	app := fiber.New()
+	app.Delete("/webhooks/:name", testAPI.DeleteWebhookHandler())
+
+	mockClient.EXPECT().
+		Delete("broken-webhook").
+		Return(errors.New("client failed")).
+		Times(1)
+
+	req := httptest.NewRequest("DELETE", "/webhooks/broken-webhook", nil)
+	resp, err := app.Test(req)
+
+	assert.NoError(t, err)
+	assert.Equal(t, http.StatusBadGateway, resp.StatusCode)
+}


### PR DESCRIPTION
## Summary

- Return HTTP 404 when named agent webhooks are missing on GET/DELETE instead of treating wrapped not-found errors as gateway failures.
- Return HTTP 404 when named agent test triggers are missing on GET.
- Add handler coverage for not-found and non-not-found client errors.

Linear: https://linear.app/kubeshop/issue/TKC-5787/agent-trigger-and-webhook-missing-resources-return-wrong-status-codes

## Validation

- `go test ./internal/app/api/v1`
- `make lint`
- `go build ./...`

Full-suite note:

- `go test ./...` was run and failed outside this change:
  - `api/testtriggers/v1`: existing Ginkgo error `BeforeSuite node was passed an unknown decorator: '60'`.
  - `pkg/event`: `TestEmbeddedServer_Start` could not start embedded NATS within 10s and then panicked while waiting for shutdown.
