### PR TITLE
fix: set TESTKUBE_REGISTRY from global.imageRegistry in runner chart

### DIFF
--- a/k8s/helm/testkube-runner/templates/deployment.yaml
+++ b/k8s/helm/testkube-runner/templates/deployment.yaml
@@ -309,6 +309,10 @@ spec:
               value: "{{ include "testkube-runner.toolkit.image" . }}"
             - name: "TESTKUBE_TW_INIT_IMAGE"
               value: "{{ include "testkube-runner.init.image" . }}"
+            {{- if .Values.global }}
+            - name: TESTKUBE_REGISTRY
+              value: "{{ .Values.global.imageRegistry }}"
+            {{- end }}
             {{- if .Values.imageInspectionCache.enabled }}
             - name: "TESTKUBE_ENABLE_IMAGE_DATA_PERSISTENT_CACHE"
               value:  "true"

--- a/k8s/helm/testkube-runner/tests/deployment_test.yaml
+++ b/k8s/helm/testkube-runner/tests/deployment_test.yaml
@@ -71,6 +71,24 @@ tests:
             name: TESTKUBE_TW_INIT_IMAGE
           any: true
 
+  - it: sets TESTKUBE_REGISTRY from global.imageRegistry when provided
+    set:
+      global.imageRegistry: 123.dkr.ecr.eu-west-1.amazonaws.com
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: TESTKUBE_REGISTRY
+            value: 123.dkr.ecr.eu-west-1.amazonaws.com
+
+  - it: renders TESTKUBE_REGISTRY with an empty value by default
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: TESTKUBE_REGISTRY
+            value: ""
+
   - it: passes runner credentials as direct env vars when set inline
     set:
       runner.id: agent-123


### PR DESCRIPTION
## Problem

The standalone agent (`testkube-api` chart) sets `TESTKUBE_REGISTRY` from `global.imageRegistry`, so any TestWorkflow step image without a registry gets the configured registry (e.g. ECR) prefixed automatically.

The runner agent (`testkube-runner` chart) never set `TESTKUBE_REGISTRY` at all. Since both run the same `testkube-api-server` binary, the runner's default registry stayed empty and the exact same unqualified step images resolved to `docker.io/`, failing with `ImagePullBackOff` on clusters that mirror images through a private registry.

This was an omission in the runner chart from the start (not a regression) `git log -S TESTKUBE_REGISTRY` shows it was never present.

## Fix

Inject `TESTKUBE_REGISTRY` from `global.imageRegistry` in the runner Deployment, mirroring the `testkube-api` chart so both agent types behave identically. The default (`global.imageRegistry: ""`) renders an empty value, i.e. a no-op for anyone not using a custom registry.

## Tests

Added helm-unittest coverage in `tests/deployment_test.yaml`:
- `TESTKUBE_REGISTRY` is set from `global.imageRegistry` when provided.
- `TESTKUBE_REGISTRY` renders with an empty value by default.

```
helm unittest k8s/helm/testkube-runner -f 'tests/deployment_test.yaml'
# 17 passed, 17 total
```