### PR TITLE
fix: make testworkflow-init runs deterministic across environments

### DIFF
--- a/cmd/testworkflow-init/runner/action_handlers.go
+++ b/cmd/testworkflow-init/runner/action_handlers.go
@@ -2,6 +2,7 @@ package runner
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -305,9 +306,65 @@ func appendSuffixIfNeeded(s, suffix string) string {
 	return s + suffix
 }
 
+type metricsFile struct {
+	path string
+	info os.FileInfo
+}
+
+// collectMetricsFiles lists the files the metrics recorder produced in dir.
+// A missing directory means the recorder had nothing to record.
+func collectMetricsFiles(dir string) ([]metricsFile, error) {
+	var files []metricsFile
+	err := filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if info.IsDir() {
+			return nil
+		}
+		files = append(files, metricsFile{path: path, info: info})
+		return nil
+	})
+	if os.IsNotExist(err) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("failed to list metrics files in %q: %v", dir, err)
+	}
+	return files, nil
+}
+
+// uploadMetricsFiles saves every collected file, best effort per file: one
+// unreadable or failed file should not prevent scraping the remaining metrics.
+func uploadMetricsFiles(storage artifacts.InternalArtifactStorage, files []metricsFile) error {
+	var errs []error
+	for _, file := range files {
+		f, err := os.Open(file.path)
+		if err != nil {
+			errs = append(errs, fmt.Errorf("failed to open metrics file %q: %v", file.path, err))
+			continue
+		}
+		target := filepath.Join("metrics", filepath.Base(file.path))
+		saveErr := storage.SaveFile(target, f, file.info)
+		f.Close()
+		if saveErr != nil {
+			errs = append(errs, fmt.Errorf("failed to save stream to %q: %v", target, saveErr))
+		}
+	}
+	return errors.Join(errs...)
+}
+
 func scrapeMetricsPostProcessor(path, step string, config testworkflowconfig.InternalConfig) func() error {
 	return func() error {
-		err := orchestration.Setup.UseCurrentEnv()
+		// When the recorder produced nothing, there is nothing to upload and
+		// connecting to the storage would only stall the step for the
+		// connection deadline.
+		files, err := collectMetricsFiles(path)
+		if err != nil || len(files) == 0 {
+			return err
+		}
+
+		err = orchestration.Setup.UseCurrentEnv()
 		if err != nil {
 			return fmt.Errorf("failed to configure environment for scraping metrics: %v", err)
 		}
@@ -323,25 +380,7 @@ func scrapeMetricsPostProcessor(path, step string, config testworkflowconfig.Int
 		if err != nil {
 			return fmt.Errorf("failed to create internal storage for metrics: %v", err)
 		}
-		err = filepath.Walk(path, func(path string, info os.FileInfo, err error) error {
-			if info.IsDir() {
-				return nil
-			}
-			if err != nil {
-				return err
-			}
-			f, err := os.Open(path)
-			if err != nil {
-				return fmt.Errorf("failed to open metrics file %q: %v", path, err)
-			}
-			defer f.Close()
-			path = filepath.Join("metrics", filepath.Base(path))
-			if err := storage.SaveFile(path, f, info); err != nil {
-				return fmt.Errorf("failed to save stream to %q: %v", path, err)
-			}
-			return nil
-		})
-		return err
+		return uploadMetricsFiles(storage, files)
 	}
 }
 

--- a/cmd/testworkflow-init/runner/action_handlers_test.go
+++ b/cmd/testworkflow-init/runner/action_handlers_test.go
@@ -1,9 +1,14 @@
 package runner
 
 import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/kubeshop/testkube/cmd/testworkflow-init/data"
 	"github.com/kubeshop/testkube/pkg/testworkflows/testworkflowconfig"
@@ -48,5 +53,96 @@ func TestNewMetricsRecorderConfig_SkipFlag(t *testing.T) {
 		cfg := newMetricsRecorderConfig("step1", true, testworkflowconfig.ContainerResourceConfig{})
 
 		assert.True(t, cfg.Skip)
+	})
+}
+
+type fakeArtifactStorage struct {
+	saved   []string
+	failFor map[string]bool
+}
+
+func (s *fakeArtifactStorage) FullPath(artifactPath string) string { return artifactPath }
+func (s *fakeArtifactStorage) SaveStream(artifactPath string, stream io.Reader) error {
+	return nil
+}
+func (s *fakeArtifactStorage) SaveFile(artifactPath string, r io.Reader, info os.FileInfo) error {
+	if s.failFor[filepath.Base(artifactPath)] {
+		return fmt.Errorf("save failed")
+	}
+	s.saved = append(s.saved, artifactPath)
+	return nil
+}
+func (s *fakeArtifactStorage) Wait() error { return nil }
+
+func TestCollectMetricsFiles(t *testing.T) {
+	tests := []struct {
+		name      string
+		dir       func(t *testing.T) string
+		wantFiles int
+		wantErr   bool
+	}{
+		{
+			name:      "missing directory means nothing to record",
+			dir:       func(t *testing.T) string { return filepath.Join(t.TempDir(), "missing") },
+			wantFiles: 0,
+		},
+		{
+			name:      "empty directory yields no files",
+			dir:       func(t *testing.T) string { return t.TempDir() },
+			wantFiles: 0,
+		},
+		{
+			name: "collects files and skips directories",
+			dir: func(t *testing.T) string {
+				dir := t.TempDir()
+				require.NoError(t, os.WriteFile(filepath.Join(dir, "a.json"), []byte("{}"), 0644))
+				require.NoError(t, os.MkdirAll(filepath.Join(dir, "sub"), 0755))
+				require.NoError(t, os.WriteFile(filepath.Join(dir, "sub", "b.json"), []byte("{}"), 0644))
+				return dir
+			},
+			wantFiles: 2,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			files, err := collectMetricsFiles(tt.dir(t))
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Len(t, files, tt.wantFiles)
+		})
+	}
+}
+
+func TestUploadMetricsFiles(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "a.json"), []byte("{}"), 0644))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "b.json"), []byte("{}"), 0644))
+	files, err := collectMetricsFiles(dir)
+	require.NoError(t, err)
+	require.Len(t, files, 2)
+
+	t.Run("uploads all files", func(t *testing.T) {
+		storage := &fakeArtifactStorage{}
+		require.NoError(t, uploadMetricsFiles(storage, files))
+		assert.Len(t, storage.saved, 2)
+	})
+
+	t.Run("one failure does not stop the remaining uploads", func(t *testing.T) {
+		storage := &fakeArtifactStorage{failFor: map[string]bool{"a.json": true}}
+		err := uploadMetricsFiles(storage, files)
+		require.Error(t, err)
+		assert.Len(t, storage.saved, 1)
+	})
+
+	t.Run("unreadable file is reported but others are saved", func(t *testing.T) {
+		missing := append([]metricsFile{{path: filepath.Join(dir, "gone.json"), info: files[0].info}}, files...)
+		storage := &fakeArtifactStorage{}
+		err := uploadMetricsFiles(storage, missing)
+		require.Error(t, err)
+		assert.Len(t, storage.saved, 2)
 	})
 }

--- a/cmd/testworkflow-init/runner/runner.go
+++ b/cmd/testworkflow-init/runner/runner.go
@@ -3,7 +3,6 @@ package runner
 import (
 	"context"
 	"fmt"
-	"os"
 	"os/signal"
 	"syscall"
 	"time"
@@ -28,15 +27,8 @@ const (
 // Group 0 runs setup actions, groups 1+ run test steps.
 // Returns 0 on success, 137 on abort, or other exit codes on failure.
 func RunInit(groupIndex int) (int, error) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
-	sigCh := make(chan os.Signal, 1)
-	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
-	go func() {
-		<-sigCh
-		cancel()
-	}()
+	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer stop()
 
 	return RunInitWithContext(ctx, groupIndex)
 }
@@ -62,7 +54,8 @@ func RunInitWithContext(ctx context.Context, groupIndex int) (int, error) {
 
 	currentContainer := lite.LiteActionContainer{}
 
-	setupAbortHandler(ctx)
+	stopAbortHandler := setupAbortHandler(ctx)
+	defer stopAbortHandler()
 
 	state := data.GetState()
 
@@ -129,12 +122,13 @@ func RunInitWithContext(ctx context.Context, groupIndex int) (int, error) {
 	}
 }
 
-// setupAbortHandler sets up context-based abort handling
-func setupAbortHandler(ctx context.Context) {
-	go func() {
-		<-ctx.Done()
-		orchestration.Executions.Abort()
-	}()
+// setupAbortHandler aborts the executions when the context ends while the run
+// is still in progress. The returned stop function detaches the handler:
+// without it, the deferred context cancellation of a finished run would later
+// call Abort() on the process-global execution group and poison the next run
+// sharing the process.
+func setupAbortHandler(ctx context.Context) (stop func() bool) {
+	return context.AfterFunc(ctx, orchestration.Executions.Abort)
 }
 
 // setupControlServer sets up the control server for pause/resume functionality

--- a/cmd/testworkflow-init/runner/runner_internal_test.go
+++ b/cmd/testworkflow-init/runner/runner_internal_test.go
@@ -1,0 +1,57 @@
+package runner
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/kubeshop/testkube/cmd/testworkflow-init/orchestration"
+)
+
+func TestSetupAbortHandler(t *testing.T) {
+	orchestration.Initialize()
+
+	tests := []struct {
+		name        string
+		detach      bool
+		wantAborted bool
+	}{
+		{
+			name:        "aborts executions when the context ends during the run",
+			detach:      false,
+			wantAborted: true,
+		},
+		{
+			name:        "never aborts once the handler is detached",
+			detach:      true,
+			wantAborted: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			orchestration.Executions.ClearAbortedStatus()
+			t.Cleanup(orchestration.Executions.ClearAbortedStatus)
+
+			ctx, cancel := context.WithCancel(context.Background())
+			stop := setupAbortHandler(ctx)
+			if tt.detach {
+				assert.True(t, stop(), "handler should detach before the context ends")
+			} else {
+				defer stop()
+			}
+			cancel()
+
+			if tt.wantAborted {
+				require.Eventually(t, orchestration.Executions.IsAborted, time.Second, 5*time.Millisecond)
+			} else {
+				time.Sleep(50 * time.Millisecond)
+				assert.False(t, orchestration.Executions.IsAborted(),
+					"a detached handler must not abort a subsequent run")
+			}
+		})
+	}
+}

--- a/cmd/testworkflow-toolkit/env/client.go
+++ b/cmd/testworkflow-toolkit/env/client.go
@@ -158,6 +158,11 @@ func CloudInternal() (cloud.TestKubeCloudAPIClient, error) {
 	var err error
 	if cloudClient == nil {
 		cfg := config2.Config().Worker.Connection
+		if cfg.Url == "" {
+			// Dialing an empty address blocks for the full connection deadline
+			// before failing; report the missing configuration right away.
+			return nil, fmt.Errorf("failed to connect with Cloud: control plane URL is not configured")
+		}
 		logger := log.NewSilent()
 		// TODO(dejan): now metrics are scrapped on each workflow execution and we get an error when connecting to Control Plane even with publicly trusted certificates.
 		// Until a better solution is implemented, TLS verification will be skipped.


### PR DESCRIPTION
## How

Three fixes that together make init runs behave the same regardless of environment.

RunInit cancels its context when it returns, and setupAbortHandler reacted to any context end by calling Abort() on the process-global execution group, with no way to detach. Every finished run therefore fired an asynchronous Abort() that could land during the next run in the same process and make its first command return exit code 137 immediately. This is why TestInitProcessCore_Integration/ExecuteCommand failed on some runners and passed on others: the outcome depended on goroutine scheduling latency, not on the code under test. The handler is now registered with context.AfterFunc and detached when the run returns. RunInit also switches to signal.NotifyContext, which releases the signal registration it previously leaked on every call. A unit test pins both handler behaviors.

The metrics post-processor connected to the control plane before checking whether the recorder produced any files, so every execute action in an environment without a reachable control plane stalled for the full connection deadline. It now collects the files first and skips the connection when there is nothing to upload. This also fixes the walk callback checking info.IsDir() before the error, which could dereference a nil info.

CloudInternal dialed even when the worker connection URL was empty, blocking for the whole deadline before failing. It now reports the missing configuration immediately.

The init integration suite failed deterministically on pristine main in a golang:1.26 container. With these changes it passes three consecutive runs there and drops from 76s to 5s, since each execute action no longer pays a 10 second dial timeout.