### PR TITLE
fix(TKC-5708): Skip log fetch for unfinished test workflow executions

### DIFF
--- a/cmd/kubectl-testkube/commands/testworkflows/executions.go
+++ b/cmd/kubectl-testkube/commands/testworkflows/executions.go
@@ -75,14 +75,19 @@ func NewGetTestWorkflowExecutionsCmd() *cobra.Command {
 			}
 
 			if outputPretty {
-				ui.Info("Getting logs for test workflow execution", execution.Id)
+				if execution.Result != nil && execution.Result.IsFinished() {
+					ui.Info("Getting logs for test workflow execution", execution.Id)
 
-				logs, err := client.GetTestWorkflowExecutionLogs(execution.Id)
-				ui.ExitOnError("getting logs from test workflow", err)
+					logs, err := client.GetTestWorkflowExecutionLogs(execution.Id)
+					ui.ExitOnError("getting logs from test workflow", err)
 
-				sigs := testworkflows.FlattenSignatures(execution.Signature)
+					sigs := testworkflows.FlattenSignatures(execution.Signature)
 
-				printRawLogLines(logs, sigs, execution)
+					printRawLogLines(logs, sigs, execution)
+				} else {
+					ui.Info("Logs are not available yet, the test workflow execution is still in progress", execution.Id)
+				}
+
 				if !logsOnly {
 					render.PrintTestWorkflowExecutionURIs(&execution)
 					common.UIShellViewExecution(execution.Id)


### PR DESCRIPTION
## Pull request description 

Fix `testkube get twe` failing with an internal error when fetching logs for an execution that's still running. Logs only exist once an execution finishes, so the CLI now guards the log fetch with `Result.IsFinished()` and prints "logs not available yet" while in progress instead of erroring out.

## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [x] tested locally
- [ ] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Breaking changes

-

## Changes

-

## Fixes

-