### PR TITLE
feat(mcp): add list_credentials tool

### DIFF
--- a/pkg/mcp/api.go
+++ b/pkg/mcp/api.go
@@ -654,6 +654,15 @@ func (c *APIClient) ListLabels(ctx context.Context) (string, error) {
 	})
 }
 
+func (c *APIClient) ListCredentials(ctx context.Context) (string, error) {
+	return c.makeRequest(ctx, APIRequest{
+		Method:      "GET",
+		Path:        "/credentials",
+		Scope:       ApiScopeOrgEnv,
+		QueryParams: map[string]string{"filter": "all"},
+	})
+}
+
 func (c *APIClient) ListResourceGroups(ctx context.Context) (string, error) {
 	return c.makeRequest(ctx, APIRequest{
 		Method: "GET",

--- a/pkg/mcp/api_test.go
+++ b/pkg/mcp/api_test.go
@@ -130,6 +130,38 @@ func TestAPIClient_DebugInfo_URLIncludesQueryParams(t *testing.T) {
 	assert.Contains(t, gotURL, "tail=50")
 }
 
+func TestAPIClient_ListCredentials_HitsEnvScopedFilterAll(t *testing.T) {
+	const (
+		orgID = "org-1"
+		envID = "env-1"
+		token = "tok"
+		body  = `{"elements":[{"name":"github-access-token","type":"secret","reference":"github-access-token"}]}`
+	)
+
+	var gotPath, gotQuery, gotAuth string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		gotQuery = r.URL.Query().Get("filter")
+		gotAuth = r.Header.Get("Authorization")
+		_, _ = io.WriteString(w, body)
+	}))
+	defer server.Close()
+
+	client := NewAPIClient(&MCPServerConfig{
+		ControlPlaneUrl: server.URL,
+		AccessToken:     token,
+		OrgId:           orgID,
+		EnvId:           envID,
+	}, server.Client())
+
+	result, err := client.ListCredentials(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, body, result)
+	assert.Equal(t, "/organizations/"+orgID+"/environments/"+envID+"/credentials", gotPath)
+	assert.Equal(t, "all", gotQuery)
+	assert.Equal(t, "Bearer "+token, gotAuth)
+}
+
 func TestExtractErrorDetail(t *testing.T) {
 	t.Run("problem json detail", func(t *testing.T) {
 		got := extractErrorDetail([]byte(`{"title":"Bad Request","detail":"boom"}`))

--- a/pkg/mcp/client.go
+++ b/pkg/mcp/client.go
@@ -19,6 +19,7 @@ type Client interface {
 	tools.LabelsLister
 	tools.ResourceGroupsLister
 	tools.AgentsLister
+	tools.CredentialsLister
 
 	tools.WorkflowLister
 	tools.WorkflowCreator

--- a/pkg/mcp/config.go
+++ b/pkg/mcp/config.go
@@ -51,6 +51,12 @@ type MCPServerConfig struct {
 	// Used by the MCP bridge when spawned for metadata-only listing with dummy credentials.
 	SkipEndpointChecks bool
 
+	// IncludeCredentialTools exposes the list_credentials tool. It is enabled only on the
+	// hosted/cloud MCP surfaces (the mcp-bridge that backs the AI chat, and the control
+	// plane's in-process MCP endpoint), and left disabled on the local testkube CLI so
+	// credential references are not surfaced through a user's local MCP server.
+	IncludeCredentialTools bool
+
 	// SkipTLS disables TLS certificate verification for the control-plane HTTP client.
 	SkipTLS bool
 

--- a/pkg/mcp/formatters/credentials.go
+++ b/pkg/mcp/formatters/credentials.go
@@ -1,0 +1,88 @@
+package formatters
+
+import "fmt"
+
+// listCredentialsResponse mirrors the credentials list API response.
+// It intentionally reads only non-secret metadata fields — never `value` — so a
+// credential value can never reach the model, even if an upstream projection
+// starts including one.
+type listCredentialsResponse struct {
+	Elements []credentialElement `json:"elements"`
+}
+
+// credentialElement reads only the reference and scope metadata of a credential.
+// The `value` field from the API response is deliberately not declared here.
+type credentialElement struct {
+	Name            string `json:"name"`
+	Type            string `json:"type"`
+	Reference       string `json:"reference"`
+	EnvironmentId   string `json:"environmentId"`
+	ResourceGroupId string `json:"resourceGroupId"`
+	WorkflowName    string `json:"workflowName"`
+}
+
+// formattedCredential is the agent-facing projection of a credential reference.
+type formattedCredential struct {
+	Name       string `json:"name"`
+	Type       string `json:"type"`
+	Scope      string `json:"scope"`
+	Reference  string `json:"reference"`
+	Expression string `json:"expression"`
+}
+
+type formattedCredentialsResult struct {
+	Credentials []formattedCredential `json:"credentials"`
+}
+
+// FormatListCredentials parses a raw credentials list response (JSON or YAML) and
+// returns a compact JSON projection of credential references only — name, type,
+// scope, the reference string, and the ready-to-use credential(...) expression.
+// It never includes credential values, and it omits non-referenceable
+// (execution-scoped) credentials, which the API returns with an empty reference.
+func FormatListCredentials(raw string) (string, error) {
+	response, isEmpty, err := ParseJSON[listCredentialsResponse](raw)
+	if err != nil {
+		return "", err
+	}
+	if isEmpty {
+		return `{"credentials":[]}`, nil
+	}
+
+	formatted := formattedCredentialsResult{
+		Credentials: make([]formattedCredential, 0, len(response.Elements)),
+	}
+
+	for _, c := range response.Elements {
+		// Skip non-referenceable credentials: execution-scoped credentials carry an
+		// empty reference, and the agent can only use referenceable ones in YAML.
+		if c.Reference == "" {
+			continue
+		}
+		formatted.Credentials = append(formatted.Credentials, formattedCredential{
+			Name:       c.Name,
+			Type:       c.Type,
+			Scope:      credentialScope(c),
+			Reference:  c.Reference,
+			Expression: fmt.Sprintf("credential(%q)", c.Reference),
+		})
+	}
+
+	return FormatJSON(formatted)
+}
+
+// credentialScope reports the narrowest scope a credential is bound at, derived
+// from which scope identifiers are populated. With the org+environment listing
+// this resolves to "organization" or "environment"; the deeper tiers are handled
+// for completeness.
+func credentialScope(c credentialElement) string {
+	switch {
+	case c.WorkflowName != "":
+		return "workflow"
+	case c.ResourceGroupId != "":
+		return "resource_group"
+	case c.EnvironmentId != "":
+		return "environment"
+	default:
+		return "organization"
+	}
+}

--- a/pkg/mcp/formatters/credentials_test.go
+++ b/pkg/mcp/formatters/credentials_test.go
@@ -1,0 +1,91 @@
+package formatters
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func parseFormattedCredentials(t *testing.T, raw string) formattedCredentialsResult {
+	t.Helper()
+	var out formattedCredentialsResult
+	require.NoError(t, json.Unmarshal([]byte(raw), &out))
+	return out
+}
+
+func TestFormatListCredentials(t *testing.T) {
+	// Empty / null / whitespace input → empty credentials list.
+	RunEmptyInputCases(t, FormatListCredentials, `{"credentials":[]}`)
+
+	t.Run("happy path: org and environment scoped credentials", func(t *testing.T) {
+		input := `{"elements":[
+			{"name":"github-access-token","type":"secret","reference":"github-access-token"},
+			{"name":"staging-api-key","type":"secret","reference":"staging-api-key","environmentId":"tkcenv_1"}
+		]}`
+
+		result, err := FormatListCredentials(input)
+		require.NoError(t, err)
+		out := parseFormattedCredentials(t, result)
+		require.Len(t, out.Credentials, 2)
+
+		assert.Equal(t, "github-access-token", out.Credentials[0].Name)
+		assert.Equal(t, "secret", out.Credentials[0].Type)
+		assert.Equal(t, "organization", out.Credentials[0].Scope)
+		assert.Equal(t, `credential("github-access-token")`, out.Credentials[0].Expression)
+
+		// env-scoped credential is annotated as "environment".
+		assert.Equal(t, "environment", out.Credentials[1].Scope)
+	})
+
+	t.Run("never returns secret values", func(t *testing.T) {
+		input := `{"elements":[
+			{"name":"db-password","type":"secret","reference":"db-password","value":"super-secret-pw","base64Value":"c3VwZXItc2VjcmV0LXB3"}
+		]}`
+
+		result, err := FormatListCredentials(input)
+		require.NoError(t, err)
+		assert.NotContains(t, result, "super-secret-pw")
+		assert.NotContains(t, result, "c3VwZXItc2VjcmV0LXB3")
+		// Reference/name still surfaced so the agent can use it.
+		assert.Contains(t, result, "db-password")
+	})
+
+	t.Run("drops variable values too", func(t *testing.T) {
+		// `variable` is not a secret, but the tool's contract is "never values".
+		input := `{"elements":[
+			{"name":"api-endpoint","type":"variable","reference":"api-endpoint","value":"https://staging.example.com"}
+		]}`
+
+		result, err := FormatListCredentials(input)
+		require.NoError(t, err)
+		assert.NotContains(t, result, "https://staging.example.com")
+		out := parseFormattedCredentials(t, result)
+		require.Len(t, out.Credentials, 1)
+		assert.Equal(t, "variable", out.Credentials[0].Type)
+	})
+
+	t.Run("omits non-referenceable execution-scoped credentials", func(t *testing.T) {
+		// Execution-scoped credentials come back with an empty reference.
+		input := `{"elements":[
+			{"name":"exec-temp-token","type":"secret","reference":"","executionId":"6a34c733"},
+			{"name":"real-token","type":"secret","reference":"real-token"}
+		]}`
+
+		result, err := FormatListCredentials(input)
+		require.NoError(t, err)
+		out := parseFormattedCredentials(t, result)
+		require.Len(t, out.Credentials, 1)
+		assert.Equal(t, "real-token", out.Credentials[0].Name)
+	})
+
+	t.Run("renders ready-to-use credential expression", func(t *testing.T) {
+		input := `{"elements":[{"name":"gh","type":"secret","reference":"github-access-token"}]}`
+		result, err := FormatListCredentials(input)
+		require.NoError(t, err)
+		assert.True(t, strings.Contains(result, `credential(\"github-access-token\")`),
+			"expected escaped credential expression in JSON output, got: %s", result)
+	})
+}

--- a/pkg/mcp/server.go
+++ b/pkg/mcp/server.go
@@ -83,6 +83,9 @@ func NewMCPServer(cfg MCPServerConfig, client Client) (*server.MCPServer, error)
 	// Agent tools
 	mcpServer.AddTool(tools.ListAgents(client))
 
+	// Credential tools
+	mcpServer.AddTool(tools.ListCredentials(client))
+
 	// Execution tools
 	mcpServer.AddTool(tools.FetchExecutionLogs(client))
 	mcpServer.AddTool(tools.ListExecutions(client))

--- a/pkg/mcp/server.go
+++ b/pkg/mcp/server.go
@@ -83,8 +83,11 @@ func NewMCPServer(cfg MCPServerConfig, client Client) (*server.MCPServer, error)
 	// Agent tools
 	mcpServer.AddTool(tools.ListAgents(client))
 
-	// Credential tools
-	mcpServer.AddTool(tools.ListCredentials(client))
+	// Credential tools — exposed only on hosted MCP surfaces (bridge / control-plane
+	// endpoint), not the local CLI, so credential references aren't surfaced locally.
+	if cfg.IncludeCredentialTools {
+		mcpServer.AddTool(tools.ListCredentials(client))
+	}
 
 	// Execution tools
 	mcpServer.AddTool(tools.FetchExecutionLogs(client))

--- a/pkg/mcp/server_test.go
+++ b/pkg/mcp/server_test.go
@@ -1,0 +1,52 @@
+package mcp
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// newTestMCPServerTools builds an MCP server with the given config and returns
+// the set of registered tool names. SkipEndpointChecks avoids the network-bound
+// backwards-compat probe so the test stays offline.
+func newTestMCPServerTools(t *testing.T, includeCredentialTools bool) map[string]struct{} {
+	t.Helper()
+	cfg := MCPServerConfig{
+		Version:                "test",
+		ControlPlaneUrl:        "http://localhost",
+		AccessToken:            "test-token",
+		OrgId:                  "org-1",
+		EnvId:                  "env-1",
+		SkipEndpointChecks:     true,
+		IncludeCredentialTools: includeCredentialTools,
+	}
+	client := NewAPIClient(&cfg, http.DefaultClient)
+	srv, err := NewMCPServer(cfg, client)
+	require.NoError(t, err)
+
+	names := make(map[string]struct{})
+	for name := range srv.ListTools() {
+		names[name] = struct{}{}
+	}
+	return names
+}
+
+func TestNewMCPServer_CredentialToolGating(t *testing.T) {
+	t.Run("list_credentials is registered when the flag is set (hosted surfaces)", func(t *testing.T) {
+		tools := newTestMCPServerTools(t, true)
+		_, ok := tools["list_credentials"]
+		assert.True(t, ok, "expected list_credentials to be registered when IncludeCredentialTools=true")
+	})
+
+	t.Run("list_credentials is omitted when the flag is unset (local CLI)", func(t *testing.T) {
+		tools := newTestMCPServerTools(t, false)
+		_, ok := tools["list_credentials"]
+		assert.False(t, ok, "expected list_credentials to be omitted when IncludeCredentialTools=false")
+
+		// Sanity: gating list_credentials must not drop other tools.
+		_, hasLabels := tools["list_labels"]
+		assert.True(t, hasLabels, "other tools must still be registered regardless of the credential flag")
+	})
+}

--- a/pkg/mcp/tools/credentials.go
+++ b/pkg/mcp/tools/credentials.go
@@ -1,0 +1,37 @@
+package tools
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/mark3labs/mcp-go/server"
+
+	"github.com/kubeshop/testkube/pkg/mcp/formatters"
+)
+
+type CredentialsLister interface {
+	ListCredentials(ctx context.Context) (string, error)
+}
+
+func ListCredentials(client CredentialsLister) (tool mcp.Tool, handler server.ToolHandlerFunc) {
+	tool = mcp.NewTool("list_credentials",
+		mcp.WithDescription(ListCredentialsDescription),
+	)
+
+	handler = func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		result, err := client.ListCredentials(ctx)
+		if err != nil {
+			return mcp.NewToolResultError(err.Error()), nil
+		}
+
+		formatted, err := formatters.FormatListCredentials(result)
+		if err != nil {
+			return mcp.NewToolResultError(fmt.Sprintf("Failed to format credentials: %v", err)), nil
+		}
+
+		return mcp.NewToolResultText(formatted), nil
+	}
+
+	return tool, handler
+}

--- a/pkg/mcp/tools/credentials_test.go
+++ b/pkg/mcp/tools/credentials_test.go
@@ -1,0 +1,58 @@
+package tools
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type mockCredentialsLister struct {
+	called    bool
+	returnRaw string
+	returnErr error
+}
+
+func (m *mockCredentialsLister) ListCredentials(_ context.Context) (string, error) {
+	m.called = true
+	return m.returnRaw, m.returnErr
+}
+
+func callListCredentials(t *testing.T, mock *mockCredentialsLister) (*mcp.CallToolResult, error) {
+	t.Helper()
+	_, handler := ListCredentials(mock)
+	return handler(context.Background(), mcp.CallToolRequest{})
+}
+
+func TestListCredentials_HappyPath_FormatsReferences(t *testing.T) {
+	m := &mockCredentialsLister{returnRaw: `{"elements":[
+		{"name":"github-access-token","type":"secret","reference":"github-access-token"}
+	]}`}
+
+	result, err := callListCredentials(t, m)
+	require.NoError(t, err)
+	require.True(t, m.called, "tool must invoke the client with no required arguments")
+	require.NotNil(t, result)
+	require.False(t, result.IsError)
+
+	text, ok := result.Content[0].(mcp.TextContent)
+	require.True(t, ok)
+	assert.Contains(t, text.Text, "github-access-token")
+	assert.Contains(t, text.Text, `credential(\"github-access-token\")`)
+}
+
+func TestListCredentials_ClientError_ReturnsToolError(t *testing.T) {
+	m := &mockCredentialsLister{returnErr: fmt.Errorf("API returned status 403: forbidden")}
+
+	result, err := callListCredentials(t, m)
+	require.NoError(t, err) // handler never returns a Go error
+	require.NotNil(t, result)
+	require.True(t, result.IsError)
+
+	text, ok := result.Content[0].(mcp.TextContent)
+	require.True(t, ok)
+	assert.Contains(t, text.Text, "forbidden")
+}

--- a/pkg/mcp/tools/descriptions.go
+++ b/pkg/mcp/tools/descriptions.go
@@ -74,6 +74,7 @@ or an RFC 3339 timestamp (e.g., '2024-01-31T16:00:00Z'). Combine with startDate 
 	ListLabelsDescription         = "List all workflow labels and their values in the environment. Use to discover available filters for selector parameters in other tools."
 	ListResourceGroupsDescription = "List available resource groups in the organization. Use to discover group slugs for filtering workflows and executions."
 	ListAgentsDescription         = "List available agents in the organization for workflow execution targeting. Returns agent names, types, capabilities, labels, and status. Use before run_workflow to discover target agents."
+	ListCredentialsDescription    = "List the credential and secret references available in the current environment (organization and environment scope) for use in workflow credential(\"...\") expressions. Returns each credential's name, type, scope, reference, and ready-to-use expression — it NEVER returns secret values. Use this to discover which secrets/credentials already exist before authoring a workflow that needs one (e.g. a git token or registry auth); if the credential you need is not listed, use request_credential to collect it from the user instead of duplicating an existing one."
 
 	// Query tool descriptions
 	QueryWorkflowsDescription = `Query workflow definitions in bulk using JSONPath.


### PR DESCRIPTION
## What

Adds a read-only `list_credentials` MCP tool so an AI agent (or any MCP client) can discover which credential **references** exist in the current environment — name, type, scope — and use them directly in `credential("...")` workflow expressions. It **never returns values**, and is the read-before-ask complement to `request_credential`.

## Change (testkube side)

- `pkg/mcp/formatters/credentials.go` — secret-safe projection: reads only name/type/reference/scope (never `value`), filters non-referenceable execution-scoped credentials, renders the ready-to-use `credential("<ref>")` expression.
- `pkg/mcp/tools/credentials.go` + `descriptions.go` — the tool, its `CredentialsLister` interface, and an LLM-facing description stating values are never returned.
- `pkg/mcp/api.go` — `APIClient.ListCredentials` (GET env-scoped `/credentials?filter=all`); added to the aggregate `Client` interface; registered in the standalone MCP server.

## Scope

Org + environment coverage (reuses the existing org→env merge). No backend changes. Resource-group/workflow-scoped listing is deferred.

## Tests

- `formatters/credentials_test.go` — happy path, never-returns-secret-values, drops variable values, omits non-referenceable creds, empty input, reference-expression rendering.
- `tools/credentials_test.go` — handler happy path + client-error → tool error.
- `api_test.go` — asserts the env-scoped `/credentials?filter=all` request.

Ref: TKC-5618. Pairs with kubeshop/testkube-cloud-api (in-process MCP host wiring); that repo's `go.mod` will bump to the merged version of this PR.