### PR TITLE
fix(images): patch OS CVEs in api-server, tw-toolkit and bump busybox

### DIFF
--- a/build/new/api-server.Dockerfile
+++ b/build/new/api-server.Dockerfile
@@ -27,7 +27,6 @@ RUN cd cmd/api-server; \
     -o /app -mod mod -a .
 
 FROM ${ALPINE_IMAGE}
-# Apply available Alpine security patches (openssl, ...) then install runtime deps.
 RUN apk --no-cache upgrade && apk --no-cache add ca-certificates libssl3 git
 WORKDIR /root/
 COPY --from=build /app /bin/app

--- a/build/new/api-server.Dockerfile
+++ b/build/new/api-server.Dockerfile
@@ -27,7 +27,8 @@ RUN cd cmd/api-server; \
     -o /app -mod mod -a .
 
 FROM ${ALPINE_IMAGE}
-RUN apk --no-cache add ca-certificates libssl3 git
+# Apply available Alpine security patches (openssl, ...) then install runtime deps.
+RUN apk --no-cache upgrade && apk --no-cache add ca-certificates libssl3 git
 WORKDIR /root/
 COPY --from=build /app /bin/app
 USER 1001

--- a/build/new/tw-toolkit.Dockerfile
+++ b/build/new/tw-toolkit.Dockerfile
@@ -22,7 +22,6 @@ RUN cd cmd/testworkflow-init; \
 
 FROM ${BUSYBOX_IMAGE} AS busybox
 FROM ${ALPINE_IMAGE}
-# Apply available Alpine security patches (openssl, ...) then install runtime deps.
 RUN apk --no-cache upgrade && apk --no-cache add ca-certificates libssl3 git openssh-client
 COPY --from=busybox /bin /.tktw-bin
 COPY --from=build /app/testworkflow-toolkit /toolkit

--- a/build/new/tw-toolkit.Dockerfile
+++ b/build/new/tw-toolkit.Dockerfile
@@ -22,7 +22,8 @@ RUN cd cmd/testworkflow-init; \
 
 FROM ${BUSYBOX_IMAGE} AS busybox
 FROM ${ALPINE_IMAGE}
-RUN apk --no-cache add ca-certificates libssl3 git openssh-client
+# Apply available Alpine security patches (openssl, ...) then install runtime deps.
+RUN apk --no-cache upgrade && apk --no-cache add ca-certificates libssl3 git openssh-client
 COPY --from=busybox /bin /.tktw-bin
 COPY --from=build /app/testworkflow-toolkit /toolkit
 COPY --from=build /app/testworkflow-init /init

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -1,6 +1,6 @@
 variable "GOCACHE"       { default = "/go/pkg" }
 variable "GOMODCACHE"    { default = "/root/.cache/go-build" }
-variable "BUSYBOX_IMAGE" { default = "busybox:1.36.1-musl"}
+variable "BUSYBOX_IMAGE" { default = "busybox:1.37.0-musl"}
 variable "ALPINE_IMAGE"  { default = "alpine:3.23.3" }
 variable "VERSION"       { default = "0.0.0-unknown"}
 


### PR DESCRIPTION
## Summary

The alpine-based runtime images still shipped the openssl **CRITICAL** `CVE-2026-31789` (libssl3/libcrypto3 `3.5.5-r0`, fixed in `3.5.6-r0`) plus several OS HIGHs.

- **api-server** and **tw-toolkit**: run `apk --no-cache upgrade` before installing runtime deps, so OS packages (openssl, ...) are patched on top of the base image.
- **docker-bake.hcl**: bump `BUSYBOX_IMAGE` `1.36.1-musl` → `1.37.0-musl` (addresses busybox `CVE-2022-48174` reported for `tw-init`).

## Result (Trivy)
| Image | CRIT before | CRIT after |
|---|---|---|
| api-server | 2 | **0** |
| tw-toolkit | 2 | **0** |

openssl `3.5.5-r0` → `3.5.7-r0`. Remaining HIGHs are Go-dependency advisories (no criticals).

## Test plan
- [x] `docker buildx bake api` / `tw-toolkit` build OK.
- [x] Trivy: CRIT 2→0 on both; container openssl confirmed `3.5.7-r0`.
- [x] api-server smoke-tested in local kind: registers as runner and connects to Kubernetes + NATS + control plane; ran real TestWorkflows (`smoke-hello`, `smoke-artifact`) to `passed`.
- [ ] CI multi-arch build green.

Made with [Cursor](https://cursor.com)