### PR TITLE
fix: [TKC-6263] paginate test workflow list in CLI and warn on truncated results

### DIFF
--- a/cmd/kubectl-testkube/commands/testworkflows/get.go
+++ b/cmd/kubectl-testkube/commands/testworkflows/get.go
@@ -63,7 +63,7 @@ func NewGetTestWorkflowsCmd() *cobra.Command {
 
 				if limit > 0 && len(workflows) == limit+1 {
 					workflows = workflows[:limit]
-					ui.NewStderrUI(false).Warn(fmt.Sprintf("Showing %d test workflows, more are available on the server. Use --limit 0 to fetch all.", limit))
+					ui.NewStderrUI(false).Warn(fmt.Sprintf("Showing %d test workflows, more are available on the server. Drop --limit (or use --limit 0) to fetch all.", limit))
 				}
 
 				if crdOnly {

--- a/cmd/kubectl-testkube/commands/testworkflows/get.go
+++ b/cmd/kubectl-testkube/commands/testworkflows/get.go
@@ -1,6 +1,7 @@
 package testworkflows
 
 import (
+	"fmt"
 	"os"
 	"strings"
 
@@ -22,6 +23,7 @@ func NewGetTestWorkflowsCmd() *cobra.Command {
 	var (
 		selectors []string
 		crdOnly   bool
+		limit     int
 	)
 
 	cmd := &cobra.Command{
@@ -30,6 +32,13 @@ func NewGetTestWorkflowsCmd() *cobra.Command {
 		Args:    cobra.MaximumNArgs(1),
 		Short:   "Get all available test workflows",
 		Long:    `Get all available test workflows. In cloud context (API key) the CLI fetches them from the connected Control Plane environment and ignores the namespace flag. In kubeconfig context it fetches them from the agent in the given namespace (default "testkube").`,
+
+		PreRunE: func(cmd *cobra.Command, args []string) error {
+			if limit < 0 {
+				return fmt.Errorf("--limit must not be negative")
+			}
+			return nil
+		},
 
 		Run: func(cmd *cobra.Command, args []string) {
 			namespace := cmd.Flag("namespace").Value.String()
@@ -45,8 +54,17 @@ func NewGetTestWorkflowsCmd() *cobra.Command {
 			}
 
 			if len(args) == 0 {
-				workflows, err := client.ListTestWorkflowWithExecutions(strings.Join(selectors, ","))
+				fetchLimit := limit
+				if limit > 0 {
+					fetchLimit = limit + 1
+				}
+				workflows, err := client.ListTestWorkflowWithExecutions(strings.Join(selectors, ","), fetchLimit)
 				ui.ExitOnError("getting all test workflows"+namespaceSuffix, err)
+
+				if limit > 0 && len(workflows) == limit+1 {
+					workflows = workflows[:limit]
+					ui.NewStderrUI(false).Warn(fmt.Sprintf("Showing %d test workflows, more are available on the server. Use --limit 0 to fetch all.", limit))
+				}
 
 				if crdOnly {
 					uicrd.PrintCRDs(common2.MapSlice(workflows, func(t testkube.TestWorkflowWithExecution) testworkflowsv1.TestWorkflow {
@@ -80,6 +98,7 @@ func NewGetTestWorkflowsCmd() *cobra.Command {
 	}
 	cmd.Flags().StringSliceVarP(&selectors, "label", "l", nil, "label key value pair: --label key1=value1")
 	cmd.Flags().BoolVar(&crdOnly, "crd-only", false, "render the fetched test workflows as crd yaml; does not read crds from the cluster")
+	cmd.Flags().IntVar(&limit, "limit", 0, "maximum number of workflows to return, 0 to fetch all")
 
 	return cmd
 }

--- a/pkg/api/v1/client/interface.go
+++ b/pkg/api/v1/client/interface.go
@@ -111,7 +111,7 @@ type TestWorkflowAPI interface {
 	GetTestWorkflow(id string) (testkube.TestWorkflow, error)
 	GetTestWorkflowWithExecution(id string) (testkube.TestWorkflowWithExecution, error)
 	ListTestWorkflows(selector string) (testkube.TestWorkflows, error)
-	ListTestWorkflowWithExecutions(selector string) (testkube.TestWorkflowWithExecutions, error)
+	ListTestWorkflowWithExecutions(selector string, limit int) (testkube.TestWorkflowWithExecutions, error)
 	DeleteTestWorkflows(selector string) error
 	CreateTestWorkflow(workflow testkube.TestWorkflow) (testkube.TestWorkflow, error)
 	UpdateTestWorkflow(workflow testkube.TestWorkflow) (testkube.TestWorkflow, error)

--- a/pkg/api/v1/client/testworkflow.go
+++ b/pkg/api/v1/client/testworkflow.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"strconv"
 
 	"github.com/kubeshop/testkube/pkg/api/v1/testkube"
 )
@@ -56,10 +57,53 @@ func (c TestWorkflowClient) ListTestWorkflows(selector string) (testkube.TestWor
 }
 
 // ListTestWorkflowWithExecutions list all test workflows with their latest executions
-func (c TestWorkflowClient) ListTestWorkflowWithExecutions(selector string) (testkube.TestWorkflowWithExecutions, error) {
+func (c TestWorkflowClient) ListTestWorkflowWithExecutions(selector string, limit int) (testkube.TestWorkflowWithExecutions, error) {
 	uri := c.testWorkflowWithExecutionTransport.GetURI("/test-workflow-with-executions")
-	params := map[string]string{"selector": selector}
-	return c.testWorkflowWithExecutionTransport.ExecuteMultiple(http.MethodGet, uri, nil, params)
+
+	if limit > 0 {
+		params := map[string]string{"selector": selector, "pageSize": strconv.Itoa(limit)}
+		return c.testWorkflowWithExecutionTransport.ExecuteMultiple(http.MethodGet, uri, nil, params)
+	}
+
+	const pageSize = 100
+	var result testkube.TestWorkflowWithExecutions
+	// The server sorts by latest execution activity, so a workflow can shift
+	// between pages while paging; dedupe by name to keep it listed only once.
+	// Unnamed items collapse under the empty key on purpose, so a full-set
+	// echo past the last page adds no new names and stops the loop below.
+	seen := make(map[string]bool)
+	for page := 0; ; page++ {
+		params := map[string]string{
+			"selector": selector,
+			"pageSize": strconv.Itoa(pageSize),
+			"page":     strconv.Itoa(page),
+		}
+		items, err := c.testWorkflowWithExecutionTransport.ExecuteMultiple(http.MethodGet, uri, nil, params)
+		if err != nil {
+			return nil, err
+		}
+
+		added := 0
+		for _, item := range items {
+			var name string
+			if item.Workflow != nil {
+				name = item.Workflow.Name
+			}
+			if seen[name] {
+				continue
+			}
+			seen[name] = true
+			result = append(result, item)
+			added++
+		}
+
+		// Stop on a short page (the last one) or a page that added nothing new.
+		if len(items) < pageSize || added == 0 {
+			break
+		}
+	}
+
+	return result, nil
 }
 
 // DeleteTestWorkflows deletes multiple test workflows by labels

--- a/pkg/api/v1/client/testworkflow_test.go
+++ b/pkg/api/v1/client/testworkflow_test.go
@@ -1,0 +1,150 @@
+package client
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/kubeshop/testkube/pkg/api/v1/testkube"
+)
+
+func newTestWorkflowClientForServer(server *httptest.Server) TestWorkflowClient {
+	return NewTestWorkflowClient(
+		NewDirectClient[testkube.TestWorkflow](server.Client(), server.URL, ""),
+		NewDirectClient[testkube.TestWorkflowWithExecution](server.Client(), server.URL, ""),
+		NewDirectClient[testkube.TestWorkflowExecution](server.Client(), server.URL, ""),
+		NewDirectClient[testkube.TestWorkflowExecutionsResult](server.Client(), server.URL, ""),
+		NewDirectClient[testkube.Artifact](server.Client(), server.URL, ""),
+	)
+}
+
+func testWorkflowExecutionItems(names ...string) testkube.TestWorkflowWithExecutions {
+	items := make(testkube.TestWorkflowWithExecutions, 0, len(names))
+	for _, name := range names {
+		items = append(items, testkube.TestWorkflowWithExecution{
+			Workflow: &testkube.TestWorkflow{Name: name},
+		})
+	}
+	return items
+}
+
+func numberedNames(prefix string, n int) []string {
+	names := make([]string, n)
+	for i := range names {
+		names[i] = fmt.Sprintf("%s-%d", prefix, i)
+	}
+	return names
+}
+
+func TestListTestWorkflowWithExecutions(t *testing.T) {
+	tests := []struct {
+		name         string
+		limit        int
+		respond      func(page string) []string
+		wantLen      int
+		wantRequests int
+		check        func(t *testing.T, workflows testkube.TestWorkflowWithExecutions, requests []*http.Request)
+	}{
+		{
+			name:  "explicit limit sends pageSize and no page",
+			limit: 25,
+			respond: func(string) []string {
+				return []string{"a", "b"}
+			},
+			wantLen:      2,
+			wantRequests: 1,
+			check: func(t *testing.T, _ testkube.TestWorkflowWithExecutions, requests []*http.Request) {
+				q := requests[0].URL.Query()
+				assert.Equal(t, "25", q.Get("pageSize"))
+				assert.False(t, q.Has("page"))
+			},
+		},
+		{
+			name:  "fetches all pages until a short page",
+			limit: 0,
+			respond: func(page string) []string {
+				switch page {
+				case "0":
+					return numberedNames("p0", 100)
+				case "1":
+					return numberedNames("p1", 100)
+				default:
+					return numberedNames("p2", 30)
+				}
+			},
+			wantLen:      230,
+			wantRequests: 3,
+			check: func(t *testing.T, _ testkube.TestWorkflowWithExecutions, requests []*http.Request) {
+				for i, req := range requests {
+					q := req.URL.Query()
+					assert.Equal(t, "100", q.Get("pageSize"))
+					assert.Equal(t, fmt.Sprintf("%d", i), q.Get("page"))
+				}
+			},
+		},
+		{
+			name:  "deduplicates items that shift between pages",
+			limit: 0,
+			respond: func(page string) []string {
+				if page == "0" {
+					return append(numberedNames("p0", 99), "shared")
+				}
+				return append([]string{"shared"}, numberedNames("p1", 9)...)
+			},
+			wantLen:      109,
+			wantRequests: 2,
+			check: func(t *testing.T, workflows testkube.TestWorkflowWithExecutions, _ []*http.Request) {
+				count := 0
+				for _, w := range workflows {
+					if w.Workflow != nil && w.Workflow.Name == "shared" {
+						count++
+					}
+				}
+				assert.Equal(t, 1, count)
+			},
+		},
+		{
+			// The standalone server returns the full result set for pages past
+			// the end, so an exact multiple of the page size must not loop
+			// forever. Unnamed items dedupe to one like any other name.
+			name:  "stops when a page adds nothing new",
+			limit: 0,
+			respond: func(string) []string {
+				return append([]string{"", ""}, numberedNames("wf", 98)...)
+			},
+			wantLen:      99,
+			wantRequests: 2,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var mu sync.Mutex
+			var requests []*http.Request
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				mu.Lock()
+				requests = append(requests, r)
+				mu.Unlock()
+				w.Header().Set("Content-Type", "application/json")
+				json.NewEncoder(w).Encode(testWorkflowExecutionItems(tt.respond(r.URL.Query().Get("page"))...))
+			}))
+			t.Cleanup(server.Close)
+
+			client := newTestWorkflowClientForServer(server)
+
+			workflows, err := client.ListTestWorkflowWithExecutions("", tt.limit)
+			require.NoError(t, err)
+			assert.Len(t, workflows, tt.wantLen)
+			assert.Len(t, requests, tt.wantRequests)
+			if tt.check != nil {
+				tt.check(t, workflows, requests)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Linear: https://linear.app/kubeshop/issue/TKC-6263

Adds a limit parameter to the test workflow list client and a `--limit` flag to `testkube get testworkflows`. The default (0) fetches every page, which matches what standalone mode already does. The client dedupes pages by workflow name because the server sorts by latest activity, so items can shift between pages while paging. With an explicit limit the CLI requests one extra item and, if it arrives, prints a notice on stderr so stdout stays clean for `--crd-only` and `-o` pipelines.