### PR TITLE
fix(TKC-5957): Cron Scheduler misses runs. Lease leader never renews

### DIFF
--- a/pkg/database/postgres/queries/leases.sql
+++ b/pkg/database/postgres/queries/leases.sql
@@ -17,4 +17,8 @@ SET
     renewed_at = @renewed_at,
     updated_at = NOW()
 WHERE id = @id
+  -- Only renew/take over if, at write time, the lease is still ours or has expired.
+  -- This makes the update atomic with the ownership/expiry decision and prevents a
+  -- stalled holder from overwriting a newer leader after failover.
+  AND (identifier = @identifier OR renewed_at < @stale_threshold)
 RETURNING id, identifier, cluster_id, acquired_at, renewed_at, created_at, updated_at;

--- a/pkg/database/postgres/sqlc/leases.sql.go
+++ b/pkg/database/postgres/sqlc/leases.sql.go
@@ -76,15 +76,20 @@ SET
     renewed_at = $4,
     updated_at = NOW()
 WHERE id = $5
+  -- Only renew/take over if, at write time, the lease is still ours or has expired.
+  -- This makes the update atomic with the ownership/expiry decision and prevents a
+  -- stalled holder from overwriting a newer leader after failover.
+  AND (identifier = $1 OR renewed_at < $6)
 RETURNING id, identifier, cluster_id, acquired_at, renewed_at, created_at, updated_at
 `
 
 type UpdateLeaseParams struct {
-	Identifier string             `db:"identifier" json:"identifier"`
-	ClusterID  string             `db:"cluster_id" json:"cluster_id"`
-	AcquiredAt pgtype.Timestamptz `db:"acquired_at" json:"acquired_at"`
-	RenewedAt  pgtype.Timestamptz `db:"renewed_at" json:"renewed_at"`
-	ID         string             `db:"id" json:"id"`
+	Identifier     string             `db:"identifier" json:"identifier"`
+	ClusterID      string             `db:"cluster_id" json:"cluster_id"`
+	AcquiredAt     pgtype.Timestamptz `db:"acquired_at" json:"acquired_at"`
+	RenewedAt      pgtype.Timestamptz `db:"renewed_at" json:"renewed_at"`
+	ID             string             `db:"id" json:"id"`
+	StaleThreshold pgtype.Timestamptz `db:"stale_threshold" json:"stale_threshold"`
 }
 
 func (q *Queries) UpdateLease(ctx context.Context, arg UpdateLeaseParams) (Lease, error) {
@@ -94,6 +99,7 @@ func (q *Queries) UpdateLease(ctx context.Context, arg UpdateLeaseParams) (Lease
 		arg.AcquiredAt,
 		arg.RenewedAt,
 		arg.ID,
+		arg.StaleThreshold,
 	)
 	var i Lease
 	err := row.Scan(

--- a/pkg/database/postgres/sqlc/leases.sql_test.go
+++ b/pkg/database/postgres/sqlc/leases.sql_test.go
@@ -103,16 +103,16 @@ SET
     acquired_at = \$3,
     renewed_at = \$4,
     updated_at = NOW\(\)
-WHERE id = \$5
-RETURNING id, identifier, cluster_id, acquired_at, renewed_at, created_at, updated_at`
+WHERE id = \$5[\s\S]*AND \(identifier = \$1 OR renewed_at < \$6\)[\s\S]*RETURNING id, identifier, cluster_id, acquired_at, renewed_at, created_at, updated_at`
 
 	testTime := time.Now()
 	params := UpdateLeaseParams{
-		Identifier: "updated-identifier",
-		ClusterID:  "updated-cluster",
-		AcquiredAt: pgtype.Timestamptz{Time: testTime, Valid: true},
-		RenewedAt:  pgtype.Timestamptz{Time: testTime, Valid: true},
-		ID:         "lease-test-cluster",
+		Identifier:     "updated-identifier",
+		ClusterID:      "updated-cluster",
+		AcquiredAt:     pgtype.Timestamptz{Time: testTime, Valid: true},
+		RenewedAt:      pgtype.Timestamptz{Time: testTime, Valid: true},
+		ID:             "lease-test-cluster",
+		StaleThreshold: pgtype.Timestamptz{Time: testTime, Valid: true},
 	}
 
 	rows := mock.NewRows([]string{
@@ -122,7 +122,7 @@ RETURNING id, identifier, cluster_id, acquired_at, renewed_at, created_at, updat
 	)
 
 	mock.ExpectQuery(expectedQuery).WithArgs(
-		params.Identifier, params.ClusterID, params.AcquiredAt, params.RenewedAt, params.ID,
+		params.Identifier, params.ClusterID, params.AcquiredAt, params.RenewedAt, params.ID, params.StaleThreshold,
 	).WillReturnRows(rows)
 
 	result, err := queries.UpdateLease(ctx, params)
@@ -240,18 +240,19 @@ func TestSQLCLeaseQueries_ParameterValidation(t *testing.T) {
 					"id", "identifier", "cluster_id", "acquired_at", "renewed_at", "created_at", "updated_at",
 				}).AddRow("lease-id", longString, longString, testTime, testTime, testTime, testTime)
 
-				mock.ExpectQuery(`UPDATE leases SET`).
-					WithArgs(longString, longString, pgtype.Timestamptz{Time: testTime, Valid: true}, pgtype.Timestamptz{Time: testTime, Valid: true}, "lease-id").
+				mock.ExpectQuery(`UPDATE leases`).
+					WithArgs(longString, longString, pgtype.Timestamptz{Time: testTime, Valid: true}, pgtype.Timestamptz{Time: testTime, Valid: true}, "lease-id", pgtype.Timestamptz{Time: testTime, Valid: true}).
 					WillReturnRows(rows)
 			},
 			executeQuery: func(q *Queries, ctx context.Context) error {
 				longString := string(make([]byte, 1000))
 				_, err := q.UpdateLease(ctx, UpdateLeaseParams{
-					Identifier: longString,
-					ClusterID:  longString,
-					AcquiredAt: pgtype.Timestamptz{Time: testTime, Valid: true},
-					RenewedAt:  pgtype.Timestamptz{Time: testTime, Valid: true},
-					ID:         "lease-id",
+					Identifier:     longString,
+					ClusterID:      longString,
+					AcquiredAt:     pgtype.Timestamptz{Time: testTime, Valid: true},
+					RenewedAt:      pgtype.Timestamptz{Time: testTime, Valid: true},
+					ID:             "lease-id",
+					StaleThreshold: pgtype.Timestamptz{Time: testTime, Valid: true},
 				})
 				return err
 			},

--- a/pkg/repository/leasebackend/mongo/mongo.go
+++ b/pkg/repository/leasebackend/mongo/mongo.go
@@ -53,6 +53,9 @@ func (b *MongoLeaseBackend) TryAcquire(ctx context.Context, id, clusterID string
 		acquiredAt = time.Now()
 	}
 	newLease, err := b.tryUpdateLease(ctx, leaseMongoID, id, clusterID, acquiredAt)
+	if err == mongo.ErrNoDocuments {
+		return false, nil
+	}
 	if err != nil {
 		return false, err
 	}
@@ -98,12 +101,24 @@ func (b *MongoLeaseBackend) tryUpdateLease(ctx context.Context, leaseMongoID, id
 		RenewedAt:  time.Now(),
 	}
 
+	staleThreshold := time.Now().Add(-leasebackend.DefaultMaxLeaseDuration)
+	filter := bson.M{
+		"_id": leaseMongoID,
+		"$or": bson.A{
+			bson.M{"identifier": id},
+			bson.M{"renewed_at": bson.M{"$lt": staleThreshold}},
+		},
+	}
+
 	res := b.coll.FindOneAndUpdate(
 		ctx,
-		bson.M{"_id": leaseMongoID},
+		filter,
 		bson.M{"$set": newLease},
 		options.FindOneAndUpdate().SetReturnDocument(options.After),
 	)
+	if res.Err() == mongo.ErrNoDocuments {
+		return nil, mongo.ErrNoDocuments
+	}
 	if res.Err() != nil {
 		return nil, errors.Wrap(res.Err(), "error finding and updating mongo db document")
 	}

--- a/pkg/repository/leasebackend/mongo/mongo.go
+++ b/pkg/repository/leasebackend/mongo/mongo.go
@@ -43,11 +43,8 @@ func (b *MongoLeaseBackend) TryAcquire(ctx context.Context, id, clusterID string
 		return false, err
 	}
 
-	acquired, renewable := leaseStatus(currentLease, id, clusterID)
-	switch {
-	case acquired:
-		return true, nil
-	case !renewable:
+	_, renewable := leaseStatus(currentLease, id, clusterID)
+	if !renewable {
 		return false, nil
 	}
 
@@ -59,7 +56,7 @@ func (b *MongoLeaseBackend) TryAcquire(ctx context.Context, id, clusterID string
 	if err != nil {
 		return false, err
 	}
-	acquired, _ = leaseStatus(newLease, id, clusterID)
+	acquired, _ := leaseStatus(newLease, id, clusterID)
 
 	return acquired, nil
 }
@@ -126,12 +123,12 @@ func leaseStatus(lease *Lease, id, clusterID string) (acquired bool, renewable b
 	isLeaseExpired := lease.RenewedAt.Before(maxLeaseDurationStaleness)
 	isMyLease := lease.Identifier == id && lease.ClusterID == clusterID
 	switch {
+	case isMyLease:
+		acquired = true
+		renewable = true
 	case isLeaseExpired:
 		acquired = false
 		renewable = true
-	case isMyLease:
-		acquired = true
-		renewable = false
 	default:
 		acquired = false
 		renewable = false

--- a/pkg/repository/leasebackend/mongo/mongo_test.go
+++ b/pkg/repository/leasebackend/mongo/mongo_test.go
@@ -11,6 +11,7 @@ import (
 	"go.mongodb.org/mongo-driver/v2/mongo"
 	"go.mongodb.org/mongo-driver/v2/mongo/options"
 
+	"github.com/kubeshop/testkube/pkg/repository/leasebackend"
 	"github.com/kubeshop/testkube/pkg/utils/test"
 )
 
@@ -123,4 +124,68 @@ func TestMongoLeaseBackend_TryAcquire_Integration(t *testing.T) {
 		assert.True(t, leased, "should acquire lease")
 		assert.NoError(t, err)
 	})
+}
+
+func TestLeaseStatus(t *testing.T) {
+	tests := []struct {
+		name              string
+		lease             *Lease
+		id                string
+		clusterID         string
+		expectedAcquired  bool
+		expectedRenewable bool
+	}{
+		{
+			name:              "Nil lease",
+			lease:             nil,
+			id:                "test",
+			clusterID:         "cluster",
+			expectedAcquired:  false,
+			expectedRenewable: false,
+		},
+		{
+			name: "Expired lease held by other",
+			lease: &Lease{
+				Identifier: "other",
+				ClusterID:  "cluster",
+				RenewedAt:  time.Now().Add(-leasebackend.DefaultMaxLeaseDuration).Add(-time.Minute),
+			},
+			id:                "test",
+			clusterID:         "cluster",
+			expectedAcquired:  false,
+			expectedRenewable: true,
+		},
+		{
+			name: "My active lease",
+			lease: &Lease{
+				Identifier: "test",
+				ClusterID:  "cluster",
+				RenewedAt:  time.Now(),
+			},
+			id:                "test",
+			clusterID:         "cluster",
+			expectedAcquired:  true,
+			expectedRenewable: true,
+		},
+		{
+			name: "Other's active lease",
+			lease: &Lease{
+				Identifier: "other",
+				ClusterID:  "cluster",
+				RenewedAt:  time.Now(),
+			},
+			id:                "test",
+			clusterID:         "cluster",
+			expectedAcquired:  false,
+			expectedRenewable: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			acquired, renewable := leaseStatus(tt.lease, tt.id, tt.clusterID)
+			assert.Equal(t, tt.expectedAcquired, acquired)
+			assert.Equal(t, tt.expectedRenewable, renewable)
+		})
+	}
 }

--- a/pkg/repository/leasebackend/postgres/postgres.go
+++ b/pkg/repository/leasebackend/postgres/postgres.go
@@ -68,11 +68,8 @@ func (b *PostgresLeaseBackend) TryAcquire(ctx context.Context, id, clusterID str
 		return false, err
 	}
 
-	acquired, renewable := leaseStatus(currentLease, id, clusterID)
-	switch {
-	case acquired:
-		return true, nil
-	case !renewable:
+	_, renewable := leaseStatus(currentLease, id, clusterID)
+	if !renewable {
 		return false, nil
 	}
 
@@ -86,7 +83,7 @@ func (b *PostgresLeaseBackend) TryAcquire(ctx context.Context, id, clusterID str
 		return false, err
 	}
 
-	acquired, _ = leaseStatus(newLease, id, clusterID)
+	acquired, _ := leaseStatus(newLease, id, clusterID)
 	return acquired, nil
 }
 
@@ -167,12 +164,12 @@ func leaseStatus(lease *sqlc.Lease, id, clusterID string) (acquired bool, renewa
 	isMyLease := lease.Identifier == id && lease.ClusterID == clusterID
 
 	switch {
+	case isMyLease:
+		acquired = true
+		renewable = true
 	case isLeaseExpired:
 		acquired = false
 		renewable = true
-	case isMyLease:
-		acquired = true
-		renewable = false
 	default:
 		acquired = false
 		renewable = false

--- a/pkg/repository/leasebackend/postgres/postgres.go
+++ b/pkg/repository/leasebackend/postgres/postgres.go
@@ -79,6 +79,9 @@ func (b *PostgresLeaseBackend) TryAcquire(ctx context.Context, id, clusterID str
 	}
 
 	newLease, err := b.tryUpdateLease(ctx, leaseID, id, clusterID, acquiredAt.Time)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return false, nil
+	}
 	if err != nil {
 		return false, err
 	}
@@ -135,11 +138,12 @@ func (b *PostgresLeaseBackend) tryUpdateLease(ctx context.Context, leaseID, id, 
 	renewedAt := time.Now()
 
 	result, err := b.queries.UpdateLease(ctx, sqlc.UpdateLeaseParams{
-		ID:         leaseID,
-		Identifier: id,
-		ClusterID:  clusterID,
-		AcquiredAt: toPgTimestamp(acquiredAt),
-		RenewedAt:  toPgTimestamp(renewedAt),
+		ID:             leaseID,
+		Identifier:     id,
+		ClusterID:      clusterID,
+		AcquiredAt:     toPgTimestamp(acquiredAt),
+		RenewedAt:      toPgTimestamp(renewedAt),
+		StaleThreshold: toPgTimestamp(renewedAt.Add(-leasebackend.DefaultMaxLeaseDuration)),
 	})
 	if err != nil {
 		return nil, fmt.Errorf("error updating lease: %w", err)

--- a/pkg/repository/leasebackend/postgres/postgres_test.go
+++ b/pkg/repository/leasebackend/postgres/postgres_test.go
@@ -200,6 +200,32 @@ func TestPostgresLeaseBackend_HolderRenewsOwnLease(t *testing.T) {
 	mockQueries.AssertCalled(t, "UpdateLease", ctx, mock.AnythingOfType("sqlc.UpdateLeaseParams"))
 }
 
+func TestPostgresLeaseBackend_LostRaceConditionalUpdate(t *testing.T) {
+	mockQueries := &MockQueriesInterface{}
+	backend := createPostgresLeaseBackend(mockQueries, nil)
+
+	ctx := context.Background()
+	id := "test-identifier"
+	clusterID := "test-cluster"
+	leaseID := "lease-test-cluster"
+
+	expiredLease := sqlc.Lease{
+		ID:         leaseID,
+		Identifier: "other-identifier",
+		ClusterID:  clusterID,
+		AcquiredAt: toPgTimestamp(time.Now().Add(-time.Hour)),
+		RenewedAt:  toPgTimestamp(time.Now().Add(-leasebackend.DefaultMaxLeaseDuration).Add(-time.Minute)),
+	}
+	mockQueries.On("FindLeaseById", ctx, leaseID).Return(expiredLease, nil)
+	mockQueries.On("UpdateLease", ctx, mock.AnythingOfType("sqlc.UpdateLeaseParams")).Return(sqlc.Lease{}, pgx.ErrNoRows)
+
+	acquired, err := backend.TryAcquire(ctx, id, clusterID)
+
+	assert.NoError(t, err)
+	assert.False(t, acquired, "must not become leader when the conditional update matched no rows")
+	mockQueries.AssertExpectations(t)
+}
+
 func TestLeaseStatus(t *testing.T) {
 	tests := []struct {
 		name              string

--- a/pkg/repository/leasebackend/postgres/postgres_test.go
+++ b/pkg/repository/leasebackend/postgres/postgres_test.go
@@ -62,6 +62,7 @@ func TestPostgresLeaseBackend_TryAcquire(t *testing.T) {
 			RenewedAt:  toPgTimestamp(time.Now()),
 		}
 		mockQueries.On("InsertLease", ctx, mock.AnythingOfType("sqlc.InsertLeaseParams")).Return(expectedLease, nil)
+		mockQueries.On("UpdateLease", ctx, mock.AnythingOfType("sqlc.UpdateLeaseParams")).Return(expectedLease, nil)
 
 		// Act
 		acquired, err := backend.TryAcquire(ctx, id, clusterID)
@@ -91,6 +92,9 @@ func TestPostgresLeaseBackend_TryAcquire(t *testing.T) {
 			RenewedAt:  toPgTimestamp(time.Now()), // Recent renewal
 		}
 		mockQueries.On("FindLeaseById", ctx, leaseID).Return(existingLease, nil)
+		renewedLease := existingLease
+		renewedLease.RenewedAt = toPgTimestamp(time.Now())
+		mockQueries.On("UpdateLease", ctx, mock.AnythingOfType("sqlc.UpdateLeaseParams")).Return(renewedLease, nil)
 
 		// Act
 		acquired, err := backend.TryAcquire(ctx, id, clusterID)
@@ -170,6 +174,32 @@ func TestPostgresLeaseBackend_TryAcquire(t *testing.T) {
 	})
 }
 
+func TestPostgresLeaseBackend_HolderRenewsOwnLease(t *testing.T) {
+	mockQueries := &MockQueriesInterface{}
+	backend := createPostgresLeaseBackend(mockQueries, nil)
+
+	ctx := context.Background()
+	id := "leader-1"
+	clusterID := "cluster"
+	leaseID := "lease-cluster"
+
+	ownLease := sqlc.Lease{
+		ID:         leaseID,
+		Identifier: id,
+		ClusterID:  clusterID,
+		AcquiredAt: toPgTimestamp(time.Now().Add(-5 * time.Minute)),
+		RenewedAt:  toPgTimestamp(time.Now().Add(-30 * time.Second)),
+	}
+	mockQueries.On("FindLeaseById", ctx, leaseID).Return(ownLease, nil)
+	mockQueries.On("UpdateLease", ctx, mock.AnythingOfType("sqlc.UpdateLeaseParams")).Return(ownLease, nil)
+
+	acquired, err := backend.TryAcquire(ctx, id, clusterID)
+
+	assert.NoError(t, err)
+	assert.True(t, acquired, "holder must keep leadership")
+	mockQueries.AssertCalled(t, "UpdateLease", ctx, mock.AnythingOfType("sqlc.UpdateLeaseParams"))
+}
+
 func TestLeaseStatus(t *testing.T) {
 	tests := []struct {
 		name              string
@@ -209,7 +239,7 @@ func TestLeaseStatus(t *testing.T) {
 			id:                "test",
 			clusterID:         "cluster",
 			expectedAcquired:  true,
-			expectedRenewable: false,
+			expectedRenewable: true,
 		},
 		{
 			name: "Other's active lease",


### PR DESCRIPTION
## Pull request description 
Fixes constant cron-scheduler leader churn caused by the DB lease never being renewed. In the Mongo and Postgres lease backends the lease holder never wrote `RenewedAt` (`TryAcquire` returned early on an owned lease), and `leaseStatus` checked expirybefore ownership. As a result the lease expired every `DefaultMaxLeaseDuration` (~60s) even while the leader was healthy, forcing a re-election every minute.


## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [x] tested locally
- [ ] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Breaking changes

-

## Changes

- `leasebackend/mongo` and `leasebackend/postgres`: the holder now renews its lease
  on every check (writes `RenewedAt`) instead of returning early, so it never goes
  stale while held.
- `leaseStatus` now checks ownership before expiry, so a live holder is never treated
  as expired. Takeover-after-expiry (failover) is preserved.

## Fixes

-