### PR TITLE
docs(grafana-dashboard): replace outdated metrics with their current corresponding ones

### DIFF
--- a/assets/grafana-dasboard.json
+++ b/assets/grafana-dasboard.json
@@ -133,7 +133,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "testkube_test_executions_count{result=\"passed\"}",
+          "expr": "testkube_testworkflow_executions_count{result=\"passed\"}",
           "hide": false,
           "instant": false,
           "interval": "1",
@@ -222,7 +222,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "testkube_test_executions_count{result=\"failed\"}",
+          "expr": "testkube_testworkflow_executions_count{result=\"failed\"}",
           "hide": false,
           "instant": false,
           "interval": "1",
@@ -276,9 +276,7 @@
         "justifyMode": "auto",
         "orientation": "auto",
         "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
+          "calcs": ["lastNotNull"],
           "fields": "",
           "values": false
         },
@@ -289,7 +287,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "testkube_test_creations_count{}",
+          "expr": "testkube_testworkflow_creations_count{}",
           "format": "table",
           "hide": false,
           "instant": false,


### PR DESCRIPTION
## Pull request description 

`assets/grafana-dashboard.json` was outdated pointing to unused metrics. I've just replaced with the actual current ones.

Closes https://github.com/kubeshop/testkube/issues/7938

<img width="1610" height="983" alt="image" src="https://github.com/user-attachments/assets/6ca61274-2c06-4020-9075-45e0bb33af9f" />


## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [x] tested locally
- [ ] tested on cluster
- [ ] added new dependencies
- [x] updated the docs
- [ ] added a test
