### PR TITLE
fix: default standalone agent to PostgreSQL instead of MongoDB

### DIFF
--- a/cmd/kubectl-testkube/commands/common/helper.go
+++ b/cmd/kubectl-testkube/commands/common/helper.go
@@ -226,7 +226,7 @@ func HelmUpgradeOrInstallTestkube(options HelmOptions) *CLIError {
 		return NewCLIError(
 			TKErrInvalidInstallConfig,
 			"Invalid database configuration",
-			"No database backend selected. Use PostgreSQL (default), or pass --no-postgres to use MongoDB. If you are using an external DB, enable exactly one backend via --values/--helm-set so the API receives the correct DSN.",
+			"No database backend selected. Use PostgreSQL (default), or pass --no-mongo=false --no-postgres to use MongoDB. If you are using an external DB, enable exactly one backend via --helm-set so the API receives the correct DSN.",
 			errors.New("both MongoDB and PostgreSQL are disabled; no database backend is selected"),
 		)
 	}

--- a/cmd/kubectl-testkube/commands/common/helper.go
+++ b/cmd/kubectl-testkube/commands/common/helper.go
@@ -215,6 +215,18 @@ func HelmUninstall(namespace string, releaseName string) *CLIError {
 }
 
 func HelmUpgradeOrInstallTestkube(options HelmOptions) *CLIError {
+	// Exactly one bundled database backend may be selected. With PostgreSQL as the
+	// default, enabling MongoDB via --no-mongo=false without also passing
+	// --no-postgres would leave both enabled and the API pointed at PostgreSQL.
+	if !options.NoMongo && !options.NoPostgres {
+		return NewCLIError(
+			TKErrInvalidInstallConfig,
+			"Invalid database configuration",
+			"Select exactly one database backend: pass --no-postgres to use MongoDB, or --no-mongo (the default) to use PostgreSQL.",
+			errors.New("both MongoDB and PostgreSQL are enabled; exactly one database backend must be selected"),
+		)
+	}
+
 	helmPath, err := lookupHelmPath()
 	if err != nil {
 		return err
@@ -396,8 +408,14 @@ func prepareCommonHelmArgs(options HelmOptions) ([]string, map[string]string) {
 		"testkube-api.multinamespace.enabled": fmt.Sprintf("%t", options.MultiNamespace),
 		"testkube-api.minio.enabled":          fmt.Sprintf("%t", !options.NoMinio),
 		"testkube-operator.installCRD":        fmt.Sprintf("%t", !options.NoCRDs),
-		"mongodb.enabled":                     fmt.Sprintf("%t", !options.NoMongo),
-		"postgresql.enabled":                  fmt.Sprintf("%t", !options.NoPostgres),
+		// Toggle both the dependency sub-chart (deploys the database) and the API
+		// backend selection (which DSN the API uses) from the same flags, so the DB
+		// choice works via CLI flags alone. Power users can still override any of
+		// these via --helm-set (SetOptions take precedence in appendHelmArgs).
+		"mongodb.enabled":                 fmt.Sprintf("%t", !options.NoMongo),
+		"postgresql.enabled":              fmt.Sprintf("%t", !options.NoPostgres),
+		"testkube-api.mongodb.enabled":    fmt.Sprintf("%t", !options.NoMongo),
+		"testkube-api.postgresql.enabled": fmt.Sprintf("%t", !options.NoPostgres),
 	}
 
 	if options.MinioReplicas > 0 {

--- a/cmd/kubectl-testkube/commands/common/helper.go
+++ b/cmd/kubectl-testkube/commands/common/helper.go
@@ -433,8 +433,8 @@ func PopulateHelmFlags(cmd *cobra.Command, options *HelmOptions) {
 	cmd.Flags().StringVar(&options.Values, "values", "", "path to Helm values file")
 
 	cmd.Flags().BoolVar(&options.NoMinio, "no-minio", false, "don't install MinIO")
-	cmd.Flags().BoolVar(&options.NoMongo, "no-mongo", false, "don't install MongoDB")
-	cmd.Flags().BoolVar(&options.NoPostgres, "no-postgres", true, "don't install PostgreSQL")
+	cmd.Flags().BoolVar(&options.NoMongo, "no-mongo", true, "don't install MongoDB (PostgreSQL is the default database; pass --no-mongo=false --no-postgres to use MongoDB instead)")
+	cmd.Flags().BoolVar(&options.NoPostgres, "no-postgres", false, "don't install PostgreSQL (default database)")
 	cmd.Flags().BoolVar(&options.NoConfirm, "no-confirm", false, "don't ask for confirmation - unatended installation mode")
 	cmd.Flags().BoolVar(&options.DryRun, "dry-run", false, "dry run mode - only print commands that would be executed")
 	cmd.Flags().BoolVar(&options.EmbeddedNATS, "embedded-nats", false, "embedded NATS server in agent")

--- a/cmd/kubectl-testkube/commands/common/helper.go
+++ b/cmd/kubectl-testkube/commands/common/helper.go
@@ -451,7 +451,7 @@ func PopulateHelmFlags(cmd *cobra.Command, options *HelmOptions) {
 	cmd.Flags().StringVar(&options.Values, "values", "", "path to Helm values file")
 
 	cmd.Flags().BoolVar(&options.NoMinio, "no-minio", false, "don't install MinIO")
-	cmd.Flags().BoolVar(&options.NoMongo, "no-mongo", true, "don't install MongoDB (default). To use MongoDB, also set Helm values to point the API at MongoDB (testkube-api.mongodb.enabled=true and testkube-api.postgresql.enabled=false)")
+	cmd.Flags().BoolVar(&options.NoMongo, "no-mongo", true, "don't install MongoDB (default). To use MongoDB instead of PostgreSQL, pass --no-mongo=false --no-postgres")
 	cmd.Flags().BoolVar(&options.NoPostgres, "no-postgres", false, "don't install PostgreSQL (default database)")
 	cmd.Flags().BoolVar(&options.NoConfirm, "no-confirm", false, "don't ask for confirmation - unattended installation mode")
 	cmd.Flags().BoolVar(&options.DryRun, "dry-run", false, "dry run mode - only print commands that would be executed")

--- a/cmd/kubectl-testkube/commands/common/helper.go
+++ b/cmd/kubectl-testkube/commands/common/helper.go
@@ -433,7 +433,7 @@ func PopulateHelmFlags(cmd *cobra.Command, options *HelmOptions) {
 	cmd.Flags().StringVar(&options.Values, "values", "", "path to Helm values file")
 
 	cmd.Flags().BoolVar(&options.NoMinio, "no-minio", false, "don't install MinIO")
-	cmd.Flags().BoolVar(&options.NoMongo, "no-mongo", true, "don't install MongoDB (PostgreSQL is the default database; pass --no-mongo=false --no-postgres to use MongoDB instead)")
+	cmd.Flags().BoolVar(&options.NoMongo, "no-mongo", true, "don't install MongoDB (default). To use MongoDB, also set Helm values to point the API at MongoDB (testkube-api.mongodb.enabled=true and testkube-api.postgresql.enabled=false)")
 	cmd.Flags().BoolVar(&options.NoPostgres, "no-postgres", false, "don't install PostgreSQL (default database)")
 	cmd.Flags().BoolVar(&options.NoConfirm, "no-confirm", false, "don't ask for confirmation - unattended installation mode")
 	cmd.Flags().BoolVar(&options.DryRun, "dry-run", false, "dry run mode - only print commands that would be executed")

--- a/cmd/kubectl-testkube/commands/common/helper.go
+++ b/cmd/kubectl-testkube/commands/common/helper.go
@@ -215,15 +215,28 @@ func HelmUninstall(namespace string, releaseName string) *CLIError {
 }
 
 func HelmUpgradeOrInstallTestkube(options HelmOptions) *CLIError {
-	// Exactly one bundled database backend may be selected. With PostgreSQL as the
-	// default, enabling MongoDB via --no-mongo=false without also passing
-	// --no-postgres would leave both backends enabled and inject both DSNs into the API.
-	if !options.NoMongo && !options.NoPostgres {
+	// Exactly one database backend should be active for a standard standalone install.
+	// Prevent the two invalid states:
+	//  - both enabled (would inject both DSNs)
+	//  - both disabled (would inject no DSN, leaving the API without a backend)
+	mongoEnabled := !options.NoMongo
+	postgresEnabled := !options.NoPostgres
+
+	if !mongoEnabled && !postgresEnabled && options.Values == "" && options.SetOptions["testkube-api.mongodb.enabled"] != "true" && options.SetOptions["testkube-api.postgresql.enabled"] != "true" {
 		return NewCLIError(
 			TKErrInvalidInstallConfig,
 			"Invalid database configuration",
-			"Select exactly one database backend: pass --no-postgres to use MongoDB, or --no-mongo (the default) to use PostgreSQL.",
-			errors.New("both MongoDB and PostgreSQL are enabled; exactly one database backend must be selected"),
+			"No database backend selected. Use PostgreSQL (default), or pass --no-postgres to use MongoDB. If you are using an external DB, enable exactly one backend via --values/--helm-set so the API receives the correct DSN.",
+			errors.New("both MongoDB and PostgreSQL are disabled; no database backend is selected"),
+		)
+	}
+
+	if mongoEnabled && postgresEnabled {
+		return NewCLIError(
+			TKErrInvalidInstallConfig,
+			"Invalid database configuration",
+			"MongoDB and PostgreSQL cannot both be enabled: pass --no-postgres to use MongoDB, or --no-mongo (the default) to use PostgreSQL.",
+			errors.New("both MongoDB and PostgreSQL are enabled; only one database backend may be selected"),
 		)
 	}
 

--- a/cmd/kubectl-testkube/commands/common/helper.go
+++ b/cmd/kubectl-testkube/commands/common/helper.go
@@ -226,7 +226,7 @@ func HelmUpgradeOrInstallTestkube(options HelmOptions) *CLIError {
 		return NewCLIError(
 			TKErrInvalidInstallConfig,
 			"Invalid database configuration",
-			"No database backend selected. Use PostgreSQL (default), or pass --no-mongo=false --no-postgres to use MongoDB. If you are using an external DB, enable exactly one backend via --helm-set so the API receives the correct DSN.",
+			"No database backend selected. Use PostgreSQL (default), or pass --no-mongo=false --no-postgres to use MongoDB.",
 			errors.New("both MongoDB and PostgreSQL are disabled; no database backend is selected"),
 		)
 	}

--- a/cmd/kubectl-testkube/commands/common/helper.go
+++ b/cmd/kubectl-testkube/commands/common/helper.go
@@ -222,7 +222,7 @@ func HelmUpgradeOrInstallTestkube(options HelmOptions) *CLIError {
 	mongoEnabled := !options.NoMongo
 	postgresEnabled := !options.NoPostgres
 
-	if !mongoEnabled && !postgresEnabled && options.SetOptions["testkube-api.mongodb.enabled"] != "true" && options.SetOptions["testkube-api.postgresql.enabled"] != "true" {
+	if !mongoEnabled && !postgresEnabled {
 		return NewCLIError(
 			TKErrInvalidInstallConfig,
 			"Invalid database configuration",

--- a/cmd/kubectl-testkube/commands/common/helper.go
+++ b/cmd/kubectl-testkube/commands/common/helper.go
@@ -217,7 +217,7 @@ func HelmUninstall(namespace string, releaseName string) *CLIError {
 func HelmUpgradeOrInstallTestkube(options HelmOptions) *CLIError {
 	// Exactly one bundled database backend may be selected. With PostgreSQL as the
 	// default, enabling MongoDB via --no-mongo=false without also passing
-	// --no-postgres would leave both enabled and the API pointed at PostgreSQL.
+	// --no-postgres would leave both backends enabled and inject both DSNs into the API.
 	if !options.NoMongo && !options.NoPostgres {
 		return NewCLIError(
 			TKErrInvalidInstallConfig,

--- a/cmd/kubectl-testkube/commands/common/helper.go
+++ b/cmd/kubectl-testkube/commands/common/helper.go
@@ -222,7 +222,7 @@ func HelmUpgradeOrInstallTestkube(options HelmOptions) *CLIError {
 	mongoEnabled := !options.NoMongo
 	postgresEnabled := !options.NoPostgres
 
-	if !mongoEnabled && !postgresEnabled && options.Values == "" && options.SetOptions["testkube-api.mongodb.enabled"] != "true" && options.SetOptions["testkube-api.postgresql.enabled"] != "true" {
+	if !mongoEnabled && !postgresEnabled && options.SetOptions["testkube-api.mongodb.enabled"] != "true" && options.SetOptions["testkube-api.postgresql.enabled"] != "true" {
 		return NewCLIError(
 			TKErrInvalidInstallConfig,
 			"Invalid database configuration",

--- a/cmd/kubectl-testkube/commands/common/helper.go
+++ b/cmd/kubectl-testkube/commands/common/helper.go
@@ -435,7 +435,7 @@ func PopulateHelmFlags(cmd *cobra.Command, options *HelmOptions) {
 	cmd.Flags().BoolVar(&options.NoMinio, "no-minio", false, "don't install MinIO")
 	cmd.Flags().BoolVar(&options.NoMongo, "no-mongo", true, "don't install MongoDB (PostgreSQL is the default database; pass --no-mongo=false --no-postgres to use MongoDB instead)")
 	cmd.Flags().BoolVar(&options.NoPostgres, "no-postgres", false, "don't install PostgreSQL (default database)")
-	cmd.Flags().BoolVar(&options.NoConfirm, "no-confirm", false, "don't ask for confirmation - unatended installation mode")
+	cmd.Flags().BoolVar(&options.NoConfirm, "no-confirm", false, "don't ask for confirmation - unattended installation mode")
 	cmd.Flags().BoolVar(&options.DryRun, "dry-run", false, "dry run mode - only print commands that would be executed")
 	cmd.Flags().BoolVar(&options.EmbeddedNATS, "embedded-nats", false, "embedded NATS server in agent")
 }

--- a/cmd/kubectl-testkube/commands/upgrade.go
+++ b/cmd/kubectl-testkube/commands/upgrade.go
@@ -113,7 +113,7 @@ func NewUpgradeCmd() *cobra.Command {
 						options.NoMongo = true
 						options.NoPostgres = false
 					default:
-					ui.Errf("Could not detect the existing database type (no in-cluster MongoDB/PostgreSQL found). Re-run with explicit --no-mongo/--no-postgres to avoid switching databases during upgrade (especially if you use an external database or customized resource names).")
+						ui.Errf("Could not detect the existing database type (no in-cluster MongoDB/PostgreSQL found). Re-run with explicit --no-mongo/--no-postgres to avoid switching databases during upgrade (especially if you use an external database or customized resource names).")
 						os.Exit(1)
 					}
 				}

--- a/cmd/kubectl-testkube/commands/upgrade.go
+++ b/cmd/kubectl-testkube/commands/upgrade.go
@@ -101,14 +101,26 @@ func NewUpgradeCmd() *cobra.Command {
 					if cliErr != nil {
 						common.HandleCLIError(cliErr)
 					}
+
+					if options.SetOptions == nil {
+						options.SetOptions = make(map[string]string)
+					}
+
 					switch dbType {
 					case config.DatabaseTypeMongoDB:
 						ui.Info("Detected existing MongoDB installation - preserving MongoDB as the database backend")
 						options.NoMongo = false
 						options.NoPostgres = true
+						options.SetOptions["testkube-api.mongodb.enabled"] = "true"
+						options.SetOptions["testkube-api.postgresql.enabled"] = "false"
 					case config.DatabaseTypePostgreSQL:
 						options.NoMongo = true
 						options.NoPostgres = false
+						options.SetOptions["testkube-api.mongodb.enabled"] = "false"
+						options.SetOptions["testkube-api.postgresql.enabled"] = "true"
+					default:
+						ui.Errf("Could not detect the existing database type. Re-run with explicit --no-mongo/--no-postgres to avoid switching databases during upgrade.")
+						os.Exit(1)
 					}
 				}
 

--- a/cmd/kubectl-testkube/commands/upgrade.go
+++ b/cmd/kubectl-testkube/commands/upgrade.go
@@ -91,6 +91,27 @@ func NewUpgradeCmd() *cobra.Command {
 			} else {
 				ui.Info("Updating Testkube")
 
+				// Fresh installs default to PostgreSQL, but an upgrade must never silently
+				// switch the database of an existing installation: doing so would disable the
+				// running MongoDB sub-chart and point the API at an empty PostgreSQL, orphaning
+				// the user's data. Preserve whichever database is currently deployed unless the
+				// user explicitly overrode the flags.
+				if !cmd.Flags().Changed("no-mongo") && !cmd.Flags().Changed("no-postgres") {
+					dbType, cliErr := common.DetectDatabaseType(options.Namespace)
+					if cliErr != nil {
+						common.HandleCLIError(cliErr)
+					}
+					switch dbType {
+					case config.DatabaseTypeMongoDB:
+						ui.Info("Detected existing MongoDB installation - preserving MongoDB as the database backend")
+						options.NoMongo = false
+						options.NoPostgres = true
+					case config.DatabaseTypePostgreSQL:
+						options.NoMongo = true
+						options.NoPostgres = false
+					}
+				}
+
 				if cliErr := common.HelmUpgradeOrInstallTestkube(options); cliErr != nil {
 					cliErr.Print()
 					os.Exit(1)

--- a/cmd/kubectl-testkube/commands/upgrade.go
+++ b/cmd/kubectl-testkube/commands/upgrade.go
@@ -113,7 +113,7 @@ func NewUpgradeCmd() *cobra.Command {
 						options.NoMongo = true
 						options.NoPostgres = false
 					default:
-						ui.Errf("Could not detect the existing database type. Re-run with explicit --no-mongo/--no-postgres to avoid switching databases during upgrade.")
+					ui.Errf("Could not detect the existing database type (no in-cluster MongoDB/PostgreSQL found). Re-run with explicit --no-mongo/--no-postgres to avoid switching databases during upgrade (especially if you use an external database or customized resource names).")
 						os.Exit(1)
 					}
 				}

--- a/cmd/kubectl-testkube/commands/upgrade.go
+++ b/cmd/kubectl-testkube/commands/upgrade.go
@@ -102,22 +102,16 @@ func NewUpgradeCmd() *cobra.Command {
 						common.HandleCLIError(cliErr)
 					}
 
-					if options.SetOptions == nil {
-						options.SetOptions = make(map[string]string)
-					}
-
+					// Only set the flags; prepareCommonHelmArgs derives both the
+					// sub-chart toggles and the API backend selection from them.
 					switch dbType {
 					case config.DatabaseTypeMongoDB:
 						ui.Info("Detected existing MongoDB installation - preserving MongoDB as the database backend")
 						options.NoMongo = false
 						options.NoPostgres = true
-						options.SetOptions["testkube-api.mongodb.enabled"] = "true"
-						options.SetOptions["testkube-api.postgresql.enabled"] = "false"
 					case config.DatabaseTypePostgreSQL:
 						options.NoMongo = true
 						options.NoPostgres = false
-						options.SetOptions["testkube-api.mongodb.enabled"] = "false"
-						options.SetOptions["testkube-api.postgresql.enabled"] = "true"
 					default:
 						ui.Errf("Could not detect the existing database type. Re-run with explicit --no-mongo/--no-postgres to avoid switching databases during upgrade.")
 						os.Exit(1)

--- a/k8s/helm/testkube-api/README.md
+++ b/k8s/helm/testkube-api/README.md
@@ -156,7 +156,7 @@ A Helm chart for Testkube api
 | minio.tolerations | list | `[]` |  |
 | mongodb.allowDiskUse | bool | `true` |  |
 | mongodb.dsn | string | `"mongodb://testkube-mongodb:27017"` |  |
-| mongodb.enabled | bool | `true` |  |
+| mongodb.enabled | bool | `false` |  |
 | multinamespace.enabled | bool | `false` |  |
 | nameOverride | string | `""` |  |
 | nats.embedded | bool | `false` |  |
@@ -180,7 +180,7 @@ A Helm chart for Testkube api
 | postgresql.secretKey | string | `""` |  |
 | postgresql.secretName | string | `""` |  |
 | priorityClassName | string | `""` |  |
-| prometheus.enabled | bool | `false` |  |
+| prometheus.enabled | bool | `true` |  |
 | prometheus.interval | string | `"15s"` |  |
 | prometheus.monitoringLabels | object | `{}` |  |
 | rbac.create | bool | `true` |  |

--- a/k8s/helm/testkube-api/README.md
+++ b/k8s/helm/testkube-api/README.md
@@ -176,11 +176,11 @@ A Helm chart for Testkube api
 | podSecurityContext | object | `{}` |  |
 | podStartTimeout | string | `"30m"` | Testkube timeout for pod start |
 | postgresql.dsn | string | `"postgres://testkube:postgres5432@testkube-postgresql:5432/backend?sslmode=disable"` |  |
-| postgresql.enabled | bool | `false` |  |
+| postgresql.enabled | bool | `true` |  |
 | postgresql.secretKey | string | `""` |  |
 | postgresql.secretName | string | `""` |  |
 | priorityClassName | string | `""` |  |
-| prometheus.enabled | bool | `true` |  |
+| prometheus.enabled | bool | `false` |  |
 | prometheus.interval | string | `"15s"` |  |
 | prometheus.monitoringLabels | object | `{}` |  |
 | rbac.create | bool | `true` |  |

--- a/k8s/helm/testkube-api/values.yaml
+++ b/k8s/helm/testkube-api/values.yaml
@@ -587,7 +587,7 @@ service:
 ##MongoDB parameters
 mongodb:
   ## Deploy MongoDB server to the cluster
-  enabled: true
+  enabled: false
   dsn: "mongodb://testkube-mongodb:27017"
   ## or use dsn in secrets
   # secretName: testkube-secrets
@@ -626,7 +626,7 @@ mongodb:
 ##PostgreSQL parameters
 postgresql:
   ## Deploy PostgreSQL server to the cluster
-  enabled: false
+  enabled: true
   ## Define PostgreSQL DSN connection string
   dsn: "postgres://testkube:postgres5432@testkube-postgresql:5432/backend?sslmode=disable"
   ## Name of the Kubernetes secret containing the PostgreSQL DSN

--- a/k8s/helm/testkube/README.md
+++ b/k8s/helm/testkube/README.md
@@ -184,7 +184,7 @@ kubectl label --overwrite crds scripts.tests.testkube.io app.kubernetes.io/manag
 | global.volumes.additionalVolumes | list | `[]` | Additional volumes to be added to the Testkube API container and Test Jobs containers |
 | mongodb.auth.enabled | bool | `false` | Toggle whether to enable MongoDB authentication |
 | mongodb.containerSecurityContext | object | `{}` | Security Context for MongoDB container |
-| mongodb.enabled | bool | `true` | Toggle whether to install MongoDB |
+| mongodb.enabled | bool | `false` | Toggle whether to install MongoDB |
 | mongodb.fullnameOverride | string | `"testkube-mongodb"` | MongoDB fullname override |
 | mongodb.image.pullSecrets | list | `[]` | MongoDB image pull Secret |
 | mongodb.image.registry | string | `"docker.io"` | MongoDB image registry |
@@ -210,7 +210,7 @@ kubectl label --overwrite crds scripts.tests.testkube.io app.kubernetes.io/manag
 | postgresql.auth.password | string | `postgres5432` | Password for the custom user to create in PostgreSQL |
 | postgresql.auth.postgresPassword | string | `postgres1234` | Password for the "postgres" admin user in PostgreSQL |
 | postgresql.fullnameOverride | string | `"testkube-postgresql"` | PostgreSQL fullname override |
-| postgresql.enabled | bool | `false` | Toggle whether to install PostgreSQL |
+| postgresql.enabled | bool | `true` | Toggle whether to install PostgreSQL |
 | postgresql.global.security.allowInsecureImages | bool | `true` | Allows skipping image verification for PostgreSQL |
 | postgresql.image.pullSecrets | list | `[]` | PostgreSQL image pull Secret |
 | postgresql.image.registry | string | `"docker.io"` | PostgreSQL image registry |
@@ -346,7 +346,7 @@ kubectl label --overwrite crds scripts.tests.testkube.io app.kubernetes.io/manag
 | testkube-api.minio.tolerations | list | `[]` | Tolerations to schedule a workload to nodes with any architecture type. Required for deployment to GKE cluster. |
 | testkube-api.mongodb.allowDiskUse | bool | `true` | Allow or prohibit writing temporary files on disk when a pipeline stage exceeds the 100 megabyte limit. |
 | testkube-api.mongodb.dsn | string | `"mongodb://testkube-mongodb:27017"` | MongoDB DSN |
-| testkube-api.mongodb.enabled | bool | `true` | use MongoDB |
+| testkube-api.mongodb.enabled | bool | `false` | use MongoDB |
 | testkube-api.multinamespace.enabled | bool | `false` |  |
 | testkube-api.nameOverride | string | `"api-server"` | Testkube API name override |
 | testkube-api.nats.embedded | bool | `false` | Start NATS embedded server in api binary instead of separate deployment |
@@ -487,7 +487,7 @@ kubectl label --overwrite crds scripts.tests.testkube.io app.kubernetes.io/manag
 | testkube-operator.podLabels | object | `{}` |  |
 | testkube-operator.podSecurityContext | object | `{}` | Testkube Operator Pod Security Context |
 | testkube-api.postgresql.dsn | string | `"postgres://testkube:postgres5432@testkube-postgresql:5432/backend?sslmode=disable"` | PostgreSQL DSN |
-| testkube-api.postgresql.enabled | bool | `false` | use PostgreSQL |
+| testkube-api.postgresql.enabled | bool | `true` | use PostgreSQL |
 | testkube-api.postgresql.secretKey | string | `""` | Secret key for PostgreSQL DSN |
 | testkube-api.postgresql.secretName | string | `""` | Secret name with PostgreSQL DSN |
 | testkube-operator.preUpgrade.annotations | object | `{}` |  |

--- a/k8s/helm/testkube/values.yaml
+++ b/k8s/helm/testkube/values.yaml
@@ -78,7 +78,7 @@ global:
 # For more configuration parameters of MongoDB chart please look here: https://github.com/bitnami/charts/tree/master/bitnami/mongodb#parameters
 mongodb:
   # -- Toggle whether to install MongoDB
-  enabled: true
+  enabled: false
   # -- MongoDB fullname override
   fullnameOverride: "testkube-mongodb"
   # MongoDB Auth settings
@@ -214,7 +214,7 @@ mongodb:
 # For more configuration parameters of PostgreSQL chart please look here: https://github.com/bitnami/charts/tree/main/bitnami/postgresql#parameters
 postgresql:
   # -- Toggle whether to install PostgreSQL
-  enabled: false
+  enabled: true
   # -- PostgreSQL fullname override
   fullnameOverride: "testkube-postgresql"
   # -- PostgreSQL architecture
@@ -1087,7 +1087,7 @@ testkube-api:
   # MongoDB parameters
   mongodb:
     # -- Enable MongoDB
-    enabled: true
+    enabled: false
     # -- MongoDB DSN
     dsn: "mongodb://testkube-mongodb:27017"
     # secretName: testkube-secrets
@@ -1121,7 +1121,7 @@ testkube-api:
     # sslCertSecretSecretKey: sslCertSecretSecretKey
 
   postgresql:
-    enabled: false
+    enabled: true
     # -- PostgreSQL DSN
     dsn: "postgres://testkube:postgres5432@testkube-postgresql:5432/backend?sslmode=disable"
     # -- Secret name with PostgreSQL DSN

--- a/pkg/event/emitter.go
+++ b/pkg/event/emitter.go
@@ -18,7 +18,7 @@ import (
 )
 
 const (
-	DefaultReconcileInterval           = 5 * time.Second
+	DefaultReconcileInterval         = 5 * time.Second
 	eventEmitterQueueName     string = "emitter"
 	DefaultEventTTL                  = 1 * time.Hour
 	DefaultEventCacheCapacity        = 100000


### PR DESCRIPTION
Switch the default database for the Testkube standalone (OSS) agent from MongoDB to PostgreSQL, across both the CLI init command and the Helm charts.

- CLI: flip `--no-mongo` (false->true) and `--no-postgres` (true->false) defaults in PopulateHelmFlags so `testkube init standalone-agent` installs PostgreSQL by default. MongoDB remains available via `--no-mongo=false --no-postgres`.
- Helm: default `mongodb.enabled=false` / `postgresql.enabled=true` in the umbrella chart (top-level and nested testkube-api) and the testkube-api subchart, so direct `helm install` also defaults to PostgreSQL.

The API server selects its backend from whichever DSN env var is injected, so no server code change is needed.

## Pull request description 



## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [x] tested locally
- [x] tested on cluster
- [ ] added new dependencies
- [x] updated the docs
- [ ] added a test

## Breaking changes

-

## Changes

-

## Fixes

-