### PR TITLE
feat: support configurable log level via LOG_LEVEL env var

### DIFF
--- a/pkg/log/log.go
+++ b/pkg/log/log.go
@@ -4,6 +4,7 @@ import (
 	"log"
 	"os"
 	"strconv"
+	"strings"
 
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
@@ -21,11 +22,32 @@ func IsTrue(name string) (is bool) {
 	return is
 }
 
+// levelFromEnv reads the optional LOG_LEVEL environment variable and parses it
+// into a zapcore.Level. Accepted values follow zap semantics: debug, info,
+// warn (the issue's "Warning"), error, dpanic, panic, fatal. zap has no Trace
+// level, so debug is the finest granularity. If LOG_LEVEL is unset or empty the
+// provided defaultLevel is returned. On parse error a non-fatal warning is
+// written to stderr and defaultLevel is returned.
+func levelFromEnv(defaultLevel zapcore.Level) zapcore.Level {
+	val, ok := os.LookupEnv("LOG_LEVEL")
+	if !ok || val == "" {
+		return defaultLevel
+	}
+
+	lvl, err := zapcore.ParseLevel(strings.ToLower(val))
+	if err != nil {
+		log.Printf("invalid LOG_LEVEL %q: %v; falling back to %s", val, err, defaultLevel)
+		return defaultLevel
+	}
+
+	return lvl
+}
+
 // New returns new logger instance
 func New() *zap.SugaredLogger {
 	atomicLevel := zap.NewAtomicLevel()
 
-	atomicLevel.SetLevel(zap.InfoLevel)
+	atomicLevel.SetLevel(levelFromEnv(zap.InfoLevel))
 	if IsTrue("DEBUG") {
 		atomicLevel.SetLevel(zap.DebugLevel)
 	}
@@ -49,7 +71,7 @@ func New() *zap.SugaredLogger {
 func NewSilent() *zap.SugaredLogger {
 	atomicLevel := zap.NewAtomicLevel()
 
-	atomicLevel.SetLevel(zap.WarnLevel)
+	atomicLevel.SetLevel(levelFromEnv(zap.WarnLevel))
 	if IsTrue("DEBUG") {
 		atomicLevel.SetLevel(zap.DebugLevel)
 	}

--- a/pkg/log/log_test.go
+++ b/pkg/log/log_test.go
@@ -1,0 +1,72 @@
+package log
+
+import (
+	"testing"
+
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+)
+
+func TestLevelFromEnv_Unset(t *testing.T) {
+	// t.Setenv to empty exercises the unset/empty short-circuit and restores
+	// any pre-existing value after the test.
+	t.Setenv("LOG_LEVEL", "")
+
+	if got := levelFromEnv(zap.InfoLevel); got != zapcore.InfoLevel {
+		t.Errorf("levelFromEnv(InfoLevel) with empty LOG_LEVEL = %v, want %v", got, zapcore.InfoLevel)
+	}
+	if got := levelFromEnv(zap.WarnLevel); got != zapcore.WarnLevel {
+		t.Errorf("levelFromEnv(WarnLevel) with empty LOG_LEVEL = %v, want %v", got, zapcore.WarnLevel)
+	}
+}
+
+func TestLevelFromEnv_Error(t *testing.T) {
+	t.Setenv("LOG_LEVEL", "error")
+
+	if got := levelFromEnv(zap.InfoLevel); got != zapcore.ErrorLevel {
+		t.Errorf("levelFromEnv(InfoLevel) with LOG_LEVEL=error = %v, want %v", got, zapcore.ErrorLevel)
+	}
+}
+
+func TestLevelFromEnv_Debug(t *testing.T) {
+	t.Setenv("LOG_LEVEL", "debug")
+
+	if got := levelFromEnv(zap.InfoLevel); got != zapcore.DebugLevel {
+		t.Errorf("levelFromEnv(InfoLevel) with LOG_LEVEL=debug = %v, want %v", got, zapcore.DebugLevel)
+	}
+}
+
+func TestLevelFromEnv_Garbage(t *testing.T) {
+	t.Setenv("LOG_LEVEL", "garbage")
+
+	if got := levelFromEnv(zap.InfoLevel); got != zapcore.InfoLevel {
+		t.Errorf("levelFromEnv(InfoLevel) with LOG_LEVEL=garbage = %v, want %v (fallback)", got, zapcore.InfoLevel)
+	}
+	if got := levelFromEnv(zap.WarnLevel); got != zapcore.WarnLevel {
+		t.Errorf("levelFromEnv(WarnLevel) with LOG_LEVEL=garbage = %v, want %v (fallback)", got, zapcore.WarnLevel)
+	}
+}
+
+func TestNew_LogLevelError(t *testing.T) {
+	t.Setenv("DEBUG", "")
+	t.Setenv("LOG_LEVEL", "error")
+
+	core := New().Desugar().Core()
+	if !core.Enabled(zapcore.ErrorLevel) {
+		t.Error("New() with LOG_LEVEL=error: expected ErrorLevel enabled")
+	}
+	if core.Enabled(zapcore.InfoLevel) {
+		t.Error("New() with LOG_LEVEL=error: expected InfoLevel disabled")
+	}
+}
+
+func TestNew_DebugOverridesLogLevel(t *testing.T) {
+	// DEBUG must keep forcing Debug regardless of LOG_LEVEL (backward compat).
+	t.Setenv("LOG_LEVEL", "error")
+	t.Setenv("DEBUG", "true")
+
+	core := New().Desugar().Core()
+	if !core.Enabled(zapcore.DebugLevel) {
+		t.Error("New() with DEBUG=true should enable DebugLevel regardless of LOG_LEVEL")
+	}
+}


### PR DESCRIPTION
## Summary

Adds an optional `LOG_LEVEL` environment variable to the API server logger in `pkg/log/log.go`. Until now the logger only supported a binary toggle: `New()` started at `Info` and `NewSilent()` at `Warn`, with `DEBUG=true` being the only way to change verbosity (forcing `Debug`). There was no way to request `Warn`, `Error`, or any other level.

`LOG_LEVEL` is parsed via `zapcore.ParseLevel` and accepts the standard zap levels: `debug`, `info`, `warn`, `error`, `dpanic`, `panic`, `fatal`. It is applied as the baseline in both `New()` (default `Info`) and `NewSilent()` (default `Warn`).

Behavior details:
- Unset or empty `LOG_LEVEL` preserves the existing defaults, so this is fully backward compatible.
- `DEBUG=true` still forces `Debug` and wins over `LOG_LEVEL`, keeping the existing override intact.
- An unparseable `LOG_LEVEL` logs a non-fatal warning and falls back to the default level rather than crashing.

A note on the maintainer's proposed level set: zap has no `Trace` level, so `debug` is the finest granularity available. `warn` maps to the issue's "Warning". This is documented in the helper's doc comment.

## Why this matters

Issue #6538 reports that the API server emits a high volume of logs with no way to quiet or increase verbosity. Maintainer @vsukhin proposed a settable default level spanning the standard set (Trace, Debug, Info, Warning, Error, Fatal, Panic), defaulting to Info. This change implements that request in a minimal, additive way confined to `pkg/log`, defaulting to `Info` exactly as proposed.

## Testing

Added `pkg/log/log_test.go` covering:
- `LOG_LEVEL` unset returns the provided default (Info and Warn).
- `LOG_LEVEL=error` resolves to `ErrorLevel`; `New()` reports `ErrorLevel` enabled and `InfoLevel` disabled.
- `LOG_LEVEL=debug` enables `DebugLevel`.
- `LOG_LEVEL=garbage` falls back to the default level with no panic.
- `DEBUG=true` still forces `Debug` regardless of `LOG_LEVEL`.

```
go vet ./pkg/log/...    # clean
go build ./pkg/log/...  # clean
go test ./pkg/log/...   # ok
```

Manual: `LOG_LEVEL=warn` suppresses Info lines; `LOG_LEVEL=debug` shows Debug lines.

Fixes #6538

AI was used for assistance.
