### PR TITLE
fix(runner): retry live-log Summary while the Job is not yet visible

### DIFF
--- a/pkg/runner/agent.go
+++ b/pkg/runner/agent.go
@@ -9,6 +9,7 @@ import (
 	"sync"
 	"time"
 
+	retrygo "github.com/avast/retry-go/v5"
 	errors2 "github.com/pkg/errors"
 	"go.uber.org/zap"
 	"golang.org/x/sync/singleflight"
@@ -22,6 +23,7 @@ import (
 	testworkflowmappers "github.com/kubeshop/testkube/pkg/mapper/testworkflows"
 	"github.com/kubeshop/testkube/pkg/repository/channels"
 	testworkflowutils "github.com/kubeshop/testkube/pkg/testworkflows"
+	"github.com/kubeshop/testkube/pkg/testworkflows/executionworker/controller"
 	"github.com/kubeshop/testkube/pkg/testworkflows/executionworker/executionworkertypes"
 	"github.com/kubeshop/testkube/pkg/testworkflows/testworkflowconfig"
 )
@@ -43,6 +45,8 @@ type agentLoop struct {
 	organizationId      string
 	legacyEnvironmentId string
 	sf                  singleflight.Group
+	// summaryRetryDelay overrides the wait between Summary retries; zero falls back to GetNotificationsRetryDelay.
+	summaryRetryDelay time.Duration
 }
 
 type AgentLoop interface {
@@ -169,10 +173,45 @@ func (a *agentLoop) init(ctx context.Context, environmentId string, execution *t
 	return err
 }
 
+// summaryWithJobRetry fetches the live-notifications summary, waiting out the
+// window where the Job is not yet List-visible (controller.ErrJobTimeout). It
+// reuses the archival path's budget (GetNotificationsRetryCount /
+// GetNotificationsRetryDelay) at a fixed delay. Other errors, successes, and
+// context cancellation return at once.
+func (a *agentLoop) summaryWithJobRetry(ctx context.Context, executionId string, opts executionworkertypes.GetOptions) (*executionworkertypes.SummaryResult, error) {
+	delay := a.summaryRetryDelay
+	if delay <= 0 {
+		delay = GetNotificationsRetryDelay
+	}
+
+	jobNotVisible := func(err error) bool { return errors.Is(err, controller.ErrJobTimeout) }
+
+	status, err := retrygo.NewWithData[*executionworkertypes.SummaryResult](
+		retrygo.Context(ctx),
+		retrygo.RetryIf(jobNotVisible),
+		retrygo.Attempts(GetNotificationsRetryCount),
+		retrygo.Delay(delay),
+		retrygo.DelayType(retrygo.FixedDelay),
+		retrygo.LastErrorOnly(true),
+		retrygo.OnRetry(func(attempt uint, _ error) {
+			a.logger.Infow("job not visible yet, retrying summary for live notifications",
+				"executionId", executionId, "attempt", attempt+1)
+		}),
+	).Do(func() (*executionworkertypes.SummaryResult, error) {
+		return a.worker.Summary(ctx, executionId, opts)
+	})
+
+	if jobNotVisible(err) {
+		a.logger.Warnw("giving up waiting for job to become visible for live notifications",
+			"executionId", executionId, "attempts", GetNotificationsRetryCount)
+	}
+	return status, err
+}
+
 func (a *agentLoop) loopNotifications(ctx context.Context) error {
 	return a.client.ProcessExecutionNotificationRequests(ctx, func(ctx context.Context, req *cloud.TestWorkflowNotificationsRequest) controlplaneclient.NotificationWatcher {
 		// Read the initial status TODO: consider getting from the database
-		status, err := a.worker.Summary(ctx, req.ExecutionId, executionworkertypes.GetOptions{})
+		status, err := a.summaryWithJobRetry(ctx, req.ExecutionId, executionworkertypes.GetOptions{})
 		if err != nil {
 			return channels.NewError[*testkube.TestWorkflowExecutionNotification](err)
 		}

--- a/pkg/runner/agent_summary_retry_test.go
+++ b/pkg/runner/agent_summary_retry_test.go
@@ -1,0 +1,155 @@
+package runner
+
+import (
+	"context"
+	stderrors "errors"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/mock/gomock"
+	"go.uber.org/zap"
+	"k8s.io/client-go/kubernetes/fake"
+
+	"github.com/kubeshop/testkube/pkg/testworkflows/executionworker/controller"
+	"github.com/kubeshop/testkube/pkg/testworkflows/executionworker/executionworkertypes"
+)
+
+func newSummaryRetryAgentLoop(worker executionworkertypes.Worker) *agentLoop {
+	return &agentLoop{
+		worker:            worker,
+		logger:            zap.NewNop().Sugar(),
+		summaryRetryDelay: time.Millisecond,
+	}
+}
+
+// Summary times out a few times, then succeeds; the helper retries and returns that result.
+func TestSummaryWithJobRetry_RetriesOnJobTimeoutThenSucceeds(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	want := &executionworkertypes.SummaryResult{}
+	const timeouts = 3
+	var calls int32
+	worker := executionworkertypes.NewMockWorker(ctrl)
+	worker.EXPECT().
+		Summary(gomock.Any(), gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ context.Context, _ string, _ executionworkertypes.GetOptions) (*executionworkertypes.SummaryResult, error) {
+			if atomic.AddInt32(&calls, 1) <= timeouts {
+				return nil, controller.ErrJobTimeout
+			}
+			return want, nil
+		}).
+		Times(timeouts + 1) // pins the retry count: stops on the first success
+
+	a := newSummaryRetryAgentLoop(worker)
+
+	status, err := a.summaryWithJobRetry(context.Background(), "exec-1", executionworkertypes.GetOptions{})
+
+	assert.NoError(t, err)
+	assert.Same(t, want, status)
+}
+
+// Errors other than ErrJobTimeout are not retried; they come back on the first call.
+func TestSummaryWithJobRetry_NonTimeoutErrorReturnsImmediately(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	wantErr := stderrors.New("permanent failure")
+	worker := executionworkertypes.NewMockWorker(ctrl)
+	worker.EXPECT().
+		Summary(gomock.Any(), gomock.Any(), gomock.Any()).
+		Return(nil, wantErr).
+		Times(1)
+
+	a := newSummaryRetryAgentLoop(worker)
+
+	status, err := a.summaryWithJobRetry(context.Background(), "exec-1", executionworkertypes.GetOptions{})
+
+	assert.ErrorIs(t, err, wantErr)
+	assert.Nil(t, status)
+}
+
+// A Job that never becomes visible is retried up to the budget, then the helper gives up and
+// returns the last ErrJobTimeout. Times() pins the bound so the loop cannot run forever.
+func TestSummaryWithJobRetry_GivesUpAfterRetryBudget(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	worker := executionworkertypes.NewMockWorker(ctrl)
+	worker.EXPECT().
+		Summary(gomock.Any(), gomock.Any(), gomock.Any()).
+		Return(nil, controller.ErrJobTimeout).
+		Times(GetNotificationsRetryCount)
+
+	a := newSummaryRetryAgentLoop(worker)
+
+	status, err := a.summaryWithJobRetry(context.Background(), "exec-1", executionworkertypes.GetOptions{})
+
+	assert.ErrorIs(t, err, controller.ErrJobTimeout)
+	assert.Nil(t, status)
+}
+
+// Cancelling the context interrupts the wait between attempts at once instead of
+// using the full delay budget.
+func TestSummaryWithJobRetry_ContextCancelledReturnsPromptly(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	worker := executionworkertypes.NewMockWorker(ctrl)
+	worker.EXPECT().
+		Summary(gomock.Any(), gomock.Any(), gomock.Any()).
+		DoAndReturn(func(context.Context, string, executionworkertypes.GetOptions) (*executionworkertypes.SummaryResult, error) {
+			cancel() // cancel mid-flight so the wait before the next attempt is cut short
+			return nil, controller.ErrJobTimeout
+		}).
+		Times(1)
+
+	a := newSummaryRetryAgentLoop(worker)
+	a.summaryRetryDelay = time.Hour // only ctx cancellation can break this wait
+
+	start := time.Now()
+	status, err := a.summaryWithJobRetry(ctx, "exec-1", executionworkertypes.GetOptions{})
+
+	assert.ErrorIs(t, err, context.Canceled)
+	assert.Nil(t, status)
+	assert.Less(t, time.Since(start), time.Second)
+}
+
+// Same as the retry test, but Summary calls the real controller.New. Against a fake cluster with
+// no Job it returns the genuine controller.ErrJobTimeout, which also proves a not-yet-visible Job
+// surfaces as that error (what the mock-based tests assume).
+func TestSummaryWithJobRetry_RealControllerErrJobTimeoutThenRecovers(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	clientSet := fake.NewSimpleClientset()
+	const namespace, executionID = "tk-int", "exec-int"
+
+	_, err := controller.New(context.Background(), clientSet, namespace, executionID, time.Now())
+	assert.ErrorIs(t, err, controller.ErrJobTimeout)
+
+	want := &executionworkertypes.SummaryResult{}
+	const timeouts = 2
+	var calls int32
+	worker := executionworkertypes.NewMockWorker(ctrl)
+	worker.EXPECT().
+		Summary(gomock.Any(), gomock.Any(), gomock.Any()).
+		DoAndReturn(func(ctx context.Context, id string, _ executionworkertypes.GetOptions) (*executionworkertypes.SummaryResult, error) {
+			if atomic.AddInt32(&calls, 1) <= timeouts {
+				_, err := controller.New(ctx, clientSet, namespace, id, time.Now())
+				return nil, err
+			}
+			return want, nil
+		}).
+		Times(timeouts + 1)
+
+	a := newSummaryRetryAgentLoop(worker)
+
+	status, err := a.summaryWithJobRetry(context.Background(), executionID, executionworkertypes.GetOptions{})
+
+	assert.NoError(t, err)
+	assert.Same(t, want, status)
+}


### PR DESCRIPTION
The live notifications path called worker.Summary once and gave up on any error. On a first execution whose Job is not yet list-visible, Summary returns controller.ErrJobTimeout and the live log session dies, so live logs never start.

This retries Summary while the Job is not yet visible, bounded by the same budget the archival path already uses, and returns promptly on context cancellation. Other errors and successful results return immediately.
