### PR TITLE
fix: make install.sh POSIX sh compatible and verify release checksums

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,138 +1,182 @@
-#!/bin/bash
-set -eo pipefail
+#!/bin/sh
+# POSIX sh compatible — this script is documented as `curl -sSLf https://get.testkube.io | sh`,
+# so it must not rely on bash-only constructs ([[ ]], =~, set -o pipefail, etc.).
+set -e
 
 echo "Getting kubectl-testkube plugin"
 
-if [ ! -z "${DEBUG}" ];
-then set -x
+if [ -n "${DEBUG}" ]; then
+  set -x
 fi
 
+GITHUB_API="https://api.github.com/repos/kubeshop/testkube"
+RELEASES_BASE_URL="https://github.com/kubeshop/testkube/releases/download"
+INSTALL_DIR=/usr/local/bin
+
 _check_required_tools() {
-  local MISSING_TOOLS=""
-  for CMD in curl jq; do
-    if ! which "${CMD}" &>/dev/null; then
+  MISSING_TOOLS=""
+  for CMD in curl jq tar; do
+    if ! command -v "${CMD}" >/dev/null 2>&1; then
       MISSING_TOOLS="${MISSING_TOOLS}${CMD} "
     fi
   done
 
-  if [[ ${MISSING_TOOLS} != "" ]]; then
-    echo "Missing required tools: ${MISSING_TOOLS}"
-    echo Please install these using your package manager and try again.
+  if [ -n "${MISSING_TOOLS}" ]; then
+    echo "Missing required tools: ${MISSING_TOOLS}" >&2
+    echo "Please install these using your package manager and try again." >&2
     exit 1
   fi
 }
 
 _detect_arch() {
-    case $(uname -m) in
-    amd64|x86_64) echo "x86_64"
-    ;;
-    arm64|aarch64) echo "arm64"
-    ;;
-    i386) echo "i386"
-    ;;
-    *) echo "Unsupported processor architecture";
+  case $(uname -m) in
+  amd64 | x86_64) echo "x86_64" ;;
+  arm64 | aarch64) echo "arm64" ;;
+  *)
+    echo "Unsupported processor architecture: $(uname -m)" >&2
     return 1
     ;;
-     esac
+  esac
 }
 
-_detect_os(){
-    case $(uname) in
-    Linux) echo "Linux"
+_detect_os() {
+  case $(uname) in
+  Linux) echo "Linux" ;;
+  Darwin) echo "Darwin" ;;
+  *)
+    echo "Unsupported operating system: $(uname)" >&2
+    echo "On Windows, download testkube from https://github.com/kubeshop/testkube/releases/latest" >&2
+    return 1
     ;;
-    Darwin) echo "Darwin"
-    ;;
-    Windows) echo "Windows"
-    ;;
-     esac
+  esac
 }
 
-_download_url() {
-  local arch
-  local os
-  local tag
-  local version
+_resolve_tag() {
+  if [ -n "${TESTKUBE_VERSION}" ]; then
+    echo "${TESTKUBE_VERSION}"
+    return 0
+  fi
 
-  arch="$(_detect_arch)"
-  os="$(_detect_os)"
-  if [ -z "$TESTKUBE_VERSION" ]; then
-    if [ "$1" = "beta" ]; then
-      tag="$(
-        curl -s "https://api.github.com/repos/kubeshop/testkube/releases" \
-        2>/dev/null \
-        | jq -r '.[].tag_name | select(test("beta"))' \
-        | head -n 1 \
-      )"
-        if [ -z "$tag" ]; then
-            echo "No beta releases found. Installing latest release" >&2
-            tag="$(
-              curl -s "https://api.github.com/repos/kubeshop/testkube/releases/latest" \
-              2>/dev/null \
-              | jq -r '.tag_name' \
-            )"
-        fi
-    else
-      tag="$(
-        curl -s "https://api.github.com/repos/kubeshop/testkube/releases/latest" \
-        2>/dev/null \
-        | jq -r '.tag_name' \
-      )"
+  if [ "$1" = "beta" ]; then
+    TAG="$(
+      curl -sSf "${GITHUB_API}/releases" 2>/dev/null |
+        jq -r '[.[] | select(.prerelease)][0].tag_name // empty'
+    )"
+    if [ -n "${TAG}" ]; then
+      echo "${TAG}"
+      return 0
     fi
+    echo "No pre-releases found. Installing latest release" >&2
+  fi
+
+  curl -sSf "${GITHUB_API}/releases/latest" 2>/dev/null | jq -r '.tag_name // empty'
+}
+
+# Normalize the tag format based on the version number when a version is
+# explicitly provided. Starting from 2.4.0, release tags dropped the 'v'
+# prefix. For auto-detected versions fetched from the API, the tag already
+# has the correct format.
+_normalize_tag() {
+  TAG="$1"
+  VERSION="$2"
+  if [ -z "${TESTKUBE_VERSION}" ]; then
+    echo "${TAG}"
+    return 0
+  fi
+
+  # Only attempt numeric comparison when the version looks like a full numeric
+  # semver (X.Y.Z). Strip any pre-release/build suffix first.
+  BASE_VERSION="${VERSION%%-*}"
+  if echo "${BASE_VERSION}" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+$'; then
+    MAJOR="$(echo "${BASE_VERSION}" | cut -d. -f1)"
+    MINOR="$(echo "${BASE_VERSION}" | cut -d. -f2)"
+    if [ "${MAJOR}" -lt 2 ] || { [ "${MAJOR}" -eq 2 ] && [ "${MINOR}" -lt 4 ]; }; then
+      echo "v${VERSION}"
+      return 0
+    fi
+    echo "${VERSION}"
+    return 0
+  fi
+  echo "${TAG}"
+}
+
+# Verify the downloaded tarball against the release's checksums.txt.
+# Skips with a warning when no sha256 tool is available or the checksum entry
+# is missing; fails hard on an actual mismatch.
+_verify_checksum() {
+  TARBALL_PATH="$1"
+  TARBALL_NAME="$2"
+
+  if command -v sha256sum >/dev/null 2>&1; then
+    ACTUAL="$(sha256sum "${TARBALL_PATH}" | cut -d' ' -f1)"
+  elif command -v shasum >/dev/null 2>&1; then
+    ACTUAL="$(shasum -a 256 "${TARBALL_PATH}" | cut -d' ' -f1)"
   else
-    tag="$TESTKUBE_VERSION"
-  fi
-  version="${tag/#v/}" # remove leading v if present
-
-  # Normalize the tag format based on the version number when a version is explicitly provided.
-  # Starting from 2.4.0, release tags dropped the 'v' prefix.
-  # For auto-detected versions fetched from the API, the tag already has the correct format.
-  if [ -n "$TESTKUBE_VERSION" ]; then
-    # Only attempt numeric comparison when the version looks like a full numeric semver (X.Y.Z).
-    # Strip any pre-release/build suffix (e.g. "2.4.0-beta" -> "2.4.0") before validation.
-    local major minor normalized_version
-    normalized_version="${version%%-*}"
-    if [[ "$normalized_version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-      major=$(echo "$normalized_version" | cut -d. -f1)
-      minor=$(echo "$normalized_version" | cut -d. -f2)
-      if [ "$major" -lt 2 ] || { [ "$major" -eq 2 ] && [ "$minor" -lt 4 ]; }; then
-        tag="v${version}"
-      else
-        tag="${version}"
-      fi
-    fi
+    echo "Warning: no sha256sum or shasum tool found, skipping checksum verification" >&2
+    return 0
   fi
 
-  echo "https://github.com/kubeshop/testkube/releases/download/${tag}/testkube_${version:-1}_${os}_$arch.tar.gz"
+  if ! curl -sSLf "${RELEASES_BASE_URL}/${TAG}/checksums.txt" >"${WORKDIR}/checksums.txt" 2>/dev/null; then
+    echo "Warning: could not download checksums.txt, skipping checksum verification" >&2
+    return 0
+  fi
+
+  EXPECTED="$(grep " ${TARBALL_NAME}\$" "${WORKDIR}/checksums.txt" | cut -d' ' -f1)"
+  if [ -z "${EXPECTED}" ]; then
+    echo "Warning: no checksum entry found for ${TARBALL_NAME}, skipping checksum verification" >&2
+    return 0
+  fi
+
+  if [ "${ACTUAL}" != "${EXPECTED}" ]; then
+    echo "Checksum verification failed for ${TARBALL_NAME}" >&2
+    echo "Expected: ${EXPECTED}" >&2
+    echo "Actual:   ${ACTUAL}" >&2
+    exit 1
+  fi
+  echo "Checksum verified"
 }
 
 _check_required_tools
 
-if [ "$1" = "beta" ]; then
-  url="$(_download_url "beta")"
-  echo "Downloading testkube from URL: $url"
-  curl -sSLf "$url" > testkube.tar.gz
-else
-  echo "Downloading testkube from URL: $(_download_url)"
-  curl -sSLf "$(_download_url)" > testkube.tar.gz
+ARCH="$(_detect_arch)"
+OS="$(_detect_os)"
+
+TAG="$(_resolve_tag "$1")"
+if [ -z "${TAG}" ]; then
+  echo "Could not determine the Testkube version to install." >&2
+  echo "Set TESTKUBE_VERSION explicitly and try again, e.g. TESTKUBE_VERSION=2.11.0" >&2
+  exit 1
 fi
 
-INSTALL_DIR=/usr/local/bin
+VERSION="${TAG#v}" # remove leading v if present
+TAG="$(_normalize_tag "${TAG}" "${VERSION}")"
+
+TARBALL_NAME="testkube_${VERSION}_${OS}_${ARCH}.tar.gz"
+URL="${RELEASES_BASE_URL}/${TAG}/${TARBALL_NAME}"
+
+WORKDIR="$(mktemp -d)"
+trap 'rm -rf "${WORKDIR}"' EXIT
+
+echo "Downloading testkube from URL: ${URL}"
+curl -sSLf "${URL}" >"${WORKDIR}/testkube.tar.gz"
+
+_verify_checksum "${WORKDIR}/testkube.tar.gz" "${TARBALL_NAME}"
+
+tar -xzf "${WORKDIR}/testkube.tar.gz" -C "${WORKDIR}" kubectl-testkube
 
 echo "Installing testkube into ${INSTALL_DIR}"
 INSTALL_PREFIX=""
-if ! [[ -w "$INSTALL_DIR" ]]; then
-  echo -e "\e[1;38;5;208m"
+if [ ! -w "${INSTALL_DIR}" ]; then
+  printf '\033[1;38;5;208m\n'
   echo "Looks like the current user does not have write access to ${INSTALL_DIR}"
   echo "You might be prompted to enter your password below by sudo"
-  echo -e "\e[0m"
+  printf '\033[0m\n'
   INSTALL_PREFIX=sudo
 fi
 
-tar -xzf testkube.tar.gz kubectl-testkube
-rm testkube.tar.gz
-${INSTALL_PREFIX} mv kubectl-testkube ${INSTALL_DIR}/kubectl-testkube
-${INSTALL_PREFIX} ln -sf ${INSTALL_DIR}/kubectl-testkube ${INSTALL_DIR}/testkube
-${INSTALL_PREFIX} ln -sf ${INSTALL_DIR}/kubectl-testkube ${INSTALL_DIR}/tk
+${INSTALL_PREFIX} mv "${WORKDIR}/kubectl-testkube" "${INSTALL_DIR}/kubectl-testkube"
+${INSTALL_PREFIX} ln -sf "${INSTALL_DIR}/kubectl-testkube" "${INSTALL_DIR}/testkube"
+${INSTALL_PREFIX} ln -sf "${INSTALL_DIR}/kubectl-testkube" "${INSTALL_DIR}/tk"
 
 echo "kubectl-testkube installed in:"
 echo "- ${INSTALL_DIR}/kubectl-testkube"
@@ -140,7 +184,7 @@ echo "- ${INSTALL_DIR}/testkube"
 echo "- ${INSTALL_DIR}/tk"
 echo ""
 
-if ! which helm &>/dev/null || ! which kubectl &>/dev/null; then
+if ! command -v helm >/dev/null 2>&1 || ! command -v kubectl >/dev/null 2>&1; then
   echo "You'll also need to install \`helm\` and \`kubectl\`."
   echo "- Install Helm: https://helm.sh/docs/intro/install/"
   echo "- Install kubectl: https://kubernetes.io/docs/tasks/tools/#kubectl"

--- a/install.sh
+++ b/install.sh
@@ -59,7 +59,7 @@ _resolve_tag() {
 
   if [ "$1" = "beta" ]; then
     TAG="$(
-      curl -sSf "${GITHUB_API}/releases" 2>/dev/null |
+      curl -sSLf "${GITHUB_API}/releases" 2>/dev/null |
         jq -r '[.[] | select(.prerelease)][0].tag_name // empty'
     )"
     if [ -n "${TAG}" ]; then
@@ -69,7 +69,7 @@ _resolve_tag() {
     echo "No pre-releases found. Installing latest release" >&2
   fi
 
-  curl -sSf "${GITHUB_API}/releases/latest" 2>/dev/null | jq -r '.tag_name // empty'
+  curl -sSLf "${GITHUB_API}/releases/latest" 2>/dev/null | jq -r '.tag_name // empty'
 }
 
 # Normalize the tag format based on the version number when a version is
@@ -121,7 +121,9 @@ _verify_checksum() {
     return 0
   fi
 
-  EXPECTED="$(grep " ${TARBALL_NAME}\$" "${WORKDIR}/checksums.txt" | cut -d' ' -f1)"
+  # Exact field match — the tarball name contains dots that grep would treat
+  # as regex wildcards.
+  EXPECTED="$(awk -v name="${TARBALL_NAME}" '$2 == name {print $1}' "${WORKDIR}/checksums.txt")"
   if [ -z "${EXPECTED}" ]; then
     echo "Warning: no checksum entry found for ${TARBALL_NAME}, skipping checksum verification" >&2
     return 0


### PR DESCRIPTION
## Summary

- Makes `install.sh` POSIX `sh` compatible — the documented install command (`curl -sSLf https://get.testkube.io | sh`) previously failed on Debian/Ubuntu where `sh` is dash, because the script used bash-only constructs (`[[ ]]`, `=~`, `set -o pipefail`). This also makes the upgrade hint surfaced by the CLI's install-source detection (`curl ... | sh`) actually work as documented.
- Removes dead code paths: `i386` assets are no longer published (goreleaser only builds amd64/arm64), the `Windows` uname case never matched (Git Bash reports `MINGW64_NT-...`), and the beta path grepped tag names for "beta" which has matched nothing since the v1.17 era — it now uses GitHub's `prerelease` flag with the same fallback to latest.
- Fails with a clear error (suggesting `TESTKUBE_VERSION=...`) when the version cannot be resolved from the GitHub API, instead of silently substituting `1` into the download URL.
- Verifies the downloaded tarball against the release's `checksums.txt` (via `sha256sum`/`shasum`); fails hard on mismatch, skips with a warning when no tool or checksum entry is available (e.g. pre-2.x releases).
- Downloads and extracts in a `mktemp -d` workdir with a cleanup trap instead of the caller's current directory.

The install dir stays hardcoded at `/usr/local/bin`, preserving the contract with the CLI's install-source detection (`cmd/kubectl-testkube/commands/common/install_source.go`).

## Test plan

- [x] `sh -n` and `dash -n` syntax checks pass
- [x] End-to-end install under `dash` (install dir redirected to a temp dir): latest release 2.11.0 downloaded, checksum verified, binary + `testkube`/`tk` symlinks created
- [x] `TESTKUBE_VERSION=2.10.1` → downloads tag `2.10.1`, checksum verified
- [x] `TESTKUBE_VERSION=1.17.68` → tag correctly normalized to `v1.17.68`, checksum verification gracefully skipped (release predates `checksums.txt`)
- [x] `install.sh beta` → no pre-releases found, falls back to latest

Made with [Cursor](https://cursor.com)