### PR TITLE
fix: Add missing /agent prefix to TestWorkflowTemplate MCP tool paths

### DIFF
--- a/pkg/mcp/api.go
+++ b/pkg/mcp/api.go
@@ -878,7 +878,7 @@ func (c *APIClient) ListWorkflowTemplates(ctx context.Context, selector string) 
 
 	return c.makeRequest(ctx, APIRequest{
 		Method:      "GET",
-		Path:        "/test-workflow-templates",
+		Path:        "/agent/test-workflow-templates",
 		Scope:       ApiScopeOrgEnv,
 		QueryParams: queryParams,
 	})
@@ -887,7 +887,7 @@ func (c *APIClient) ListWorkflowTemplates(ctx context.Context, selector string) 
 func (c *APIClient) GetWorkflowTemplateDefinition(ctx context.Context, templateName string) (string, error) {
 	return c.makeRequest(ctx, APIRequest{
 		Method: "GET",
-		Path:   "/test-workflow-templates/{templateName}",
+		Path:   "/agent/test-workflow-templates/{templateName}",
 		Scope:  ApiScopeOrgEnv,
 		PathParams: map[string]string{
 			"templateName": templateName,
@@ -901,7 +901,7 @@ func (c *APIClient) GetWorkflowTemplateDefinition(ctx context.Context, templateN
 func (c *APIClient) CreateWorkflowTemplate(ctx context.Context, templateDefinition string) (string, error) {
 	return c.makeRequest(ctx, APIRequest{
 		Method: "POST",
-		Path:   "/test-workflow-templates",
+		Path:   "/agent/test-workflow-templates",
 		Scope:  ApiScopeOrgEnv,
 		Body:   templateDefinition,
 		Headers: map[string]string{
@@ -913,7 +913,7 @@ func (c *APIClient) CreateWorkflowTemplate(ctx context.Context, templateDefiniti
 func (c *APIClient) UpdateWorkflowTemplate(ctx context.Context, templateName, templateDefinition string) (string, error) {
 	return c.makeRequest(ctx, APIRequest{
 		Method: "PUT",
-		Path:   "/test-workflow-templates/{templateName}",
+		Path:   "/agent/test-workflow-templates/{templateName}",
 		Scope:  ApiScopeOrgEnv,
 		PathParams: map[string]string{
 			"templateName": templateName,


### PR DESCRIPTION
## Summary

- The TestWorkflowTemplate MCP tools (`list_workflowtemplates`, `get_workflowtemplate_definition`, `create_workflowtemplate`, `update_workflowtemplate`) were returning **404** when invoked (e.g. from the dashboard chat using the built-in MCP server).
- Root cause: the `APIClient` targeted `/test-workflow-templates`, but the control plane serves these routes only under `/agent/test-workflow-templates` (the environment router is mounted at `.../environments/{id}/agent`). Every workflow tool already includes the `/agent` segment; only the template tools omitted it.
- Fix: prefix the four template client paths with `/agent` in `pkg/mcp/api.go` so they resolve to the registered routes.

A companion fix in `testkube-cloud-api` (`internal/server/mcp_client.go`) applies the same prefix for the in-process handler client: kubeshop/testkube-cloud-api#TBD

## Test plan

- [ ] Invoke each TestWorkflowTemplate MCP tool against an environment and confirm 200s instead of 404s.
- [ ] Confirm workflow tools continue to work unchanged.

Made with [Cursor](https://cursor.com)