### PR TITLE
fix(logs): reconnect a running container's log stream on any break, not just EOF

### DIFF
--- a/pkg/testworkflows/executionworker/controller/logs.go
+++ b/pkg/testworkflows/executionworker/controller/logs.go
@@ -405,7 +405,9 @@ func watchContainerLogsWithStream(parentCtx context.Context, opener logStreamOpe
 					return
 				}
 
+				logBufferMu.Lock()
 				logLen := logBufferLog.Len()
+				logBufferMu.Unlock()
 				if logLen == 0 {
 					select {
 					case <-bufferCtx.Done():
@@ -491,19 +493,30 @@ func watchContainerLogsWithStream(parentCtx context.Context, opener logStreamOpe
 				lastTs = tsReader.ts
 			}
 
-			// If the stream is finished,
-			// either the logfile has been rotated, or the container actually finished.
-			// Consider the container is done only when either:
-			// - there was EOF without any logs since, or
-			// - the last expected instruction was already delivered
-			if err == io.EOF && (!readerAnyContent || completed) {
+			// The logs are finished only when the container is: the last expected
+			// instruction was delivered, or there is no more content and the container
+			// reports finished. Any other EOF is a broken connection to reconnect,
+			// never the end of logs.
+			logsFinished := completed || (!readerAnyContent && isDone())
+			if errors.Is(err, io.EOF) && logsFinished {
 				return
 			}
 
-			// If there was EOF, and we are not sure if container is done,
-			// reinitialize the stream from the time we have finished.
-			// Similarly for GOAWAY, that may be caused by too long connection.
-			if err == io.EOF || (err != nil && strings.Contains(err.Error(), "GOAWAY")) {
+			// Any other read error means the stream broke, and we do not care why (a
+			// connection reset, a GOAWAY, a load balancer cutting a long-lived socket).
+			// While the container is still running we reopen from just after the last
+			// line we saw and keep tailing; a contentless reopen backs off first so a
+			// stream that fails immediately cannot busy-loop. ErrInvalidTimestamp is a
+			// content-parse issue, not a broken stream, so it falls through to the
+			// handler below.
+			if err != nil && !errors.Is(err, ErrInvalidTimestamp) {
+				if !readerAnyContent {
+					select {
+					case <-ctx.Done():
+						return
+					case <-time.After(LogRetryOnConnectionLostDelay):
+					}
+				}
 				since = common.Ptr(lastTs.Add(1))
 				stream, err = openStream(since)
 				if err != nil {

--- a/pkg/testworkflows/executionworker/controller/logs_test.go
+++ b/pkg/testworkflows/executionworker/controller/logs_test.go
@@ -346,6 +346,16 @@ func (r *blockingReader) Read(p []byte) (int, error) {
 	return 0, r.ctx.Err()
 }
 
+// errReader fails every read with a non-EOF error, standing in for a connection
+// reset, an idle-timed-out socket, or a load balancer cutting a long-lived stream.
+type errReader struct {
+	err error
+}
+
+func (r *errReader) Read(p []byte) (int, error) {
+	return 0, r.err
+}
+
 func TestWatchContainerLogsIdleTimeoutCancelsWhenDoneWithoutError(t *testing.T) {
 	t.Parallel()
 
@@ -542,8 +552,100 @@ func TestWatchContainerLogsReopensOnEOF(t *testing.T) {
 	ch := watchContainerLogsWithStream(
 		ctx,
 		func(_ context.Context, _ kubernetes.Interface, _, _, _ string, _ func() bool, _ *time.Time) (io.Reader, error) {
-			call := atomic.AddInt32(&calls, 1)
-			if call == 1 {
+			if atomic.AddInt32(&calls, 1) == 1 {
+				return bytes.NewBufferString(line), nil
+			}
+			// Every reopen after the first returns a contentless EOF.
+			return bytes.NewBuffer(nil), nil
+		},
+		nil,
+		"default",
+		"pod",
+		"container",
+		testBufferSizeLarge,
+		func() bool { return false }, // container still running
+		func(*instructions.Instruction) bool { return false },
+		testIdleTimeoutDefault,
+	)
+
+	// A contentless EOF while the container is still running is an idle timeout, not
+	// end of logs, so the source must re-follow instead of closing. Consume frames
+	// for a window: the channel must not close, and the opener must be called
+	// repeatedly (each re-follow reopens the stream).
+	deadline := time.After(testDeadlineMedium)
+	for {
+		select {
+		case msg, ok := <-ch:
+			if !ok {
+				t.Fatal("source ended on a contentless EOF while the container was still running")
+			}
+			if msg.Error != nil {
+				t.Fatalf("unexpected error from logs channel: %v", msg.Error)
+			}
+		case <-deadline:
+			assert.GreaterOrEqual(t, atomic.LoadInt32(&calls), int32(3),
+				"expected repeated re-follows on a contentless EOF while running")
+			return
+		}
+	}
+}
+
+func TestWatchContainerLogsReopensOnNonEOFError(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	var calls int32
+	ch := watchContainerLogsWithStream(
+		ctx,
+		func(_ context.Context, _ kubernetes.Interface, _, _, _ string, _ func() bool, _ *time.Time) (io.Reader, error) {
+			atomic.AddInt32(&calls, 1)
+			// A broken read that is neither EOF nor GOAWAY, e.g. a connection reset.
+			return &errReader{err: fmt.Errorf("read tcp 10.0.0.1:443: connection reset by peer")}, nil
+		},
+		nil,
+		"default",
+		"pod",
+		"container",
+		testBufferSizeLarge,
+		func() bool { return false }, // container still running
+		func(*instructions.Instruction) bool { return false },
+		testIdleTimeoutDefault,
+	)
+
+	// A broken read while the container is still running must reopen and keep tailing
+	// regardless of the error cause, not surface the error or close the source.
+	deadline := time.After(testDeadlineMedium)
+	for {
+		select {
+		case msg, ok := <-ch:
+			if !ok {
+				t.Fatal("source ended on a non-EOF read error while the container was still running")
+			}
+			if msg.Error != nil {
+				t.Fatalf("unexpected error surfaced instead of reconnecting: %v", msg.Error)
+			}
+		case <-deadline:
+			assert.GreaterOrEqual(t, atomic.LoadInt32(&calls), int32(3),
+				"expected repeated reopens on a non-EOF read error while running")
+			return
+		}
+	}
+}
+
+func TestWatchContainerLogsEndsOnContentlessEOFWhenDone(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	var calls int32
+	line := "2024-06-07T12:41:49.037275300Z hello\n"
+	ch := watchContainerLogsWithStream(
+		ctx,
+		func(_ context.Context, _ kubernetes.Interface, _, _, _ string, _ func() bool, _ *time.Time) (io.Reader, error) {
+			if atomic.AddInt32(&calls, 1) == 1 {
 				return bytes.NewBufferString(line), nil
 			}
 			return bytes.NewBuffer(nil), nil
@@ -553,31 +655,23 @@ func TestWatchContainerLogsReopensOnEOF(t *testing.T) {
 		"pod",
 		"container",
 		testBufferSizeLarge,
-		func() bool { return false },
+		func() bool { return true }, // container already done
 		func(*instructions.Instruction) bool { return false },
 		testIdleTimeoutDefault,
 	)
 
+	// With the container done, a contentless EOF after the drained content is a real
+	// end of logs and must close the source.
 	deadline := time.NewTimer(testDeadlineMedium)
 	defer deadline.Stop()
-
-	var gotLog bool
 	for {
 		select {
-		case msg, ok := <-ch:
+		case _, ok := <-ch:
 			if !ok {
-				assert.True(t, gotLog, "expected at least one log message before channel close")
-				assert.GreaterOrEqual(t, atomic.LoadInt32(&calls), int32(2))
 				return
 			}
-			if msg.Error != nil {
-				t.Fatalf("unexpected error from logs channel: %v", msg.Error)
-			}
-			if bytes.Contains(msg.Value.Log, []byte("hello")) {
-				gotLog = true
-			}
 		case <-deadline.C:
-			t.Fatal("timed out waiting for log stream to close")
+			t.Fatal("source did not end on a contentless EOF while the container was done")
 		}
 	}
 }


### PR DESCRIPTION
## How

The agent's container log watcher followed a stream and only knew how to recover from two named failures: an `io.EOF` (reconnect) and an error containing `GOAWAY` (reconnect). Every other broken read, a connection reset, an idle-timed-out socket, a load balancer cutting a long-lived connection, fell through to forward the error and keep reading from the same dead stream. On top of that, a contentless idle EOF was treated as end of logs even while the container was still running, so a test that stays quiet during the run and only prints near the end ended its live-log source early and tore the session down.

The watcher now stops only when the container is done: the last expected instruction was delivered, or there is no more content and the container reports finished. Any other end of the followed stream is treated as a broken connection and reconnected, regardless of the cause. The reconnect resumes from just after the last line already seen, and a contentless reopen backs off briefly so a stream that fails immediately cannot busy-loop. A parse-level `ErrInvalidTimestamp` is left on its existing content path rather than reconnecting.

Reopening routes back through the existing open-time retry classifier, so connection-lost, TLS, and proxy errors keep their bounded retry/backoff behavior; a genuinely unretryable open error still terminates the watch.

Also locks the log buffer around the length read in the flush goroutine, closing a pre-existing race that the longer-lived source made reachable.