### PR TITLE
fix: [TKC-5836] force custom plan for execution list

### DIFF
--- a/pkg/repository/testworkflow/postgres/postgres.go
+++ b/pkg/repository/testworkflow/postgres/postgres.go
@@ -758,7 +758,12 @@ func (r *PostgresRepository) GetExecutions(ctx context.Context, filter testworkf
 		return nil, err
 	}
 
-	rows, err := r.queries.GetTestWorkflowExecutions(ctx, params)
+	var rows []sqlc.GetTestWorkflowExecutionsRow
+	err = r.withForceCustomPlan(ctx, func(qtx sqlc.TestWorkflowExecutionQueriesInterface) error {
+		var qerr error
+		rows, qerr = qtx.GetTestWorkflowExecutions(ctx, params)
+		return qerr
+	})
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/repository/testworkflow/postgres/postgres_test.go
+++ b/pkg/repository/testworkflow/postgres/postgres_test.go
@@ -1036,7 +1036,9 @@ func TestIsNameOnlyFilter(t *testing.T) {
 
 func TestPostgresRepository_GetExecutions(t *testing.T) {
 	mockQueries := &MockTestWorkflowExecutionQueriesInterface{}
-	repo := &PostgresRepository{queries: mockQueries}
+	mockDB := &MockDatabaseInterface{}
+	mockTx := &MockTx{}
+	repo := &PostgresRepository{db: mockDB, queries: mockQueries}
 
 	t.Run("Success", func(t *testing.T) {
 		ctx := context.Background()
@@ -1046,6 +1048,7 @@ func TestPostgresRepository_GetExecutions(t *testing.T) {
 			sqlc.GetTestWorkflowExecutionsRow(createTestRow()),
 		}
 
+		expectForceCustomPlanTx(mockDB, mockTx, mockQueries, ctx)
 		mockQueries.On("GetTestWorkflowExecutions", ctx, mock.AnythingOfType("sqlc.GetTestWorkflowExecutionsParams")).Return(rows, nil)
 
 		result, err := repo.GetExecutions(ctx, filter)


### PR DESCRIPTION
## Summary
> this route has a query shape where PostgreSQL can choose two radically different plans for the same request. One  returns in milliseconds. The other can run longer than the API’s 30s timeout. The fix forces PostgreSQL to plan using the actual equest parameters each time, so it chooses the fast plan consistently.


- force the Postgres workflow execution list query through the existing custom-plan transaction wrapper
- keep list behavior aligned with the summary and totals execution query paths
- update the repository unit test to verify the custom-plan wrapper is used

## Validation
- go test ./pkg/repository/testworkflow/postgres

## Notes
- The ORDER BY/index-alignment fix is already present on main via #7756. This PR adds the missing custom-plan guard for the full execution list path.