### PR TITLE
fix(testworkflow-init): scope process kill/pause/resume to the init's own descendants

### DIFF
--- a/cmd/testworkflow-init/orchestration/executions.go
+++ b/cmd/testworkflow-init/orchestration/executions.go
@@ -103,9 +103,8 @@ func (e *executionGroup) Pause() (err error) {
 		output.Std.Direct().Warnf("warn: failed to pause: failed to list some processes: %v\n", err)
 	}
 
-	// Ignore the init process, to not suspend it accidentally
-	ps.VirtualizePath(int32(os.Getpid()))
-	err = ps.Suspend()
+	// Scope to our own descendants, never the init process or unrelated ones.
+	err = ps.childrenOf(int32(os.Getpid())).Suspend()
 	return errors.Wrap(err, "failed to pause")
 }
 
@@ -130,9 +129,8 @@ func (e *executionGroup) Resume() (err error) {
 		output.Std.Direct().Warnf("warn: failed to resume: failed to list some processes: %v\n", err)
 	}
 
-	// Ignore the init process, to not suspend it accidentally
-	ps.VirtualizePath(int32(os.Getpid()))
-	err = ps.Resume()
+	// Scope to our own descendants, never the init process or unrelated ones.
+	err = ps.childrenOf(int32(os.Getpid())).Resume()
 	return errors.Wrap(err, "failed to resume")
 }
 
@@ -155,9 +153,8 @@ func (e *executionGroup) Kill() (err error) {
 		output.Std.Direct().Warnf("warn: failed to kill: failed to list some processes: %v\n", err.Error())
 	}
 
-	// Ignore the init process, to not suspend it accidentally
-	ps.VirtualizePath(int32(os.Getpid()))
-	err = ps.Kill()
+	// Scope to our own descendants, never the init process or unrelated ones.
+	err = ps.childrenOf(int32(os.Getpid())).Kill()
 	return errors.Wrap(err, "failed to kill")
 }
 

--- a/cmd/testworkflow-init/orchestration/processes.go
+++ b/cmd/testworkflow-init/orchestration/processes.go
@@ -12,39 +12,33 @@ type processNode struct {
 	nodes map[*processNode]struct{}
 }
 
-func (p *processNode) Find(pid int32) []*processNode {
+func (p *processNode) find(pid int32) *processNode {
 	if p.pid == pid {
-		return []*processNode{p}
+		return p
 	}
-	// Try to find directly
 	for n := range p.nodes {
-		if n.pid == pid {
-			return append([]*processNode{p}, n)
+		if found := n.find(pid); found != nil {
+			return found
 		}
 	}
-
-	// Try to find in the children
-	for n := range p.nodes {
-		found := n.Find(pid)
-		if found != nil {
-			return append([]*processNode{p}, found...)
-		}
-	}
-
 	return nil
 }
 
-func (p *processNode) VirtualizePath(pid int32) {
-	for ps := range p.nodes {
-		if ps.pid == pid {
-			for sub := range ps.nodes {
-				p.nodes[sub] = struct{}{}
-			}
-			delete(p.nodes, ps)
-		} else {
-			ps.VirtualizePath(pid)
+// childrenOf returns a virtual root (pid -1) holding the descendant subtree of
+// the process with the given pid, or an empty root when it isn't found. Killing,
+// suspending or resuming it affects only that process's own children, never the
+// process itself or anything outside its subtree. When the init runs as PID 1 in
+// a pod this is the full step process tree (matching the previous whole-tree
+// behavior); on a shared host such as CI it stays scoped, so concurrent test
+// binaries can't reach into each other's trees.
+func (p *processNode) childrenOf(pid int32) *processNode {
+	virtual := &processNode{pid: -1, nodes: map[*processNode]struct{}{}}
+	if target := p.find(pid); target != nil {
+		for child := range target.nodes {
+			virtual.nodes[child] = struct{}{}
 		}
 	}
+	return virtual
 }
 
 // Suspend all the processes in group, starting from top

--- a/cmd/testworkflow-init/orchestration/processes_test.go
+++ b/cmd/testworkflow-init/orchestration/processes_test.go
@@ -1,0 +1,48 @@
+package orchestration
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// collectPIDs returns every non-virtual pid reachable below p.
+func collectPIDs(p *processNode) map[int32]bool {
+	out := map[int32]bool{}
+	for n := range p.nodes {
+		if n.pid != -1 {
+			out[n.pid] = true
+		}
+		for k := range collectPIDs(n) {
+			out[k] = true
+		}
+	}
+	return out
+}
+
+// TestProcessNodeChildrenOf verifies childrenOf returns only the target's
+// descendant subtree, excluding the target itself and any sibling.
+func TestProcessNodeChildrenOf(t *testing.T) {
+	// root(-1) -> a(10) -> { a1(11) -> a11(13), a2(12) }
+	//          -> b(20) -> b1(21)
+	a11 := &processNode{pid: 13, nodes: map[*processNode]struct{}{}}
+	a1 := &processNode{pid: 11, nodes: map[*processNode]struct{}{a11: {}}}
+	a2 := &processNode{pid: 12, nodes: map[*processNode]struct{}{}}
+	a := &processNode{pid: 10, nodes: map[*processNode]struct{}{a1: {}, a2: {}}}
+	b1 := &processNode{pid: 21, nodes: map[*processNode]struct{}{}}
+	b := &processNode{pid: 20, nodes: map[*processNode]struct{}{b1: {}}}
+	root := &processNode{pid: -1, nodes: map[*processNode]struct{}{a: {}, b: {}}}
+
+	// childrenOf(10) is exactly a's descendants: never a itself, never a sibling.
+	got := collectPIDs(root.childrenOf(10))
+	assert.Equal(t, map[int32]bool{11: true, 12: true, 13: true}, got)
+	assert.NotContains(t, got, int32(10), "must not include the target process itself")
+	assert.NotContains(t, got, int32(20), "must not include a sibling")
+	assert.NotContains(t, got, int32(21), "must not include a sibling's child")
+
+	// A leaf has no descendants.
+	assert.Empty(t, collectPIDs(root.childrenOf(13)))
+
+	// An unknown pid scopes to nothing, never falling back to the whole tree.
+	assert.Empty(t, collectPIDs(root.childrenOf(999)))
+}


### PR DESCRIPTION
The orchestration teardown (Kill/Pause/Resume) enumerated the entire host process tree and acted on everything except the current PID. In a pod this is harmless because init runs as PID 1 and owns every process, but when integration-test packages run in parallel off-pod one package's teardown could reach into a sibling's process tree and SIGKILL its children, surfacing as a spurious exit 137.

## How

- Add `processNode.childrenOf(pid)`, which returns a virtual root holding only the descendant subtree of the given PID.
- Kill/Pause/Resume now scope to `childrenOf(os.Getpid())` instead of the whole tree, so they only ever touch the init's own children, never the init process itself or unrelated processes.
- In a pod (init as PID 1, everything reparents to it) this is identical to the previous whole-tree behavior; off-pod it stays correctly scoped.