### PR TITLE
feat(testworkflows): enrich eviction diagnostics and stream pod events

### DIFF
--- a/pkg/testworkflows/executionworker/controller/watchers/executionstate.go
+++ b/pkg/testworkflows/executionworker/controller/watchers/executionstate.go
@@ -417,13 +417,24 @@ func (e *executionState) PodExecutionError() string {
 		errorStr = e.pod.ExecutionError()
 	}
 
-	if (errorStr == "" || errorStr == "Error") && e.podEvents.Error() {
+	buildPodEventError := func() string {
 		reason := e.podEvents.ErrorReason()
 		message := e.podEvents.ErrorMessage()
 		if message == "" {
 			return reason
 		}
 		return fmt.Sprintf("%s: %s", reason, message)
+	}
+
+	if (errorStr == "" || errorStr == "Error") && e.podEvents.Error() {
+		return buildPodEventError()
+	}
+
+	if strings.HasPrefix(errorStr, "EvictionByEvictionAPI:") && e.podEvents.Error() {
+		podEventErr := buildPodEventError()
+		if podEventErr != "" && !strings.Contains(errorStr, podEventErr) {
+			return fmt.Sprintf("%s (pod event: %s)", errorStr, podEventErr)
+		}
 	}
 
 	if errorStr == "Error" {

--- a/pkg/testworkflows/executionworker/controller/watchers/executionstate_test.go
+++ b/pkg/testworkflows/executionworker/controller/watchers/executionstate_test.go
@@ -1,0 +1,54 @@
+package watchers
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestPodExecutionError_UsesPodEventsForGenericEvictionCondition(t *testing.T) {
+	state := NewExecutionState(
+		nil,
+		NewPod(&corev1.Pod{Status: corev1.PodStatus{Conditions: []corev1.PodCondition{{
+			Type:    corev1.DisruptionTarget,
+			Status:  corev1.ConditionTrue,
+			Reason:  "EvictionByEvictionAPI",
+			Message: "Eviction API: evicting",
+		}}}}),
+		NewJobEvents(nil),
+		NewPodEvents([]*corev1.Event{{
+			Reason:  "Evicted",
+			Message: "The node was low on resource: ephemeral-storage",
+			ObjectMeta: metav1.ObjectMeta{
+				CreationTimestamp: metav1.Now(),
+			},
+		}}),
+		nil,
+	)
+
+	assert.Equal(
+		t,
+		"EvictionByEvictionAPI: Eviction API: evicting (pod event: Evicted: The node was low on resource: ephemeral-storage)",
+		state.PodExecutionError(),
+	)
+}
+
+func TestPodExecutionError_UsesPodEventsWhenPodErrorEmpty(t *testing.T) {
+	state := NewExecutionState(
+		nil,
+		NewPod(&corev1.Pod{}),
+		NewJobEvents(nil),
+		NewPodEvents([]*corev1.Event{{
+			Reason:  "Evicted",
+			Message: "The node was low on resource: memory",
+			ObjectMeta: metav1.ObjectMeta{
+				CreationTimestamp: metav1.Now(),
+			},
+		}}),
+		nil,
+	)
+
+	assert.Equal(t, "Evicted: The node was low on resource: memory", state.PodExecutionError())
+}

--- a/pkg/testworkflows/executionworker/controller/watchinstrumentedpod.go
+++ b/pkg/testworkflows/executionworker/controller/watchinstrumentedpod.go
@@ -6,6 +6,7 @@ import (
 	"slices"
 	"time"
 
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/kubernetes"
 
 	"github.com/kubeshop/testkube/cmd/testworkflow-init/constants"
@@ -24,6 +25,17 @@ type WatchInstrumentedPodOptions struct {
 	DisableFollow       bool
 	LogAbortedDetails   bool
 	ContainerLogOptions ContainerLogOptions
+}
+
+func mapPodEventRef(container, stepRef string, ev *corev1.Event) (string, bool) {
+	name := GetEventContainerName(ev)
+	if name == "" {
+		return "", true
+	}
+	if name == container && ev.Reason != "Created" && ev.Reason != "Started" {
+		return stepRef, true
+	}
+	return "", false
 }
 
 func WatchInstrumentedPod(parentCtx context.Context, clientSet kubernetes.Interface, signature []stage.Signature, scheduledAt time.Time, watcher watchers2.ExecutionWatcher, opts WatchInstrumentedPodOptions) (<-chan ChannelMessage[Notification], error) {
@@ -84,10 +96,9 @@ func WatchInstrumentedPod(parentCtx context.Context, clientSet kubernetes.Interf
 			for _, ev := range watcher.State().PodEvents().Original()[currentPodEventsIndex:] {
 				currentPodEventsIndex++
 
-				// Display only events that are unrelated to further containers
-				name := GetEventContainerName(ev)
-				if name == "" {
-					notifier.Event("", watchers2.GetEventTimestamp(ev), ev.Type, ev.Reason, ev.Message, executionId)
+				ref, emit := mapPodEventRef("", "", ev)
+				if emit {
+					notifier.Event(ref, watchers2.GetEventTimestamp(ev), ev.Type, ev.Reason, ev.Message, executionId)
 				}
 			}
 
@@ -161,10 +172,9 @@ func WatchInstrumentedPod(parentCtx context.Context, clientSet kubernetes.Interf
 				for _, ev := range watcher.State().PodEvents().Original()[currentPodEventsIndex:] {
 					currentPodEventsIndex++
 
-					// Display only events that are unrelated to further containers
-					name := GetEventContainerName(ev)
-					if name == container && ev.Reason != "Created" && ev.Reason != "Started" {
-						notifier.Event(initialRefs[containerIndex], watchers2.GetEventTimestamp(ev), ev.Type, ev.Reason, ev.Message, executionId)
+					ref, emit := mapPodEventRef(container, initialRefs[containerIndex], ev)
+					if emit {
+						notifier.Event(ref, watchers2.GetEventTimestamp(ev), ev.Type, ev.Reason, ev.Message, executionId)
 					}
 				}
 
@@ -195,6 +205,15 @@ func WatchInstrumentedPod(parentCtx context.Context, clientSet kubernetes.Interf
 			for {
 				select {
 				case <-updatesCh:
+					for _, ev := range watcher.State().PodEvents().Original()[currentPodEventsIndex:] {
+						currentPodEventsIndex++
+
+						ref, emit := mapPodEventRef(container, lastStarted, ev)
+						if emit {
+							notifier.Event(ref, watchers2.GetEventTimestamp(ev), ev.Type, ev.Reason, ev.Message, executionId)
+						}
+					}
+
 					// Force empty notification on container ready (for services)
 					nextContainersReady := watcher.State().ContainersReady()
 					if containersReady != nextContainersReady {
@@ -238,6 +257,15 @@ func WatchInstrumentedPod(parentCtx context.Context, clientSet kubernetes.Interf
 
 			// Wait until the Container is terminated
 			for ok := true; ok; _, ok = <-updatesCh {
+				for _, ev := range watcher.State().PodEvents().Original()[currentPodEventsIndex:] {
+					currentPodEventsIndex++
+
+					ref, emit := mapPodEventRef(container, lastStarted, ev)
+					if emit {
+						notifier.Event(ref, watchers2.GetEventTimestamp(ev), ev.Type, ev.Reason, ev.Message, executionId)
+					}
+				}
+
 				// Determine if the container should be already stopped
 				if watcher.State().ContainerFinished(container) || watcher.State().Completed() || opts.DisableFollow {
 					break

--- a/pkg/testworkflows/executionworker/controller/watchinstrumentedpod_test.go
+++ b/pkg/testworkflows/executionworker/controller/watchinstrumentedpod_test.go
@@ -1,0 +1,43 @@
+package controller
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMapPodEventRef(t *testing.T) {
+	t.Run("emits pod-level events", func(t *testing.T) {
+		ev := &corev1.Event{}
+		ref, emit := mapPodEventRef("1", "step/a", ev)
+		assert.True(t, emit)
+		assert.Equal(t, "", ref)
+	})
+
+	t.Run("emits non-start lifecycle container events for current container", func(t *testing.T) {
+		ev := &corev1.Event{Reason: "Killing", InvolvedObject: corev1.ObjectReference{FieldPath: "spec.containers{1}"}}
+		ref, emit := mapPodEventRef("1", "step/a", ev)
+		assert.True(t, emit)
+		assert.Equal(t, "step/a", ref)
+	})
+
+	t.Run("skips created and started events for current container", func(t *testing.T) {
+		created := &corev1.Event{Reason: "Created", InvolvedObject: corev1.ObjectReference{FieldPath: "spec.containers{1}"}}
+		started := &corev1.Event{Reason: "Started", InvolvedObject: corev1.ObjectReference{FieldPath: "spec.containers{1}"}}
+
+		_, emitCreated := mapPodEventRef("1", "step/a", created)
+		_, emitStarted := mapPodEventRef("1", "step/a", started)
+
+		assert.False(t, emitCreated)
+		assert.False(t, emitStarted)
+	})
+
+	t.Run("skips events from another container", func(t *testing.T) {
+		ev := &corev1.Event{Reason: "Killing", InvolvedObject: corev1.ObjectReference{FieldPath: "spec.containers{2}", UID: types.UID("x")}}
+		_, emit := mapPodEventRef("1", "step/a", ev)
+		assert.False(t, emit)
+	})
+}


### PR DESCRIPTION
## Summary

Improve diagnostics for intermittent Test Workflow pod evictions by preserving and surfacing richer runtime context.

## Changes

- Stream pod events continuously while execution is active, not only during initial setup.
- Enrich execution-level pod errors by appending concrete pod event details when available.
- Add tests covering event routing and enriched eviction error formatting.

## Validation

- make lint ✅
- make build ✅
- make test ✅ (executed with HOME=/tmp/tkhome in this local environment to bypass machine-level git auto-signing interference in informer tests)
- go test ./pkg/testworkflows/executionworker/controller/... ./pkg/testworkflows/executionworker/controller/watchers/... ✅
