### PR TITLE
chore: [TKC-5840] fix lint failures

### DIFF
--- a/pkg/git/informer/informer.go
+++ b/pkg/git/informer/informer.go
@@ -355,10 +355,6 @@ func (i *Informer) hasNewMatchingCommitWithCache(ctx context.Context, key string
 	return false, nil
 }
 
-func (i *Informer) hasNewHeadCommit(ctx context.Context, key string, trigger testkube.TestTrigger) (bool, error) {
-	return i.hasNewHeadCommitWithCache(ctx, key, trigger, nil)
-}
-
 func (i *Informer) hasNewHeadCommitWithCache(ctx context.Context, key string, trigger testkube.TestTrigger, cache *reconcileCache) (bool, error) {
 	headHash, err := i.remoteHeadHashWithCache(ctx, trigger.Namespace, trigger.ContentSelector.Git, cache)
 	if err != nil {
@@ -552,14 +548,6 @@ func (i *Informer) remoteHeadHash(ctx context.Context, namespace string, gitConf
 		return "", err
 	}
 	return remoteHeadHashWithClientOptions(gitConfig, i.options, clientOptions)
-}
-
-func remoteHeadHash(gitConfig *testkube.TestTriggerContentGit, options Options) (string, error) {
-	clientOptions, err := authClientOptions(gitConfig)
-	if err != nil {
-		return "", err
-	}
-	return remoteHeadHashWithClientOptions(gitConfig, options, clientOptions)
 }
 
 func remoteHeadHashWithClientOptions(gitConfig *testkube.TestTriggerContentGit, options Options, clientOptions []client.Option) (string, error) {
@@ -783,7 +771,7 @@ func (i *Informer) resolveSecretKeyRefValue(ctx context.Context, namespace strin
 	}
 	secret, err := i.kubeClient.CoreV1().Secrets(namespace).Get(ctx, ref.Name, metav1.GetOptions{})
 	if err != nil {
-		if !(apierrors.IsNotFound(err) && ref.Optional != nil && *ref.Optional) {
+		if !apierrors.IsNotFound(err) || ref.Optional == nil || !*ref.Optional {
 			log.DefaultLogger.Warnf("git informer: failed to read secret %s/%s key %s: %v", namespace, ref.Name, ref.Key, err)
 		}
 		return "", false
@@ -803,7 +791,7 @@ func (i *Informer) resolveConfigMapKeyRefValue(ctx context.Context, namespace st
 	}
 	configMap, err := i.kubeClient.CoreV1().ConfigMaps(namespace).Get(ctx, ref.Name, metav1.GetOptions{})
 	if err != nil {
-		if !(apierrors.IsNotFound(err) && ref.Optional != nil && *ref.Optional) {
+		if !apierrors.IsNotFound(err) || ref.Optional == nil || !*ref.Optional {
 			log.DefaultLogger.Warnf("git informer: failed to read configmap %s/%s key %s: %v", namespace, ref.Name, ref.Key, err)
 		}
 		return "", false

--- a/pkg/mapper/common/envvarsource_openapi_kube_test.go
+++ b/pkg/mapper/common/envvarsource_openapi_kube_test.go
@@ -55,12 +55,12 @@ func TestMapEnvVarSourceAPIToKube_RoundTripSecretAndConfigMapRefs(t *testing.T) 
 	roundTripped := MapEnvVarSourceAPIToKube(MapEnvVarSourceKubeToAPI(source))
 	if assert.NotNil(t, roundTripped) {
 		if assert.NotNil(t, roundTripped.SecretKeyRef) {
-			assert.Equal(t, source.SecretKeyRef.LocalObjectReference.Name, roundTripped.SecretKeyRef.LocalObjectReference.Name)
+			assert.Equal(t, source.SecretKeyRef.Name, roundTripped.SecretKeyRef.Name)
 			assert.Equal(t, source.SecretKeyRef.Key, roundTripped.SecretKeyRef.Key)
 			assert.Equal(t, source.SecretKeyRef.Optional, roundTripped.SecretKeyRef.Optional)
 		}
 		if assert.NotNil(t, roundTripped.ConfigMapKeyRef) {
-			assert.Equal(t, source.ConfigMapKeyRef.LocalObjectReference.Name, roundTripped.ConfigMapKeyRef.LocalObjectReference.Name)
+			assert.Equal(t, source.ConfigMapKeyRef.Name, roundTripped.ConfigMapKeyRef.Name)
 			assert.Equal(t, source.ConfigMapKeyRef.Key, roundTripped.ConfigMapKeyRef.Key)
 			assert.Equal(t, source.ConfigMapKeyRef.Optional, roundTripped.ConfigMapKeyRef.Optional)
 		}

--- a/pkg/mapper/workflowtriggers/mapper.go
+++ b/pkg/mapper/workflowtriggers/mapper.go
@@ -60,10 +60,6 @@ func MapAPIToCRD(api testkube.WorkflowTrigger) workflowtriggersv1.WorkflowTrigge
 	}
 }
 
-func mapEnvVarSourceKubeToAPI(v *corev1.EnvVarSource) *testkube.EnvVarSource {
-	return commonmapper.MapEnvVarSourceKubeToAPI(v)
-}
-
 func mapEnvVarSourceAPIToKube(v *testkube.EnvVarSource) *corev1.EnvVarSource {
 	return commonmapper.MapEnvVarSourceAPIToKube(v)
 }

--- a/pkg/triggers/git_trigger_test.go
+++ b/pkg/triggers/git_trigger_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/kubeshop/testkube/api/testtriggers/v1"
+	v1 "github.com/kubeshop/testkube/api/testtriggers/v1"
 	workflowtriggersv1 "github.com/kubeshop/testkube/api/workflowtriggers/v1"
 	"github.com/kubeshop/testkube/internal/app/api/metrics"
 	"github.com/kubeshop/testkube/pkg/log"


### PR DESCRIPTION
## Summary
- remove unused git informer helpers flagged by lint
- simplify optional secret/configmap error checks
- clean up mapper/test style issues reported by staticcheck/goimports
- add the missing transitive yq TOML parser checksum required by CRD generation in CI

## Validation
- make lint
- go build ./...
- make verify-crds-generated

Linear: https://linear.app/kubeshop/issue/TKC-5840/fix-current-testkube-lint-failures