### PR TITLE
fix(TKC-5895): Fix empty or and env ids in mcp build dasboard url for…

### DIFF
--- a/pkg/mcp/context/context.go
+++ b/pkg/mcp/context/context.go
@@ -1,0 +1,39 @@
+package mcpcontext
+
+import (
+	"context"
+)
+
+type contextKey string
+
+// Context keys for per-request org/env IDs.
+// In CLI mode these are static for the server lifetime, but in cloud mode
+// they change per HTTP request. Tools that need org/env should read these
+// from context as a fallback when their initialization-time values are empty.
+const (
+	orgIDKey contextKey = "mcp_org_id"
+	envIDKey contextKey = "mcp_env_id"
+)
+
+// WithOrgEnv returns a context carrying the given organization and environment IDs.
+func WithOrgEnv(ctx context.Context, orgID, envID string) context.Context {
+	ctx = context.WithValue(ctx, orgIDKey, orgID)
+	ctx = context.WithValue(ctx, envIDKey, envID)
+	return ctx
+}
+
+// GetOrgID returns the organization ID stored in ctx, or "" if absent.
+func GetOrgID(ctx context.Context) string {
+	if id, ok := ctx.Value(orgIDKey).(string); ok {
+		return id
+	}
+	return ""
+}
+
+// GetEnvID returns the environment ID stored in ctx, or "" if absent.
+func GetEnvID(ctx context.Context) string {
+	if id, ok := ctx.Value(envIDKey).(string); ok {
+		return id
+	}
+	return ""
+}

--- a/pkg/mcp/tools/dashboard.go
+++ b/pkg/mcp/tools/dashboard.go
@@ -8,6 +8,8 @@ import (
 
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
+
+	mcpcontext "github.com/kubeshop/testkube/pkg/mcp/context"
 )
 
 func BuildDashboardUrl(dashboardUrl string, orgId string, envId string) (tool mcp.Tool, handler server.ToolHandlerFunc) {
@@ -56,7 +58,22 @@ func BuildDashboardUrl(dashboardUrl string, orgId string, envId string) (tool mc
 			executionTab = "log-output"
 		}
 
-		baseDashboardPath := fmt.Sprintf("/organization/%s/environment/%s/dashboard", orgId, envId)
+		// Resolve org/env IDs: prefer closure values (CLI mode), fall back to
+		// per-request context values (cloud mode where the closure is empty).
+		effectiveOrgID := orgId
+		if effectiveOrgID == "" {
+			effectiveOrgID = mcpcontext.GetOrgID(ctx)
+		}
+		effectiveEnvID := envId
+		if effectiveEnvID == "" {
+			effectiveEnvID = mcpcontext.GetEnvID(ctx)
+		}
+
+		if effectiveOrgID == "" || effectiveEnvID == "" {
+			return mcp.NewToolResultError("organization and environment IDs are required but not available"), nil
+		}
+
+		baseDashboardPath := fmt.Sprintf("/organization/%s/environment/%s/dashboard", effectiveOrgID, effectiveEnvID)
 
 		// Build URL based on resource type
 		var resultURL string

--- a/pkg/mcp/tools/dashboard_test.go
+++ b/pkg/mcp/tools/dashboard_test.go
@@ -8,6 +8,8 @@ import (
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	mcpcontext "github.com/kubeshop/testkube/pkg/mcp/context"
 )
 
 func TestBuildDashboardUrl(t *testing.T) {
@@ -202,5 +204,63 @@ func TestBuildDashboardUrl(t *testing.T) {
 		require.NoError(t, err)
 		require.NotNil(t, result)
 		assert.True(t, result.IsError)
+	})
+
+	t.Run("context fallback when closure org/env are empty", func(t *testing.T) {
+		_, handler := BuildDashboardUrl(dashboardUrl, "", "")
+		ctx := mcpcontext.WithOrgEnv(context.Background(), "ctx-org", "ctx-env")
+		request := mcp.CallToolRequest{}
+		request.Params.Arguments = map[string]any{
+			"resourceType": "workflow",
+			"workflowName": "my-wf",
+		}
+		result, err := handler(ctx, request)
+		require.NoError(t, err)
+		url := parseURL(t, result)
+		assert.Equal(t, dashboardUrl+"/organization/ctx-org/environment/ctx-env/dashboard/test-workflows/my-wf", url)
+	})
+
+	t.Run("closure values take precedence over context", func(t *testing.T) {
+		_, handler := BuildDashboardUrl(dashboardUrl, orgId, envId)
+		ctx := mcpcontext.WithOrgEnv(context.Background(), "ctx-org", "ctx-env")
+		request := mcp.CallToolRequest{}
+		request.Params.Arguments = map[string]any{
+			"resourceType": "workflow",
+			"workflowName": "my-wf",
+		}
+		result, err := handler(ctx, request)
+		require.NoError(t, err)
+		url := parseURL(t, result)
+		// Closure values (orgId, envId) should win over context values
+		assert.Equal(t, dashboardUrl+basePath+"/test-workflows/my-wf", url)
+	})
+
+	t.Run("error when both closure and context org/env are empty", func(t *testing.T) {
+		_, handler := BuildDashboardUrl(dashboardUrl, "", "")
+		request := mcp.CallToolRequest{}
+		request.Params.Arguments = map[string]any{
+			"resourceType": "workflow",
+			"workflowName": "my-wf",
+		}
+		result, err := handler(context.Background(), request)
+		require.NoError(t, err)
+		require.NotNil(t, result)
+		assert.True(t, result.IsError)
+	})
+
+	t.Run("context fallback with execution URL and stepRef", func(t *testing.T) {
+		_, handler := BuildDashboardUrl(dashboardUrl, "", "")
+		ctx := mcpcontext.WithOrgEnv(context.Background(), "ctx-org", "ctx-env")
+		request := mcp.CallToolRequest{}
+		request.Params.Arguments = map[string]any{
+			"resourceType": "execution",
+			"workflowName": "my-wf",
+			"executionId":  "exec-1",
+			"stepRef":      "rwhc2zn",
+		}
+		result, err := handler(ctx, request)
+		require.NoError(t, err)
+		url := parseURL(t, result)
+		assert.Equal(t, dashboardUrl+"/organization/ctx-org/environment/ctx-env/dashboard/test-workflows/my-wf/execution/exec-1/log-output?ref=rwhc2zn", url)
 	})
 }


### PR DESCRIPTION
Fix empty org/env IDs in MCP `build_dashboard_url` when called via the cloud HTTP endpoint.## Pull request description 

## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [x] tested locally
- [ ] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Breaking changes

-

## Changes
-  Added `pkg/mcp/context`package with shared context helpers (`WithOrgEnv`, `GetOrgID`, `GetEnvID`)
- `BuildDashboardUrl` handler now falls back to per-request context values when closure org/env IDs are empty (cloud mode)
- Returns explicit error when neither source provides org/env IDs

## Fixes

-