### PR TITLE
fix: remove namespace from roleRef as it's not allowed by k8s

### DIFF
--- a/k8s/helm/testkube-api/templates/rolebinding.yaml
+++ b/k8s/helm/testkube-api/templates/rolebinding.yaml
@@ -592,7 +592,6 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
   name: create-get-list-secrets-role-{{ $rangeItem.namespace  }}
-  namespace: {{ .Release.Namespace }}
 subjects:
   - kind: ServiceAccount
     name: {{ include "testkube-api.serviceAccountName" . }}
@@ -616,7 +615,6 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
   name: get-configmaps-role-{{ $rangeItem.namespace  }}
-  namespace: {{ .Release.Namespace }}
 subjects:
   - kind: ServiceAccount
     name: {{ include "testkube-api.serviceAccountName" . }}


### PR DESCRIPTION
## Pull request description 
This fixes invalid RBAC generated for `testkube-api.executionNamespaces`.

The chart was rendering `roleRef.namespace` on these `RoleBinding`:
- `create-get-list-secrets-role-rb-{{ $rangeItem.namespace }}`
- `get-configmaps-role-rb-{{ $rangeItem.namespace }}`


## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [ ] tested locally
- [ ] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Breaking changes

-

## Changes

-

## Fixes

-