### PR TITLE
feat: Track telemetry opt-out via a final CLI event

### DIFF
--- a/cmd/kubectl-testkube/commands/telemetry/disable.go
+++ b/cmd/kubectl-testkube/commands/telemetry/disable.go
@@ -20,8 +20,34 @@ func NewDisableTelemetryCmd() *cobra.Command {
 
 			cfg, err := config.Load()
 			// Remember whether telemetry was actually on, so we only record a
-			// genuine on->off transition once we know the opt-out persisted.
+			// genuine on->off transition - and only while it is still enabled.
 			wasEnabled := err == nil && cfg.TelemetryEnabled
+
+			client, _, clientErr := common.GetClient(cmd)
+			ui.WarnOnError("getting client", clientErr)
+
+			apiDisabled := false
+			if clientErr == nil {
+				if _, apiErr := client.UpdateConfig(testkube.Config{EnableTelemetry: false}); apiErr != nil {
+					ui.PrintDisabled("Telemetry on API", "failed")
+					ui.PrintConfigError(apiErr)
+				} else {
+					ui.PrintDisabled("Telemetry on API", "disabled")
+					apiDisabled = true
+				}
+			}
+
+			// Emit the final opt-out event while telemetry is still enabled
+			// locally, but only once the API opt-out has persisted. If the API
+			// update failed, the root post-run sync would re-enable the CLI
+			// config, so sending here would record a false opt-out.
+			if wasEnabled && apiDisabled {
+				if _, sendErr := telemetry.SendTelemetryOptOutEvent(cmd, common.Version); sendErr != nil {
+					ui.Debug("sending telemetry opt-out event failed", sendErr.Error())
+				}
+			}
+
+			// Persist the local opt-out last, after the final event has been sent.
 			if err == nil {
 				cfg.DisableAnalytics()
 				err = config.Save(cfg)
@@ -31,29 +57,6 @@ func NewDisableTelemetryCmd() *cobra.Command {
 				ui.PrintConfigError(err)
 			} else {
 				ui.PrintDisabled("Telemetry on CLI", "disabled")
-			}
-
-			client, _, err := common.GetClient(cmd)
-			ui.WarnOnError("getting client", err)
-			if err != nil {
-				return
-			}
-
-			_, err = client.UpdateConfig(testkube.Config{EnableTelemetry: false})
-			if err != nil {
-				ui.PrintDisabled("Telemetry on API", "failed")
-				ui.PrintConfigError(err)
-			} else {
-				ui.PrintDisabled("Telemetry on API", "disabled")
-				// Only record the opt-out now that it has persisted on both the
-				// CLI and the API. If the API update had failed, the root
-				// post-run sync would re-enable the CLI config, leaving the user
-				// opted in - so sending earlier would produce a false opt-out.
-				if wasEnabled {
-					if _, sendErr := telemetry.SendTelemetryOptOutEvent(cmd, common.Version); sendErr != nil {
-						ui.Debug("sending telemetry opt-out event failed", sendErr.Error())
-					}
-				}
 			}
 
 			ui.NL()

--- a/cmd/kubectl-testkube/commands/telemetry/disable.go
+++ b/cmd/kubectl-testkube/commands/telemetry/disable.go
@@ -19,14 +19,10 @@ func NewDisableTelemetryCmd() *cobra.Command {
 			ui.Print(ui.IconRocket + "  Disabling telemetry on the testkube CLI")
 
 			cfg, err := config.Load()
+			// Remember whether telemetry was actually on, so we only record a
+			// genuine on->off transition once we know the opt-out persisted.
+			wasEnabled := err == nil && cfg.TelemetryEnabled
 			if err == nil {
-				// Send a final opt-out event while telemetry is still enabled.
-				// Once the opt-out is persisted, no further events may be sent.
-				if cfg.TelemetryEnabled {
-					if _, sendErr := telemetry.SendTelemetryOptOutEvent(cmd, common.Version); sendErr != nil {
-						ui.Debug("sending telemetry opt-out event failed", sendErr.Error())
-					}
-				}
 				cfg.DisableAnalytics()
 				err = config.Save(cfg)
 			}
@@ -49,6 +45,15 @@ func NewDisableTelemetryCmd() *cobra.Command {
 				ui.PrintConfigError(err)
 			} else {
 				ui.PrintDisabled("Telemetry on API", "disabled")
+				// Only record the opt-out now that it has persisted on both the
+				// CLI and the API. If the API update had failed, the root
+				// post-run sync would re-enable the CLI config, leaving the user
+				// opted in - so sending earlier would produce a false opt-out.
+				if wasEnabled {
+					if _, sendErr := telemetry.SendTelemetryOptOutEvent(cmd, common.Version); sendErr != nil {
+						ui.Debug("sending telemetry opt-out event failed", sendErr.Error())
+					}
+				}
 			}
 
 			ui.NL()

--- a/cmd/kubectl-testkube/commands/telemetry/disable.go
+++ b/cmd/kubectl-testkube/commands/telemetry/disable.go
@@ -6,6 +6,7 @@ import (
 	"github.com/kubeshop/testkube/cmd/kubectl-testkube/commands/common"
 	"github.com/kubeshop/testkube/cmd/kubectl-testkube/config"
 	"github.com/kubeshop/testkube/pkg/api/v1/testkube"
+	"github.com/kubeshop/testkube/pkg/telemetry"
 	"github.com/kubeshop/testkube/pkg/ui"
 )
 
@@ -19,6 +20,13 @@ func NewDisableTelemetryCmd() *cobra.Command {
 
 			cfg, err := config.Load()
 			if err == nil {
+				// Send a final opt-out event while telemetry is still enabled.
+				// Once the opt-out is persisted, no further events may be sent.
+				if cfg.TelemetryEnabled {
+					if _, sendErr := telemetry.SendTelemetryOptOutEvent(cmd, common.Version); sendErr != nil {
+						ui.Debug("sending telemetry opt-out event failed", sendErr.Error())
+					}
+				}
 				cfg.DisableAnalytics()
 				err = config.Save(cfg)
 			}

--- a/pkg/telemetry/telemetry.go
+++ b/pkg/telemetry/telemetry.go
@@ -121,6 +121,14 @@ func SendCmdInitEvent(cmd *cobra.Command, version string) (string, error) {
 	return sendData(senders, payload)
 }
 
+// SendTelemetryOptOutEvent records that the user disabled telemetry. It must be
+// called while telemetry is still enabled (before the opt-out is persisted), as
+// no further events may be sent once the user has opted out.
+func SendTelemetryOptOutEvent(cmd *cobra.Command, version string) (string, error) {
+	payload := NewCLIPayload(getCurrentContext(), getUserID(cmd), "telemetry_opt_out", version, "cli_command_execution", GetClusterType())
+	return sendData(senders, payload)
+}
+
 // SendPreviewEvent sends a preview-specific telemetry event with execution context
 func SendPreviewEvent(cmd *cobra.Command, version, executionID string, artifactCount int32, skipArtifacts bool, previewErr string) (string, error) {
 	machineID := GetMachineID()


### PR DESCRIPTION
## Summary

The Testkube CLI only sends telemetry while it is enabled. Because the telemetry send happens in `PersistentPostRun` (after the flag is flipped), **enabling** telemetry was recorded but **disabling** it was invisible — by the time the post-run hook fires, telemetry is already off and `handleTelemetry` short-circuits.

This adds an explicit opt-out signal so we can measure when users turn telemetry off:

- New `telemetry.SendTelemetryOptOutEvent` emits a dedicated, easily queryable `telemetry_opt_out` event (category `cli_command_execution`, same GA + Segment senders as other CLI events).
- `testkube disable telemetry` now sends this event **before** persisting the opt-out, and only on a genuine on→off transition (`cfg.TelemetryEnabled`), so consent is still in effect at send time and we don't emit noise when telemetry is already off.
- Send failures are non-fatal (logged only in verbose mode); the opt-out always succeeds.
- No double-counting: the post-run `handleTelemetry` sees the flag already off and stays silent.

Scope: this covers opt-outs performed via the CLI `disable telemetry` command. Opt-outs originating from the dashboard / direct API are out of scope here (would be a separate server-side change in `UpdateConfigsHandler`).

## Test plan

- [x] `go build ./pkg/telemetry/... ./cmd/kubectl-testkube/commands/telemetry/...`
- [x] `gofmt` clean, no linter errors
- [ ] Manual: `testkube enable telemetry` then `testkube disable telemetry --verbose` → observe a single `telemetry_opt_out` event sent
- [ ] Manual: `testkube disable telemetry` when already disabled → no event sent

Made with [Cursor](https://cursor.com)