### PR TITLE
fix: make git informer unit tests hermetic instead of fetching from GitHub

### DIFF
--- a/pkg/git/informer/informer_test.go
+++ b/pkg/git/informer/informer_test.go
@@ -672,6 +672,49 @@ func TestRestoreCommitBaseline(t *testing.T) {
 	assert.False(t, exists)
 }
 
+// initLocalRemoteWithCommit creates a bare repository with a single commit
+// pushed to main, so informer tests can list and fetch refs without touching
+// the network.
+func initLocalRemoteWithCommit(t *testing.T) string {
+	t.Helper()
+	tmpDir := t.TempDir()
+	remoteDir := filepath.Join(tmpDir, "remote.git")
+	_, err := git.PlainInit(remoteDir, true)
+	require.NoError(t, err)
+
+	workDir := filepath.Join(tmpDir, "work")
+	workRepo, err := git.PlainInit(workDir, false)
+	require.NoError(t, err)
+	_, err = workRepo.CreateRemote(&config.RemoteConfig{
+		Name: "origin",
+		URLs: []string{remoteDir},
+	})
+	require.NoError(t, err)
+	require.NoError(t, workRepo.Storer.SetReference(
+		plumbing.NewSymbolicReference(plumbing.HEAD, plumbing.NewBranchReferenceName("main")),
+	))
+	worktree, err := workRepo.Worktree()
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(filepath.Join(workDir, "README.md"), []byte("initial\n"), 0o644))
+	_, err = worktree.Add("README.md")
+	require.NoError(t, err)
+	_, err = worktree.Commit("initial", &git.CommitOptions{
+		Author: &object.Signature{
+			Name:  "test",
+			Email: "test@example.com",
+			When:  time.Now(),
+		},
+	})
+	require.NoError(t, err)
+	require.NoError(t, workRepo.Push(&git.PushOptions{
+		RemoteName: "origin",
+		RefSpecs: []config.RefSpec{
+			config.RefSpec("refs/heads/main:refs/heads/main"),
+		},
+	}))
+	return remoteDir
+}
+
 func TestUpdateRepositories_RestoresBaselineWhenMatchFails(t *testing.T) {
 	resource := testkube.CONTENT_TestTriggerResources
 	trigger := testkube.TestTrigger{
@@ -681,7 +724,7 @@ func TestUpdateRepositories_RestoresBaselineWhenMatchFails(t *testing.T) {
 		Resource:  &resource,
 		ContentSelector: &testkube.TestTriggerContentSelector{
 			Git: &testkube.TestTriggerContentGit{
-				Uri:      "https://github.com/kubeshop/testkube.git",
+				Uri:      initLocalRemoteWithCommit(t),
 				Branches: []string{"main"},
 			},
 		},
@@ -705,8 +748,8 @@ func TestUpdateRepositories_RestoresBaselineWhenMatchFails(t *testing.T) {
 	)
 	informer.commits[key] = "old-head"
 
-	// updateRepositories will try to contact remote, fail, and not call matcher.
-	// Baseline should remain unchanged since the remote call fails before matching.
+	// The remote lists a new HEAD, the matcher fails, and the baseline must be
+	// restored so the commit is retried on the next reconcile.
 	informer.updateRepositories(context.Background())
 
 	assert.Equal(t, "old-head", informer.commits[key])
@@ -761,7 +804,7 @@ func TestUpdateRepositories_ContinuesWhenNamespaceListFails(t *testing.T) {
 		Resource:  &resource,
 		ContentSelector: &testkube.TestTriggerContentSelector{
 			Git: &testkube.TestTriggerContentGit{
-				Uri:      "https://github.com/kubeshop/testkube.git",
+				Uri:      initLocalRemoteWithCommit(t),
 				Branches: []string{"main"},
 			},
 		},
@@ -868,25 +911,16 @@ func TestUpdateRepositories_MatchesTestTriggerWithGitPaths(t *testing.T) {
 	pushMain()
 
 	key := triggerKey(testTriggerSource, "testkube", "trigger-a")
-	repoDir := triggerRepositoryPathFromKey(key)
+	// The informer opens per-ref clones at the ref-suffixed path, so the
+	// pre-seeded clone must live there for the pull path to be exercised.
+	repoDir := triggerRepositoryPathFromKey(key) + refDelimiter + refDirectorySuffix("refs/heads/main")
 	t.Cleanup(func() { _ = os.RemoveAll(repoDir) })
 	_ = os.RemoveAll(repoDir)
 
-	localRepo, err := git.PlainClone(repoDir, &git.CloneOptions{
+	_, err = git.PlainClone(repoDir, &git.CloneOptions{
 		URL:           remoteDir,
 		ReferenceName: plumbing.NewBranchReferenceName("main"),
 		SingleBranch:  true,
-	})
-	require.NoError(t, err)
-	require.NoError(t, localRepo.DeleteRemote("origin"))
-	// Keep the real test remote first (used for fetch/pull) and include the
-	// GitHub URL to satisfy repositoryOriginMatches for kubeshop/testkube.
-	_, err = localRepo.CreateRemote(&config.RemoteConfig{
-		Name: "origin",
-		URLs: []string{
-			remoteDir,
-			"https://github.com/kubeshop/testkube.git",
-		},
 	})
 	require.NoError(t, err)
 
@@ -901,7 +935,7 @@ func TestUpdateRepositories_MatchesTestTriggerWithGitPaths(t *testing.T) {
 		Resource:  &resource,
 		ContentSelector: &testkube.TestTriggerContentSelector{
 			Git: &testkube.TestTriggerContentGit{
-				Uri:      "https://github.com/kubeshop/testkube.git",
+				Uri:      remoteDir,
 				Branches: []string{"main"},
 				Paths:    []string{"/test", "/pkg"},
 			},


### PR DESCRIPTION
## Why

The Unit Tests CI job has been intermittently OOM-killing its Depot runner since June 2, on unrelated branches. The VM died before logs were uploaded, so each occurrence showed up as a 15 minute failure with no logs. Healthy runs take about 4 minutes.

The cause is in `pkg/git/informer`. Three tests use https://github.com/kubeshop/testkube.git as the trigger URI, so every CI run does a live ls-remote against GitHub. One of them, `TestUpdateRepositories_MatchesTestTriggerWithGitPaths`, also seeds its local fixture at the wrong path (it misses the ref suffix the informer appends to per-ref clone directories), so the informer never finds the fixture and falls back to a full clone of `kubeshop/testkube` inside a unit test. The assertions then pass against live commit data from the real repository. When GitHub is slow or throttles the fetch, go-git buffers it in memory until the 8GB runner dies.

This reproduces locally: with go test -shuffle the package hangs in worktree.Pull on every seed.

## How

The informer tests now run against a local bare repository with a single pushed commit (new initLocalRemoteWithCommit helper), and the paths test seeds its clone at the correct ref-suffixed directory. The package passes all shuffle seeds in about a second, including with HTTPS_PROXY pointed at a dead port to confirm nothing reaches the network anymore.