### PR TITLE
fix: [TKC-6152] subtract paused time as milliseconds in HealDuration

### DIFF
--- a/pkg/api/v1/testkube/model_test_workflow_result_extended.go
+++ b/pkg/api/v1/testkube/model_test_workflow_result_extended.go
@@ -361,7 +361,7 @@ func (r *TestWorkflowResult) HealDuration(scheduledAt time.Time) {
 			queuedAt = scheduledAt
 		}
 		totalDuration := r.FinishedAt.Sub(scheduledAt)
-		duration := totalDuration - time.Duration(1e3*r.PausedMs)
+		duration := totalDuration - time.Duration(r.PausedMs)*time.Millisecond
 		if totalDuration < 0 {
 			totalDuration = time.Duration(0)
 		}

--- a/pkg/api/v1/testkube/model_test_workflow_result_extended_test.go
+++ b/pkg/api/v1/testkube/model_test_workflow_result_extended_test.go
@@ -1,0 +1,63 @@
+package testkube
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestHealDuration(t *testing.T) {
+	scheduled := time.Date(2025, 3, 1, 10, 0, 0, 0, time.UTC)
+	finished := scheduled.Add(5 * time.Minute)
+	passed := PASSED_TestWorkflowStatus
+
+	tests := []struct {
+		name           string
+		pauses         []TestWorkflowPause
+		steps          map[string]TestWorkflowStepResult
+		wantPausedMs   int32
+		wantDurationMs int32
+		wantDuration   string
+	}{
+		{
+			name: "subtracts paused time from duration",
+			pauses: []TestWorkflowPause{{
+				Ref:       "step1",
+				PausedAt:  scheduled.Add(1 * time.Minute),
+				ResumedAt: scheduled.Add(3 * time.Minute),
+			}},
+			steps: map[string]TestWorkflowStepResult{
+				"step1": {StartedAt: scheduled, FinishedAt: finished},
+			},
+			wantPausedMs:   2 * 60 * 1000,
+			wantDurationMs: 3 * 60 * 1000,
+			wantDuration:   "3m0s",
+		},
+		{
+			name:           "no pauses keeps duration equal to total",
+			wantPausedMs:   0,
+			wantDurationMs: 5 * 60 * 1000,
+			wantDuration:   "5m0s",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := &TestWorkflowResult{
+				Status:     &passed,
+				QueuedAt:   scheduled,
+				FinishedAt: finished,
+				Pauses:     tt.pauses,
+				Steps:      tt.steps,
+			}
+			r.HealDuration(scheduled)
+
+			assert.Equal(t, tt.wantPausedMs, r.PausedMs)
+			assert.Equal(t, tt.wantDurationMs, r.DurationMs)
+			assert.Equal(t, tt.wantDuration, r.Duration)
+			assert.Equal(t, int32(5*60*1000), r.TotalDurationMs)
+			assert.Equal(t, "5m0s", r.TotalDuration)
+		})
+	}
+}


### PR DESCRIPTION
## How

HealDuration converted PausedMs to a time.Duration with a factor of 1e3, which yields microseconds instead of milliseconds: a two minute pause shortened the reported duration by 120 microseconds. The conversion now uses time.Millisecond, and a unit test pins both the paused and unpaused paths.

Refs TKC-6152

🤖 Generated with [Claude Code](https://claude.com/claude-code)