### PR TITLE
fix(cli): fallback dashboard storage port-forward to Seaweed

### DIFF
--- a/cmd/kubectl-testkube/commands/dashboard.go
+++ b/cmd/kubectl-testkube/commands/dashboard.go
@@ -90,12 +90,11 @@ func openOnPremDashboard(cmd *cobra.Command, cfg config.Data, verbose, skipBrows
 		sendErrTelemetry(cmd, cfg, "port_forward", license, "port forwarding dex", err)
 	}
 	ui.ExitOnError("port forwarding dex", err)
-	ui.Debug("Port forwarding for minio", config.EnterpriseMinioName)
-	err = k8sclient.PortForward(ctx, cfg.Namespace, config.EnterpriseMinioName, config.EnterpriseMinioPort, config.EnterpriseMinioPortFrwardingPort, verbose)
+	err = portForwardOnPremStorage(ctx, cfg, verbose)
 	if err != nil {
-		sendErrTelemetry(cmd, cfg, "port_forward", license, "port forwarding minio", err)
+		sendErrTelemetry(cmd, cfg, "port_forward", license, "port forwarding storage", err)
 	}
-	ui.ExitOnError("port forwarding minio", err)
+	ui.ExitOnError("port forwarding storage", err)
 
 	if !skipBrowser {
 		ui.Debug("Opening dashboard in browser", uri)
@@ -116,6 +115,48 @@ func openOnPremDashboard(cmd *cobra.Command, cfg config.Data, verbose, skipBrows
 	ui.Success("Port forwarding the necessary services, hit Ctrl+c (or Cmd+c) to stop")
 	<-c
 	cancel()
+}
+
+type storageForwardTarget struct {
+	name        string
+	servicePort int
+	localPort   int
+	label       string
+}
+
+func portForwardOnPremStorage(ctx context.Context, cfg config.Data, verbose bool) error {
+	targets := []storageForwardTarget{
+		{
+			name:        config.EnterpriseMinioName,
+			servicePort: config.EnterpriseMinioPort,
+			localPort:   config.EnterpriseMinioPortFrwardingPort,
+			label:       "minio",
+		},
+		{
+			name:        config.EnterpriseSeaweedS3Name,
+			servicePort: config.EnterpriseSeaweedS3Port,
+			localPort:   config.EnterpriseMinioPortFrwardingPort,
+			label:       "seaweed-s3",
+		},
+		{
+			name:        config.EnterpriseSeaweedFilerName,
+			servicePort: config.EnterpriseSeaweedS3Port,
+			localPort:   config.EnterpriseMinioPortFrwardingPort,
+			label:       "seaweed-filer",
+		},
+	}
+
+	for _, target := range targets {
+		running, err := k8sclient.IsPodOfServiceRunning(ctx, cfg.Namespace, target.name)
+		if err != nil || !running {
+			continue
+		}
+
+		ui.Debug("Port forwarding for storage", target.label, target.name)
+		return k8sclient.PortForward(ctx, cfg.Namespace, target.name, target.servicePort, target.localPort, verbose)
+	}
+
+	return fmt.Errorf("no compatible storage service found for dashboard port-forward (checked: %s, %s, %s)", config.EnterpriseMinioName, config.EnterpriseSeaweedS3Name, config.EnterpriseSeaweedFilerName)
 }
 
 func localPortCheck(port int) error {

--- a/cmd/kubectl-testkube/commands/dashboard.go
+++ b/cmd/kubectl-testkube/commands/dashboard.go
@@ -145,12 +145,6 @@ func portForwardOnPremStorage(ctx context.Context, cfg config.Data, verbose bool
 			localPort:   config.EnterpriseMinioPortFrwardingPort,
 			label:       "seaweed-filer-s3",
 		},
-		{
-			name:        config.EnterpriseSeaweedFilerName,
-			servicePort: config.EnterpriseSeaweedFilerPort,
-			localPort:   config.EnterpriseMinioPortFrwardingPort,
-			label:       "seaweed-filer-http",
-		},
 	}
 
 	var attempts []string

--- a/cmd/kubectl-testkube/commands/dashboard.go
+++ b/cmd/kubectl-testkube/commands/dashboard.go
@@ -7,6 +7,7 @@ import (
 	"net"
 	"os"
 	"os/signal"
+	"strings"
 	"syscall"
 
 	"github.com/skratchdot/open-golang/open"
@@ -142,21 +143,40 @@ func portForwardOnPremStorage(ctx context.Context, cfg config.Data, verbose bool
 			name:        config.EnterpriseSeaweedFilerName,
 			servicePort: config.EnterpriseSeaweedS3Port,
 			localPort:   config.EnterpriseMinioPortFrwardingPort,
-			label:       "seaweed-filer",
+			label:       "seaweed-filer-s3",
+		},
+		{
+			name:        config.EnterpriseSeaweedFilerName,
+			servicePort: config.EnterpriseSeaweedFilerPort,
+			localPort:   config.EnterpriseMinioPortFrwardingPort,
+			label:       "seaweed-filer-http",
 		},
 	}
 
+	var attempts []string
 	for _, target := range targets {
 		running, err := k8sclient.IsPodOfServiceRunning(ctx, cfg.Namespace, target.name)
-		if err != nil || !running {
+		if err != nil {
+			attempts = append(attempts, fmt.Sprintf("%s check failed: %v", target.label, err))
+			continue
+		}
+		if !running {
 			continue
 		}
 
 		ui.Debug("Port forwarding for storage", target.label, target.name)
-		return k8sclient.PortForward(ctx, cfg.Namespace, target.name, target.servicePort, target.localPort, verbose)
+		if err := k8sclient.PortForward(ctx, cfg.Namespace, target.name, target.servicePort, target.localPort, verbose); err != nil {
+			attempts = append(attempts, fmt.Sprintf("%s forward failed: %v", target.label, err))
+			continue
+		}
+		return nil
 	}
 
-	return fmt.Errorf("no compatible storage service found for dashboard port-forward (checked: %s, %s, %s)", config.EnterpriseMinioName, config.EnterpriseSeaweedS3Name, config.EnterpriseSeaweedFilerName)
+	if len(attempts) == 0 {
+		return fmt.Errorf("no compatible storage service found for dashboard port-forward (checked: %s, %s, %s)", config.EnterpriseMinioName, config.EnterpriseSeaweedS3Name, config.EnterpriseSeaweedFilerName)
+	}
+
+	return fmt.Errorf("unable to port-forward compatible storage service (%s)", strings.Join(attempts, "; "))
 }
 
 func localPortCheck(port int) error {

--- a/cmd/kubectl-testkube/config/storage.go
+++ b/cmd/kubectl-testkube/config/storage.go
@@ -22,6 +22,9 @@ const (
 	EnterpriseMinioName              string = "testkube-enterprise-minio"
 	EnterpriseMinioPort              int    = 9000
 	EnterpriseMinioPortFrwardingPort int    = 9000
+	EnterpriseSeaweedS3Name          string = "testkube-enterprise-seaweedfs-s3"
+	EnterpriseSeaweedFilerName       string = "testkube-enterprise-seaweedfs-filer"
+	EnterpriseSeaweedS3Port          int    = 8333
 
 	configDirName = ".testkube"
 	configFile    = "config.json"

--- a/cmd/kubectl-testkube/config/storage.go
+++ b/cmd/kubectl-testkube/config/storage.go
@@ -25,7 +25,6 @@ const (
 	EnterpriseSeaweedS3Name          string = "testkube-enterprise-seaweedfs-s3"
 	EnterpriseSeaweedFilerName       string = "testkube-enterprise-seaweedfs-filer"
 	EnterpriseSeaweedS3Port          int    = 8333
-	EnterpriseSeaweedFilerPort       int    = 8888
 
 	configDirName = ".testkube"
 	configFile    = "config.json"

--- a/cmd/kubectl-testkube/config/storage.go
+++ b/cmd/kubectl-testkube/config/storage.go
@@ -25,6 +25,7 @@ const (
 	EnterpriseSeaweedS3Name          string = "testkube-enterprise-seaweedfs-s3"
 	EnterpriseSeaweedFilerName       string = "testkube-enterprise-seaweedfs-filer"
 	EnterpriseSeaweedS3Port          int    = 8333
+	EnterpriseSeaweedFilerPort       int    = 8888
 
 	configDirName = ".testkube"
 	configFile    = "config.json"


### PR DESCRIPTION
## Summary
- make `testkube dashboard` pick the first running storage service instead of hard-failing on `testkube-enterprise-minio`
- add Seaweed service constants (`testkube-enterprise-seaweedfs-s3`, `testkube-enterprise-seaweedfs-filer`) and use them as fallback targets
- keep existing behavior for MinIO-first clusters while unblocking local enterprise setups with `minio.enabled=false`

## Test plan
- [x] `go test ./cmd/kubectl-testkube/commands ./cmd/kubectl-testkube/config`
- [x] built CLI locally with `go build -o /tmp/tk-local ./cmd/kubectl-testkube`
- [x] validated in local kind cluster: with MinIO service selector intentionally disabled and a Seaweed service endpoint available, `testkube dashboard --skip-browser --verbose` succeeded and port-forwarded storage instead of failing on MinIO not found
- [x] restored local kind services after the validation


Made with [Cursor](https://cursor.com)