### PR TITLE
feat: Add is_silent flag to workflow execution telemetry

### DIFF
--- a/pkg/event/kind/testworkflowexecutiontelemetry/listener.go
+++ b/pkg/event/kind/testworkflowexecutiontelemetry/listener.go
@@ -163,6 +163,8 @@ func (l *testWorkflowExecutionTelemetryListener) sendRunWorkflowTelemetry(ctx co
 		}
 	}
 
+	isSilent := isSilentExecution(execution.SilentMode)
+
 	out, err := telemetry.SendRunWorkflowEvent("testkube_api_run_test_workflow", telemetry.RunWorkflowParams{
 		RunParams: telemetry.RunParams{
 			AppVersion: version.Version,
@@ -190,6 +192,7 @@ func (l *testWorkflowExecutionTelemetryListener) sendRunWorkflowTelemetry(ctx co
 			RcInterfaceType: interfaceType,
 			TriggeredBy:     triggeredByBucket(actorType, interfaceType),
 		},
+		IsSilent: isSilent,
 	})
 
 	if err != nil {
@@ -197,4 +200,15 @@ func (l *testWorkflowExecutionTelemetryListener) sendRunWorkflowTelemetry(ctx co
 	} else {
 		log.DefaultLogger.Debugw("sending run test workflow telemetry event", "output", out)
 	}
+}
+
+// isSilentExecution reports whether the execution was triggered as fully silent
+// (the --silent CLI flag, the dashboard silent toggle, or a workflow-level silent
+// execution — all of which silence every aspect). Partial silencing of individual
+// aspects (e.g. the deprecated --disable-webhooks) does not count.
+func isSilentExecution(silentMode *testkube.SilentMode) bool {
+	if silentMode == nil {
+		return false
+	}
+	return silentMode.Webhooks && silentMode.Insights && silentMode.Health && silentMode.Metrics && silentMode.Cdevents
 }

--- a/pkg/telemetry/payload.go
+++ b/pkg/telemetry/payload.go
@@ -53,6 +53,7 @@ type Params struct {
 	RcActorType                string     `json:"rc_actor_type,omitempty"`
 	RcInterfaceType            string     `json:"rc_interface_type,omitempty"`
 	TriggeredBy                string     `json:"triggered_by,omitempty"`
+	IsSilent                   bool       `json:"is_silent,omitempty"`
 	License                    string     `json:"license,omitempty"`
 	Step                       string     `json:"step,omitempty"`
 	Email                      string     `json:"email,omitempty"`
@@ -130,6 +131,7 @@ type CreateWorkflowParams struct {
 type RunWorkflowParams struct {
 	RunParams
 	WorkflowParams
+	IsSilent bool
 }
 
 func NewCLIPayload(context RunContext, id, name, version, category, clusterType string) Payload {
@@ -337,6 +339,7 @@ func NewRunWorkflowPayload(name, clusterType string, params RunWorkflowParams) P
 					RcActorType:                params.RcActorType,
 					RcInterfaceType:            params.RcInterfaceType,
 					TriggeredBy:                params.TriggeredBy,
+					IsSilent:                   params.IsSilent,
 				},
 			}},
 	}


### PR DESCRIPTION
## Summary

- Adds an `is_silent` boolean to the `testkube_api_run_test_workflow` telemetry event so silent executions can be distinguished in analytics dashboards.
- The flag is populated from `execution.SilentMode` in the workflow-execution telemetry listener.
- `is_silent` is `true` **only** when an execution was triggered as fully silent — the `--silent` CLI flag, the dashboard silent toggle, or a workflow-level silent execution — all of which resolve to `NewSilenceAllSilentMode()` (every aspect silenced). Partial silencing of individual aspects (e.g. the deprecated `--disable-webhooks`, which sets only `Webhooks`) does **not** set it.

## Background

Previously there was no way to tell from workflow execution telemetry whether an execution was triggered as silent. `SilentMode` is persisted on the execution record but was never surfaced to the analytics event, and the telemetry listener does not (and still does not) silence telemetry itself.

## Changes

- `pkg/telemetry/payload.go`: add `IsSilent` to `Params` (`json:"is_silent,omitempty"`) and to `RunWorkflowParams`; map it in `NewRunWorkflowPayload`.
- `pkg/event/kind/testworkflowexecutiontelemetry/listener.go`: compute `is_silent` from `execution.SilentMode` via a new `isSilentExecution` helper (requires all aspects enabled) and pass it through.

## Test plan

- [x] `go build ./...`
- [x] `make lint`
- [ ] Trigger a workflow with `--silent` and confirm the telemetry event carries `is_silent=true`
- [ ] Trigger with `--disable-webhooks` only and confirm `is_silent` is absent/false

Made with [Cursor](https://cursor.com)