### PR TITLE
fix: switch triggers from modified to deployment-image-update

### DIFF
--- a/test/env/dev/dev-mongo/triggers/trigger-cloud-ui-e2e-on-deployment.yaml
+++ b/test/env/dev/dev-mongo/triggers/trigger-cloud-ui-e2e-on-deployment.yaml
@@ -8,7 +8,7 @@ spec:
       testkube.io/resource-kind: Deployment
       testkube.io/resource-name: tk-api-testkube-cloud-api
       testkube.io/resource-namespace: app-mongo
-  event: eployment-image-update
+  event: deployment-image-update
   action: run
   execution: testworkflow
   testSelector:

--- a/test/env/dev/dev-mongo/triggers/trigger-cloud-ui-e2e-on-deployment.yaml
+++ b/test/env/dev/dev-mongo/triggers/trigger-cloud-ui-e2e-on-deployment.yaml
@@ -8,7 +8,7 @@ spec:
       testkube.io/resource-kind: Deployment
       testkube.io/resource-name: tk-api-testkube-cloud-api
       testkube.io/resource-namespace: app-mongo
-  event: modified
+  event: deployment-image-modified
   action: run
   execution: testworkflow
   testSelector:

--- a/test/env/dev/dev-mongo/triggers/trigger-cloud-ui-e2e-on-deployment.yaml
+++ b/test/env/dev/dev-mongo/triggers/trigger-cloud-ui-e2e-on-deployment.yaml
@@ -8,7 +8,7 @@ spec:
       testkube.io/resource-kind: Deployment
       testkube.io/resource-name: tk-api-testkube-cloud-api
       testkube.io/resource-namespace: app-mongo
-  event: deployment-image-modified
+  event: eployment-image-update
   action: run
   execution: testworkflow
   testSelector:

--- a/test/env/dev/dev-mongo/triggers/trigger-small-suite-on-deployment.yaml
+++ b/test/env/dev/dev-mongo/triggers/trigger-small-suite-on-deployment.yaml
@@ -8,7 +8,7 @@ spec:
       testkube.io/resource-kind: Deployment
       testkube.io/resource-name: tk-api-testkube-cloud-api
       testkube.io/resource-namespace: app-mongo
-  event: eployment-image-update
+  event: deployment-image-update
   action: run
   execution: testworkflow
   testSelector:

--- a/test/env/dev/dev-mongo/triggers/trigger-small-suite-on-deployment.yaml
+++ b/test/env/dev/dev-mongo/triggers/trigger-small-suite-on-deployment.yaml
@@ -8,7 +8,7 @@ spec:
       testkube.io/resource-kind: Deployment
       testkube.io/resource-name: tk-api-testkube-cloud-api
       testkube.io/resource-namespace: app-mongo
-  event: modified
+  event: deployment-image-modified
   action: run
   execution: testworkflow
   testSelector:

--- a/test/env/dev/dev-mongo/triggers/trigger-small-suite-on-deployment.yaml
+++ b/test/env/dev/dev-mongo/triggers/trigger-small-suite-on-deployment.yaml
@@ -8,7 +8,7 @@ spec:
       testkube.io/resource-kind: Deployment
       testkube.io/resource-name: tk-api-testkube-cloud-api
       testkube.io/resource-namespace: app-mongo
-  event: deployment-image-modified
+  event: eployment-image-update
   action: run
   execution: testworkflow
   testSelector:

--- a/test/env/dev/dev-postgres/triggers/trigger-cloud-ui-e2e-on-deployment.yaml
+++ b/test/env/dev/dev-postgres/triggers/trigger-cloud-ui-e2e-on-deployment.yaml
@@ -8,7 +8,7 @@ spec:
       testkube.io/resource-kind: Deployment
       testkube.io/resource-name: tk-api-testkube-cloud-api
       testkube.io/resource-namespace: testkube-dev
-  event: deployment-image-modified
+  event: eployment-image-update
   action: run
   execution: testworkflow
   testSelector:

--- a/test/env/dev/dev-postgres/triggers/trigger-cloud-ui-e2e-on-deployment.yaml
+++ b/test/env/dev/dev-postgres/triggers/trigger-cloud-ui-e2e-on-deployment.yaml
@@ -8,7 +8,7 @@ spec:
       testkube.io/resource-kind: Deployment
       testkube.io/resource-name: tk-api-testkube-cloud-api
       testkube.io/resource-namespace: testkube-dev
-  event: modified
+  event: deployment-image-modified
   action: run
   execution: testworkflow
   testSelector:

--- a/test/env/dev/dev-postgres/triggers/trigger-cloud-ui-e2e-on-deployment.yaml
+++ b/test/env/dev/dev-postgres/triggers/trigger-cloud-ui-e2e-on-deployment.yaml
@@ -8,7 +8,7 @@ spec:
       testkube.io/resource-kind: Deployment
       testkube.io/resource-name: tk-api-testkube-cloud-api
       testkube.io/resource-namespace: testkube-dev
-  event: eployment-image-update
+  event: deployment-image-update
   action: run
   execution: testworkflow
   testSelector:

--- a/test/env/dev/dev-postgres/triggers/trigger-small-suite-on-deployment.yaml
+++ b/test/env/dev/dev-postgres/triggers/trigger-small-suite-on-deployment.yaml
@@ -8,7 +8,7 @@ spec:
       testkube.io/resource-kind: Deployment
       testkube.io/resource-name: tk-api-testkube-cloud-api
       testkube.io/resource-namespace: testkube-dev
-  event: deployment-image-modified
+  event: eployment-image-update
   action: run
   execution: testworkflow
   testSelector:

--- a/test/env/dev/dev-postgres/triggers/trigger-small-suite-on-deployment.yaml
+++ b/test/env/dev/dev-postgres/triggers/trigger-small-suite-on-deployment.yaml
@@ -8,7 +8,7 @@ spec:
       testkube.io/resource-kind: Deployment
       testkube.io/resource-name: tk-api-testkube-cloud-api
       testkube.io/resource-namespace: testkube-dev
-  event: modified
+  event: deployment-image-modified
   action: run
   execution: testworkflow
   testSelector:

--- a/test/env/dev/dev-postgres/triggers/trigger-small-suite-on-deployment.yaml
+++ b/test/env/dev/dev-postgres/triggers/trigger-small-suite-on-deployment.yaml
@@ -8,7 +8,7 @@ spec:
       testkube.io/resource-kind: Deployment
       testkube.io/resource-name: tk-api-testkube-cloud-api
       testkube.io/resource-namespace: testkube-dev
-  event: eployment-image-update
+  event: deployment-image-update
   action: run
   execution: testworkflow
   testSelector:


### PR DESCRIPTION
`modified` will run on replicaCount changes meaning autoscaling can retrigger tests. The intention with these triggers is to focus on code changes, so `deployment-image-update` is a more narrow selector.