### PR TITLE
fix(runner): resume live logs across reconnects instead of resetting the stream

### DIFF
--- a/pkg/controlplaneclient/client.go
+++ b/pkg/controlplaneclient/client.go
@@ -2,6 +2,7 @@ package controlplaneclient
 
 import (
 	"strings"
+	"sync"
 	"time"
 
 	"go.uber.org/zap"
@@ -22,6 +23,15 @@ type client struct {
 	proContext config.ProContext
 	opts       ClientOptions
 	logger     *zap.SugaredLogger
+
+	// Persistent notification stream session managers, one per stream kind, created
+	// lazily on first use with the agent's long-lived context. Keeping them across gRPC
+	// reconnects preserves each session's replay buffer and pod-log source, so a
+	// reconnect resumes from the cursor instead of falling back to resume_unavailable.
+	notifMu              sync.Mutex
+	workflowNotifManager *notificationStreamSessionManager[*cloud.TestWorkflowNotificationsRequest]
+	parallelNotifManager *notificationStreamSessionManager[*cloud.TestWorkflowParallelStepNotificationsRequest]
+	serviceNotifManager  *notificationStreamSessionManager[*cloud.TestWorkflowServiceNotificationsRequest]
 }
 
 type ClientOptions struct {

--- a/pkg/controlplaneclient/runner.go
+++ b/pkg/controlplaneclient/runner.go
@@ -192,7 +192,11 @@ func serviceNotificationSessionKey(req *cloud.TestWorkflowServiceNotificationsRe
 
 func (c *client) ProcessExecutionNotificationRequests(ctx context.Context, process func(ctx context.Context, req *cloud.TestWorkflowNotificationsRequest) NotificationWatcher) error {
 	c.notifMu.Lock()
-	if c.workflowNotifManager == nil {
+	// Recreate the manager if its context has been cancelled. The manager binds to
+	// the context of the first call and is reused across reconnects; that context is
+	// the agent lifetime today, but rebuilding it on a dead context avoids silently
+	// running with sources and a sweeper that can never start.
+	if c.workflowNotifManager == nil || c.workflowNotifManager.ctx.Err() != nil {
 		c.workflowNotifManager = newNotificationStreamSessionManager(ctx, workflowNotificationSessionKey, process)
 	}
 	manager := c.workflowNotifManager
@@ -214,7 +218,7 @@ func (c *client) ProcessExecutionNotificationRequests(ctx context.Context, proce
 
 func (c *client) ProcessExecutionParallelWorkerNotificationRequests(ctx context.Context, process func(ctx context.Context, req *cloud.TestWorkflowParallelStepNotificationsRequest) NotificationWatcher) error {
 	c.notifMu.Lock()
-	if c.parallelNotifManager == nil {
+	if c.parallelNotifManager == nil || c.parallelNotifManager.ctx.Err() != nil {
 		c.parallelNotifManager = newNotificationStreamSessionManager(ctx, parallelWorkerNotificationSessionKey, process)
 	}
 	manager := c.parallelNotifManager
@@ -236,7 +240,7 @@ func (c *client) ProcessExecutionParallelWorkerNotificationRequests(ctx context.
 
 func (c *client) ProcessExecutionServiceNotificationRequests(ctx context.Context, process func(ctx context.Context, req *cloud.TestWorkflowServiceNotificationsRequest) NotificationWatcher) error {
 	c.notifMu.Lock()
-	if c.serviceNotifManager == nil {
+	if c.serviceNotifManager == nil || c.serviceNotifManager.ctx.Err() != nil {
 		c.serviceNotifManager = newNotificationStreamSessionManager(ctx, serviceNotificationSessionKey, process)
 	}
 	manager := c.serviceNotifManager

--- a/pkg/controlplaneclient/runner.go
+++ b/pkg/controlplaneclient/runner.go
@@ -175,12 +175,25 @@ func (c *client) WatchRunnerRequests(ctx context.Context) RunnerRequestsWatcher 
 	return watcher
 }
 
+// The session key identifies a notification stream session, so a reconnect with the
+// same key reattaches to the live session and its replay buffer instead of starting a
+// fresh one. It encodes the execution plus the per-stream discriminators.
+func workflowNotificationSessionKey(req *cloud.TestWorkflowNotificationsRequest) string {
+	return fmt.Sprintf("workflow:%s:%s", req.GetEnvironmentId(), req.GetExecutionId())
+}
+
+func parallelWorkerNotificationSessionKey(req *cloud.TestWorkflowParallelStepNotificationsRequest) string {
+	return fmt.Sprintf("parallel:%s:%s:%s:%d", req.GetEnvironmentId(), req.GetExecutionId(), req.GetRef(), req.GetWorkerIndex())
+}
+
+func serviceNotificationSessionKey(req *cloud.TestWorkflowServiceNotificationsRequest) string {
+	return fmt.Sprintf("service:%s:%s:%s:%d", req.GetEnvironmentId(), req.GetExecutionId(), req.GetServiceName(), req.GetServiceIndex())
+}
+
 func (c *client) ProcessExecutionNotificationRequests(ctx context.Context, process func(ctx context.Context, req *cloud.TestWorkflowNotificationsRequest) NotificationWatcher) error {
 	c.notifMu.Lock()
 	if c.workflowNotifManager == nil {
-		c.workflowNotifManager = newNotificationStreamSessionManager(ctx, func(req *cloud.TestWorkflowNotificationsRequest) string {
-			return fmt.Sprintf("workflow:%s:%s", req.GetEnvironmentId(), req.GetExecutionId())
-		}, process)
+		c.workflowNotifManager = newNotificationStreamSessionManager(ctx, workflowNotificationSessionKey, process)
 	}
 	manager := c.workflowNotifManager
 	c.notifMu.Unlock()
@@ -202,9 +215,7 @@ func (c *client) ProcessExecutionNotificationRequests(ctx context.Context, proce
 func (c *client) ProcessExecutionParallelWorkerNotificationRequests(ctx context.Context, process func(ctx context.Context, req *cloud.TestWorkflowParallelStepNotificationsRequest) NotificationWatcher) error {
 	c.notifMu.Lock()
 	if c.parallelNotifManager == nil {
-		c.parallelNotifManager = newNotificationStreamSessionManager(ctx, func(req *cloud.TestWorkflowParallelStepNotificationsRequest) string {
-			return fmt.Sprintf("parallel:%s:%s:%s:%d", req.GetEnvironmentId(), req.GetExecutionId(), req.GetRef(), req.GetWorkerIndex())
-		}, process)
+		c.parallelNotifManager = newNotificationStreamSessionManager(ctx, parallelWorkerNotificationSessionKey, process)
 	}
 	manager := c.parallelNotifManager
 	c.notifMu.Unlock()
@@ -226,9 +237,7 @@ func (c *client) ProcessExecutionParallelWorkerNotificationRequests(ctx context.
 func (c *client) ProcessExecutionServiceNotificationRequests(ctx context.Context, process func(ctx context.Context, req *cloud.TestWorkflowServiceNotificationsRequest) NotificationWatcher) error {
 	c.notifMu.Lock()
 	if c.serviceNotifManager == nil {
-		c.serviceNotifManager = newNotificationStreamSessionManager(ctx, func(req *cloud.TestWorkflowServiceNotificationsRequest) string {
-			return fmt.Sprintf("service:%s:%s:%s:%d", req.GetEnvironmentId(), req.GetExecutionId(), req.GetServiceName(), req.GetServiceIndex())
-		}, process)
+		c.serviceNotifManager = newNotificationStreamSessionManager(ctx, serviceNotificationSessionKey, process)
 	}
 	manager := c.serviceNotifManager
 	c.notifMu.Unlock()

--- a/pkg/controlplaneclient/runner.go
+++ b/pkg/controlplaneclient/runner.go
@@ -176,6 +176,14 @@ func (c *client) WatchRunnerRequests(ctx context.Context) RunnerRequestsWatcher 
 }
 
 func (c *client) ProcessExecutionNotificationRequests(ctx context.Context, process func(ctx context.Context, req *cloud.TestWorkflowNotificationsRequest) NotificationWatcher) error {
+	c.notifMu.Lock()
+	if c.workflowNotifManager == nil {
+		c.workflowNotifManager = newNotificationStreamSessionManager(ctx, func(req *cloud.TestWorkflowNotificationsRequest) string {
+			return fmt.Sprintf("workflow:%s:%s", req.GetEnvironmentId(), req.GetExecutionId())
+		}, process)
+	}
+	manager := c.workflowNotifManager
+	c.notifMu.Unlock()
 	return processNotifications(
 		ctx,
 		c.metadata().GRPC(),
@@ -184,10 +192,7 @@ func (c *client) ProcessExecutionNotificationRequests(ctx context.Context, proce
 		buildCloudNotification,
 		buildCloudError,
 		buildCloudProtocol,
-		func(req *cloud.TestWorkflowNotificationsRequest) string {
-			return fmt.Sprintf("workflow:%s:%s", req.GetEnvironmentId(), req.GetExecutionId())
-		},
-		process,
+		manager,
 		c.opts.SendTimeout,
 		c.opts.RecvTimeout,
 		c.logger,
@@ -195,6 +200,14 @@ func (c *client) ProcessExecutionNotificationRequests(ctx context.Context, proce
 }
 
 func (c *client) ProcessExecutionParallelWorkerNotificationRequests(ctx context.Context, process func(ctx context.Context, req *cloud.TestWorkflowParallelStepNotificationsRequest) NotificationWatcher) error {
+	c.notifMu.Lock()
+	if c.parallelNotifManager == nil {
+		c.parallelNotifManager = newNotificationStreamSessionManager(ctx, func(req *cloud.TestWorkflowParallelStepNotificationsRequest) string {
+			return fmt.Sprintf("parallel:%s:%s:%s:%d", req.GetEnvironmentId(), req.GetExecutionId(), req.GetRef(), req.GetWorkerIndex())
+		}, process)
+	}
+	manager := c.parallelNotifManager
+	c.notifMu.Unlock()
 	return processNotifications(
 		ctx,
 		c.metadata().GRPC(),
@@ -203,10 +216,7 @@ func (c *client) ProcessExecutionParallelWorkerNotificationRequests(ctx context.
 		buildParallelStepCloudNotification,
 		buildParallelStepCloudError,
 		buildParallelStepCloudProtocol,
-		func(req *cloud.TestWorkflowParallelStepNotificationsRequest) string {
-			return fmt.Sprintf("parallel:%s:%s:%s:%d", req.GetEnvironmentId(), req.GetExecutionId(), req.GetRef(), req.GetWorkerIndex())
-		},
-		process,
+		manager,
 		c.opts.SendTimeout,
 		c.opts.RecvTimeout,
 		c.logger,
@@ -214,6 +224,14 @@ func (c *client) ProcessExecutionParallelWorkerNotificationRequests(ctx context.
 }
 
 func (c *client) ProcessExecutionServiceNotificationRequests(ctx context.Context, process func(ctx context.Context, req *cloud.TestWorkflowServiceNotificationsRequest) NotificationWatcher) error {
+	c.notifMu.Lock()
+	if c.serviceNotifManager == nil {
+		c.serviceNotifManager = newNotificationStreamSessionManager(ctx, func(req *cloud.TestWorkflowServiceNotificationsRequest) string {
+			return fmt.Sprintf("service:%s:%s:%s:%d", req.GetEnvironmentId(), req.GetExecutionId(), req.GetServiceName(), req.GetServiceIndex())
+		}, process)
+	}
+	manager := c.serviceNotifManager
+	c.notifMu.Unlock()
 	return processNotifications(
 		ctx,
 		c.metadata().GRPC(),
@@ -222,10 +240,7 @@ func (c *client) ProcessExecutionServiceNotificationRequests(ctx context.Context
 		buildServiceCloudNotification,
 		buildServiceCloudError,
 		buildServiceCloudProtocol,
-		func(req *cloud.TestWorkflowServiceNotificationsRequest) string {
-			return fmt.Sprintf("service:%s:%s:%s:%d", req.GetEnvironmentId(), req.GetExecutionId(), req.GetServiceName(), req.GetServiceIndex())
-		},
-		process,
+		manager,
 		c.opts.SendTimeout,
 		c.opts.RecvTimeout,
 		c.logger,

--- a/pkg/controlplaneclient/testworkflows_test.go
+++ b/pkg/controlplaneclient/testworkflows_test.go
@@ -78,6 +78,7 @@ func TestNotificationStreamSessionManagerReplaysAfterCursor(t *testing.T) {
 	t.Cleanup(cancel)
 
 	manager := newNotificationStreamSessionManager(
+		ctx,
 		func(req *cloud.TestWorkflowNotificationsRequest) string {
 			return req.ExecutionId
 		},
@@ -93,7 +94,7 @@ func TestNotificationStreamSessionManagerReplaysAfterCursor(t *testing.T) {
 		},
 	)
 
-	session, sub, replay, available, _, done := manager.attach(ctx, &cloud.TestWorkflowNotificationsRequest{ExecutionId: "exec-1", StreamId: "stream-1"})
+	session, sub, replay, available, _, done := manager.attach(&cloud.TestWorkflowNotificationsRequest{ExecutionId: "exec-1", StreamId: "stream-1"})
 	require.True(t, available)
 	require.False(t, done)
 	require.Empty(t, replay)
@@ -103,13 +104,65 @@ func TestNotificationStreamSessionManagerReplaysAfterCursor(t *testing.T) {
 
 	assert.Equal(t, []uint32{1, 2, 3}, firstPass)
 
-	session, sub, replay, available, lastSeqNo, done := manager.attach(ctx, &cloud.TestWorkflowNotificationsRequest{ExecutionId: "exec-1", StreamId: "stream-1", ResumeAfterSeqNo: 1})
+	session, sub, replay, available, lastSeqNo, done := manager.attach(&cloud.TestWorkflowNotificationsRequest{ExecutionId: "exec-1", StreamId: "stream-1", ResumeAfterSeqNo: 1})
 	require.True(t, available)
 	require.True(t, done)
 	require.Equal(t, uint32(3), lastSeqNo)
 	require.Len(t, replay, 2)
 	assert.Equal(t, []uint32{2, 3}, []uint32{replay[0].seqNo, replay[1].seqNo})
 	session.unsubscribe(sub)
+}
+
+// TestNotificationStreamSessionSurvivesReaderDropAndResumesLive locks in the resume fix:
+// the source runs under the manager's long-lived context, so it keeps filling the buffer
+// after a reader disconnects (e.g. a gRPC reconnect). A later attach with the same streamId
+// then resumes from the cursor instead of returning resume_unavailable and re-streaming.
+func TestNotificationStreamSessionSurvivesReaderDropAndResumesLive(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	emit := make(chan string)
+	manager := newNotificationStreamSessionManager(
+		ctx,
+		func(req *cloud.TestWorkflowNotificationsRequest) string {
+			return req.ExecutionId
+		},
+		func(context.Context, *cloud.TestWorkflowNotificationsRequest) NotificationWatcher {
+			watcher := channels.NewWatcher[*testkube.TestWorkflowExecutionNotification]()
+			go func() {
+				for log := range emit {
+					watcher.Send(&testkube.TestWorkflowExecutionNotification{Log: log})
+				}
+				watcher.Close(nil)
+			}()
+			return watcher
+		},
+	)
+
+	// First reader attaches; the source starts producing.
+	session, sub, _, available, _, done := manager.attach(&cloud.TestWorkflowNotificationsRequest{ExecutionId: "exec-1", StreamId: "stream-1"})
+	require.True(t, available)
+	require.False(t, done)
+	emit <- "a"
+	emit <- "b"
+	require.Eventually(t, func() bool { return session.currentSeqNo() == 2 }, time.Second, 5*time.Millisecond)
+
+	// The reader disconnects, but the source keeps running under the manager context.
+	session.unsubscribe(sub)
+	emit <- "c"
+	emit <- "d"
+	require.Eventually(t, func() bool { return session.currentSeqNo() == 4 }, time.Second, 5*time.Millisecond)
+
+	// A reconnect with the same streamId resumes from the cursor, not resume_unavailable.
+	session2, sub2, replay, available2, lastSeqNo, done2 := manager.attach(&cloud.TestWorkflowNotificationsRequest{ExecutionId: "exec-1", StreamId: "stream-1", ResumeAfterSeqNo: 2})
+	require.True(t, available2, "resume must be available: the source survived the reader disconnect")
+	require.False(t, done2)
+	require.Equal(t, uint32(4), lastSeqNo)
+	require.Len(t, replay, 2)
+	assert.Equal(t, []uint32{3, 4}, []uint32{replay[0].seqNo, replay[1].seqNo})
+
+	session2.unsubscribe(sub2)
+	close(emit)
 }
 
 func TestSendNotificationResponseReturnsContextErrorWhenCanceled(t *testing.T) {
@@ -196,6 +249,7 @@ func TestNotificationStreamSessionManagerStartsFreshAfterDoneSessionWithoutResum
 
 	var processCalls atomic.Int32
 	manager := newNotificationStreamSessionManager(
+		ctx,
 		func(req *cloud.TestWorkflowNotificationsRequest) string {
 			return req.ExecutionId
 		},
@@ -210,11 +264,11 @@ func TestNotificationStreamSessionManagerStartsFreshAfterDoneSessionWithoutResum
 		},
 	)
 
-	session1, sub1, _, _, _, _ := manager.attach(ctx, &cloud.TestWorkflowNotificationsRequest{ExecutionId: "exec-1", StreamId: "stream-1"})
+	session1, sub1, _, _, _, _ := manager.attach(&cloud.TestWorkflowNotificationsRequest{ExecutionId: "exec-1", StreamId: "stream-1"})
 	waitForNotificationSubscriptionDone(t, sub1)
 	session1.unsubscribe(sub1)
 
-	session2, sub2, replay, available, _, _ := manager.attach(ctx, &cloud.TestWorkflowNotificationsRequest{ExecutionId: "exec-1", StreamId: "stream-1"})
+	session2, sub2, replay, available, _, _ := manager.attach(&cloud.TestWorkflowNotificationsRequest{ExecutionId: "exec-1", StreamId: "stream-1"})
 	waitForNotificationSubscriptionDone(t, sub2)
 	session2.unsubscribe(sub2)
 
@@ -231,6 +285,7 @@ func TestNotificationStreamSessionManagerStartsFreshAfterErroredDoneSessionWithR
 	releaseSecond := make(chan struct{})
 	var processCalls atomic.Int32
 	manager := newNotificationStreamSessionManager(
+		ctx,
 		func(req *cloud.TestWorkflowNotificationsRequest) string {
 			return req.ExecutionId
 		},
@@ -252,12 +307,12 @@ func TestNotificationStreamSessionManagerStartsFreshAfterErroredDoneSessionWithR
 		},
 	)
 
-	session1, sub1, _, _, _, _ := manager.attach(ctx, &cloud.TestWorkflowNotificationsRequest{ExecutionId: "exec-1", StreamId: "stream-1"})
+	session1, sub1, _, _, _, _ := manager.attach(&cloud.TestWorkflowNotificationsRequest{ExecutionId: "exec-1", StreamId: "stream-1"})
 	firstPass := collectNotificationSubscriptionSeqNos(t, sub1)
 	session1.unsubscribe(sub1)
 	require.NotEmpty(t, firstPass)
 
-	session2, sub2, replay, available, lastSeqNo, done := manager.attach(ctx, &cloud.TestWorkflowNotificationsRequest{ExecutionId: "exec-1", StreamId: "stream-1", ResumeAfterSeqNo: firstPass[len(firstPass)-1]})
+	session2, sub2, replay, available, lastSeqNo, done := manager.attach(&cloud.TestWorkflowNotificationsRequest{ExecutionId: "exec-1", StreamId: "stream-1", ResumeAfterSeqNo: firstPass[len(firstPass)-1]})
 	defer session2.unsubscribe(sub2)
 
 	require.NotSame(t, session1, session2)
@@ -288,6 +343,7 @@ func TestNotificationStreamSessionManagerFreshResumeStartsFromLiveTail(t *testin
 
 	release := make(chan struct{})
 	manager := newNotificationStreamSessionManager(
+		ctx,
 		func(req *cloud.TestWorkflowNotificationsRequest) string {
 			return req.ExecutionId
 		},
@@ -304,7 +360,7 @@ func TestNotificationStreamSessionManagerFreshResumeStartsFromLiveTail(t *testin
 		},
 	)
 
-	session, sub, replay, available, lastSeqNo, done := manager.attach(ctx, &cloud.TestWorkflowNotificationsRequest{
+	session, sub, replay, available, lastSeqNo, done := manager.attach(&cloud.TestWorkflowNotificationsRequest{
 		ExecutionId:      "exec-1",
 		StreamId:         "stream-1",
 		ResumeAfterSeqNo: 7,
@@ -332,6 +388,7 @@ func TestNotificationStreamSessionManagerMarksResumeUnavailableForFreshSessionWi
 
 	release := make(chan struct{})
 	manager := newNotificationStreamSessionManager(
+		ctx,
 		func(req *cloud.TestWorkflowNotificationsRequest) string {
 			return req.ExecutionId
 		},
@@ -345,7 +402,7 @@ func TestNotificationStreamSessionManagerMarksResumeUnavailableForFreshSessionWi
 		},
 	)
 
-	session, sub, replay, available, lastSeqNo, done := manager.attach(ctx, &cloud.TestWorkflowNotificationsRequest{ExecutionId: "exec-1", StreamId: "stream-1", ResumeAfterSeqNo: 7})
+	session, sub, replay, available, lastSeqNo, done := manager.attach(&cloud.TestWorkflowNotificationsRequest{ExecutionId: "exec-1", StreamId: "stream-1", ResumeAfterSeqNo: 7})
 	defer session.unsubscribe(sub)
 	defer close(release)
 
@@ -363,6 +420,7 @@ func TestNotificationStreamSessionManagerStartsFreshForConcurrentViewersWithoutR
 	releaseSecond := make(chan struct{})
 	var processCalls atomic.Int32
 	manager := newNotificationStreamSessionManager(
+		ctx,
 		func(req *cloud.TestWorkflowNotificationsRequest) string {
 			return req.ExecutionId
 		},
@@ -382,9 +440,9 @@ func TestNotificationStreamSessionManagerStartsFreshForConcurrentViewersWithoutR
 		},
 	)
 
-	session1, sub1, _, available1, _, done1 := manager.attach(ctx, &cloud.TestWorkflowNotificationsRequest{ExecutionId: "exec-1", StreamId: "stream-1"})
+	session1, sub1, _, available1, _, done1 := manager.attach(&cloud.TestWorkflowNotificationsRequest{ExecutionId: "exec-1", StreamId: "stream-1"})
 	defer session1.unsubscribe(sub1)
-	session2, sub2, replay2, available2, _, done2 := manager.attach(ctx, &cloud.TestWorkflowNotificationsRequest{ExecutionId: "exec-1", StreamId: "stream-2"})
+	session2, sub2, replay2, available2, _, done2 := manager.attach(&cloud.TestWorkflowNotificationsRequest{ExecutionId: "exec-1", StreamId: "stream-2"})
 	defer session2.unsubscribe(sub2)
 	defer close(releaseFirst)
 	defer close(releaseSecond)
@@ -413,6 +471,7 @@ func TestNotificationStreamSessionManagerExpiresDoneSessionsWithoutAttach(t *tes
 
 	release := make(chan struct{})
 	manager := newNotificationStreamSessionManager(
+		ctx,
 		func(req *cloud.TestWorkflowNotificationsRequest) string {
 			return req.ExecutionId
 		},
@@ -428,7 +487,7 @@ func TestNotificationStreamSessionManagerExpiresDoneSessionsWithoutAttach(t *tes
 	)
 	manager.sessionIdleTTL = 10 * time.Millisecond
 
-	session, sub, _, _, _, _ := manager.attach(ctx, &cloud.TestWorkflowNotificationsRequest{ExecutionId: "exec-1", StreamId: "stream-1"})
+	session, sub, _, _, _, _ := manager.attach(&cloud.TestWorkflowNotificationsRequest{ExecutionId: "exec-1", StreamId: "stream-1"})
 	close(release)
 	waitForNotificationSubscriptionDone(t, sub)
 	session.unsubscribe(sub)

--- a/pkg/controlplaneclient/testworkflows_test.go
+++ b/pkg/controlplaneclient/testworkflows_test.go
@@ -113,10 +113,6 @@ func TestNotificationStreamSessionManagerReplaysAfterCursor(t *testing.T) {
 	session.unsubscribe(sub)
 }
 
-// TestNotificationStreamSessionSurvivesReaderDropAndResumesLive locks in the resume fix:
-// the source runs under the manager's long-lived context, so it keeps filling the buffer
-// after a reader disconnects (e.g. a gRPC reconnect). A later attach with the same streamId
-// then resumes from the cursor instead of returning resume_unavailable and re-streaming.
 func TestNotificationStreamSessionSurvivesReaderDropAndResumesLive(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)
@@ -497,6 +493,55 @@ func TestNotificationStreamSessionManagerExpiresDoneSessionsWithoutAttach(t *tes
 		defer manager.mu.Unlock()
 		return len(manager.sessions) == 0
 	}, time.Second, time.Millisecond)
+}
+
+func TestNotificationStreamSessionManagerSweepExpiredRemovesDonePastTTLSession(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	release := make(chan struct{})
+	manager := newNotificationStreamSessionManager(
+		ctx,
+		func(req *cloud.TestWorkflowNotificationsRequest) string {
+			return req.ExecutionId
+		},
+		func(context.Context, *cloud.TestWorkflowNotificationsRequest) NotificationWatcher {
+			watcher := channels.NewWatcher[*testkube.TestWorkflowExecutionNotification]()
+			go func() {
+				watcher.Send(&testkube.TestWorkflowExecutionNotification{Log: "done"})
+				<-release
+				watcher.Close(nil)
+			}()
+			return watcher
+		},
+	)
+	manager.sessionIdleTTL = time.Minute
+
+	session, sub, _, _, _, _ := manager.attach(&cloud.TestWorkflowNotificationsRequest{ExecutionId: "exec-1", StreamId: "stream-1"})
+	close(release)
+	waitForNotificationSubscriptionDone(t, sub)
+	session.unsubscribe(sub)
+
+	require.Eventually(t, func() bool {
+		done, _ := session.status()
+		return done
+	}, time.Second, time.Millisecond)
+
+	manager.mu.Lock()
+	require.Len(t, manager.sessions, 1)
+	manager.mu.Unlock()
+
+	// A sweep at now-before-TTL leaves the session in place.
+	manager.sweepExpired(time.Now())
+	manager.mu.Lock()
+	require.Len(t, manager.sessions, 1)
+	manager.mu.Unlock()
+
+	// A sweep at a time past the TTL reclaims it with no further attach traffic.
+	manager.sweepExpired(time.Now().Add(2 * manager.sessionIdleTTL))
+	manager.mu.Lock()
+	require.Len(t, manager.sessions, 0)
+	manager.mu.Unlock()
 }
 
 func collectNotificationSubscriptionSeqNos(t *testing.T, sub *notificationStreamSubscription) []uint32 {

--- a/pkg/controlplaneclient/testworkflows_test.go
+++ b/pkg/controlplaneclient/testworkflows_test.go
@@ -586,3 +586,56 @@ func waitForNotificationSubscriptionDone(t *testing.T, sub *notificationStreamSu
 		t.Fatal("timed out waiting for notification subscription to finish")
 	}
 }
+
+func TestNotificationStreamSessionReplacementCancelsOrphanedSource(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	sourceCtxs := make(chan context.Context, 4)
+	release := make(chan struct{})
+	t.Cleanup(func() { close(release) })
+
+	manager := newNotificationStreamSessionManager(
+		ctx,
+		func(req *cloud.TestWorkflowNotificationsRequest) string { return req.ExecutionId },
+		func(sourceCtx context.Context, _ *cloud.TestWorkflowNotificationsRequest) NotificationWatcher {
+			sourceCtxs <- sourceCtx
+			watcher := channels.NewWatcher[*testkube.TestWorkflowExecutionNotification]()
+			go func() {
+				select {
+				case <-sourceCtx.Done():
+				case <-release:
+				}
+				watcher.Close(nil)
+			}()
+			return watcher
+		},
+	)
+
+	req := &cloud.TestWorkflowNotificationsRequest{ExecutionId: "exec-1", StreamId: "stream-1"}
+	session1, sub1, _, _, _, _ := manager.attach(req)
+	t.Cleanup(func() { session1.unsubscribe(sub1) })
+
+	var firstSource context.Context
+	select {
+	case firstSource = <-sourceCtxs:
+	case <-time.After(2 * time.Second):
+		t.Fatal("first source was not started")
+	}
+
+	// A resume-from-zero attach with the same key replaces the session; the old
+	// source must be cancelled instead of running orphaned until execution end.
+	session2, sub2, _, _, _, _ := manager.attach(&cloud.TestWorkflowNotificationsRequest{
+		ExecutionId:      "exec-1",
+		StreamId:         "stream-1",
+		ResumeAfterSeqNo: 0,
+	})
+	t.Cleanup(func() { session2.unsubscribe(sub2) })
+	require.NotSame(t, session1, session2, "resume-from-zero must create a new session")
+
+	select {
+	case <-firstSource.Done():
+	case <-time.After(2 * time.Second):
+		t.Fatal("replaced session source context was not cancelled")
+	}
+}

--- a/pkg/controlplaneclient/utils.go
+++ b/pkg/controlplaneclient/utils.go
@@ -467,6 +467,12 @@ func processNotifications[Request notificationRequest, Response any, Srv notific
 	// Process the requests
 	g.Go(func() error {
 		var wg sync.WaitGroup
+		// activeStreams dedups subscriptions by session key. The control plane re-asserts
+		// the same stream request periodically so a dropped connection self-heals; while a
+		// subscription is already live it already covers that stream, so a duplicate
+		// request is ignored to avoid double-delivering notifications.
+		activeStreams := make(map[string]struct{})
+		var activeStreamsMu sync.Mutex
 		defer func() {
 			wg.Wait()
 			close(responses)
@@ -518,11 +524,27 @@ func processNotifications[Request notificationRequest, Response any, Srv notific
 				continue
 			}
 
-			// Start reading the notifications
+			// Start reading the notifications. Ignore a request whose session is already
+			// being streamed on this connection (the control plane re-asserts requests to
+			// self-heal, so duplicates are expected while a subscription is live).
+			streamKey := sessionManager.sessionKey(req)
+			activeStreamsMu.Lock()
+			if _, streaming := activeStreams[streamKey]; streaming {
+				activeStreamsMu.Unlock()
+				continue
+			}
+			activeStreams[streamKey] = struct{}{}
+			activeStreamsMu.Unlock()
+
 			wg.Add(1)
 			g.Go(func(req Request) func() error {
 				return func() error {
 					defer wg.Done()
+					defer func() {
+						activeStreamsMu.Lock()
+						delete(activeStreams, streamKey)
+						activeStreamsMu.Unlock()
+					}()
 
 					session, sub, replay, resumeAvailable, lastSeqNo, done := sessionManager.attach(req)
 					defer session.unsubscribe(sub)

--- a/pkg/controlplaneclient/utils.go
+++ b/pkg/controlplaneclient/utils.go
@@ -121,6 +121,7 @@ func (s *notificationStreamSubscription) close() {
 
 type notificationStreamSession struct {
 	mu          sync.Mutex
+	cancel      context.CancelFunc
 	nextSeqNo   uint32
 	replay      []notificationStreamEvent
 	replayBytes int
@@ -217,6 +218,19 @@ func (s *notificationStreamSession) close(errored bool) {
 	for id, sub := range s.subscribers {
 		sub.close()
 		delete(s.subscribers, id)
+	}
+}
+
+// stopSource cancels the session's pod-log source. It runs when the session is
+// removed from the manager (replaced on a resume-from-zero, or evicted) so an
+// orphaned source does not keep running until the execution ends, and in
+// runSource's defer to release the derived context. Safe to call more than once.
+func (s *notificationStreamSession) stopSource() {
+	s.mu.Lock()
+	cancel := s.cancel
+	s.mu.Unlock()
+	if cancel != nil {
+		cancel()
 	}
 }
 
@@ -353,8 +367,14 @@ func (m *notificationStreamSessionManager[Request]) attach(req Request) (*notifi
 	m.sweepExpired(now)
 
 	m.mu.Lock()
+	// A resume-from-zero request abandons any existing session under this key (the
+	// client reset after resume_unavailable). Capture it so its source can be
+	// stopped: once replaced in the map it is unreachable and would otherwise run
+	// orphaned until the execution ends.
+	var replaced *notificationStreamSession
 	session := m.sessions[key]
 	if req.GetResumeAfterSeqNo() == 0 {
+		replaced = session
 		session = nil
 	} else if session != nil {
 		done, errored := session.status()
@@ -364,13 +384,19 @@ func (m *notificationStreamSessionManager[Request]) attach(req Request) (*notifi
 		}
 	}
 	freshSession := false
+	var sourceCtx context.Context
 	if session == nil {
 		session = newNotificationStreamSession()
+		sourceCtx, session.cancel = context.WithCancel(m.ctx)
 		m.sessions[key] = session
 		freshSession = true
 	}
 	subscriptionID := m.nextID.Add(1)
 	m.mu.Unlock()
+
+	if replaced != nil {
+		replaced.stopSource()
+	}
 
 	subscribeAfterSeqNo := req.GetResumeAfterSeqNo()
 	if freshSession && req.GetResumeAfterSeqNo() > 0 {
@@ -382,7 +408,7 @@ func (m *notificationStreamSessionManager[Request]) attach(req Request) (*notifi
 		if req.GetResumeAfterSeqNo() > 0 {
 			liveOnlyAfter = time.Now()
 		}
-		go m.runSource(m.ctx, key, session, req, liveOnlyAfter)
+		go m.runSource(sourceCtx, key, session, req, liveOnlyAfter)
 		if req.GetResumeAfterSeqNo() > 0 {
 			available = false
 		}
@@ -418,6 +444,7 @@ func (m *notificationStreamSessionManager[Request]) runSource(ctx context.Contex
 	var sourceErr error
 	defer func() {
 		session.close(sourceErr != nil)
+		session.stopSource()
 		m.scheduleExpiration(key, session)
 	}()
 

--- a/pkg/controlplaneclient/utils.go
+++ b/pkg/controlplaneclient/utils.go
@@ -280,6 +280,11 @@ func sendNotificationResponse[Response any](ctx context.Context, responses chan<
 }
 
 type notificationStreamSessionManager[Request notificationRequest] struct {
+	// ctx is the long-lived agent context, NOT the per-connection gRPC stream context.
+	// runSource runs under it so a session's pod-log source and replay buffer survive a
+	// gRPC reconnect: the next attach with the same streamId finds the live session and
+	// replays from the cursor instead of falling back to resume_unavailable.
+	ctx            context.Context
 	mu             sync.Mutex
 	nextID         atomic.Uint64
 	sessions       map[string]*notificationStreamSession
@@ -289,10 +294,12 @@ type notificationStreamSessionManager[Request notificationRequest] struct {
 }
 
 func newNotificationStreamSessionManager[Request notificationRequest](
+	ctx context.Context,
 	key func(Request) string,
 	process func(ctx context.Context, req Request) NotificationWatcher,
 ) *notificationStreamSessionManager[Request] {
 	return &notificationStreamSessionManager[Request]{
+		ctx:            ctx,
 		sessions:       make(map[string]*notificationStreamSession),
 		sessionIdleTTL: workflowNotificationSessionIdleTTL,
 		key:            key,
@@ -308,7 +315,7 @@ func (m *notificationStreamSessionManager[Request]) sessionKey(req Request) stri
 	return fmt.Sprintf("%s:%s", key, req.GetStreamId())
 }
 
-func (m *notificationStreamSessionManager[Request]) attach(ctx context.Context, req Request) (*notificationStreamSession, *notificationStreamSubscription, []notificationStreamEvent, bool, uint32, bool) {
+func (m *notificationStreamSessionManager[Request]) attach(req Request) (*notificationStreamSession, *notificationStreamSubscription, []notificationStreamEvent, bool, uint32, bool) {
 	key := m.sessionKey(req)
 	now := time.Now()
 
@@ -348,7 +355,7 @@ func (m *notificationStreamSessionManager[Request]) attach(ctx context.Context, 
 		if req.GetResumeAfterSeqNo() > 0 {
 			liveOnlyAfter = time.Now()
 		}
-		go m.runSource(ctx, key, session, req, liveOnlyAfter)
+		go m.runSource(m.ctx, key, session, req, liveOnlyAfter)
 		if req.GetResumeAfterSeqNo() > 0 {
 			available = false
 		}
@@ -412,8 +419,7 @@ func processNotifications[Request notificationRequest, Response any, Srv notific
 	buildNotification func(streamId string, seqNo uint32, notification *testkube.TestWorkflowExecutionNotification) Response,
 	buildError func(streamId string, message string) Response,
 	buildProtocol func(streamId string, seqNo uint32, notificationType cloud.TestWorkflowNotificationType, message string) Response,
-	sessionKey func(req Request) string,
-	process func(ctx context.Context, req Request) NotificationWatcher,
+	sessionManager *notificationStreamSessionManager[Request],
 	sendTimeout time.Duration,
 	recvTimeout time.Duration,
 	logger *zap.SugaredLogger,
@@ -428,7 +434,6 @@ func processNotifications[Request notificationRequest, Response any, Srv notific
 	sendResponse := func(response Response) error {
 		return sendNotificationResponse(ctx, responses, response)
 	}
-	sessionManager := newNotificationStreamSessionManager(sessionKey, process)
 
 	// Send responses in sequence
 	// GRPC stream have special requirements for concurrency on SendMsg, and RecvMsg calls.
@@ -519,7 +524,7 @@ func processNotifications[Request notificationRequest, Response any, Srv notific
 				return func() error {
 					defer wg.Done()
 
-					session, sub, replay, resumeAvailable, lastSeqNo, done := sessionManager.attach(ctx, req)
+					session, sub, replay, resumeAvailable, lastSeqNo, done := sessionManager.attach(req)
 					defer session.unsubscribe(sub)
 
 					// READY means the agent accepted this request and attached it to a logical stream session.

--- a/pkg/controlplaneclient/utils.go
+++ b/pkg/controlplaneclient/utils.go
@@ -71,6 +71,7 @@ const (
 	workflowNotificationReplayMaxEvents   = 10_000
 	workflowNotificationReplayMaxBytes    = 10 * 1024 * 1024
 	workflowNotificationSessionIdleTTL    = 15 * time.Minute
+	workflowNotificationSweepInterval     = 60 * time.Second
 )
 
 type notificationStreamEvent struct {
@@ -298,12 +299,31 @@ func newNotificationStreamSessionManager[Request notificationRequest](
 	key func(Request) string,
 	process func(ctx context.Context, req Request) NotificationWatcher,
 ) *notificationStreamSessionManager[Request] {
-	return &notificationStreamSessionManager[Request]{
+	m := &notificationStreamSessionManager[Request]{
 		ctx:            ctx,
 		sessions:       make(map[string]*notificationStreamSession),
 		sessionIdleTTL: workflowNotificationSessionIdleTTL,
 		key:            key,
 		process:        process,
+	}
+	go m.runSweeper(workflowNotificationSweepInterval)
+	return m
+}
+
+// runSweeper reclaims expired sessions on a fixed interval regardless of attach
+// traffic. This covers a manager that goes idle (attach never runs to sweep) and a
+// done session re-attached near its TTL boundary that escapes scheduleExpiration's
+// single AfterFunc. It stops when the manager's context is done.
+func (m *notificationStreamSessionManager[Request]) runSweeper(interval time.Duration) {
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-m.ctx.Done():
+			return
+		case <-ticker.C:
+			m.sweepExpired(time.Now())
+		}
 	}
 }
 
@@ -315,17 +335,24 @@ func (m *notificationStreamSessionManager[Request]) sessionKey(req Request) stri
 	return fmt.Sprintf("%s:%s", key, req.GetStreamId())
 }
 
-func (m *notificationStreamSessionManager[Request]) attach(req Request) (*notificationStreamSession, *notificationStreamSubscription, []notificationStreamEvent, bool, uint32, bool) {
-	key := m.sessionKey(req)
-	now := time.Now()
-
+// sweepExpired removes every session that is done and past the idle TTL as of now.
+func (m *notificationStreamSessionManager[Request]) sweepExpired(now time.Time) {
 	m.mu.Lock()
+	defer m.mu.Unlock()
 	for sessionKey, session := range m.sessions {
 		if session.expired(now, m.sessionIdleTTL) {
 			delete(m.sessions, sessionKey)
 		}
 	}
+}
 
+func (m *notificationStreamSessionManager[Request]) attach(req Request) (*notificationStreamSession, *notificationStreamSubscription, []notificationStreamEvent, bool, uint32, bool) {
+	key := m.sessionKey(req)
+	now := time.Now()
+
+	m.sweepExpired(now)
+
+	m.mu.Lock()
 	session := m.sessions[key]
 	if req.GetResumeAfterSeqNo() == 0 {
 		session = nil


### PR DESCRIPTION
## How

The agent's notification stream session manager (the replay buffer + resume cursors keyed by executionId+streamId) was created inside `processNotifications`, which runs once per gRPC connection. So every reconnect built a fresh, empty manager and the pod-log source was tied to the per-connection context. When the agent-to-control-plane stream dropped (a gateway timeout, a deploy, a network blip), the buffer was discarded and the source torn down. The next reconnect's `resumeAfterSeqNo` hit an empty manager, got a fresh session, and was answered with `resume_unavailable`, so the client reset its cursor and re-streamed live-only, losing the logs between the drop and the reconnect.

This lifts the session managers to the client, one per stream kind (workflow / service / parallel step), created once with the agent's long-lived context and reused across reconnects. `runSource` now runs under that context, so a session's pod-log source keeps filling its buffer while no reader is connected. A reconnect with the same streamId then finds the live session and replays from the cursor (`resume` available) instead of resetting.

Added `TestNotificationStreamSessionSurvivesReaderDropAndResumesLive`: a source keeps producing after its reader disconnects, and a later attach with the cursor resumes and replays the gap. Existing session-manager tests pass unchanged under `-race`.