### PR TITLE
feat:  [TKC-6082] Improve debugging: human-readable execution context in logs + runner-pod labels

### DIFF
--- a/pkg/api/v1/testkube/model_test_workflow_execution_extended.go
+++ b/pkg/api/v1/testkube/model_test_workflow_execution_extended.go
@@ -136,6 +136,29 @@ func (e *TestWorkflowExecution) Assigned() bool {
 	return e.Result.IsFinished() || len(e.Signature) > 0
 }
 
+// LogFields returns human-readable structured logging key/value pairs describing the
+// execution, so logs carry context (workflow name, trigger/source) beyond the execution ID.
+// It is null-safe for the optional Workflow and RunningContext fields.
+func (e *TestWorkflowExecution) LogFields() []any {
+	if e == nil {
+		return nil
+	}
+
+	fields := []any{"executionId", e.Id}
+	if e.Workflow != nil {
+		fields = append(fields, "workflowName", e.Workflow.Name)
+	}
+	if e.RunningContext != nil && e.RunningContext.Actor != nil {
+		if e.RunningContext.Actor.Type_ != nil {
+			fields = append(fields, "runContextType", string(*e.RunningContext.Actor.Type_))
+		}
+		if e.RunningContext.Actor.Name != "" {
+			fields = append(fields, "runContextName", e.RunningContext.Actor.Name)
+		}
+	}
+	return fields
+}
+
 func (e *TestWorkflowExecution) Clone() *TestWorkflowExecution {
 	if e == nil {
 		return nil

--- a/pkg/controlplane/scheduling/enqueuer.go
+++ b/pkg/controlplane/scheduling/enqueuer.go
@@ -385,8 +385,7 @@ func (e *Enqueuer) persistExecution(ctx context.Context, executions []*testworkf
 			},
 		)
 		if err != nil {
-			logger.Errorw("failed to update the TestWorkflow exec in database", append(exec.Execution().LogFields(), "recoverable", false, "error", err)...)
-		}
+			logger.Errorw("failed to insert the TestWorkflow exec in database", append(exec.Execution().LogFields(), "recoverable", false, "error", err)...)
 
 		result = append(result, *exec.Execution())
 	}

--- a/pkg/controlplane/scheduling/enqueuer.go
+++ b/pkg/controlplane/scheduling/enqueuer.go
@@ -379,13 +379,14 @@ func (e *Enqueuer) persistExecution(ctx context.Context, executions []*testworkf
 			func() error {
 				err := e.executionRepository.Insert(ctx, *exec.Execution())
 				if err != nil {
-					logger.Warnw("failed to update the TestWorkflow exec in database", append(exec.Execution().LogFields(), "recoverable", true, "error", err)...)
+					logger.Warnw("failed to insert the TestWorkflow exec in database", append(exec.Execution().LogFields(), "recoverable", true, "error", err)...)
 				}
 				return err
 			},
 		)
 		if err != nil {
 			logger.Errorw("failed to insert the TestWorkflow exec in database", append(exec.Execution().LogFields(), "recoverable", false, "error", err)...)
+		}
 
 		result = append(result, *exec.Execution())
 	}

--- a/pkg/controlplane/scheduling/enqueuer.go
+++ b/pkg/controlplane/scheduling/enqueuer.go
@@ -379,13 +379,13 @@ func (e *Enqueuer) persistExecution(ctx context.Context, executions []*testworkf
 			func() error {
 				err := e.executionRepository.Insert(ctx, *exec.Execution())
 				if err != nil {
-					logger.Warnw("failed to update the TestWorkflow exec in database", "recoverable", true, "executionId", exec.Execution().Id, "error", err)
+					logger.Warnw("failed to update the TestWorkflow exec in database", append(exec.Execution().LogFields(), "recoverable", true, "error", err)...)
 				}
 				return err
 			},
 		)
 		if err != nil {
-			logger.Errorw("failed to update the TestWorkflow exec in database", "recoverable", false, "executionId", exec.Execution().Id, "error", err)
+			logger.Errorw("failed to update the TestWorkflow exec in database", append(exec.Execution().LogFields(), "recoverable", false, "error", err)...)
 		}
 
 		result = append(result, *exec.Execution())

--- a/pkg/mapper/k8sevents/mapper.go
+++ b/pkg/mapper/k8sevents/mapper.go
@@ -11,6 +11,7 @@ import (
 
 	testworkflowsv1 "github.com/kubeshop/testkube/api/testworkflows/v1"
 	"github.com/kubeshop/testkube/pkg/api/v1/testkube"
+	"github.com/kubeshop/testkube/pkg/utils"
 )
 
 // TestkubeEventPrefix is prefix for testkube event
@@ -95,7 +96,7 @@ func sanitizeLabels(labels map[string]string) map[string]string {
 		}
 
 		// Sanitize the label value
-		sanitizedValue := sanitizeLabelValue(value)
+		sanitizedValue := utils.SanitizeLabelValue(value)
 		if sanitizedValue == "" {
 			// Drop the label if the value cannot be sanitized
 			continue
@@ -152,38 +153,6 @@ func sanitizeLabelKey(key string) string {
 	}
 
 	return key
-}
-
-// sanitizeLabelValue sanitizes a label value to conform to Kubernetes label value rules.
-func sanitizeLabelValue(value string) string {
-	if value == "" {
-		return value
-	}
-
-	// Replace invalid characters with hyphens
-	sanitized := strings.Map(func(r rune) rune {
-		if isAllowedLabelRune(r) {
-			return r
-		}
-		return '-'
-	}, value)
-
-	// Truncate if too long
-	if len(sanitized) > validation.LabelValueMaxLength {
-		sanitized = sanitized[:validation.LabelValueMaxLength]
-	}
-
-	// Trim non-alphanumeric characters from start and end
-	sanitized = strings.TrimLeftFunc(sanitized, func(r rune) bool { return !isAlphaNumeric(r) })
-	sanitized = strings.TrimRightFunc(sanitized, func(r rune) bool { return !isAlphaNumeric(r) })
-
-	// Final validation
-	errs := validation.IsValidLabelValue(sanitized)
-	if len(errs) > 0 {
-		return ""
-	}
-
-	return sanitized
 }
 
 // sanitizeDNSSubdomain sanitizes a string to be a valid DNS subdomain.
@@ -248,11 +217,6 @@ func sanitizeDNSLabel(s string) string {
 	}
 
 	return sanitized
-}
-
-// isAllowedLabelRune returns true if the rune is allowed in a label value.
-func isAllowedLabelRune(r rune) bool {
-	return isAlphaNumeric(r) || r == '-' || r == '_' || r == '.'
 }
 
 // isAlphaNumeric returns true if the rune is alphanumeric.

--- a/pkg/mapper/k8sevents/mapper_test.go
+++ b/pkg/mapper/k8sevents/mapper_test.go
@@ -184,52 +184,6 @@ func TestSanitizeLabelKey(t *testing.T) {
 	}
 }
 
-func TestSanitizeLabelValue(t *testing.T) {
-	tests := []struct {
-		name     string
-		input    string
-		expected string
-	}{
-		{
-			name:     "empty value",
-			input:    "",
-			expected: "",
-		},
-		{
-			name:     "valid value",
-			input:    "my-app-123",
-			expected: "my-app-123",
-		},
-		{
-			name:     "value with invalid characters",
-			input:    "test@app#name",
-			expected: "test-app-name",
-		},
-		{
-			name:     "value with leading and trailing hyphens",
-			input:    "-test-",
-			expected: "test",
-		},
-		{
-			name:     "value with only invalid characters",
-			input:    "@@@",
-			expected: "",
-		},
-		{
-			name:     "value with underscores and dots",
-			input:    "test_app.name",
-			expected: "test_app.name",
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			result := sanitizeLabelValue(tt.input)
-			assert.Equal(t, tt.expected, result)
-		})
-	}
-}
-
 func TestSanitizeDNSSubdomain(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/pkg/runner/agent.go
+++ b/pkg/runner/agent.go
@@ -364,7 +364,7 @@ func (a *agentLoop) runTestWorkflow(environmentId string, executionId string, ex
 
 func (a *agentLoop) directRunTestWorkflow(environmentId string, executionId string, executionToken string, runtime *cloud.TestWorkflowRuntime) error {
 	ctx := context.Background()
-	logger := a.logger.With("environmentId", environmentId, "executionId", executionId)
+	logger := a.logger.With("environmentId", environmentId)
 
 	// Get the execution details
 	execution, err := a.client.GetExecution(ctx, environmentId, executionId)
@@ -372,9 +372,8 @@ func (a *agentLoop) directRunTestWorkflow(environmentId string, executionId stri
 		return errors2.Wrapf(err, "failed to get execution details '%s/%s' from Control Plane", environmentId, executionId)
 	}
 
-	// Enrich the scoped logger with human-readable context (workflow name, trigger/source)
-	// so every downstream log line for this execution is easy to identify.
-	logger = a.logger.With("environmentId", environmentId)
+	// Enrich the scoped logger with human-readable context (execution ID, workflow name,
+	// trigger/source) so every downstream log line for this execution is easy to identify.
 	logger = logger.With(execution.LogFields()...)
 	if execution.RunnerId != a.proContext.Agent.ID && execution.RunnerId != "" {
 		return errors.New("execution is assigned to a different runner")

--- a/pkg/runner/agent.go
+++ b/pkg/runner/agent.go
@@ -371,6 +371,11 @@ func (a *agentLoop) directRunTestWorkflow(environmentId string, executionId stri
 	if err != nil {
 		return errors2.Wrapf(err, "failed to get execution details '%s/%s' from Control Plane", environmentId, executionId)
 	}
+
+	// Enrich the scoped logger with human-readable context (workflow name, trigger/source)
+	// so every downstream log line for this execution is easy to identify.
+	logger = a.logger.With("environmentId", environmentId)
+	logger = logger.With(execution.LogFields()...)
 	if execution.RunnerId != a.proContext.Agent.ID && execution.RunnerId != "" {
 		return errors.New("execution is assigned to a different runner")
 	}
@@ -392,7 +397,6 @@ func (a *agentLoop) directRunTestWorkflow(environmentId string, executionId stri
 			Variables: runtime.EnvVars,
 		}
 		logger.Debugw("Received runtime configuration from control plane",
-			"executionId", executionId,
 			"variableCount", len(runtime.EnvVars))
 	}
 
@@ -400,8 +404,7 @@ func (a *agentLoop) directRunTestWorkflow(environmentId string, executionId stri
 	if testworkflowutils.IsWorkflowSilent(execution.ResolvedWorkflow) {
 		// This overrides any SilentMode settings from the request (CLI flags)
 		execution.SilentMode = testworkflowutils.NewSilenceAllSilentMode()
-		logger.Debugw("Workflow is silent, activated SilentMode for execution",
-			"executionId", executionId)
+		logger.Debugw("Workflow is silent, activated SilentMode for execution")
 	}
 
 	result, err := a.runner.Execute(executionworkertypes.ExecuteRequest{

--- a/pkg/runner/agent.go
+++ b/pkg/runner/agent.go
@@ -138,7 +138,7 @@ func (a *agentLoop) saveEmptyLogs(ctx context.Context, environmentId string, exe
 		return a._saveEmptyLogs(ctx, environmentId, execution)
 	})
 	if err != nil {
-		a.logger.Errorw("failed to save empty log", "executionId", execution.Id, "error", err)
+		a.logger.Errorw("failed to save empty log", append(execution.LogFields(), "error", err)...)
 	}
 	return err
 }
@@ -147,28 +147,28 @@ func (a *agentLoop) finishExecution(ctx context.Context, environmentId string, e
 	err := retry(saveResultRetryMaxAttempts, saveResultRetryBaseDelay, func(_ int) error {
 		err := a.client.FinishExecutionResult(ctx, environmentId, execution.Id, execution.Result)
 		if err != nil {
-			a.logger.Warnw("failed to finish the TestWorkflow execution in database", "recoverable", true, "executionId", execution.Id, "error", err)
+			a.logger.Warnw("failed to finish the TestWorkflow execution in database", append(execution.LogFields(), "recoverable", true, "error", err)...)
 			return err
 		}
 		return nil
 	})
 	if err != nil {
-		a.logger.Errorw("failed to finish the TestWorkflow execution in database", "recoverable", false, "executionId", execution.Id, "error", err)
+		a.logger.Errorw("failed to finish the TestWorkflow execution in database", append(execution.LogFields(), "recoverable", false, "error", err)...)
 	}
 	return err
 }
 
 func (a *agentLoop) init(ctx context.Context, environmentId string, execution *testkube.TestWorkflowExecution) error {
 	err := retry(saveResultRetryMaxAttempts, saveResultRetryBaseDelay, func(retryCount int) (err error) {
-		a.logger.Infow("Initializing execution", "executionId", execution.Id, "attempt", retryCount)
+		a.logger.Infow("Initializing execution", append(execution.LogFields(), "attempt", retryCount)...)
 		err = a.client.InitExecution(ctx, environmentId, execution.Id, execution.Signature, execution.Namespace)
 		if err != nil {
-			a.logger.Warnw("failed to initialize the TestWorkflow execution in database", "recoverable", true, "executionId", execution.Id, "error", err)
+			a.logger.Warnw("failed to initialize the TestWorkflow execution in database", append(execution.LogFields(), "recoverable", true, "error", err)...)
 		}
 		return err
 	})
 	if err != nil {
-		a.logger.Errorw("failed to initialize the TestWorkflow execution in database", "recoverable", false, "executionId", execution.Id, "error", err)
+		a.logger.Errorw("failed to initialize the TestWorkflow execution in database", append(execution.LogFields(), "recoverable", false, "error", err)...)
 	}
 	return err
 }

--- a/pkg/runner/executionsaver.go
+++ b/pkg/runner/executionsaver.go
@@ -153,7 +153,7 @@ func (s *executionSaver) End(ctx context.Context, result testkube.TestWorkflowRe
 				return err
 			}
 		} else {
-			log.DefaultLogger.Infow("TestWorkflow log archive is not required; skipping log archive upload", "id", s.id)
+			log.DefaultLogger.Infow("TestWorkflow log archive is not required; skipping log archive upload", "executionId", s.id)
 		}
 	}
 

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -441,13 +441,13 @@ func (r *runner) Monitor(ctx context.Context, organizationId string, environment
 	err := retry(GetExecutionRetryCount, GetExecutionRetryDelay, func(_ int) (err error) {
 		execution, err = r.client.GetExecution(ctx, environmentId, id)
 		if err != nil {
-			log.DefaultLogger.Warnw("failed to get execution for monitoring, retrying...", "id", id, "error", err)
+			log.DefaultLogger.Warnw("failed to get execution for monitoring, retrying...", "executionId", id, "error", err)
 		}
 		return err
 	})
 	if err != nil {
 		r.watching.Delete(id)
-		log.DefaultLogger.Errorw("failed to get execution for monitoring", "id", id, "error", err)
+		log.DefaultLogger.Errorw("failed to get execution for monitoring", "executionId", id, "error", err)
 		return err
 	}
 	return r.monitor(ctx, organizationId, environmentId, *execution)
@@ -498,22 +498,22 @@ func (r *runner) execute(request executionworkertypes.ExecuteRequest) (*executio
 			err := retry(MonitorRetryCount, MonitorRetryDelay, func(_ int) error {
 				err := r.Monitor(context.Background(), request.Execution.OrganizationId, request.Execution.EnvironmentId, request.Execution.Id)
 				if err != nil {
-					log.DefaultLogger.Warnw("failed to monitor execution, retrying...", "id", request.Execution.Id, "error", err)
+					log.DefaultLogger.Warnw("failed to monitor execution, retrying...", "executionId", request.Execution.Id, "error", err)
 				}
 				return err
 			})
 			if err != nil {
 				log.DefaultLogger.Errorw(
 					"failed to monitor execution and retry limit is reached, assuming execution is stuck and running cleanup...",
-					"id", request.Execution.Id,
+					"executionId", request.Execution.Id,
 					"error", err,
 				)
 				// At this point, all retries have failed and nothing is monitoring the execution anymore.
 				// We can assume that the execution is stuck in running state and we need to abort it.
 				if err := r.abortExecution(context.Background(), request.Execution.EnvironmentId, request.Execution.Id); err != nil {
-					log.DefaultLogger.Errorw("failed to abort stuck execution", "id", request.Execution.Id, "error", err)
+					log.DefaultLogger.Errorw("failed to abort stuck execution", "executionId", request.Execution.Id, "error", err)
 				}
-				log.DefaultLogger.Warnw("aborted execution stuck in running state", "id", request.Execution.Id)
+				log.DefaultLogger.Warnw("aborted execution stuck in running state", "executionId", request.Execution.Id)
 			}
 		}()
 	}

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -495,25 +495,27 @@ func (r *runner) execute(request executionworkertypes.ExecuteRequest) (*executio
 	res, err := r.worker.Execute(context.Background(), request)
 	if err == nil {
 		go func() {
+			// The full execution object isn't available here (only the ExecuteRequest), so we
+			// scope with the fields we do have: the execution ID and the workflow name.
+			logger := log.DefaultLogger.With("executionId", request.Execution.Id, "workflowName", request.Workflow.Name)
 			err := retry(MonitorRetryCount, MonitorRetryDelay, func(_ int) error {
 				err := r.Monitor(context.Background(), request.Execution.OrganizationId, request.Execution.EnvironmentId, request.Execution.Id)
 				if err != nil {
-					log.DefaultLogger.Warnw("failed to monitor execution, retrying...", "executionId", request.Execution.Id, "error", err)
+					logger.Warnw("failed to monitor execution, retrying...", "error", err)
 				}
 				return err
 			})
 			if err != nil {
-				log.DefaultLogger.Errorw(
+				logger.Errorw(
 					"failed to monitor execution and retry limit is reached, assuming execution is stuck and running cleanup...",
-					"executionId", request.Execution.Id,
 					"error", err,
 				)
 				// At this point, all retries have failed and nothing is monitoring the execution anymore.
 				// We can assume that the execution is stuck in running state and we need to abort it.
 				if err := r.abortExecution(context.Background(), request.Execution.EnvironmentId, request.Execution.Id); err != nil {
-					log.DefaultLogger.Errorw("failed to abort stuck execution", "executionId", request.Execution.Id, "error", err)
+					logger.Errorw("failed to abort stuck execution", "error", err)
 				}
-				log.DefaultLogger.Warnw("aborted execution stuck in running state", "executionId", request.Execution.Id)
+				logger.Warnw("aborted execution stuck in running state")
 			}
 		}()
 	}

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -108,6 +108,10 @@ func New(
 func (r *runner) monitor(ctx context.Context, organizationId string, environmentId string, execution testkube.TestWorkflowExecution) error {
 	defer r.watching.Delete(execution.Id)
 
+	// Scoped logger carrying human-readable context (workflow name, trigger/source) so every
+	// log line emitted while monitoring this execution is easy to identify.
+	logger := log.DefaultLogger.With(execution.LogFields()...)
+
 	var notifications executionworkertypes.NotificationsWatcher
 	for i := 0; i < GetNotificationsRetryCount; i++ {
 		notifications = r.worker.Notifications(ctx, execution.Id, executionworkertypes.NotificationsOptions{})
@@ -187,13 +191,13 @@ func (r *runner) monitor(ctx context.Context, organizationId string, environment
 				currentRef = n.Ref
 				err = logs.WriteStart(n.Ref)
 				if err != nil {
-					log.DefaultLogger.Errorw("failed to write start logs", "id", execution.Id, "ref", n.Ref)
+					logger.Errorw("failed to write start logs", "ref", n.Ref)
 					continue
 				}
 			}
 			_, err = logs.Write([]byte(n.Log))
 			if err != nil {
-				log.DefaultLogger.Errorw("failed to write logs", "id", execution.Id, "ref", n.Ref)
+				logger.Errorw("failed to write logs", "ref", n.Ref)
 				continue
 			}
 		}
@@ -205,11 +209,11 @@ func (r *runner) monitor(ctx context.Context, organizationId string, environment
 	}
 
 	if notifications.Err() != nil {
-		log.DefaultLogger.Errorw("error from TestWorkflow watcher", "id", execution.Id, "error", notifications.Err())
+		logger.Errorw("error from TestWorkflow watcher", "error", notifications.Err())
 	}
 
 	if lastResult == nil || !lastResult.IsFinished() {
-		log.DefaultLogger.Errorw("not finished TestWorkflow result received, trying to recover...", "id", execution.Id)
+		logger.Errorw("not finished TestWorkflow result received, trying to recover...")
 		watcher := r.worker.Notifications(ctx, execution.Id, executionworkertypes.NotificationsOptions{
 			NoFollow: true,
 		})
@@ -225,7 +229,7 @@ func (r *runner) monitor(ctx context.Context, organizationId string, environment
 			lastResult = execution.Result
 		}
 		if !lastResult.IsFinished() {
-			log.DefaultLogger.Errorw("failed to recover TestWorkflow result, marking as fatal error...", "id", execution.Id)
+			logger.Errorw("failed to recover TestWorkflow result, marking as fatal error...")
 			lastResult.Fatal(err, true, time.Now())
 		}
 	}
@@ -234,7 +238,7 @@ func (r *runner) monitor(ctx context.Context, organizationId string, environment
 	if lastResult.IsAborted() || lastResult.IsCanceled() {
 		// Service logs
 		if len(services) > 0 {
-			log.DefaultLogger.Warnw("TestWorkflow execution has been aborted or canceled, while some services are still running. Recovering their logs.", "executionId", execution.Id, "count", len(services))
+			logger.Warnw("TestWorkflow execution has been aborted or canceled, while some services are still running. Recovering their logs.", "count", len(services))
 			for svc := range services {
 				err := r.recoverServiceData(ctx, saver, environmentId, &execution, commands.ServiceInfo{
 					Group: svc.GroupId,
@@ -242,37 +246,36 @@ func (r *runner) monitor(ctx context.Context, organizationId string, environment
 					Name:  svc.Name,
 				})
 				if err == nil {
-					log.DefaultLogger.Infow("recovered TestWorkflow execution service logs", "executionId", execution.Id, "serviceName", svc.Name, "serviceIndex", svc.Index)
+					logger.Infow("recovered TestWorkflow execution service logs", "serviceName", svc.Name, "serviceIndex", svc.Index)
 				} else {
-					log.DefaultLogger.Errorw("failed to recover TestWorkflow execution service logs", "executionId", execution.Id, "serviceName", svc.Name, "serviceIndex", svc.Index, "error", err)
+					logger.Errorw("failed to recover TestWorkflow execution service logs", "serviceName", svc.Name, "serviceIndex", svc.Index, "error", err)
 				}
 			}
 		}
 
 		// Parallel steps logs
 		if len(parallel) > 0 {
-			log.DefaultLogger.Warnw("TestWorkflow execution has been aborted or canceled, while some parallel steps are still running. Recovering their logs.", "executionId", execution.Id, "count", len(parallel))
+			logger.Warnw("TestWorkflow execution has been aborted or canceled, while some parallel steps are still running. Recovering their logs.", "count", len(parallel))
 			for step := range parallel {
 				err := r.recoverParallelStepData(ctx, saver, environmentId, &execution, step.GroupId, int(step.Index))
 				if err == nil {
-					log.DefaultLogger.Infow("recovered TestWorkflow execution parallel step logs", "executionId", execution.Id, "stepRef", step.GroupId, "stepIndex", step.Index)
+					logger.Infow("recovered TestWorkflow execution parallel step logs", "stepRef", step.GroupId, "stepIndex", step.Index)
 				} else {
-					log.DefaultLogger.Errorw("failed to recover TestWorkflow execution parallel step logs", "executionId", execution.Id, "stepRef", step.GroupId, "stepIndex", step.Index, "error", err)
+					logger.Errorw("failed to recover TestWorkflow execution parallel step logs", "stepRef", step.GroupId, "stepIndex", step.Index, "error", err)
 				}
 			}
 		}
 	}
 
-	log.DefaultLogger.Infow("Saving execution", "id", execution.Id)
+	logger.Infow("Saving execution")
 	for i := 0; i < SaveEndResultRetryCount; i++ {
 		err = saver.End(ctx, *lastResult)
 		if err == nil {
 			break
 		}
 		sleepDuration := time.Duration(i/10) * SaveEndResultRetryBaseDelay
-		log.DefaultLogger.Warnw(
+		logger.Warnw(
 			"failed to end execution and save execution data, retrying...",
-			"id", execution.Id,
 			"retryCount", i,
 			"retryDelay", sleepDuration,
 			"error", err,
@@ -282,14 +285,14 @@ func (r *runner) monitor(ctx context.Context, organizationId string, environment
 
 	// Handle fatal error
 	if err != nil {
-		log.DefaultLogger.Errorw("failed to save execution data", "id", execution.Id, "error", err)
+		logger.Errorw("failed to save execution data", "error", err)
 		return errors.Wrapf(err, "failed to save execution '%s' data", execution.Id)
 	}
 
 	err = r.worker.Destroy(context.Background(), execution.Id, executionworkertypes.DestroyOptions{})
 	if err != nil {
 		// TODO: what to do on error?
-		log.DefaultLogger.Errorw("failed to cleanup TestWorkflow resources", "id", execution.Id, "error", err)
+		logger.Errorw("failed to cleanup TestWorkflow resources", "error", err)
 	}
 
 	return nil

--- a/pkg/runner/service.go
+++ b/pkg/runner/service.go
@@ -95,9 +95,12 @@ func (s *service) reattach(ctx context.Context) (err error) {
 				return
 			}
 
+			// Enrich logs with human-readable context now that the execution is loaded.
+			logger := s.logger.With(execution.LogFields()...)
+
 			// Ignore if it's still queued - orchestrator will reattach to it later
 			if execution.Result.IsQueued() {
-				s.logger.Warnw("execution to monitor is still queued: leaving it for orchestrator", "id", executionId)
+				logger.Warnw("execution to monitor is still queued: leaving it for orchestrator")
 				return
 			}
 
@@ -120,9 +123,9 @@ func (s *service) reattach(ctx context.Context) (err error) {
 			execution.Result.HealMissingPauseStatuses()
 			execution.Result.HealStatus(sigSequence)
 			if err = s.client.FinishExecutionResult(ctx, environmentId, executionId, execution.Result); err != nil {
-				s.logger.Errorw("failed to recover execution: saving execution", "id", executionId, "error", err)
+				logger.Errorw("failed to recover execution: saving execution", "error", err)
 			} else {
-				s.logger.Infow("recovered execution", "id", executionId, "error", err)
+				logger.Infow("recovered execution")
 			}
 		}(exec.EnvironmentId, exec.Id)
 	}

--- a/pkg/runner/service.go
+++ b/pkg/runner/service.go
@@ -82,16 +82,16 @@ func (s *service) reattach(ctx context.Context) (err error) {
 				return
 			}
 			if !errors.Is(err, registry.ErrResourceNotFound) && !errors.Is(err, controller.ErrJobAborted) {
-				s.logger.Errorw("failed to monitor execution", "id", executionId, "error", err)
+				s.logger.Errorw("failed to monitor execution", "executionId", executionId, "error", err)
 				return
 			}
 
-			s.logger.Warnw("execution to monitor not found. reattaching again.", "id", executionId, "error", err)
+			s.logger.Warnw("execution to monitor not found. reattaching again.", "executionId", executionId, "error", err)
 
 			// Get the existing execution
 			execution, err := s.client.GetExecution(ctx, environmentId, executionId)
 			if err != nil {
-				s.logger.Errorw("failed to reattach to execution: getting execution", "id", executionId, "error", err)
+				s.logger.Errorw("failed to reattach to execution: getting execution", "executionId", executionId, "error", err)
 				return
 			}
 

--- a/pkg/testworkflows/testworkflowprocessor/constants/constants.go
+++ b/pkg/testworkflows/testworkflowprocessor/constants/constants.go
@@ -24,6 +24,7 @@ const (
 	RootResourceIdLabelName         = "testkube.io/root"
 	RunnerIdLabelName               = "testkube.io/runner"
 	GroupIdLabelName                = "testkube.io/contextGroup"
+	WorkflowNameLabelName           = "testkube.io/workflow-name"
 	SignatureAnnotationName         = "testkube.io/signature"
 	SignatureAnnotationFieldPath    = "metadata.annotations['" + SignatureAnnotationName + "']"
 	ScheduledAtAnnotationName       = "testkube.io/at"

--- a/pkg/testworkflows/testworkflowprocessor/processor.go
+++ b/pkg/testworkflows/testworkflowprocessor/processor.go
@@ -25,6 +25,7 @@ import (
 	"github.com/kubeshop/testkube/pkg/testworkflows/testworkflowprocessor/constants"
 	"github.com/kubeshop/testkube/pkg/testworkflows/testworkflowprocessor/stage"
 	"github.com/kubeshop/testkube/pkg/testworkflows/testworkflowresolver"
+	"github.com/kubeshop/testkube/pkg/utils"
 )
 
 //go:generate go tool mockgen -destination=./mock_processor.go -package=testworkflowprocessor "github.com/kubeshop/testkube/pkg/testworkflows/testworkflowprocessor" Processor
@@ -621,6 +622,12 @@ func (p *processor) Bundle(ctx context.Context, workflow *testworkflowsv1.TestWo
 		return nil, errors.Wrap(err, "finalizing job spec")
 	}
 	jobSpec.Spec.Template = podSpec
+
+	// Stamp the human-readable workflow name as a label on the job and its pod template so
+	// runner pods can be selected by workflow in observability tooling (Prometheus/Grafana).
+	if workflowNameLabel := utils.SanitizeLabelValue(options.Config.Workflow.Name); workflowNameLabel != "" {
+		AnnotateWorkflowName(&jobSpec, workflowNameLabel)
+	}
 
 	// TODO(TKC-2585): Avoid adding the secrets to all the groups without isolation
 	addEnvVarToContainerSpec(mapEnv, jobSpec.Spec.Template.Spec.InitContainers)

--- a/pkg/testworkflows/testworkflowprocessor/processor_test.go
+++ b/pkg/testworkflows/testworkflowprocessor/processor_test.go
@@ -13,6 +13,7 @@ import (
 	testworkflowsv1 "github.com/kubeshop/testkube/api/testworkflows/v1"
 	"github.com/kubeshop/testkube/pkg/imageinspector"
 	"github.com/kubeshop/testkube/pkg/testworkflows/testworkflowconfig"
+	"github.com/kubeshop/testkube/pkg/testworkflows/testworkflowprocessor/constants"
 )
 
 type dummyInspector struct{}
@@ -105,6 +106,65 @@ func TestBundle_InvalidDefaultRunnerResources_ReturnsError(t *testing.T) {
 
 	require.Error(t, err)
 	require.ErrorContains(t, err, `invalid worker default runner CPU request "not-valid"`)
+}
+
+func TestBundle_WorkflowNameLabel_Applied(t *testing.T) {
+	proc := New(&dummyInspector{}).
+		Register(ProcessRunCommand).
+		Register(ProcessShellCommand).
+		Register(ProcessNestedSteps)
+	workflow := &testworkflowsv1.TestWorkflow{
+		Spec: testworkflowsv1.TestWorkflowSpec{
+			Steps: []testworkflowsv1.Step{
+				{StepOperations: testworkflowsv1.StepOperations{Shell: "echo hello"}},
+			},
+		},
+	}
+
+	bundle, err := proc.Bundle(context.Background(), workflow, BundleOptions{
+		Config: testworkflowconfig.InternalConfig{
+			Resource: testworkflowconfig.ResourceConfig{
+				Id:     "resource-id",
+				RootId: "resource-root-id",
+			},
+			Workflow: testworkflowconfig.WorkflowConfig{
+				Name: "my-workflow",
+			},
+		},
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, "my-workflow", bundle.Job.Labels[constants.WorkflowNameLabelName])
+	assert.Equal(t, "my-workflow", bundle.Job.Spec.Template.Labels[constants.WorkflowNameLabelName])
+}
+
+func TestBundle_WorkflowNameLabel_Sanitized(t *testing.T) {
+	proc := New(&dummyInspector{}).
+		Register(ProcessRunCommand).
+		Register(ProcessShellCommand).
+		Register(ProcessNestedSteps)
+	workflow := &testworkflowsv1.TestWorkflow{
+		Spec: testworkflowsv1.TestWorkflowSpec{
+			Steps: []testworkflowsv1.Step{
+				{StepOperations: testworkflowsv1.StepOperations{Shell: "echo hello"}},
+			},
+		},
+	}
+
+	bundle, err := proc.Bundle(context.Background(), workflow, BundleOptions{
+		Config: testworkflowconfig.InternalConfig{
+			Resource: testworkflowconfig.ResourceConfig{
+				Id:     "resource-id",
+				RootId: "resource-root-id",
+			},
+			Workflow: testworkflowconfig.WorkflowConfig{
+				Name: "My Workflow/Name",
+			},
+		},
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, "My-Workflow-Name", bundle.Job.Spec.Template.Labels[constants.WorkflowNameLabelName])
 }
 
 func TestBundle_DefaultImagePullPolicy_Applied(t *testing.T) {

--- a/pkg/testworkflows/testworkflowprocessor/processor_test.go
+++ b/pkg/testworkflows/testworkflowprocessor/processor_test.go
@@ -164,6 +164,7 @@ func TestBundle_WorkflowNameLabel_Sanitized(t *testing.T) {
 	})
 
 	require.NoError(t, err)
+	assert.Equal(t, "My-Workflow-Name", bundle.Job.Labels[constants.WorkflowNameLabelName])
 	assert.Equal(t, "My-Workflow-Name", bundle.Job.Spec.Template.Labels[constants.WorkflowNameLabelName])
 }
 

--- a/pkg/testworkflows/testworkflowprocessor/utils.go
+++ b/pkg/testworkflows/testworkflowprocessor/utils.go
@@ -22,6 +22,23 @@ func AnnotateControlledBy(obj metav1.Object, rootId, id string) {
 	}
 }
 
+// AnnotateWorkflowName stamps the human-readable TestWorkflow name as a label so runner
+// pods/jobs can be selected by workflow in observability tooling (Prometheus/Grafana).
+// The name must already be sanitized to a valid Kubernetes label value.
+func AnnotateWorkflowName(obj metav1.Object, name string) {
+	labels := obj.GetLabels()
+	if labels == nil {
+		labels = map[string]string{}
+	}
+	labels[constants.WorkflowNameLabelName] = name
+	obj.SetLabels(labels)
+
+	// Annotate Pod template in the Job
+	if v, ok := obj.(*batchv1.Job); ok {
+		AnnotateWorkflowName(&v.Spec.Template, name)
+	}
+}
+
 func AnnotateGroupId(obj metav1.Object, id string) {
 	labels := obj.GetLabels()
 	if labels == nil {

--- a/pkg/triggers/executor.go
+++ b/pkg/triggers/executor.go
@@ -188,8 +188,8 @@ func (s *Service) execute(ctx context.Context, e *watcherEvent, t *internalTrigg
 	}
 
 	// Record the TestTrigger as the running context so downstream logs and APIs carry the
-	// human-readable trigger name and source. Built without the TCL helper so it applies to
-	// the OSS/standalone agent as well as Pro editions.
+	// human-readable trigger name. Built without the TCL helper so it applies to the
+	// OSS/standalone agent as well as Pro editions.
 	request.RunningContext, _ = testworkflowexecutor.GetNewRunningContext(newTriggerRunningContext(t.Name), nil)
 
 	if t.Delay != nil {

--- a/pkg/triggers/executor.go
+++ b/pkg/triggers/executor.go
@@ -19,10 +19,8 @@ import (
 	"github.com/kubeshop/testkube/pkg/api/v1/testkube"
 	"github.com/kubeshop/testkube/pkg/cloud"
 	"github.com/kubeshop/testkube/pkg/expressions"
-	"github.com/kubeshop/testkube/pkg/log"
 	"github.com/kubeshop/testkube/pkg/mapper/testworkflows"
 	"github.com/kubeshop/testkube/pkg/newclients/testworkflowclient"
-	triggerstcl "github.com/kubeshop/testkube/pkg/tcl/testworkflowstcl/triggers"
 	"github.com/kubeshop/testkube/pkg/testworkflows/testworkflowexecutor"
 	"github.com/kubeshop/testkube/pkg/utils"
 )
@@ -35,6 +33,20 @@ const (
 )
 
 type ExecutorF func(context.Context, *watcherEvent, *internalTrigger) error
+
+// newTriggerRunningContext builds the running context recorded on executions started by a
+// TestTrigger, identifying the trigger by name. It applies in OSS as well as Pro editions.
+func newTriggerRunningContext(triggerName string) *testkube.TestWorkflowRunningContext {
+	return &testkube.TestWorkflowRunningContext{
+		Interface_: &testkube.TestWorkflowRunningContextInterface{
+			Type_: common.Ptr(testkube.INTERNAL_TestWorkflowRunningContextInterfaceType),
+		},
+		Actor: &testkube.TestWorkflowRunningContextActor{
+			Name:  triggerName,
+			Type_: common.Ptr(testkube.TESTTRIGGER_TestWorkflowRunningContextActorType),
+		},
+	}
+}
 
 func (s *Service) execute(ctx context.Context, e *watcherEvent, t *internalTrigger) error {
 	// If the trigger was removed between match() and execute() (concurrent
@@ -175,34 +187,39 @@ func (s *Service) execute(ctx context.Context, e *watcherEvent, t *internalTrigg
 		}),
 	}
 
-	// Pro edition only (tcl protected code)
-	if s.proContext != nil && s.proContext.APIKey != "" {
-		request.RunningContext, _ = testworkflowexecutor.GetNewRunningContext(triggerstcl.GetRunningContext(t.Name), nil)
-	}
+	// Record the TestTrigger as the running context so downstream logs and APIs carry the
+	// human-readable trigger name and source. Built without the TCL helper so it applies to
+	// the OSS/standalone agent as well as Pro editions.
+	request.RunningContext, _ = testworkflowexecutor.GetNewRunningContext(newTriggerRunningContext(t.Name), nil)
 
 	if t.Delay != nil {
 		s.logger.Infof(
-			"trigger service: executor component: trigger %s/%s has delayed testworkflow execution configured for %f seconds",
-			t.Namespace, t.Name, t.Delay.Seconds(),
+			"trigger service: executor component: trigger %s/%s (source %s) has delayed testworkflow execution configured for %f seconds",
+			t.Namespace, t.Name, t.Source, t.Delay.Seconds(),
 		)
 		time.Sleep(*t.Delay)
 	}
 	s.logger.Infof(
-		"trigger service: executor component: scheduling testworkflow executions for trigger %s/%s",
-		t.Namespace, t.Name,
+		"trigger service: executor component: scheduling testworkflow executions for trigger %s/%s (source %s)",
+		t.Namespace, t.Name, t.Source,
 	)
 
 	executions, err := s.testWorkflowExecutor.Execute(ctx, request)
 	if err != nil {
-		log.DefaultLogger.Errorw(fmt.Sprintf("trigger service: error executing testworkflow for trigger %s/%s", t.Namespace, t.Name), "error", err)
+		s.logger.Errorw(fmt.Sprintf("trigger service: error executing testworkflow for trigger %s/%s (source %s)", t.Namespace, t.Name, t.Source), "error", err)
 		return nil
 	}
+	executionIDs := make([]string, 0, len(executions))
 	for _, exec := range executions {
 		status.addTestWorkflowExecutionID(exec.Id)
+		executionIDs = append(executionIDs, exec.Id)
 	}
 
 	status.start()
-	s.logger.Debugf("trigger service: executor component: started test execution for trigger %s/%s", t.Namespace, t.Name)
+	s.logger.Infof(
+		"trigger service: executor component: started testworkflow executions %v for trigger %s/%s (source %s)",
+		executionIDs, t.Namespace, t.Name, t.Source,
+	)
 
 	return nil
 }

--- a/pkg/triggers/executor_test.go
+++ b/pkg/triggers/executor_test.go
@@ -6,7 +6,29 @@ import (
 	"github.com/stretchr/testify/assert"
 	appsv1 "k8s.io/api/apps/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/kubeshop/testkube/pkg/api/v1/testkube"
+	"github.com/kubeshop/testkube/pkg/cloud"
+	"github.com/kubeshop/testkube/pkg/testworkflows/testworkflowexecutor"
 )
+
+// TestNewTriggerRunningContext verifies that executions started by a TestTrigger record the
+// trigger name as their running context, and that it maps to the TESTTRIGGER cloud context.
+// This applies regardless of edition (previously the running context was only set in Pro).
+func TestNewTriggerRunningContext(t *testing.T) {
+	legacy := newTriggerRunningContext("my-trigger")
+
+	assert.NotNil(t, legacy.Actor)
+	assert.Equal(t, "my-trigger", legacy.Actor.Name)
+	assert.NotNil(t, legacy.Actor.Type_)
+	assert.Equal(t, testkube.TESTTRIGGER_TestWorkflowRunningContextActorType, *legacy.Actor.Type_)
+
+	runningContext, untrustedUser := testworkflowexecutor.GetNewRunningContext(legacy, nil)
+	assert.Nil(t, untrustedUser)
+	assert.NotNil(t, runningContext)
+	assert.Equal(t, cloud.RunningContextType_TESTTRIGGER, runningContext.Type)
+	assert.Equal(t, "my-trigger", runningContext.Name)
+}
 
 // TestGetTemplateData_MetadataLabels verifies that Go templates in v1
 // TestTrigger actionParameters work with BOTH JSON-style field names

--- a/pkg/triggers/matcher.go
+++ b/pkg/triggers/matcher.go
@@ -100,7 +100,7 @@ func (s *Service) match(ctx context.Context, e *watcherEvent) error {
 			}
 		}
 
-		s.logger.Infof("trigger service: matcher component: event %s matches trigger %s/%s for resource %s", e.eventType, t.Namespace, t.Name, e.resource)
+		s.logger.Infof("trigger service: matcher component: event %s matches trigger %s/%s (source %s) for resource %s", e.eventType, t.Namespace, t.Name, t.Source, e.resource)
 
 		var causes []string
 		for _, cause := range e.causes {

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -134,9 +134,9 @@ func SanitizeName(path string) string {
 }
 
 // SanitizeLabelValue sanitizes a string so it conforms to Kubernetes label value rules
-// (max 63 characters, alphanumeric plus '-', '_' and '.', beginning and ending with an
-// alphanumeric character). Invalid characters are replaced with '-'. It returns an empty
-// string if the value cannot be made into a valid label value.
+// (max 63 characters; alphanumeric plus '-', '_' and '.', optionally empty).
+// Invalid characters are replaced with '-'. It returns "" if the input is empty or if the
+// value cannot be sanitized into a valid label value.
 func SanitizeLabelValue(value string) string {
 	if value == "" {
 		return value

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -16,6 +16,7 @@ import (
 	"github.com/Masterminds/sprig/v3"
 	"github.com/jackc/pgx/v5"
 	"go.mongodb.org/mongo-driver/v2/mongo"
+	"k8s.io/apimachinery/pkg/util/validation"
 )
 
 func IsNotFound(err error) bool {
@@ -130,6 +131,50 @@ func SanitizeName(path string) string {
 	}
 
 	return path
+}
+
+// SanitizeLabelValue sanitizes a string so it conforms to Kubernetes label value rules
+// (max 63 characters, alphanumeric plus '-', '_' and '.', beginning and ending with an
+// alphanumeric character). Invalid characters are replaced with '-'. It returns an empty
+// string if the value cannot be made into a valid label value.
+func SanitizeLabelValue(value string) string {
+	if value == "" {
+		return value
+	}
+
+	// Replace invalid characters with hyphens
+	sanitized := strings.Map(func(r rune) rune {
+		if isAllowedLabelRune(r) {
+			return r
+		}
+		return '-'
+	}, value)
+
+	// Truncate if too long
+	if len(sanitized) > validation.LabelValueMaxLength {
+		sanitized = sanitized[:validation.LabelValueMaxLength]
+	}
+
+	// Trim non-alphanumeric characters from start and end
+	sanitized = strings.TrimLeftFunc(sanitized, func(r rune) bool { return !isAlphaNumeric(r) })
+	sanitized = strings.TrimRightFunc(sanitized, func(r rune) bool { return !isAlphaNumeric(r) })
+
+	// Final validation
+	if errs := validation.IsValidLabelValue(sanitized); len(errs) > 0 {
+		return ""
+	}
+
+	return sanitized
+}
+
+// isAllowedLabelRune returns true if the rune is allowed in a Kubernetes label value.
+func isAllowedLabelRune(r rune) bool {
+	return isAlphaNumeric(r) || r == '-' || r == '_' || r == '.'
+}
+
+// isAlphaNumeric returns true if the rune is an ASCII alphanumeric character.
+func isAlphaNumeric(r rune) bool {
+	return (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9')
 }
 
 // EscapeDots escapes dots for MongoDB fields

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -71,6 +71,31 @@ func TestSanitizeName(t *testing.T) {
 	})
 }
 
+func TestSanitizeLabelValue(t *testing.T) {
+	tests := []struct {
+		name  string
+		value string
+		want  string
+	}{
+		{name: "empty stays empty", value: "", want: ""},
+		{name: "valid value unchanged", value: "my-workflow.name_1", want: "my-workflow.name_1"},
+		{name: "invalid chars replaced with hyphen", value: "my workflow/name", want: "my-workflow-name"},
+		{name: "leading and trailing punctuation trimmed", value: ".-my-workflow-.", want: "my-workflow"},
+		{name: "truncated to 63 chars", value: strings.Repeat("a", 100), want: strings.Repeat("a", 63)},
+		{name: "unsanitizable value becomes empty", value: strings.Repeat("/", 5), want: ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := SanitizeLabelValue(tt.value)
+			assert.Equal(t, tt.want, got)
+			if got != "" {
+				assert.LessOrEqual(t, len(got), 63)
+			}
+		})
+	}
+}
+
 func TestNewTemplate(t *testing.T) {
 
 	t.Run("sprig functions should be available", func(t *testing.T) {


### PR DESCRIPTION
## Context

  Debugging failures is slow because execution-related logs often carry only the execution ID, omitting the context needed to find the relevant event —
  the TestWorkflow name, TestTrigger name, and trigger source. Separately, runner pods only carry the workflow name inside a JSON annotation
  (testkube.io/config), so observability tools (Prometheus/Grafana) can't select pods by workflow.

  The data needed for richer logs is already on the objects in scope at every major log site; it just wasn't being logged. This PR enriches the log
  chokepoints, adds a queryable workflow-name label to runner pods, and closes an OSS gap where the trigger name was never recorded on an execution's
  RunningContext.

  ## Changes

  ### Enriched execution logs with workflow/trigger context

  - Added (*TestWorkflowExecution).LogFields() — a null-safe helper returning executionId, workflowName, and runContextType/runContextName.
  - Re-scoped the per-execution loggers to carry those fields in pkg/runner/agent.go, pkg/runner/runner.go (monitor), pkg/runner/service.go (reattach),
  and pkg/controlplane/scheduling/enqueuer.go; dropped the now-redundant inline id/executionId args.
  - Added the trigger source to trigger logs (matcher.go, executor.go), switched the error log off the global logger to the scoped s.logger, and made
  the "started" log list the scheduled execution IDs so a trigger ties to its executions.

  ### Added a queryable workflow-name label to runner pods

  - New label constant testkube.io/workflow-name.
  - New exported utils.SanitizeLabelValue (extracted from existing k8sevents logic): valid K8s label value, ≤63 chars, empty if unsalvageable.
  - AnnotateWorkflowName helper + a call in processor.go Bundle() stamping the sanitized name onto the Job and its pod template.

  kubectl get pods -l testkube.io/workflow-name={name}

### Recorded trigger RunningContext for OSS executions

  - Removed the Pro-only (APIKey) gate in pkg/triggers/executor.go; the trigger name / TESTTRIGGER context is now built inline via
  newTriggerRunningContext (no TCL import) and set unconditionally. The Pro path produces the identical value, so behavior there is unchanged.

  ## Tests

  - TestSanitizeLabelValue — empty, >63 chars, invalid chars, leading/trailing punctuation, unsalvageable.
  - TestNewTriggerRunningContext — running context populated and maps to RunningContextType_TESTTRIGGER regardless of edition.
  - TestBundle_WorkflowNameLabel_Applied / _Sanitized — pod template + job carry the sanitized label.
