### PR TITLE
fix: [TKC-5836] optimize workflow execution listing order

### DIFF
--- a/pkg/database/postgres/queries/executions.sql
+++ b/pkg/database/postgres/queries/executions.sql
@@ -725,7 +725,7 @@ WHERE (e.organization_id = @organization_id AND e.environment_id = @environment_
             ) = (SELECT COUNT(DISTINCT split_part(cond, '=', 1)) FROM unnest(@selector_conditions::text[]) AS cond)
         )
     )
-ORDER BY e.scheduled_at DESC
+ORDER BY e.organization_id, e.environment_id, e.scheduled_at DESC
 LIMIT NULLIF(@lmt, 0) OFFSET @fst;
 
 -- name: InsertTestWorkflowExecution :exec

--- a/pkg/database/postgres/sqlc/executions.sql.go
+++ b/pkg/database/postgres/sqlc/executions.sql.go
@@ -2273,7 +2273,7 @@ WHERE (e.organization_id = $1 AND e.environment_id = $2)
             ) = (SELECT COUNT(DISTINCT split_part(cond, '=', 1)) FROM unnest($22::text[]) AS cond)
         )
     )
-ORDER BY e.scheduled_at DESC
+ORDER BY e.organization_id, e.environment_id, e.scheduled_at DESC
 LIMIT NULLIF($24, 0) OFFSET $23
 `
 


### PR DESCRIPTION
## Summary
- update the Postgres `GetTestWorkflowExecutions` ordering to include the fixed `organization_id` and `environment_id` prefix before `scheduled_at DESC`
- regenerate sqlc output for the query
