### PR TITLE
fix: set resource-kind event labels for CRD objects in dynamic informer

### DIFF
--- a/pkg/triggers/event.go
+++ b/pkg/triggers/event.go
@@ -10,7 +10,9 @@ import (
 	"go.uber.org/zap"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/validation"
 	"k8s.io/client-go/kubernetes"
 
@@ -169,6 +171,20 @@ func (s *Service) newWatcherEvent(
 			w.EventLabels[eventLabelKeyResourceKind] = gvk.Kind
 			w.EventLabels[eventLabelKeyResourceGroup] = gvk.Group
 			w.EventLabels[eventLabelKeyResourceVersion] = gvk.Version
+		}
+	}
+
+	// Fallback for CRD objects from the dynamic informer: dynamic_informer.go passes
+	// newU.Object (map[string]interface{}) as `object`, which doesn't implement runtime.Object,
+	// so scheme.ObjectKinds() is never called and the resource-kind label stays empty.
+	// Use objectMeta (*unstructured.Unstructured) as the fallback GVK source so that
+	// selector.matchLabels works for CRDs the same as for builtin types.
+	if w.EventLabels[eventLabelKeyResourceKind] == "" {
+		if u, ok := objectMeta.(*unstructured.Unstructured); ok && u.GetKind() != "" {
+			w.EventLabels[eventLabelKeyResourceKind] = u.GetKind()
+			gv, _ := schema.ParseGroupVersion(u.GetAPIVersion())
+			w.EventLabels[eventLabelKeyResourceGroup] = gv.Group
+			w.EventLabels[eventLabelKeyResourceVersion] = gv.Version
 		}
 	}
 

--- a/pkg/triggers/event.go
+++ b/pkg/triggers/event.go
@@ -177,7 +177,7 @@ func (s *Service) newWatcherEvent(
 	// For CRD objects from the dynamic informer: dynamic_informer.go passes
 	// newU.Object (map[string]interface{}) as `object`, which doesn't implement runtime.Object,
 	// so scheme.ObjectKinds() is never called. Use objectMeta (*unstructured.Unstructured) as
-	// the authoritative GVK source — unconditionally, to match scheme.ObjectKinds() behaviour
+	// the authoritative GVK source unconditionally, to match scheme.ObjectKinds() behaviour
 	// and avoid a stale global eventLabel overriding the real kind.
 	if u, ok := objectMeta.(*unstructured.Unstructured); ok && u.GetKind() != "" {
 		w.EventLabels[eventLabelKeyResourceKind] = u.GetKind()

--- a/pkg/triggers/event.go
+++ b/pkg/triggers/event.go
@@ -174,18 +174,16 @@ func (s *Service) newWatcherEvent(
 		}
 	}
 
-	// Fallback for CRD objects from the dynamic informer: dynamic_informer.go passes
+	// For CRD objects from the dynamic informer: dynamic_informer.go passes
 	// newU.Object (map[string]interface{}) as `object`, which doesn't implement runtime.Object,
-	// so scheme.ObjectKinds() is never called and the resource-kind label stays empty.
-	// Use objectMeta (*unstructured.Unstructured) as the fallback GVK source so that
-	// selector.matchLabels works for CRDs the same as for builtin types.
-	if w.EventLabels[eventLabelKeyResourceKind] == "" {
-		if u, ok := objectMeta.(*unstructured.Unstructured); ok && u.GetKind() != "" {
-			w.EventLabels[eventLabelKeyResourceKind] = u.GetKind()
-			gv, _ := schema.ParseGroupVersion(u.GetAPIVersion())
-			w.EventLabels[eventLabelKeyResourceGroup] = gv.Group
-			w.EventLabels[eventLabelKeyResourceVersion] = gv.Version
-		}
+	// so scheme.ObjectKinds() is never called. Use objectMeta (*unstructured.Unstructured) as
+	// the authoritative GVK source — unconditionally, to match scheme.ObjectKinds() behaviour
+	// and avoid a stale global eventLabel overriding the real kind.
+	if u, ok := objectMeta.(*unstructured.Unstructured); ok && u.GetKind() != "" {
+		w.EventLabels[eventLabelKeyResourceKind] = u.GetKind()
+		gv, _ := schema.ParseGroupVersion(u.GetAPIVersion())
+		w.EventLabels[eventLabelKeyResourceGroup] = gv.Group
+		w.EventLabels[eventLabelKeyResourceVersion] = gv.Version
 	}
 
 	for _, opt := range opts {

--- a/pkg/triggers/event_test.go
+++ b/pkg/triggers/event_test.go
@@ -8,6 +8,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/validation"
@@ -104,4 +105,39 @@ func TestNewWatcherEventSanitizesEventLabels(t *testing.T) {
 	assert.Equal(t, longLabel[:validation.LabelValueMaxLength], customLabel)
 	assert.Empty(t, validation.IsValidLabelValue(customLabel))
 	assert.LessOrEqual(t, len(customLabel), validation.LabelValueMaxLength)
+}
+
+func TestNewWatcherEventUnstructuredCRD(t *testing.T) {
+	s := runtime.NewScheme()
+	metav1.AddToGroupVersion(s, schema.GroupVersion{Version: "v1"})
+	k8sscheme.AddToScheme(s)
+
+	service := &Service{
+		agentName:         "testkube-agent",
+		testkubeNamespace: "testkube-ns",
+		informers:         &k8sInformers{scheme: s},
+		logger:            log.DefaultLogger,
+	}
+
+	rollout := &unstructured.Unstructured{}
+	rollout.SetName("my-rollout")
+	rollout.SetNamespace("my-ns")
+	rollout.SetLabels(map[string]string{"app": "my-rollout"})
+	rollout.SetGroupVersionKind(schema.GroupVersionKind{
+		Group:   "argoproj.io",
+		Version: "v1alpha1",
+		Kind:    "Rollout",
+	})
+
+	// Simulate exactly what dynamic_informer.go does:
+	//   objectMeta = rollout (*unstructured.Unstructured)
+	//   object     = rollout.Object (map[string]interface{}, not a runtime.Object)
+	event := service.newWatcherEvent("modified", rollout, rollout.Object, "rollout")
+
+	assert.Equal(t, "Rollout", event.EventLabels[eventLabelKeyResourceKind],
+		"resource-kind label must be set for CRD objects via the unstructured fallback")
+	assert.Equal(t, "argoproj.io", event.EventLabels[eventLabelKeyResourceGroup])
+	assert.Equal(t, "v1alpha1", event.EventLabels[eventLabelKeyResourceVersion])
+	assert.Equal(t, "my-rollout", event.EventLabels[eventLabelKeyResourceName])
+	assert.Equal(t, "my-ns", event.EventLabels[eventLabelKeyResourceNamespace])
 }

--- a/pkg/triggers/event_test.go
+++ b/pkg/triggers/event_test.go
@@ -140,4 +140,18 @@ func TestNewWatcherEventUnstructuredCRD(t *testing.T) {
 	assert.Equal(t, "v1alpha1", event.EventLabels[eventLabelKeyResourceVersion])
 	assert.Equal(t, "my-rollout", event.EventLabels[eventLabelKeyResourceName])
 	assert.Equal(t, "my-ns", event.EventLabels[eventLabelKeyResourceNamespace])
+
+	// A global eventLabel configured by the operator must not shadow the real CRD kind.
+	// maps.Copy(w.EventLabels, s.eventLabels) runs before the fallback, so a stale
+	// global testkube.io/resource-kind must be unconditionally overwritten.
+	serviceWithStaleGlobal := &Service{
+		agentName:         "testkube-agent",
+		testkubeNamespace: "testkube-ns",
+		informers:         &k8sInformers{scheme: s},
+		logger:            log.DefaultLogger,
+		eventLabels:       map[string]string{eventLabelKeyResourceKind: "StalePod"},
+	}
+	event2 := serviceWithStaleGlobal.newWatcherEvent("modified", rollout, rollout.Object, "rollout")
+	assert.Equal(t, "Rollout", event2.EventLabels[eventLabelKeyResourceKind],
+		"stale global resource-kind label must be overwritten by the unstructured fallback")
 }


### PR DESCRIPTION
## Summary

- `selector.matchLabels` with `testkube.io/resource-kind` doesn't work for CRD objects (Argo Rollouts, custom resources) because `newWatcherEvent()` never sets the event label for objects coming from the dynamic informer
- The dynamic informer passes `newU.Object` (`map[string]interface{}`) as the `object` parameter it doesn't implement `runtime.Object`, so `scheme.ObjectKinds()` is skipped entirely and `testkube.io/resource-kind/group/version` labels stay empty
- For builtin types (`Deployment`, etc.) `watcher.go` passes the typed object which does implement `runtime.Object`, so they work correctly

**Fix**: after the `scheme.ObjectKinds()` block, if `resource-kind` is still empty, fall back to `objectMeta.(*unstructured.Unstructured).GetKind()` / `GetAPIVersion()`. `objectMeta` is always the `*unstructured.Unstructured` for dynamic informer calls.

## Test plan

- [ ] `CGO_ENABLED=0 go test ./pkg/triggers/... -v -run TestNewWatcherEvent` all 3 tests pass including `TestNewWatcherEventUnstructuredCRD` (new)
- [ ] `TestNewWatcherEventUnstructuredCRD` simulates exactly what `dynamic_informer.go` does: `objectMeta = *unstructured.Unstructured`, `object = u.Object` (map), verifies that `resource-kind/group/version` labels are now set correctly
- [ ] Verified end-to-end in local k3d cluster: `selector.matchLabels` with `testkube.io/resource-kind: Rollout` now matches Argo Rollout events without needing a workaround label on the Rollout object