### PR TITLE
fix: logging level adjustments and configurable frequency

### DIFF
--- a/cmd/api-server/main.go
+++ b/cmd/api-server/main.go
@@ -189,11 +189,13 @@ func main() {
 	// Resolve the lease check interval once and reuse it across all lease consumers
 	// (events emitter, triggers, leader coordinator). Clamps unsafe values.
 	leaseCheckInterval := resolveLeaseCheckInterval(cfg.LeaseCheckInterval)
+	eventEmitterReconcileInterval := resolveEventEmitterReconcileInterval(cfg.EventEmitterReconcileInterval)
 
 	// TODO(emil): do we need a mongo/postgres backend for leases like for test triggers?
 	eventsEmitterLeaseBackend := leasebackendk8s.NewK8sLeaseBackend(clientset, "testkube-agent-"+cfg.APIServerFullname, cfg.TestkubeNamespace)
 	eventsEmitter := event.NewEmitter(eventBus, eventsEmitterLeaseBackend, "agentevents", cfg.TestkubeClusterName, event.DefaultEventTTL, event.DefaultEventCacheCapacity,
 		event.WithLeaseCheckInterval(leaseCheckInterval),
+		event.WithReconcileInterval(eventEmitterReconcileInterval),
 		event.WithLeaderElectionDisabled(cfg.LeaderElectionDisabled))
 
 	// Connect to the Control Plane
@@ -1063,6 +1065,13 @@ func resolveLeaseCheckInterval(interval time.Duration) time.Duration {
 			"clamped", maxSafe.String(),
 			"leaseDuration", leasebackend.DefaultMaxLeaseDuration.String())
 		return maxSafe
+	}
+	return interval
+}
+
+func resolveEventEmitterReconcileInterval(interval time.Duration) time.Duration {
+	if interval <= 0 {
+		return event.DefaultReconcileInterval
 	}
 	return interval
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -218,6 +218,8 @@ type Config struct {
 	// single-replica deployments; tune how often the lease is checked/renewed.
 	LeaderElectionDisabled bool          `envconfig:"LEADER_ELECTION_DISABLED" default:"false"`
 	LeaseCheckInterval     time.Duration `envconfig:"LEASE_CHECK_INTERVAL" default:"5s"`
+	// How often the event emitter leader reloads webhook/listener configuration.
+	EventEmitterReconcileInterval time.Duration `envconfig:"EVENT_EMITTER_RECONCILE_INTERVAL" default:"5s"`
 
 	TestkubeProWorkerCount          int      `envconfig:"TESTKUBE_PRO_WORKER_COUNT" default:"50"`
 	TestkubeProLogStreamWorkerCount int      `envconfig:"TESTKUBE_PRO_LOG_STREAM_WORKER_COUNT" default:"25"`

--- a/pkg/controlplaneclient/utils.go
+++ b/pkg/controlplaneclient/utils.go
@@ -474,7 +474,6 @@ func processNotifications[Request notificationRequest, Response any, Srv notific
 
 			// Handle the error
 			if err != nil {
-				logger.Errorw("process notifications error", "error", err)
 				return err
 			}
 
@@ -497,14 +496,12 @@ func processNotifications[Request notificationRequest, Response any, Srv notific
 				req = result.req
 				err = result.err
 				if err != nil {
-					logger.Errorw("process notifications error", "error", err)
 					return err
 				}
 			case <-ctx.Done():
 				return ctx.Err()
 			case <-time.After(recvTimeout):
 				err = errors.New("receive request too slow")
-				logger.Errorw("process notifications error", "error", err)
 				return err
 			}
 

--- a/pkg/event/emitter.go
+++ b/pkg/event/emitter.go
@@ -18,7 +18,7 @@ import (
 )
 
 const (
-	reconcileInterval                = time.Second
+	DefaultReconcileInterval           = 5 * time.Second
 	eventEmitterQueueName     string = "emitter"
 	DefaultEventTTL                  = 1 * time.Hour
 	DefaultEventCacheCapacity        = 100000
@@ -43,6 +43,16 @@ func WithLeaseCheckInterval(interval time.Duration) EmitterOption {
 	return func(e *Emitter) {
 		if interval > 0 {
 			e.leaseCheckInterval = interval
+		}
+	}
+}
+
+// WithReconcileInterval overrides how often the leader reloads listeners from
+// registered loaders. Non-positive values are ignored (the default is kept).
+func WithReconcileInterval(interval time.Duration) EmitterOption {
+	return func(e *Emitter) {
+		if interval > 0 {
+			e.reconcileInterval = interval
 		}
 	}
 }
@@ -82,6 +92,7 @@ func NewEmitter(eventBus bus.Bus, leaseBackend leasebackend.Repository, subjectR
 		eventCache:          cache,
 		leaseClusterID:      DefaultLeaseClusterID,
 		leaseCheckInterval:  defaultLeaseCheckInterval,
+		reconcileInterval:   DefaultReconcileInterval,
 	}
 	for _, opt := range opts {
 		opt(e)
@@ -108,6 +119,7 @@ type Emitter struct {
 	clusterName            string
 	leaseClusterID         string
 	leaseCheckInterval     time.Duration
+	reconcileInterval      time.Duration
 	leaderElectionDisabled bool
 	eventCache             *ttlcache.Cache[string, bool]
 }
@@ -322,7 +334,7 @@ func (e *Emitter) leaderLoop(ctx context.Context) {
 		"subject", subscribeSubject)
 	// Reconcilation loop
 	e.log.Info("event emitter leader started reconciler")
-	ticker := time.NewTicker(reconcileInterval)
+	ticker := time.NewTicker(e.reconcileInterval)
 	for {
 		select {
 		case <-ctx.Done():

--- a/pkg/event/emitter_test.go
+++ b/pkg/event/emitter_test.go
@@ -887,3 +887,35 @@ func TestEmitterLeaseClusterID(t *testing.T) {
 		assert.True(t, <-leaseChan)
 	})
 }
+
+func TestEmitterReconcileInterval(t *testing.T) {
+	t.Run("default reconcile interval", func(t *testing.T) {
+		eventBus := bus.NewEventBusMock()
+		mockCtrl := gomock.NewController(t)
+		defer mockCtrl.Finish()
+		mockLeaseRepo := leasebackend.NewMockRepository(mockCtrl)
+		emitter := NewEmitter(eventBus, mockLeaseRepo, "agentevents", "", DefaultEventTTL, DefaultEventCacheCapacity)
+		defer emitter.eventCache.Stop()
+		assert.Equal(t, DefaultReconcileInterval, emitter.reconcileInterval)
+	})
+
+	t.Run("WithReconcileInterval overrides default", func(t *testing.T) {
+		eventBus := bus.NewEventBusMock()
+		mockCtrl := gomock.NewController(t)
+		defer mockCtrl.Finish()
+		mockLeaseRepo := leasebackend.NewMockRepository(mockCtrl)
+		emitter := NewEmitter(eventBus, mockLeaseRepo, "agentevents", "", DefaultEventTTL, DefaultEventCacheCapacity, WithReconcileInterval(12*time.Second))
+		defer emitter.eventCache.Stop()
+		assert.Equal(t, 12*time.Second, emitter.reconcileInterval)
+	})
+
+	t.Run("WithReconcileInterval non-positive does not override", func(t *testing.T) {
+		eventBus := bus.NewEventBusMock()
+		mockCtrl := gomock.NewController(t)
+		defer mockCtrl.Finish()
+		mockLeaseRepo := leasebackend.NewMockRepository(mockCtrl)
+		emitter := NewEmitter(eventBus, mockLeaseRepo, "agentevents", "", DefaultEventTTL, DefaultEventCacheCapacity, WithReconcileInterval(0))
+		defer emitter.eventCache.Stop()
+		assert.Equal(t, DefaultReconcileInterval, emitter.reconcileInterval)
+	})
+}

--- a/pkg/event/emitter_test.go
+++ b/pkg/event/emitter_test.go
@@ -236,6 +236,8 @@ func TestEmitter_GroupedListenersReceiveQueuedAndStartedWorkflowEvents(t *testin
 }
 
 func TestEmitter_Listen_reconciliation(t *testing.T) {
+	const reconcileInterval = 100 * time.Millisecond
+
 	t.Run("emitter refresh listeners in reconcile loop", func(t *testing.T) {
 		eventBus := bus.NewEventBusMock()
 		mockCtrl := gomock.NewController(t)
@@ -244,7 +246,7 @@ func TestEmitter_Listen_reconciliation(t *testing.T) {
 		mockLeaseRepository.EXPECT().
 			TryAcquire(gomock.Any(), gomock.Any(), gomock.Any()).
 			Return(true, nil).AnyTimes()
-		emitter := NewEmitter(eventBus, mockLeaseRepository, "agentevents", "", DefaultEventTTL, DefaultEventCacheCapacity)
+		emitter := NewEmitter(eventBus, mockLeaseRepository, "agentevents", "", DefaultEventTTL, DefaultEventCacheCapacity, WithReconcileInterval(reconcileInterval))
 		defer emitter.eventCache.Stop()
 		emitter.RegisterLoader(&dummy.DummyLoader{IdPrefix: "dummy1"})
 		emitter.RegisterLoader(&dummy.DummyLoader{IdPrefix: "dummy2"})
@@ -262,7 +264,7 @@ func TestEmitter_Listen_reconciliation(t *testing.T) {
 		emitter.RegisterLoader(&dummy.DummyLoader{IdPrefix: "dummy3"})
 
 		// then each reconciler (3 reconcilers) should load 2 listeners
-		time.Sleep(1100 * time.Millisecond)
+		time.Sleep(2 * reconcileInterval)
 		assert.Len(t, emitter.getListeners(), 6)
 	})
 
@@ -274,7 +276,7 @@ func TestEmitter_Listen_reconciliation(t *testing.T) {
 		mockLeaseRepository.EXPECT().
 			TryAcquire(gomock.Any(), gomock.Any(), gomock.Any()).
 			Return(true, nil).AnyTimes()
-		emitter := NewEmitter(eventBus, mockLeaseRepository, "agentevents", "", DefaultEventTTL, DefaultEventCacheCapacity)
+		emitter := NewEmitter(eventBus, mockLeaseRepository, "agentevents", "", DefaultEventTTL, DefaultEventCacheCapacity, WithReconcileInterval(reconcileInterval))
 		defer emitter.eventCache.Stop()
 		registeredListener := &dummy.DummyListener{Id: "registered", Types: []testkube.EventType{
 			testkube.BECOME_TESTWORKFLOW_UP_EventType,
@@ -295,7 +297,7 @@ func TestEmitter_Listen_reconciliation(t *testing.T) {
 		// on next reconiliation loop
 		emitter.RegisterLoader(&dummy.DummyLoader{IdPrefix: "dummy1", SelectorString: "v2"})
 
-		time.Sleep(1100 * time.Millisecond)
+		time.Sleep(2 * reconcileInterval)
 		assert.Len(t, emitter.getListeners(), 3)
 		assert.Equal(t, "v2", emitter.getListeners()[1].Selector())
 	})
@@ -308,7 +310,7 @@ func TestEmitter_Listen_reconciliation(t *testing.T) {
 		mockLeaseRepository.EXPECT().
 			TryAcquire(gomock.Any(), gomock.Any(), gomock.Any()).
 			Return(true, nil).AnyTimes()
-		emitter := NewEmitter(eventBus, mockLeaseRepository, "agentevents", "", DefaultEventTTL, DefaultEventCacheCapacity)
+		emitter := NewEmitter(eventBus, mockLeaseRepository, "agentevents", "", DefaultEventTTL, DefaultEventCacheCapacity, WithReconcileInterval(reconcileInterval))
 		defer emitter.eventCache.Stop()
 		loader := &dummy.DummyLoader{IdPrefix: "dummy1", SelectorString: "v1"}
 		registeredListener := &dummy.DummyListener{Id: "registered", Types: []testkube.EventType{
@@ -331,7 +333,7 @@ func TestEmitter_Listen_reconciliation(t *testing.T) {
 		loader.ListenersOverride = []common.Listener{}
 
 		// Wait to next reconcillation loop
-		time.Sleep(1100 * time.Millisecond)
+		time.Sleep(2 * reconcileInterval)
 		// Only the registered listener should remain
 		assert.Len(t, emitter.getListeners(), 1)
 		assert.Equal(t, "registered", emitter.getListeners()[0].Name())

--- a/pkg/event/kind/webhook/loader.go
+++ b/pkg/event/kind/webhook/loader.go
@@ -159,7 +159,6 @@ func (r WebhooksLoader) Load() (listeners common.Listeners, err error) {
 	// load all webhooks from kubernetes CRDs
 	webhookList, err := r.webhookClient.List("")
 	if err != nil {
-		r.log.Errorw("failed to list webhooks", "error", err)
 		return listeners, err
 	}
 

--- a/pkg/event/kind/webhook/loader.go
+++ b/pkg/event/kind/webhook/loader.go
@@ -176,7 +176,7 @@ func (r WebhooksLoader) Load() (listeners common.Listeners, err error) {
 			}
 
 			if webhookTemplate.Spec.Disabled {
-				r.log.Errorw("error webhook template is disabled", "name", webhook.Name, "template", webhook.Spec.WebhookTemplateRef.Name)
+				r.log.Debugw("webhook template is disabled", "name", webhook.Name, "template", webhook.Spec.WebhookTemplateRef.Name)
 				continue
 			}
 

--- a/pkg/event/loader.go
+++ b/pkg/event/loader.go
@@ -33,7 +33,7 @@ func (s *loader) Reconcile() (listeners common.Listeners) {
 		log.Tracef(s.Log, "Got listeners from loader %T %+v\n", loader, l)
 
 		if err != nil {
-			s.Log.Errorw("error loading listeners", "error", err)
+			s.Log.Warnw("error loading listeners", "error", err)
 			continue
 		}
 		listeners = append(listeners, l...)

--- a/pkg/runner/agent.go
+++ b/pkg/runner/agent.go
@@ -95,7 +95,7 @@ func (a *agentLoop) Start(ctx context.Context, withRunnerRequests bool) error {
 					// After context cancellation exit the loop.
 					return
 				case err != nil:
-					a.logger.Errorw("error running agent connection",
+					a.logger.Warnw("error running agent connection",
 						"name", name,
 						"error", err)
 				}

--- a/pkg/runner/agent_conn_test.go
+++ b/pkg/runner/agent_conn_test.go
@@ -143,8 +143,8 @@ func TestAgentLoop_GetRunnerRequests_ReconnectionOnReceiveTimeout(t *testing.T) 
 		"test-env",
 	)
 
-	// Create context with timeout longer than 2x receive timeout + reconnect timeout
-	ctx, cancel := context.WithTimeout(context.Background(), (2*testTimeout)+agentLoopReconnectionDelay)
+	// Create context with timeout long enough for two receive timeouts and reconnect delays.
+	ctx, cancel := context.WithTimeout(context.Background(), 2*(testTimeout+agentLoopReconnectionDelay)+500*time.Millisecond)
 	defer cancel()
 
 	// Start the agent loop
@@ -213,8 +213,8 @@ func TestAgentLoop_GetNotifications_ReconnectionOnReceiveTimeout(t *testing.T) {
 		"test-env",
 	)
 
-	// Create context with timeout longer than 2x receive timeout + reconnect timeout
-	ctx, cancel := context.WithTimeout(context.Background(), (2*testTimeout)+agentLoopReconnectionDelay)
+	// Create context with timeout long enough for two receive timeouts and reconnect delays.
+	ctx, cancel := context.WithTimeout(context.Background(), 2*(testTimeout+agentLoopReconnectionDelay)+500*time.Millisecond)
 	defer cancel()
 
 	// Start the agent loop
@@ -225,8 +225,7 @@ func TestAgentLoop_GetNotifications_ReconnectionOnReceiveTimeout(t *testing.T) {
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "context deadline exceeded")
 
-	// Should have made multiple calls due to receive timeout reconnections
-	// Each call should timeout after 2 seconds, so we expect at least 2 calls in 7 seconds
-	assert.GreaterOrEqual(t, testServer.GetCallCount(), 2,
-		"Expected at least 2 calls due to receive timeout reconnections, got %d", testServer.GetCallCount())
+	// Should have made multiple notification stream connections due to receive timeout reconnections
+	assert.GreaterOrEqual(t, testServer.GetNotificationStreamCallCount(), 2,
+		"Expected at least 2 notification stream calls due to receive timeout reconnections, got %d", testServer.GetNotificationStreamCallCount())
 }

--- a/pkg/runner/mock_grpc_server.go
+++ b/pkg/runner/mock_grpc_server.go
@@ -28,6 +28,7 @@ type testGRPCServer struct {
 	getTestWorkflowServiceNotificationsSendPing           bool
 	getTestWorkflowParallelStepNotificationsSendPing      bool
 	callCount                                             int
+	notificationStreamCallCount                           int
 	mu                                                    sync.Mutex
 }
 
@@ -67,6 +68,10 @@ func (s *testGRPCServer) GetRunnerRequests(stream cloud.TestKubeCloudAPI_GetRunn
 }
 
 func (s *testGRPCServer) GetTestWorkflowNotificationsStream(stream cloud.TestKubeCloudAPI_GetTestWorkflowNotificationsStreamServer) error {
+	s.mu.Lock()
+	s.notificationStreamCallCount++
+	s.mu.Unlock()
+
 	if s.getTestWorkflowNotificationsErrorToReturn != nil {
 		return s.getTestWorkflowNotificationsErrorToReturn
 	}
@@ -140,6 +145,12 @@ func (s *testGRPCServer) GetCallCount() int {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	return s.callCount
+}
+
+func (s *testGRPCServer) GetNotificationStreamCallCount() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.notificationStreamCallCount
 }
 
 // Helper function to create a test gRPC server and client

--- a/pkg/testworkflows/executionworker/controller/controller.go
+++ b/pkg/testworkflows/executionworker/controller/controller.go
@@ -99,7 +99,7 @@ func New(parentCtx context.Context, clientSet kubernetes.Interface, namespace, i
 
 		// There was a job or pod for this execution, so we may only assume it is aborted
 		if !watcher.State().JobEvents().FirstTimestamp().IsZero() || !watcher.State().PodEvents().FirstTimestamp().IsZero() {
-			log.DefaultLogger.Errorw("connecting to aborted execution", "executionId", watcher.State().ResourceId(), "debug", watcher.State().Debug())
+			log.DefaultLogger.Warnw("connecting to aborted execution", "executionId", watcher.State().ResourceId(), "debug", watcher.State().Debug())
 			return nil, ErrJobAborted
 		}
 

--- a/pkg/triggers/watcher.go
+++ b/pkg/triggers/watcher.go
@@ -407,7 +407,7 @@ func (s *Service) startCloudTestTriggerWatch(ctx context.Context, stop <-chan st
 		for _, namespace := range namespaces {
 			list, err := s.testTriggersClient.List(ctx, s.getEnvironmentId(), testtriggerclient.ListOptions{}, namespace)
 			if err != nil {
-				s.logger.Errorf("trigger service: error listing cloud test triggers in namespace %q: %v", namespace, err)
+				s.logger.Warnf("trigger service: error listing cloud test triggers in namespace %q: %v", namespace, err)
 				failedNamespaces[namespace] = struct{}{}
 				continue
 			}

--- a/pkg/triggers/watcher.go
+++ b/pkg/triggers/watcher.go
@@ -311,7 +311,7 @@ func (s *Service) startCloudWorkflowTriggerWatch(ctx context.Context, stop <-cha
 		for _, namespace := range namespaces {
 			list, err := s.workflowTriggersClient.List(ctx, s.getEnvironmentId(), workflowtriggerclient.ListOptions{}, namespace)
 			if err != nil {
-				s.logger.Errorf("trigger service: error listing cloud workflow triggers in namespace %q: %v", namespace, err)
+				s.logger.Warnf("trigger service: error listing cloud workflow triggers in namespace %q: %v", namespace, err)
 				failedNamespaces[namespace] = struct{}{}
 				continue
 			}


### PR DESCRIPTION
- Logging updates
   - Removed `failed to list webhooks` log from WebhookLoader when webhooks fail to load entirely. This function already returns the error and the higher level orchestrator will log accordingly.
   - Remove `process notifications error` logs from utils/processesNotifications. Similar reasoning, these return the errors and they are already logged higher up.
   - Downgrade `webhook template is disabled` to a debug. This is intentional configuration of the webhook, not an error.
   - Downgrade `error loading listeners` to a warn. We will attempt self healing in the next reconcile loop.
   - Downgrade `error running agent connection` to warn. Same as above.
   - Downgrade `error listing cloud workflow triggers` to warn. Similar to above, this will attempt a self heal in the next loop.
   - Downgrade `error listing cloud test triggers` to warn. Same as above.
   - Downgrade `connecting to aborted execution` to warn. This is an abnormal situation, but is handled via the returned error. 
- Other updates
   -  Make the webhook/listener reconcile interval configurable and extend the default to 5 seconds. 1 second intervals can lead to log spam, especially in the case of transient network issues.