### PR TITLE
feat: Show current context in testkube CLI status command

### DIFF
--- a/cmd/kubectl-testkube/commands/status.go
+++ b/cmd/kubectl-testkube/commands/status.go
@@ -21,6 +21,8 @@ func NewStatusCmd() *cobra.Command {
 			cfg, err := config.Load()
 			ui.ExitOnError("   Loading config file failed", err)
 
+			printContextStatus(cmd, cfg)
+
 			if cfg.TelemetryEnabled {
 				ui.PrintEnabled("Telemetry on CLI", "enabled")
 			} else {
@@ -45,4 +47,48 @@ func NewStatusCmd() *cobra.Command {
 	cmd.AddCommand(telemetry.NewStatusTelemetryCmd())
 
 	return cmd
+}
+
+// printContextStatus reports whether the CLI is talking to the Testkube
+// Control Plane (cloud context) or a local/standalone agent (kubeconfig
+// context), along with the connection details relevant to that context.
+func printContextStatus(cmd *cobra.Command, cfg config.Data) {
+	if cfg.ContextType == config.ContextTypeCloud {
+		ui.PrintEnabled("Context", "connected to Testkube Control Plane")
+
+		orgName := cfg.CloudContext.OrganizationName
+		if orgName == "" {
+			orgName = cfg.CloudContext.OrganizationId
+		}
+		envName := cfg.CloudContext.EnvironmentName
+		if envName == "" {
+			envName = cfg.CloudContext.EnvironmentId
+		}
+
+		contextData := map[string]string{
+			"Organization": orgName,
+			"Environment ": envName,
+			"API URI     ": cfg.CloudContext.ApiUri,
+			"Namespace   ": cfg.Namespace,
+		}
+		ui.InfoGrid(contextData)
+	} else {
+		ui.PrintEnabled("Context", "connected to a local standalone agent")
+
+		namespace := cfg.Namespace
+		if flag := cmd.Flag("namespace"); flag != nil && flag.Value.String() != "" {
+			namespace = flag.Value.String()
+		}
+		apiURI := cfg.APIURI
+		if flag := cmd.Flag("api-uri"); flag != nil && flag.Value.String() != "" {
+			apiURI = flag.Value.String()
+		}
+
+		ui.InfoGrid(map[string]string{
+			"Namespace": namespace,
+			"API URI  ": apiURI,
+		})
+	}
+
+	ui.NL()
 }

--- a/cmd/kubectl-testkube/commands/status.go
+++ b/cmd/kubectl-testkube/commands/status.go
@@ -65,30 +65,29 @@ func printContextStatus(cmd *cobra.Command, cfg config.Data) {
 			envName = cfg.CloudContext.EnvironmentId
 		}
 
-		contextData := map[string]string{
-			"Organization": orgName,
-			"Environment ": envName,
-			"API URI     ": cfg.CloudContext.ApiUri,
-			"Namespace   ": cfg.Namespace,
-		}
-		ui.InfoGrid(contextData)
+		// Use Properties (ordered slice) instead of InfoGrid (map) so the
+		// padded fields render in a stable order on every run.
+		ui.Properties([][]string{
+			{"Organization", orgName},
+			{"Environment ", envName},
+			{"API URI     ", cfg.CloudContext.ApiUri},
+			{"Namespace   ", cfg.Namespace},
+		})
 	} else {
 		ui.PrintEnabled("Context", "connected to a local standalone agent")
 
 		namespace := cfg.Namespace
-		if flag := cmd.Flag("namespace"); flag != nil && flag.Value.String() != "" {
+		if flag := cmd.Flag("namespace"); flag != nil && flag.Changed {
 			namespace = flag.Value.String()
 		}
 		apiURI := cfg.APIURI
-		if flag := cmd.Flag("api-uri"); flag != nil && flag.Value.String() != "" {
+		if flag := cmd.Flag("api-uri"); flag != nil && flag.Changed {
 			apiURI = flag.Value.String()
 		}
 
-		ui.InfoGrid(map[string]string{
-			"Namespace": namespace,
-			"API URI  ": apiURI,
+		ui.Properties([][]string{
+			{"Namespace", namespace},
+			{"API URI  ", apiURI},
 		})
 	}
-
-	ui.NL()
 }


### PR DESCRIPTION
## Summary

- The `testkube status` command now reports the **current CLI context** in addition to telemetry status.
- It distinguishes whether the CLI is connected to the **Testkube Control Plane** (`cloud` context) or a **local standalone agent** (`kubeconfig` context), and prints the relevant connection details:
  - **Control Plane**: Organization, Environment, API URI, Namespace
  - **Standalone agent**: Namespace, API URI (honoring `--namespace` / `--api-uri` overrides)

## Test plan

- [x] `make build-testkube-cli` builds successfully
- [x] `./bin/app/testkube status` shows the new context section (verified standalone/kubeconfig path)
- [x] `make lint` → 0 issues
- [x] `go test ./cmd/kubectl-testkube/commands/...` passes
- [ ] Verify Control Plane (`cloud`) context output against a connected environment

### Example output (standalone agent)

```
🚀  Getting status on the testkube CLI
🥇  Context connected to a local standalone agent
  Namespace: testkube
  API URI  : http://localhost:8088

🥇  Telemetry on CLI enabled
🥇  Telemetry on API enabled
```

Made with [Cursor](https://cursor.com)