### PR TITLE
fix(testworkflows): pass execution tags into expression machine

### DIFF
--- a/pkg/runner/agent.go
+++ b/pkg/runner/agent.go
@@ -375,6 +375,7 @@ func (a *agentLoop) directRunTestWorkflow(environmentId string, executionId stri
 			Number:           execution.Number,
 			ScheduledAt:      execution.ScheduledAt,
 			DisableWebhooks:  execution.DisableWebhooks,
+			Tags:             execution.Tags,
 			Debug:            false,
 			OrganizationId:   a.organizationId,
 			OrganizationSlug: a.proContext.OrgSlug,

--- a/pkg/testworkflows/testworkflowexecutor/prepared.go
+++ b/pkg/testworkflows/testworkflowexecutor/prepared.go
@@ -316,6 +316,14 @@ func (e *IntermediateExecution) Resolve(organizationId, organizationSlug, enviro
 		e.dirty = true
 	}
 
+	// Compute the merged execution tags (spec defaults + per-execution overrides) so that
+	// expressions like {{ execution.tags.env }} are resolved correctly.
+	executionTags := make(map[string]string)
+	if e.cr.Spec.Execution != nil {
+		maps.Copy(executionTags, e.cr.Spec.Execution.Tags)
+	}
+	maps.Copy(executionTags, e.tags)
+
 	executionMachine := testworkflowconfig.CreateExecutionMachine(&testworkflowconfig.ExecutionConfig{
 		Id:               e.execution.Id,
 		GroupId:          e.execution.GroupId,
@@ -323,6 +331,7 @@ func (e *IntermediateExecution) Resolve(organizationId, organizationSlug, enviro
 		Number:           e.execution.Number,
 		ScheduledAt:      e.execution.ScheduledAt,
 		DisableWebhooks:  e.execution.DisableWebhooks,
+		Tags:             executionTags,
 		Debug:            debug,
 		OrganizationId:   organizationId,
 		OrganizationSlug: organizationSlug,


### PR DESCRIPTION
## Summary
- propagate merged execution tags into the execution expression machine during workflow resolve
- include execution tags in runner ExecutionConfig so runtime TK_CFG exposes execution.tags

## Why
Template expressions like {{ execution.tags.env }} were resolving empty because tags were not passed into ExecutionConfig before CreateExecutionMachine was built.

## Scope
- pkg/testworkflows/testworkflowexecutor/prepared.go
- pkg/runner/agent.go
