### PR TITLE
ci: tighten cache settings

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -12,3 +12,10 @@ test
 skaffold.yaml
 bin
 js/
+dist
+tmp
+.tmp
+*.log
+.DS_Store
+coverage.out
+.coverage

--- a/build/mcp-server/Dockerfile
+++ b/build/mcp-server/Dockerfile
@@ -5,6 +5,8 @@ ARG ALPINE_IMAGE=alpine:3.24.1
 FROM --platform=$BUILDPLATFORM golang:1.26-alpine AS build
 ARG TARGETOS
 ARG TARGETARCH
+ARG GOCACHE="/root/.cache/go-build"
+ARG GOMODCACHE="/go/pkg/mod"
 ARG VERSION=1.0.0
 ARG GIT_SHA=unknown
 
@@ -12,12 +14,14 @@ WORKDIR /build
 COPY . .
 
 # Build the kubectl-testkube binary with MCP support
-RUN cd cmd/kubectl-testkube && \
+RUN --mount=type=cache,target="$GOMODCACHE" \
+    --mount=type=cache,target="$GOCACHE" \
+    cd cmd/kubectl-testkube && \
     GOOS=$TARGETOS GOARCH=$TARGETARCH CGO_ENABLED=0 go build \
     -ldflags "-X github.com/kubeshop/testkube/pkg/version.Version=${VERSION} \
               -X github.com/kubeshop/testkube/pkg/version.Commit=${GIT_SHA}" \
     -o /app/kubectl-testkube \
-    -mod mod -a .
+    -mod mod .
 
 # Final stage
 FROM ${ALPINE_IMAGE}

--- a/build/new/api-server.Dockerfile
+++ b/build/new/api-server.Dockerfile
@@ -4,6 +4,8 @@ ARG ALPINE_IMAGE
 FROM --platform=$BUILDPLATFORM golang:1.26-alpine AS build
 ARG TARGETOS
 ARG TARGETARCH
+ARG GOCACHE="/root/.cache/go-build"
+ARG GOMODCACHE="/go/pkg/mod"
 
 ARG VERSION
 ARG GIT_SHA
@@ -15,7 +17,9 @@ ARG CLOUD_SEGMENTIO_KEY
 
 WORKDIR /build
 COPY . .
-RUN cd cmd/api-server; \
+RUN --mount=type=cache,target="$GOMODCACHE" \
+    --mount=type=cache,target="$GOCACHE" \
+    cd cmd/api-server; \
     GOOS=$TARGETOS GOARCH=$TARGETARCH CGO_ENABLED=0 go build -ldflags \
      "-X github.com/kubeshop/testkube/pkg/version.Version=${VERSION} \
       -X github.com/kubeshop/testkube/pkg/version.Commit=${GIT_SHA} \
@@ -24,7 +28,7 @@ RUN cd cmd/api-server; \
       -X github.com/kubeshop/testkube/pkg/telemetry.TestkubeMeasurementSecret=${ANALYTICS_API_KEY} \
       -X github.com/kubeshop/testkube/pkg/telemetry.SegmentioKey=${SEGMENTIO_KEY} \
       -X github.com/kubeshop/testkube/pkg/telemetry.CloudSegmentioKey=${CLOUD_SEGMENTIO_KEY}" \
-    -o /app -mod mod -a .
+    -o /app -mod mod .
 
 FROM ${ALPINE_IMAGE}
 RUN apk --no-cache upgrade && apk --no-cache add ca-certificates libssl3 git

--- a/build/new/tw-init.Dockerfile
+++ b/build/new/tw-init.Dockerfile
@@ -3,14 +3,18 @@ ARG BUSYBOX_IMAGE
 FROM --platform=$BUILDPLATFORM golang:1.26-alpine AS build
 ARG TARGETOS
 ARG TARGETARCH
+ARG GOCACHE="/root/.cache/go-build"
+ARG GOMODCACHE="/go/pkg/mod"
 WORKDIR /app
 COPY . .
-RUN cd cmd/testworkflow-init; \
+RUN --mount=type=cache,target="$GOMODCACHE" \
+    --mount=type=cache,target="$GOCACHE" \
+    cd cmd/testworkflow-init; \
     GOOS=$TARGETOS GOARCH=$TARGETARCH CGO_ENABLED=0 go build -ldflags \
        "-X github.com/kubeshop/testkube/pkg/version.Version=${VERSION} \
         -X github.com/kubeshop/testkube/pkg/version.Commit=${GIT_SHA} \
         -s -w" \
-    -o /app/testworkflow-init -mod mod -a .
+    -o /app/testworkflow-init -mod mod .
 
 
 FROM ${BUSYBOX_IMAGE}
@@ -18,5 +22,3 @@ RUN cp -rf /bin /.tktw-bin
 COPY --from=build /app/testworkflow-init /init
 USER 1001
 ENTRYPOINT ["/init"]
-
-

--- a/build/new/tw-toolkit.Dockerfile
+++ b/build/new/tw-toolkit.Dockerfile
@@ -4,21 +4,27 @@ ARG ALPINE_IMAGE
 FROM --platform=$BUILDPLATFORM golang:1.26-alpine AS build
 ARG TARGETOS
 ARG TARGETARCH
+ARG GOCACHE="/root/.cache/go-build"
+ARG GOMODCACHE="/go/pkg/mod"
 WORKDIR /app
 COPY . .
-RUN cd cmd/testworkflow-toolkit; \
+RUN --mount=type=cache,target="$GOMODCACHE" \
+    --mount=type=cache,target="$GOCACHE" \
+    cd cmd/testworkflow-toolkit; \
     GOOS=$TARGETOS GOARCH=$TARGETARCH CGO_ENABLED=0 go build -ldflags \
     "-X github.com/kubeshop/testkube/pkg/version.Version=${VERSION} \
      -X github.com/kubeshop/testkube/pkg/version.Commit=${GIT_SHA} \
      -s -w" \
-     -o /app/testworkflow-toolkit -mod mod -a .
+     -o /app/testworkflow-toolkit -mod mod .
 
-RUN cd cmd/testworkflow-init; \
+RUN --mount=type=cache,target="$GOMODCACHE" \
+    --mount=type=cache,target="$GOCACHE" \
+    cd cmd/testworkflow-init; \
     GOOS=$TARGETOS GOARCH=$TARGETARCH CGO_ENABLED=0 go build -ldflags \
     "-X github.com/kubeshop/testkube/pkg/version.Version=${VERSION} \
      -X github.com/kubeshop/testkube/pkg/version.Commit=${GIT_SHA} \
      -s -w" \
-     -o /app/testworkflow-init -mod mod -a .
+     -o /app/testworkflow-init -mod mod .
 
 FROM ${BUSYBOX_IMAGE} AS busybox
 FROM ${ALPINE_IMAGE}
@@ -29,4 +35,3 @@ COPY --from=build /app/testworkflow-init /init
 RUN adduser --disabled-password --home / --no-create-home --uid 1001 default
 USER 1001
 ENTRYPOINT ["/toolkit"]
-


### PR DESCRIPTION
## Pull request description 
In this PR
- Removed -a from Go go build commands in the Dockerfiles so Go can reuse valid artifacts instead of forcing full rebuilds every time.
- Added BuildKit cache mounts for Go module and build caches in th Dockerfiles
- Tightened .dockerignore by excluding obvious local/temp artifacts such as dist, temp directories, log files, coverage files, and .DS_Store.

## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [ ] tested locally
- [ ] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Breaking changes

-

## Changes

-

## Fixes

-