### PR TITLE
feat(TKC-5953): Make Runner lease coordination configurable

### DIFF
--- a/cmd/api-server/main.go
+++ b/cmd/api-server/main.go
@@ -1007,11 +1007,9 @@ func main() {
 		leaderClusterID = leasebackend.SanitizeForK8sName(leaderClusterID)
 
 		coordinatorLogger := log.DefaultLogger.With("component", "leader-coordinator")
-		leaderOpts := []leader.Option{leader.WithCheckInterval(leaseCheckInterval)}
-		if cfg.LeaderElectionDisabled {
-			leaderOpts = append(leaderOpts, leader.WithLeaderElectionDisabled())
-		}
-		leaderCoordinator := leader.New(leaderLeaseBackend, leaderIdentifier, leaderClusterID, coordinatorLogger, leaderOpts...)
+		leaderCoordinator := leader.New(leaderLeaseBackend, leaderIdentifier, leaderClusterID, coordinatorLogger,
+			leader.WithCheckInterval(leaseCheckInterval),
+			leader.WithLeaderElectionDisabled(cfg.LeaderElectionDisabled))
 		for _, task := range leaderTasks {
 			leaderCoordinator.Register(task)
 		}

--- a/cmd/api-server/main.go
+++ b/cmd/api-server/main.go
@@ -180,9 +180,15 @@ func main() {
 	if cfg.Trace {
 		eventBus.TraceEvents()
 	}
+	// Resolve the lease check interval once and reuse it across all lease consumers
+	// (events emitter, triggers, leader coordinator). Clamps unsafe values.
+	leaseCheckInterval := resolveLeaseCheckInterval(cfg.LeaseCheckInterval)
+
 	// TODO(emil): do we need a mongo/postgres backend for leases like for test triggers?
 	eventsEmitterLeaseBackend := leasebackendk8s.NewK8sLeaseBackend(clientset, "testkube-agent-"+cfg.APIServerFullname, cfg.TestkubeNamespace)
-	eventsEmitter := event.NewEmitter(eventBus, eventsEmitterLeaseBackend, "agentevents", cfg.TestkubeClusterName, event.DefaultEventTTL, event.DefaultEventCacheCapacity)
+	eventsEmitter := event.NewEmitter(eventBus, eventsEmitterLeaseBackend, "agentevents", cfg.TestkubeClusterName, event.DefaultEventTTL, event.DefaultEventCacheCapacity,
+		event.WithLeaseCheckInterval(leaseCheckInterval),
+		event.WithLeaderElectionDisabled(cfg.LeaderElectionDisabled))
 
 	// Connect to the Control Plane
 	var grpcConn *grpc.ClientConn
@@ -862,6 +868,8 @@ func main() {
 			triggers.WithWorkflowTriggersClient(workflowTriggersClient),
 			triggers.WithEventLabels(cfg.EventLabels),
 			triggers.WithDynamicClient(dynamicClient),
+			triggers.WithLeaseCheckInterval(leaseCheckInterval),
+			triggers.WithLeaderElectionDisabled(cfg.LeaderElectionDisabled),
 		)
 
 		// Start git content informer when enabled for trigger source-of-truth (cloud or OSS).
@@ -999,7 +1007,11 @@ func main() {
 		leaderClusterID = leasebackend.SanitizeForK8sName(leaderClusterID)
 
 		coordinatorLogger := log.DefaultLogger.With("component", "leader-coordinator")
-		leaderCoordinator := leader.New(leaderLeaseBackend, leaderIdentifier, leaderClusterID, coordinatorLogger)
+		leaderOpts := []leader.Option{leader.WithCheckInterval(leaseCheckInterval)}
+		if cfg.LeaderElectionDisabled {
+			leaderOpts = append(leaderOpts, leader.WithLeaderElectionDisabled())
+		}
+		leaderCoordinator := leader.New(leaderLeaseBackend, leaderIdentifier, leaderClusterID, coordinatorLogger, leaderOpts...)
 		for _, task := range leaderTasks {
 			leaderCoordinator.Register(task)
 		}
@@ -1012,6 +1024,26 @@ func main() {
 	if err := g.Wait(); err != nil {
 		log.DefaultLogger.Fatalf("Testkube is shutting down: %v", err)
 	}
+}
+
+const defaultLeaseCheckInterval = 5 * time.Second
+
+// resolveLeaseCheckInterval validates the configured lease check interval. The lease
+// expires after leasebackend.DefaultMaxLeaseDuration, so checking/renewing less often
+// than that would let the lease lapse between checks and cause leadership churn. We
+// keep a safety margin (half the lease duration) and clamp anything larger.
+func resolveLeaseCheckInterval(interval time.Duration) time.Duration {
+	if interval <= 0 {
+		return defaultLeaseCheckInterval
+	}
+	if maxSafe := leasebackend.DefaultMaxLeaseDuration / 2; interval > maxSafe {
+		log.DefaultLogger.Warnw("configured lease check interval is too high relative to the lease duration; clamping to avoid leadership churn",
+			"configured", interval.String(),
+			"clamped", maxSafe.String(),
+			"leaseDuration", leasebackend.DefaultMaxLeaseDuration.String())
+		return maxSafe
+	}
+	return interval
 }
 
 func resolveLeaderIdentifier() string {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -204,15 +204,21 @@ type Config struct {
 	CronJobConfig
 	WebhookConfig
 	// Tracing
-	TracingEnabled                  bool     `envconfig:"TRACING_ENABLED" default:"false"`
-	OTLPEndpoint                    string   `envconfig:"OTLP_ENDPOINT" default:"http://localhost:4317"`
-	OTLPServiceName                 string   `envconfig:"OTLP_SERVICE_NAME" default:"testkube"`
-	TracingSampleRate               float64  `envconfig:"TRACING_SAMPLE_RATE" default:"1.0"`
-	DisableDefaultAgent             bool     `envconfig:"DISABLE_DEFAULT_AGENT" default:"false"`
-	TestkubeConfigDir               string   `envconfig:"TESTKUBE_CONFIG_DIR" default:"config"`
-	TestkubeAnalyticsEnabled        bool     `envconfig:"TESTKUBE_ANALYTICS_ENABLED" default:"false"`
-	TestkubeNamespace               string   `envconfig:"TESTKUBE_NAMESPACE" default:"testkube"`
-	TestkubeLeaseName               string   `envconfig:"TESTKUBE_LEASE_NAME" default:""`
+	TracingEnabled           bool    `envconfig:"TRACING_ENABLED" default:"false"`
+	OTLPEndpoint             string  `envconfig:"OTLP_ENDPOINT" default:"http://localhost:4317"`
+	OTLPServiceName          string  `envconfig:"OTLP_SERVICE_NAME" default:"testkube"`
+	TracingSampleRate        float64 `envconfig:"TRACING_SAMPLE_RATE" default:"1.0"`
+	DisableDefaultAgent      bool    `envconfig:"DISABLE_DEFAULT_AGENT" default:"false"`
+	TestkubeConfigDir        string  `envconfig:"TESTKUBE_CONFIG_DIR" default:"config"`
+	TestkubeAnalyticsEnabled bool    `envconfig:"TESTKUBE_ANALYTICS_ENABLED" default:"false"`
+	TestkubeNamespace        string  `envconfig:"TESTKUBE_NAMESPACE" default:"testkube"`
+	TestkubeLeaseName        string  `envconfig:"TESTKUBE_LEASE_NAME" default:""`
+
+	// Leader election / lease coordination (runner). Disable election for explicitly
+	// single-replica deployments; tune how often the lease is checked/renewed.
+	LeaderElectionDisabled bool          `envconfig:"LEADER_ELECTION_DISABLED" default:"false"`
+	LeaseCheckInterval     time.Duration `envconfig:"LEASE_CHECK_INTERVAL" default:"5s"`
+
 	TestkubeProWorkerCount          int      `envconfig:"TESTKUBE_PRO_WORKER_COUNT" default:"50"`
 	TestkubeProLogStreamWorkerCount int      `envconfig:"TESTKUBE_PRO_LOG_STREAM_WORKER_COUNT" default:"25"`
 	TestkubeProMigrate              string   `envconfig:"TESTKUBE_PRO_MIGRATE" default:"false"`

--- a/pkg/coordination/leader/coordinator.go
+++ b/pkg/coordination/leader/coordinator.go
@@ -84,16 +84,16 @@ func WithCheckInterval(interval time.Duration) Option {
 	}
 }
 
-// WithLeaderElectionDisabled turns leader election off entirely: Run starts the
-// registered tasks directly and never contacts the lease backend (no lease object,
-// no periodic API calls). It is intended for explicitly single-replica deployments
-// where election is unnecessary overhead.
+// WithLeaderElectionDisabled controls whether leader election runs. When disabled,
+// Run starts the registered tasks directly and never contacts the lease backend (no
+// lease object, no periodic API calls). It is intended for explicitly single-replica
+// deployments where election is unnecessary overhead.
 //
-// WARNING: do not enable this with more than one replica — every replica would run
+// WARNING: do not disable this with more than one replica — every replica would run
 // the leader-only tasks simultaneously.
-func WithLeaderElectionDisabled() Option {
+func WithLeaderElectionDisabled(disabled bool) Option {
 	return func(c *Coordinator) {
-		c.disabled = true
+		c.disabled = disabled
 	}
 }
 

--- a/pkg/coordination/leader/coordinator.go
+++ b/pkg/coordination/leader/coordinator.go
@@ -36,10 +36,11 @@ type Coordinator struct {
 
 	checkInterval time.Duration
 
-	mu     sync.Mutex
-	tasks  []Task
-	active *taskGroup
-	leader bool
+	mu       sync.Mutex
+	tasks    []Task
+	active   *taskGroup
+	leader   bool
+	disabled bool
 }
 
 const (
@@ -83,6 +84,19 @@ func WithCheckInterval(interval time.Duration) Option {
 	}
 }
 
+// WithLeaderElectionDisabled turns leader election off entirely: Run starts the
+// registered tasks directly and never contacts the lease backend (no lease object,
+// no periodic API calls). It is intended for explicitly single-replica deployments
+// where election is unnecessary overhead.
+//
+// WARNING: do not enable this with more than one replica — every replica would run
+// the leader-only tasks simultaneously.
+func WithLeaderElectionDisabled() Option {
+	return func(c *Coordinator) {
+		c.disabled = true
+	}
+}
+
 // Register adds a task that must only run while this instance holds the leader lease. Register must be
 // called before Run.
 func (c *Coordinator) Register(task Task) {
@@ -95,6 +109,17 @@ func (c *Coordinator) Register(task Task) {
 // Run participates in leader election until the provided context is cancelled. It returns ctx.Err() when
 // shutting down gracefully.
 func (c *Coordinator) Run(ctx context.Context) error {
+	// Leader election disabled: run the registered tasks directly as the sole owner,
+	// without ever contacting the lease backend. acquire()/release() handle task
+	// lifecycle and never touch the backend, so this adds zero lease/API load.
+	if c.disabled {
+		c.logger.Infow("leader coordinator: leader election disabled, running tasks directly without lease coordination")
+		c.acquire(ctx)
+		<-ctx.Done()
+		c.release()
+		return ctx.Err()
+	}
+
 	ticker := time.NewTicker(c.checkInterval)
 	defer ticker.Stop()
 

--- a/pkg/coordination/leader/coordinator_test.go
+++ b/pkg/coordination/leader/coordinator_test.go
@@ -210,7 +210,7 @@ func TestCoordinatorDisabledRunsTasksWithoutLease(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	coord := New(backend, "id-1", "cluster-1", nil, WithLeaderElectionDisabled())
+	coord := New(backend, "id-1", "cluster-1", nil, WithLeaderElectionDisabled(true))
 	coord.Register(task)
 
 	done := make(chan struct{})

--- a/pkg/coordination/leader/coordinator_test.go
+++ b/pkg/coordination/leader/coordinator_test.go
@@ -192,6 +192,50 @@ func TestCoordinatorTreatsErrorsAsLeaseLoss(t *testing.T) {
 	waitFor(func() bool { return isClosed(stopped) }, 500*time.Millisecond, t)
 }
 
+func TestCoordinatorDisabledRunsTasksWithoutLease(t *testing.T) {
+	// No responses are pushed: if the coordinator touched the backend it would block,
+	// and we also assert calls == 0 below.
+	backend := newStubLeaseBackend(1)
+
+	var started atomic.Int32
+	task := Task{
+		Name: "direct",
+		Start: func(ctx context.Context) error {
+			started.Add(1)
+			<-ctx.Done()
+			return nil
+		},
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	coord := New(backend, "id-1", "cluster-1", nil, WithLeaderElectionDisabled())
+	coord.Register(task)
+
+	done := make(chan struct{})
+	go func() {
+		if err := coord.Run(ctx); err != context.Canceled {
+			t.Errorf("expected context.Canceled, got %v", err)
+		}
+		close(done)
+	}()
+
+	// The task runs immediately, without any lease coordination.
+	waitFor(func() bool { return started.Load() == 1 }, 200*time.Millisecond, t)
+
+	if got := backend.calls.Load(); got != 0 {
+		t.Fatalf("expected lease backend to never be called when election is disabled, got %d calls", got)
+	}
+
+	cancel()
+	waitFor(func() bool { return isClosed(done) }, 200*time.Millisecond, t)
+
+	if got := started.Load(); got != 1 {
+		t.Fatalf("expected task to start exactly once, got %d", got)
+	}
+}
+
 func waitFor(cond func() bool, timeout time.Duration, t *testing.T) {
 	t.Helper()
 

--- a/pkg/event/emitter.go
+++ b/pkg/event/emitter.go
@@ -37,6 +37,23 @@ func WithLeaseClusterID(id string) EmitterOption {
 	}
 }
 
+// WithLeaseCheckInterval overrides how often the emitter checks/renews its lease.
+// Non-positive values are ignored (the default is kept).
+func WithLeaseCheckInterval(interval time.Duration) EmitterOption {
+	return func(e *Emitter) {
+		if interval > 0 {
+			e.leaseCheckInterval = interval
+		}
+	}
+}
+
+// WARNING: must not be enabled with more than one replica.
+func WithLeaderElectionDisabled(disabled bool) EmitterOption {
+	return func(e *Emitter) {
+		e.leaderElectionDisabled = disabled
+	}
+}
+
 // SetLeaseClusterID overrides the lease cluster ID used by the emitter's
 // leader-election loop. When empty, the current value is not changed.
 func (e *Emitter) SetLeaseClusterID(id string) {
@@ -64,6 +81,7 @@ func NewEmitter(eventBus bus.Bus, leaseBackend leasebackend.Repository, subjectR
 		clusterName:         clusterName,
 		eventCache:          cache,
 		leaseClusterID:      DefaultLeaseClusterID,
+		leaseCheckInterval:  defaultLeaseCheckInterval,
 	}
 	for _, opt := range opts {
 		opt(e)
@@ -79,17 +97,19 @@ type Interface interface {
 type Emitter struct {
 	*loader
 
-	log                 *zap.SugaredLogger
-	registeredListeners common.Listeners
-	listeners           common.Listeners
-	mutex               sync.RWMutex
-	bus                 bus.Bus
-	instanceId          string
-	leaseBackend        leasebackend.Repository
-	subjectRoot         string
-	clusterName         string
-	leaseClusterID      string
-	eventCache          *ttlcache.Cache[string, bool]
+	log                    *zap.SugaredLogger
+	registeredListeners    common.Listeners
+	listeners              common.Listeners
+	mutex                  sync.RWMutex
+	bus                    bus.Bus
+	instanceId             string
+	leaseBackend           leasebackend.Repository
+	subjectRoot            string
+	clusterName            string
+	leaseClusterID         string
+	leaseCheckInterval     time.Duration
+	leaderElectionDisabled bool
+	eventCache             *ttlcache.Cache[string, bool]
 }
 
 // uniqueListeners keeps a unique set of listeners by kind, group and name.
@@ -176,15 +196,27 @@ func (e *Emitter) eventTopic(event testkube.Event) string {
 }
 
 const (
-	leaseCheckInterval           = 5 * time.Second
-	DefaultLeaseClusterID string = "event-emitters"
+	defaultLeaseCheckInterval        = 5 * time.Second
+	DefaultLeaseClusterID     string = "event-emitters"
 )
 
 // TODO(emil): convert to using new common coordinator package for lease acquisition
 func (e *Emitter) leaseCheckLoop(ctx context.Context, leaseChan chan<- bool) {
+	if e.leaderElectionDisabled {
+		e.log.Info("event emitter: leader election disabled, running without lease coordination")
+		select {
+		case leaseChan <- true:
+		case <-ctx.Done():
+			return
+		}
+		<-ctx.Done()
+		e.log.Info("event emitter stopped lease checks")
+		return
+	}
+
 	e.log.Info("event emitter waiting for lease")
 	e.leaseCheck(ctx, leaseChan)
-	ticker := time.NewTicker(leaseCheckInterval)
+	ticker := time.NewTicker(e.leaseCheckInterval)
 	for {
 		select {
 		case <-ctx.Done():

--- a/pkg/triggers/service.go
+++ b/pkg/triggers/service.go
@@ -158,11 +158,9 @@ func NewService(
 	}
 
 	coordinatorLogger := logger.With("component", "trigger-service", "identifier", s.identifier)
-	leaderOpts := []leader.Option{leader.WithCheckInterval(s.leaseCheckInterval)}
-	if s.leaderElectionDisabled {
-		leaderOpts = append(leaderOpts, leader.WithLeaderElectionDisabled())
-	}
-	s.coordinator = leader.New(leaseBackend, s.identifier, s.clusterID, coordinatorLogger, leaderOpts...)
+	s.coordinator = leader.New(leaseBackend, s.identifier, s.clusterID, coordinatorLogger,
+		leader.WithCheckInterval(s.leaseCheckInterval),
+		leader.WithLeaderElectionDisabled(s.leaderElectionDisabled))
 
 	s.coordinator.Register(leader.Task{
 		Name: "trigger-watcher",

--- a/pkg/triggers/service.go
+++ b/pkg/triggers/service.go
@@ -63,6 +63,8 @@ type Service struct {
 	agentName                     string
 	triggerExecutor               ExecutorF
 	scraperInterval               time.Duration
+	leaseCheckInterval            time.Duration
+	leaderElectionDisabled        bool
 	defaultConditionsCheckTimeout time.Duration
 	defaultConditionsCheckBackoff time.Duration
 	defaultProbesCheckTimeout     time.Duration
@@ -156,7 +158,11 @@ func NewService(
 	}
 
 	coordinatorLogger := logger.With("component", "trigger-service", "identifier", s.identifier)
-	s.coordinator = leader.New(leaseBackend, s.identifier, s.clusterID, coordinatorLogger)
+	leaderOpts := []leader.Option{leader.WithCheckInterval(s.leaseCheckInterval)}
+	if s.leaderElectionDisabled {
+		leaderOpts = append(leaderOpts, leader.WithLeaderElectionDisabled())
+	}
+	s.coordinator = leader.New(leaseBackend, s.identifier, s.clusterID, coordinatorLogger, leaderOpts...)
 
 	s.coordinator.Register(leader.Task{
 		Name: "trigger-watcher",
@@ -175,6 +181,22 @@ func NewService(
 	})
 
 	return s
+}
+
+// WithLeaseCheckInterval overrides how often the trigger service's leader coordinator
+// checks/renews its lease. Non-positive values keep the coordinator default.
+func WithLeaseCheckInterval(interval time.Duration) Option {
+	return func(s *Service) {
+		s.leaseCheckInterval = interval
+	}
+}
+
+// WithLeaderElectionDisabled disables leader election for the trigger service: its
+// leader-only tasks run directly without lease coordination. Single-replica only.
+func WithLeaderElectionDisabled(disabled bool) Option {
+	return func(s *Service) {
+		s.leaderElectionDisabled = disabled
+	}
 }
 
 func WithHostnameIdentifier() Option {


### PR DESCRIPTION
## Pull request description 
Makes the runner's lease coordination configurable and optional.

- `LEASE_CHECK_INTERVAL` (duration, default `5s`): how often the lease is checked/renewed.
- `LEADER_ELECTION_DISABLED` (bool, default `false`): for explicitly single-replica runners: skips leader election entirely, so tasks run directly with no lease object and no periodic API calls.
  
## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [x] tested locally
- [ ] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Breaking changes

-

## Changes

-

## Fixes

-