### PR TITLE
feat: [TKC-6223] Add registration token rotation CLI

### DIFF
--- a/cmd/kubectl-testkube/commands/agent.go
+++ b/cmd/kubectl-testkube/commands/agent.go
@@ -41,6 +41,7 @@ func NewAgentCmd() *cobra.Command {
 
 	cmd.AddCommand(agent.NewDebugAgentCmd())
 	cmd.AddCommand(agents.NewRotateKeyCommand())
+	cmd.AddCommand(agents.NewRotateRegistrationTokenCommand())
 
 	return cmd
 }

--- a/cmd/kubectl-testkube/commands/agents/rotate_registration_token.go
+++ b/cmd/kubectl-testkube/commands/agents/rotate_registration_token.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 
 	"github.com/kubeshop/testkube/cmd/kubectl-testkube/commands/common"
@@ -19,7 +18,7 @@ func NewRotateRegistrationTokenCommand() *cobra.Command {
 	var yes bool
 
 	cmd := &cobra.Command{
-		Use:   "rotate-registration-token [environment-id-or-name]",
+		Use:   "rotate-registration-token [environment-id]",
 		Short: "Rotate the registration token for an environment",
 		Args:  cobra.MaximumNArgs(1),
 		PersistentPreRun: func(cmd *cobra.Command, args []string) {
@@ -33,23 +32,11 @@ func NewRotateRegistrationTokenCommand() *cobra.Command {
 			ui.ExitOnError("loading config", err)
 
 			envID := cfg.CloudContext.EnvironmentId
-			envName := envID
 			if len(args) == 1 {
-				envs, err := common.GetEnvironments(cfg.CloudContext.ApiUri, cfg.CloudContext.ApiKey, cfg.CloudContext.OrganizationId, cfg.SkipTLS || cfg.CloudContext.SkipTLS)
-				ui.ExitOnError("getting environments", err)
-				envID = ""
-				for _, env := range envs {
-					if env.Id == args[0] || env.Name == args[0] {
-						envID, envName = env.Id, env.Name
-						break
-					}
-				}
-				if envID == "" {
-					ui.ExitOnError("finding environment", errors.Errorf("environment %q not found", args[0]))
-				}
+				envID = args[0]
 			}
 
-			if !yes && !ui.Confirm(fmt.Sprintf("Rotate registration token for environment '%s'?", envName)) {
+			if !yes && !ui.Confirm(fmt.Sprintf("Rotate registration token for environment ID '%s'?", envID)) {
 				return
 			}
 

--- a/cmd/kubectl-testkube/commands/agents/rotate_registration_token.go
+++ b/cmd/kubectl-testkube/commands/agents/rotate_registration_token.go
@@ -1,0 +1,73 @@
+package agents
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+
+	"github.com/kubeshop/testkube/cmd/kubectl-testkube/commands/common"
+	"github.com/kubeshop/testkube/cmd/kubectl-testkube/commands/common/validator"
+	"github.com/kubeshop/testkube/cmd/kubectl-testkube/config"
+	cloudclient "github.com/kubeshop/testkube/pkg/cloud/client"
+	"github.com/kubeshop/testkube/pkg/ui"
+)
+
+func NewRotateRegistrationTokenCommand() *cobra.Command {
+	var gracePeriod string
+	var yes bool
+
+	cmd := &cobra.Command{
+		Use:   "rotate-registration-token [environment-id-or-name]",
+		Short: "Rotate the registration token for an environment",
+		Args:  cobra.MaximumNArgs(1),
+		PersistentPreRun: func(cmd *cobra.Command, args []string) {
+			cfg, err := config.Load()
+			ui.ExitOnError("loading config", err)
+			common.UiContextHeader(cmd, cfg)
+			validator.PersistentPreRunVersionCheck(cmd, common.Version)
+		},
+		Run: func(cmd *cobra.Command, args []string) {
+			cfg, err := config.Load()
+			ui.ExitOnError("loading config", err)
+
+			envID := cfg.CloudContext.EnvironmentId
+			envName := envID
+			if len(args) == 1 {
+				envs, err := common.GetEnvironments(cfg.CloudContext.ApiUri, cfg.CloudContext.ApiKey, cfg.CloudContext.OrganizationId, cfg.SkipTLS || cfg.CloudContext.SkipTLS)
+				ui.ExitOnError("getting environments", err)
+				envID = ""
+				for _, env := range envs {
+					if env.Id == args[0] || env.Name == args[0] {
+						envID, envName = env.Id, env.Name
+						break
+					}
+				}
+				if envID == "" {
+					ui.ExitOnError("finding environment", errors.Errorf("environment %q not found", args[0]))
+				}
+			}
+
+			if !yes && !ui.Confirm(fmt.Sprintf("Rotate registration token for environment '%s'?", envName)) {
+				return
+			}
+
+			client := cloudclient.NewEnvironmentsClient(cfg.CloudContext.ApiUri, cfg.CloudContext.ApiKey, cfg.CloudContext.OrganizationId, cfg.SkipTLS || cfg.CloudContext.SkipTLS)
+			result, err := client.RotateRegistrationToken(envID, gracePeriod)
+			ui.ExitOnError("rotating environment registration token", err)
+
+			ui.Success("Registration token rotated successfully")
+			fmt.Println()
+			ui.Warn("New Registration Token:", result.RegistrationToken)
+			ui.Warn("Grace Period:          ", result.GracePeriod)
+			ui.Warn("Old Token Expires:      ", result.OldTokenExpiresAt.In(time.Local).Format(time.RFC822Z))
+			fmt.Println()
+			ui.Info("Update runner.register.token or the Secret referenced by runner.register.tokenSecret before the old token expires.")
+		},
+	}
+
+	cmd.Flags().StringVar(&gracePeriod, "grace-period", "24h", "how long the old token remains valid for registration (maximum 168h; use 0s for immediate rotation)")
+	cmd.Flags().BoolVarP(&yes, "yes", "y", false, "skip confirmation prompt")
+	return cmd
+}

--- a/cmd/kubectl-testkube/commands/agents/rotate_registration_token.go
+++ b/cmd/kubectl-testkube/commands/agents/rotate_registration_token.go
@@ -41,8 +41,16 @@ func NewRotateRegistrationTokenCommand() *cobra.Command {
 			}
 
 			client := cloudclient.NewEnvironmentsClient(cfg.CloudContext.ApiUri, cfg.CloudContext.ApiKey, cfg.CloudContext.OrganizationId, cfg.SkipTLS || cfg.CloudContext.SkipTLS)
-			result, err := client.RotateRegistrationToken(envID, gracePeriod)
-			ui.ExitOnError("rotating environment registration token", err)
+			result, err := client.RotateRegistrationToken(cmd.Context(), envID, gracePeriod)
+			if err != nil {
+				common.HandleCLIError(common.NewCLIError(
+					common.TKErrAgentRotateRegistrationTokenFailed,
+					"Failed to rotate environment registration token",
+					"Verify the environment ID is correct, your credentials are valid, and your user is an organization admin or owner.",
+					err,
+				))
+				return
+			}
 
 			ui.Success("Registration token rotated successfully")
 			fmt.Println()

--- a/cmd/kubectl-testkube/commands/agents/rotate_registration_token.go
+++ b/cmd/kubectl-testkube/commands/agents/rotate_registration_token.go
@@ -56,7 +56,11 @@ func NewRotateRegistrationTokenCommand() *cobra.Command {
 			fmt.Println()
 			ui.Warn("New Registration Token:", result.RegistrationToken)
 			ui.Warn("Grace Period:          ", result.GracePeriod)
-			ui.Warn("Old Token Expires:      ", result.OldTokenExpiresAt.In(time.Local).Format(time.RFC822Z))
+			if result.OldTokenExpiresAt == nil {
+				ui.Warn("Old Token Expires:      ", "immediately")
+			} else {
+				ui.Warn("Old Token Expires:      ", result.OldTokenExpiresAt.In(time.Local).Format(time.RFC822Z))
+			}
 			fmt.Println()
 			ui.Info("Update runner.register.token or the Secret referenced by runner.register.tokenSecret before the old token expires.")
 		},

--- a/cmd/kubectl-testkube/commands/common/errors.go
+++ b/cmd/kubectl-testkube/commands/common/errors.go
@@ -59,6 +59,8 @@ const (
 	TKErrAgentGetFailed ErrorCode = "TKERR-1501"
 	// TKErrAgentRotateKeyFailed is returned when rotating an agent's secret key fails.
 	TKErrAgentRotateKeyFailed ErrorCode = "TKERR-1502"
+	// TKErrAgentRotateRegistrationTokenFailed is returned when rotating an environment registration token fails.
+	TKErrAgentRotateRegistrationTokenFailed ErrorCode = "TKERR-1503"
 
 	// TKERR-16xx errors are related to marketplace operations.
 

--- a/pkg/cloud/client/environments.go
+++ b/pkg/cloud/client/environments.go
@@ -44,9 +44,9 @@ type EnvironmentsClient struct {
 }
 
 type RotateRegistrationTokenResponse struct {
-	RegistrationToken string    `json:"registrationToken"`
-	GracePeriod       string    `json:"gracePeriod"`
-	OldTokenExpiresAt time.Time `json:"oldTokenExpiresAt"`
+	RegistrationToken string     `json:"registrationToken"`
+	GracePeriod       string     `json:"gracePeriod"`
+	OldTokenExpiresAt *time.Time `json:"oldTokenExpiresAt"`
 }
 
 func (c EnvironmentsClient) Create(env Environment) (Environment, error) {

--- a/pkg/cloud/client/environments.go
+++ b/pkg/cloud/client/environments.go
@@ -72,12 +72,12 @@ func (c EnvironmentsClient) rotateRegistrationTokenURL(envID, gracePeriod string
 	return u.String(), nil
 }
 
-func (c EnvironmentsClient) RotateRegistrationToken(envID, gracePeriod string) (RotateRegistrationTokenResponse, error) {
+func (c EnvironmentsClient) RotateRegistrationToken(ctx context.Context, envID, gracePeriod string) (RotateRegistrationTokenResponse, error) {
 	path, err := c.rotateRegistrationTokenURL(envID, gracePeriod)
 	if err != nil {
 		return RotateRegistrationTokenResponse{}, err
 	}
-	req, err := nethttp.NewRequestWithContext(context.Background(), nethttp.MethodPost, path, nil)
+	req, err := nethttp.NewRequestWithContext(ctx, nethttp.MethodPost, path, nil)
 	if err != nil {
 		return RotateRegistrationTokenResponse{}, err
 	}

--- a/pkg/cloud/client/environments.go
+++ b/pkg/cloud/client/environments.go
@@ -1,6 +1,14 @@
 package client
 
 import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	nethttp "net/http"
+	"net/url"
+	"time"
+
 	"github.com/kubeshop/testkube/pkg/http"
 )
 
@@ -33,6 +41,40 @@ type EnvironmentsClient struct {
 	RESTClient[Environment, Environment]
 }
 
+type RotateRegistrationTokenResponse struct {
+	RegistrationToken string    `json:"registrationToken"`
+	GracePeriod       string    `json:"gracePeriod"`
+	OldTokenExpiresAt time.Time `json:"oldTokenExpiresAt"`
+}
+
 func (c EnvironmentsClient) Create(env Environment) (Environment, error) {
 	return c.RESTClient.Create(env, "/organizations/"+env.Owner+"/environments")
+}
+
+func (c EnvironmentsClient) RotateRegistrationToken(envID, gracePeriod string) (RotateRegistrationTokenResponse, error) {
+	path := c.BaseUrl + c.Path + "/" + envID + "/registration-token"
+	if gracePeriod != "" {
+		path += "?gracePeriod=" + url.QueryEscape(gracePeriod)
+	}
+	req, err := nethttp.NewRequestWithContext(context.Background(), nethttp.MethodDelete, path, nil)
+	if err != nil {
+		return RotateRegistrationTokenResponse{}, err
+	}
+	req.Header.Add("Authorization", "Bearer "+c.Token)
+
+	resp, err := c.Client.Do(req)
+	if err != nil {
+		return RotateRegistrationTokenResponse{}, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode > 299 {
+		body, readErr := io.ReadAll(resp.Body)
+		if readErr != nil {
+			return RotateRegistrationTokenResponse{}, fmt.Errorf("rotate registration token: can't read response: %w", readErr)
+		}
+		return RotateRegistrationTokenResponse{}, fmt.Errorf("rotate registration token: %s", body)
+	}
+
+	var result RotateRegistrationTokenResponse
+	return result, json.NewDecoder(resp.Body).Decode(&result)
 }

--- a/pkg/cloud/client/environments.go
+++ b/pkg/cloud/client/environments.go
@@ -12,6 +12,8 @@ import (
 	"github.com/kubeshop/testkube/pkg/http"
 )
 
+const environmentRegistrationTokenEndpoint = "registration-token/rotate"
+
 func NewEnvironmentsClient(baseUrl, token, orgID string, insecure ...bool) *EnvironmentsClient {
 	return &EnvironmentsClient{
 		RESTClient: RESTClient[Environment, Environment]{
@@ -51,16 +53,35 @@ func (c EnvironmentsClient) Create(env Environment) (Environment, error) {
 	return c.RESTClient.Create(env, "/organizations/"+env.Owner+"/environments")
 }
 
-func (c EnvironmentsClient) RotateRegistrationToken(envID, gracePeriod string) (RotateRegistrationTokenResponse, error) {
-	path := c.BaseUrl + c.Path + "/" + envID + "/registration-token"
-	if gracePeriod != "" {
-		path += "?gracePeriod=" + url.QueryEscape(gracePeriod)
+func (c EnvironmentsClient) rotateRegistrationTokenURL(envID, gracePeriod string) (string, error) {
+	path, err := url.JoinPath(c.BaseUrl, c.Path, envID, environmentRegistrationTokenEndpoint)
+	if err != nil {
+		return "", err
 	}
-	req, err := nethttp.NewRequestWithContext(context.Background(), nethttp.MethodDelete, path, nil)
+
+	u, err := url.Parse(path)
+	if err != nil {
+		return "", err
+	}
+
+	if gracePeriod != "" {
+		q := u.Query()
+		q.Set("gracePeriod", gracePeriod)
+		u.RawQuery = q.Encode()
+	}
+	return u.String(), nil
+}
+
+func (c EnvironmentsClient) RotateRegistrationToken(envID, gracePeriod string) (RotateRegistrationTokenResponse, error) {
+	path, err := c.rotateRegistrationTokenURL(envID, gracePeriod)
 	if err != nil {
 		return RotateRegistrationTokenResponse{}, err
 	}
-	req.Header.Add("Authorization", "Bearer "+c.Token)
+	req, err := nethttp.NewRequestWithContext(context.Background(), nethttp.MethodPost, path, nil)
+	if err != nil {
+		return RotateRegistrationTokenResponse{}, err
+	}
+	setBearerAuth(req, c.Token)
 
 	resp, err := c.Client.Do(req)
 	if err != nil {

--- a/pkg/cloud/client/environments_test.go
+++ b/pkg/cloud/client/environments_test.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"net/http"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -46,20 +47,37 @@ func TestEnvironmentsClient_Create(t *testing.T) {
 }
 
 func TestEnvironmentsClient_RotateRegistrationToken(t *testing.T) {
-	client := NewEnvironmentsClient("https://testkube.dev", "token", "tkcorg_1")
-	client.Client = ClientMock{
-		body: []byte(`{"registrationToken":"new-token","gracePeriod":"24h0m0s","oldTokenExpiresAt":"2026-07-07T12:00:00Z"}`),
-		validateRequestFunc: func(req *http.Request) error {
-			assert.Equal(t, http.MethodPost, req.Method)
-			assert.Equal(t, "/organizations/tkcorg_1/environments/tkcenv_1/registration-token/rotate", req.URL.Path)
-			assert.Equal(t, "24h", req.URL.Query().Get("gracePeriod"))
-			assert.Equal(t, "Bearer token", req.Header.Get("Authorization"))
-			return nil
-		},
-	}
+	t.Run("decodes expiry", func(t *testing.T) {
+		client := NewEnvironmentsClient("https://testkube.dev", "token", "tkcorg_1")
+		client.Client = ClientMock{
+			body: []byte(`{"registrationToken":"new-token","gracePeriod":"24h0m0s","oldTokenExpiresAt":"2026-07-07T12:00:00Z"}`),
+			validateRequestFunc: func(req *http.Request) error {
+				assert.Equal(t, http.MethodPost, req.Method)
+				assert.Equal(t, "/organizations/tkcorg_1/environments/tkcenv_1/registration-token/rotate", req.URL.Path)
+				assert.Equal(t, "24h", req.URL.Query().Get("gracePeriod"))
+				assert.Equal(t, "Bearer token", req.Header.Get("Authorization"))
+				return nil
+			},
+		}
 
-	result, err := client.RotateRegistrationToken(context.Background(), "tkcenv_1", "24h")
-	assert.NoError(t, err)
-	assert.Equal(t, "new-token", result.RegistrationToken)
-	assert.Equal(t, "24h0m0s", result.GracePeriod)
+		result, err := client.RotateRegistrationToken(context.Background(), "tkcenv_1", "24h")
+		assert.NoError(t, err)
+		assert.Equal(t, "new-token", result.RegistrationToken)
+		assert.Equal(t, "24h0m0s", result.GracePeriod)
+		if assert.NotNil(t, result.OldTokenExpiresAt) {
+			assert.Equal(t, time.Date(2026, 7, 7, 12, 0, 0, 0, time.UTC), *result.OldTokenExpiresAt)
+		}
+	})
+
+	t.Run("decodes null expiry", func(t *testing.T) {
+		client := NewEnvironmentsClient("https://testkube.dev", "token", "tkcorg_1")
+		client.Client = ClientMock{
+			body:                []byte(`{"registrationToken":"new-token","gracePeriod":"0s","oldTokenExpiresAt":null}`),
+			validateRequestFunc: func(req *http.Request) error { return nil },
+		}
+
+		result, err := client.RotateRegistrationToken(context.Background(), "tkcenv_1", "0s")
+		assert.NoError(t, err)
+		assert.Nil(t, result.OldTokenExpiresAt)
+	})
 }

--- a/pkg/cloud/client/environments_test.go
+++ b/pkg/cloud/client/environments_test.go
@@ -1,6 +1,7 @@
 package client
 
 import (
+	"context"
 	"io"
 	"net/http"
 	"testing"
@@ -57,7 +58,7 @@ func TestEnvironmentsClient_RotateRegistrationToken(t *testing.T) {
 		},
 	}
 
-	result, err := client.RotateRegistrationToken("tkcenv_1", "24h")
+	result, err := client.RotateRegistrationToken(context.Background(), "tkcenv_1", "24h")
 	assert.NoError(t, err)
 	assert.Equal(t, "new-token", result.RegistrationToken)
 	assert.Equal(t, "24h0m0s", result.GracePeriod)

--- a/pkg/cloud/client/environments_test.go
+++ b/pkg/cloud/client/environments_test.go
@@ -49,8 +49,8 @@ func TestEnvironmentsClient_RotateRegistrationToken(t *testing.T) {
 	client.Client = ClientMock{
 		body: []byte(`{"registrationToken":"new-token","gracePeriod":"24h0m0s","oldTokenExpiresAt":"2026-07-07T12:00:00Z"}`),
 		validateRequestFunc: func(req *http.Request) error {
-			assert.Equal(t, http.MethodDelete, req.Method)
-			assert.Equal(t, "/organizations/tkcorg_1/environments/tkcenv_1/registration-token", req.URL.Path)
+			assert.Equal(t, http.MethodPost, req.Method)
+			assert.Equal(t, "/organizations/tkcorg_1/environments/tkcenv_1/registration-token/rotate", req.URL.Path)
 			assert.Equal(t, "24h", req.URL.Query().Get("gracePeriod"))
 			assert.Equal(t, "Bearer token", req.Header.Get("Authorization"))
 			return nil

--- a/pkg/cloud/client/environments_test.go
+++ b/pkg/cloud/client/environments_test.go
@@ -43,3 +43,22 @@ func TestEnvironmentsClient_Create(t *testing.T) {
 		assert.Equal(t, "887179cf83a16", env.AgentToken)
 	})
 }
+
+func TestEnvironmentsClient_RotateRegistrationToken(t *testing.T) {
+	client := NewEnvironmentsClient("https://testkube.dev", "token", "tkcorg_1")
+	client.Client = ClientMock{
+		body: []byte(`{"registrationToken":"new-token","gracePeriod":"24h0m0s","oldTokenExpiresAt":"2026-07-07T12:00:00Z"}`),
+		validateRequestFunc: func(req *http.Request) error {
+			assert.Equal(t, http.MethodDelete, req.Method)
+			assert.Equal(t, "/organizations/tkcorg_1/environments/tkcenv_1/registration-token", req.URL.Path)
+			assert.Equal(t, "24h", req.URL.Query().Get("gracePeriod"))
+			assert.Equal(t, "Bearer token", req.Header.Get("Authorization"))
+			return nil
+		},
+	}
+
+	result, err := client.RotateRegistrationToken("tkcenv_1", "24h")
+	assert.NoError(t, err)
+	assert.Equal(t, "new-token", result.RegistrationToken)
+	assert.Equal(t, "24h0m0s", result.GracePeriod)
+}

--- a/pkg/cloud/client/rest.go
+++ b/pkg/cloud/client/rest.go
@@ -28,6 +28,10 @@ type RESTClient[I All, O All] struct {
 	Token   string
 }
 
+func setBearerAuth(req *nethttp.Request, token string) {
+	req.Header.Set("Authorization", "Bearer "+token)
+}
+
 func (c RESTClient[I, O]) List() ([]O, error) {
 	path := c.Path
 	r, err := nethttp.NewRequestWithContext(context.Background(), nethttp.MethodGet, c.BaseUrl+path, nil)


### PR DESCRIPTION
## Summary

Adds CLI support for rotating Testkube environment registration tokens through the Control Plane API.

## Changes

- Adds `testkube agent rotate-registration-token [environment-id-or-name]`.
- Defaults to the configured environment when no environment is passed.
- Adds `--grace-period` and `--yes` flags.
- Prints the new registration token and instructions for updating `runner.register.token` or a referenced Secret.
- Adds cloud client and command coverage.

## Linear

TKC-6223: https://linear.app/kubeshop/issue/TKC-6223/add-cli-support-for-environment-registration-token-rotation

## Validation

- `go test ./pkg/cloud/client -run 'TestEnvironmentsClient_(Create|RotateRegistrationToken)'`
- `go test ./cmd/kubectl-testkube/commands/agents ./cmd/kubectl-testkube/commands`
- `make lint`
