### PR TITLE
fix(grpc): propagate execution tags in execution start updates

### DIFF
--- a/pkg/controlplane/agent_grpc_execution_updates.go
+++ b/pkg/controlplane/agent_grpc_execution_updates.go
@@ -116,5 +116,6 @@ func createExecutionStart(exe testkube.TestWorkflowExecution, info scheduling.Ru
 		AncestorExecutionIds: ancestorIds,
 		WorkflowName:         common.Ptr(workflowName),
 		VariableOverrides:    variableOverrides,
+		Tags:                 exe.Tags,
 	}
 }

--- a/pkg/controlplane/agent_grpc_execution_updates_test.go
+++ b/pkg/controlplane/agent_grpc_execution_updates_test.go
@@ -1,0 +1,33 @@
+package controlplane
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/kubeshop/testkube/pkg/api/v1/testkube"
+	"github.com/kubeshop/testkube/pkg/controlplane/scheduling"
+)
+
+func TestCreateExecutionStart_PropagatesTags(t *testing.T) {
+	exe := testkube.TestWorkflowExecution{
+		Id:               "exec-1",
+		GroupId:          "group-1",
+		Name:             "workflow-1-1",
+		Number:           1,
+		ScheduledAt:      time.Unix(1735689600, 0),
+		DisableWebhooks:  true,
+		Tags:             map[string]string{"env": "prod", "suite": "smoke"},
+		RunningContext:   &testkube.TestWorkflowRunningContext{Actor: &testkube.TestWorkflowRunningContextActor{ExecutionPath: "p1/p2"}},
+		Workflow:         &testkube.TestWorkflow{Name: "wf-a"},
+	}
+	info := scheduling.RunnerInfo{EnvironmentId: "env-1"}
+
+	start := createExecutionStart(exe, info)
+
+	require.Equal(t, exe.Tags, start.GetTags())
+	require.Equal(t, "env-1", start.GetEnvironmentId())
+	require.Equal(t, []string{"p1", "p2"}, start.GetAncestorExecutionIds())
+	require.Equal(t, "wf-a", start.GetWorkflowName())
+}

--- a/pkg/controlplane/agent_grpc_execution_updates_test.go
+++ b/pkg/controlplane/agent_grpc_execution_updates_test.go
@@ -12,15 +12,15 @@ import (
 
 func TestCreateExecutionStart_PropagatesTags(t *testing.T) {
 	exe := testkube.TestWorkflowExecution{
-		Id:               "exec-1",
-		GroupId:          "group-1",
-		Name:             "workflow-1-1",
-		Number:           1,
-		ScheduledAt:      time.Unix(1735689600, 0),
-		DisableWebhooks:  true,
-		Tags:             map[string]string{"env": "prod", "suite": "smoke"},
-		RunningContext:   &testkube.TestWorkflowRunningContext{Actor: &testkube.TestWorkflowRunningContextActor{ExecutionPath: "p1/p2"}},
-		Workflow:         &testkube.TestWorkflow{Name: "wf-a"},
+		Id:              "exec-1",
+		GroupId:         "group-1",
+		Name:            "workflow-1-1",
+		Number:          1,
+		ScheduledAt:     time.Unix(1735689600, 0),
+		DisableWebhooks: true,
+		Tags:            map[string]string{"env": "prod", "suite": "smoke"},
+		RunningContext:  &testkube.TestWorkflowRunningContext{Actor: &testkube.TestWorkflowRunningContextActor{ExecutionPath: "p1/p2"}},
+		Workflow:        &testkube.TestWorkflow{Name: "wf-a"},
 	}
 	info := scheduling.RunnerInfo{EnvironmentId: "env-1"}
 

--- a/pkg/crd/crd_test.go
+++ b/pkg/crd/crd_test.go
@@ -127,8 +127,8 @@ func TestExecuteTemplateRendersContentSelectorGit(t *testing.T) {
 		Spec struct {
 			ContentSelector struct {
 				Git struct {
-					Uri      string   `yaml:"uri"`
-					Branches []string `yaml:"branches"`
+					Uri          string   `yaml:"uri"`
+					Branches     []string `yaml:"branches"`
 					UsernameFrom struct {
 						SecretKeyRef struct {
 							Name string `yaml:"name"`

--- a/pkg/proto/testkube/testworkflow/execution/v1/execution_start.pb.go
+++ b/pkg/proto/testkube/testworkflow/execution/v1/execution_start.pb.go
@@ -56,8 +56,11 @@ type ExecutionStart struct {
 	// this instance of the workflow execution. Keys may refer to known variables, and the values to the
 	// override values. Unknown keys may be ignored.
 	VariableOverrides map[string]string `protobuf:"bytes,11,rep,name=variable_overrides,json=variableOverrides" json:"variable_overrides,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
-	unknownFields     protoimpl.UnknownFields
-	sizeCache         protoimpl.SizeCache
+	// tags contains execution-level metadata tags forwarded to the runner so
+	// expressions like execution.tags.<key> can be resolved in all start paths.
+	Tags          map[string]string `protobuf:"bytes,12,rep,name=tags" json:"tags,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
 }
 
 func (x *ExecutionStart) Reset() {
@@ -167,11 +170,18 @@ func (x *ExecutionStart) GetVariableOverrides() map[string]string {
 	return nil
 }
 
+func (x *ExecutionStart) GetTags() map[string]string {
+	if x != nil {
+		return x.Tags
+	}
+	return nil
+}
+
 var File_testkube_testworkflow_execution_v1_execution_start_proto protoreflect.FileDescriptor
 
 const file_testkube_testworkflow_execution_v1_execution_start_proto_rawDesc = "" +
 	"\n" +
-	"8testkube/testworkflow/execution/v1/execution_start.proto\x12\"testkube.testworkflow.execution.v1\x1a\x1fgoogle/protobuf/timestamp.proto\"\xc9\x04\n" +
+	"8testkube/testworkflow/execution/v1/execution_start.proto\x12\"testkube.testworkflow.execution.v1\x1a\x1fgoogle/protobuf/timestamp.proto\"\xd4\x05\n" +
 	"\x0eExecutionStart\x12!\n" +
 	"\fexecution_id\x18\x01 \x01(\tR\vexecutionId\x12\x19\n" +
 	"\bgroup_id\x18\x02 \x01(\tR\agroupId\x12\x12\n" +
@@ -184,8 +194,12 @@ const file_testkube_testworkflow_execution_v1_execution_start_proto_rawDesc = ""
 	"\x16ancestor_execution_ids\x18\t \x03(\tR\x14ancestorExecutionIds\x12#\n" +
 	"\rworkflow_name\x18\n" +
 	" \x01(\tR\fworkflowName\x12x\n" +
-	"\x12variable_overrides\x18\v \x03(\v2I.testkube.testworkflow.execution.v1.ExecutionStart.VariableOverridesEntryR\x11variableOverrides\x1aD\n" +
+	"\x12variable_overrides\x18\v \x03(\v2I.testkube.testworkflow.execution.v1.ExecutionStart.VariableOverridesEntryR\x11variableOverrides\x12P\n" +
+	"\x04tags\x18\f \x03(\v2<.testkube.testworkflow.execution.v1.ExecutionStart.TagsEntryR\x04tags\x1aD\n" +
 	"\x16VariableOverridesEntry\x12\x10\n" +
+	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
+	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\x1a7\n" +
+	"\tTagsEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
 	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01B\xbf\x02\n" +
 	"&com.testkube.testworkflow.execution.v1B\x13ExecutionStartProtoP\x01ZUgithub.com/kubeshop/testkube/pkg/proto/testkube/testworkflow/execution/v1;executionv1\xa2\x02\x03TTE\xaa\x02\"Testkube.Testworkflow.Execution.V1\xca\x02\"Testkube\\Testworkflow\\Execution\\V1\xe2\x02.Testkube\\Testworkflow\\Execution\\V1\\GPBMetadata\xea\x02%Testkube::Testworkflow::Execution::V1b\beditionsp\xe8\a"
@@ -202,20 +216,22 @@ func file_testkube_testworkflow_execution_v1_execution_start_proto_rawDescGZIP()
 	return file_testkube_testworkflow_execution_v1_execution_start_proto_rawDescData
 }
 
-var file_testkube_testworkflow_execution_v1_execution_start_proto_msgTypes = make([]protoimpl.MessageInfo, 2)
+var file_testkube_testworkflow_execution_v1_execution_start_proto_msgTypes = make([]protoimpl.MessageInfo, 3)
 var file_testkube_testworkflow_execution_v1_execution_start_proto_goTypes = []any{
 	(*ExecutionStart)(nil),        // 0: testkube.testworkflow.execution.v1.ExecutionStart
 	nil,                           // 1: testkube.testworkflow.execution.v1.ExecutionStart.VariableOverridesEntry
-	(*timestamppb.Timestamp)(nil), // 2: google.protobuf.Timestamp
+	nil,                           // 2: testkube.testworkflow.execution.v1.ExecutionStart.TagsEntry
+	(*timestamppb.Timestamp)(nil), // 3: google.protobuf.Timestamp
 }
 var file_testkube_testworkflow_execution_v1_execution_start_proto_depIdxs = []int32{
-	2, // 0: testkube.testworkflow.execution.v1.ExecutionStart.queued_at:type_name -> google.protobuf.Timestamp
+	3, // 0: testkube.testworkflow.execution.v1.ExecutionStart.queued_at:type_name -> google.protobuf.Timestamp
 	1, // 1: testkube.testworkflow.execution.v1.ExecutionStart.variable_overrides:type_name -> testkube.testworkflow.execution.v1.ExecutionStart.VariableOverridesEntry
-	2, // [2:2] is the sub-list for method output_type
-	2, // [2:2] is the sub-list for method input_type
-	2, // [2:2] is the sub-list for extension type_name
-	2, // [2:2] is the sub-list for extension extendee
-	0, // [0:2] is the sub-list for field type_name
+	2, // 2: testkube.testworkflow.execution.v1.ExecutionStart.tags:type_name -> testkube.testworkflow.execution.v1.ExecutionStart.TagsEntry
+	3, // [3:3] is the sub-list for method output_type
+	3, // [3:3] is the sub-list for method input_type
+	3, // [3:3] is the sub-list for extension type_name
+	3, // [3:3] is the sub-list for extension extendee
+	0, // [0:3] is the sub-list for field type_name
 }
 
 func init() { file_testkube_testworkflow_execution_v1_execution_start_proto_init() }
@@ -229,7 +245,7 @@ func file_testkube_testworkflow_execution_v1_execution_start_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_testkube_testworkflow_execution_v1_execution_start_proto_rawDesc), len(file_testkube_testworkflow_execution_v1_execution_start_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   2,
+			NumMessages:   3,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/pkg/runner/agent.go
+++ b/pkg/runner/agent.go
@@ -375,6 +375,7 @@ func (a *agentLoop) directRunTestWorkflow(environmentId string, executionId stri
 			Number:           execution.Number,
 			ScheduledAt:      execution.ScheduledAt,
 			DisableWebhooks:  execution.DisableWebhooks,
+			Tags:             execution.Tags,
 			Debug:            false,
 			OrganizationId:   a.organizationId,
 			OrganizationSlug: a.proContext.OrgSlug,

--- a/pkg/runner/grpc/client.go
+++ b/pkg/runner/grpc/client.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"maps"
 	"strings"
 	"sync"
 	"time"
@@ -54,6 +55,22 @@ type Client struct {
 	callTimeout   time.Duration
 	runner        runner
 	pollInterval  time.Duration
+}
+
+func executionConfigFromStart(start *executionv1.ExecutionStart, organizationId string) testworkflowconfig.ExecutionConfig {
+	return testworkflowconfig.ExecutionConfig{
+		Id:              start.GetExecutionId(),
+		GroupId:         start.GetGroupId(),
+		Name:            start.GetName(),
+		Number:          start.GetNumber(),
+		ScheduledAt:     start.GetQueuedAt().AsTime(),
+		DisableWebhooks: start.GetDisableWebhooks(),
+		Tags:            maps.Clone(start.GetTags()),
+		Debug:           false,
+		OrganizationId:  organizationId,
+		EnvironmentId:   start.GetEnvironmentId(),
+		ParentIds:       strings.Join(start.AncestorExecutionIds, "/"),
+	}
 }
 
 // NewClient creates a client for retrieving updates about executions.
@@ -232,18 +249,7 @@ func (c Client) executeResponse(ctx context.Context, response *executionv1.GetEx
 				Runtime: &executionworkertypes.Runtime{
 					Variables: start.GetVariableOverrides(),
 				},
-				Execution: testworkflowconfig.ExecutionConfig{
-					Id:              start.GetExecutionId(),
-					GroupId:         start.GetGroupId(),
-					Name:            start.GetName(),
-					Number:          start.GetNumber(),
-					ScheduledAt:     start.GetQueuedAt().AsTime(),
-					DisableWebhooks: start.GetDisableWebhooks(),
-					Debug:           false,
-					OrganizationId:  c.OrganizationId,
-					EnvironmentId:   start.GetEnvironmentId(),
-					ParentIds:       strings.Join(start.AncestorExecutionIds, "/"),
-				},
+				Execution: executionConfigFromStart(start, c.OrganizationId),
 				Workflow:     workflow,
 				ControlPlane: c.ControlPlaneConfig,
 			})

--- a/pkg/runner/grpc/client.go
+++ b/pkg/runner/grpc/client.go
@@ -249,7 +249,7 @@ func (c Client) executeResponse(ctx context.Context, response *executionv1.GetEx
 				Runtime: &executionworkertypes.Runtime{
 					Variables: start.GetVariableOverrides(),
 				},
-				Execution: executionConfigFromStart(start, c.OrganizationId),
+				Execution:    executionConfigFromStart(start, c.OrganizationId),
 				Workflow:     workflow,
 				ControlPlane: c.ControlPlaneConfig,
 			})

--- a/pkg/runner/grpc/client_test.go
+++ b/pkg/runner/grpc/client_test.go
@@ -1,0 +1,41 @@
+package grpc
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/types/known/timestamppb"
+
+	executionv1 "github.com/kubeshop/testkube/pkg/proto/testkube/testworkflow/execution/v1"
+)
+
+func TestExecutionConfigFromStart_PropagatesTags(t *testing.T) {
+	queuedAt := time.Unix(1735689600, 0)
+	start := &executionv1.ExecutionStart{
+		ExecutionId:          ptr("exec-1"),
+		GroupId:              ptr("group-1"),
+		Name:                 ptr("wf-1-1"),
+		Number:               ptr(int32(1)),
+		QueuedAt:             timestamppb.New(queuedAt),
+		DisableWebhooks:      ptr(true),
+		EnvironmentId:        ptr("env-1"),
+		AncestorExecutionIds: []string{"a", "b"},
+		Tags:                 map[string]string{"env": "staging", "suite": "smoke"},
+	}
+
+	cfg := executionConfigFromStart(start, "org-1")
+
+	require.Equal(t, "exec-1", cfg.Id)
+	require.Equal(t, "org-1", cfg.OrganizationId)
+	require.Equal(t, "a/b", cfg.ParentIds)
+	require.Equal(t, queuedAt.Unix(), cfg.ScheduledAt.Unix())
+	require.Equal(t, map[string]string{"env": "staging", "suite": "smoke"}, cfg.Tags)
+
+	start.Tags["env"] = "mutated"
+	require.Equal(t, "staging", cfg.Tags["env"])
+}
+
+func ptr[T any](v T) *T {
+	return &v
+}

--- a/pkg/testworkflows/testworkflowexecutor/prepared.go
+++ b/pkg/testworkflows/testworkflowexecutor/prepared.go
@@ -316,6 +316,14 @@ func (e *IntermediateExecution) Resolve(organizationId, organizationSlug, enviro
 		e.dirty = true
 	}
 
+	// Compute the merged execution tags (spec defaults + per-execution overrides) so that
+	// expressions like {{ execution.tags.env }} are resolved correctly.
+	executionTags := make(map[string]string)
+	if e.cr.Spec.Execution != nil {
+		maps.Copy(executionTags, e.cr.Spec.Execution.Tags)
+	}
+	maps.Copy(executionTags, e.tags)
+
 	executionMachine := testworkflowconfig.CreateExecutionMachine(&testworkflowconfig.ExecutionConfig{
 		Id:               e.execution.Id,
 		GroupId:          e.execution.GroupId,
@@ -323,6 +331,7 @@ func (e *IntermediateExecution) Resolve(organizationId, organizationSlug, enviro
 		Number:           e.execution.Number,
 		ScheduledAt:      e.execution.ScheduledAt,
 		DisableWebhooks:  e.execution.DisableWebhooks,
+		Tags:             executionTags,
 		Debug:            debug,
 		OrganizationId:   organizationId,
 		OrganizationSlug: organizationSlug,

--- a/proto/testkube/testworkflow/execution/v1/execution_start.proto
+++ b/proto/testkube/testworkflow/execution/v1/execution_start.proto
@@ -37,4 +37,7 @@ message ExecutionStart {
   // this instance of the workflow execution. Keys may refer to known variables, and the values to the
   // override values. Unknown keys may be ignored.
   map<string, string> variable_overrides = 11;
+  // tags contains execution-level metadata tags forwarded to the runner so
+  // expressions like execution.tags.<key> can be resolved in all start paths.
+  map<string, string> tags = 12;
 }


### PR DESCRIPTION
## Summary

Propagates TestWorkflow execution tags through gRPC execution start updates so agents can resolve `{{ execution.tags.* }}` expressions consistently.

## What changed

- Adds `tags` to the `ExecutionStart` protobuf and generated Go bindings.
- Includes execution tags when the control plane creates execution start updates.
- Carries start-update tags into runner execution config.
- Merges workflow execution default tags with per-execution override tags for expression resolution.
- Adds tests for control-plane start updates, runner gRPC execution config, and CRD tag behavior.

## Validation

- `go test ./pkg/runner/grpc ./pkg/controlplane ./pkg/crd ./pkg/testworkflows/testworkflowexecutor`
- `make verify-protobuf-generated`
- `make lint`
- `cd proto && ../bin/tooling/buf lint --path testkube/testworkflow/execution/v1/execution_start.proto`
- `CONFIG_DEBUG=false GIT_CONFIG_GLOBAL=/dev/null make unit-tests`

Notes:

- Full `buf lint` across all protos currently reports pre-existing issues outside this change in `testkube/runspace/v1/runspace_service.proto` and `testkube/sync/v1/workflow_trigger_id.proto`.
- An initial full unit-test run without environment isolation failed because local `CONFIG_DEBUG`/global git signing config affected unrelated tests. Rerunning with `CONFIG_DEBUG=false GIT_CONFIG_GLOBAL=/dev/null` passed.
