### PR TITLE
chore: [TKC-6265] clarify crd-only flag and namespace semantics in workflow get commands

### DIFF
--- a/cmd/kubectl-testkube/commands/testworkflows/get.go
+++ b/cmd/kubectl-testkube/commands/testworkflows/get.go
@@ -10,6 +10,7 @@ import (
 	"github.com/kubeshop/testkube/cmd/kubectl-testkube/commands/common"
 	"github.com/kubeshop/testkube/cmd/kubectl-testkube/commands/common/render"
 	"github.com/kubeshop/testkube/cmd/kubectl-testkube/commands/testworkflows/renderer"
+	"github.com/kubeshop/testkube/cmd/kubectl-testkube/config"
 	common2 "github.com/kubeshop/testkube/internal/common"
 	"github.com/kubeshop/testkube/pkg/api/v1/testkube"
 	"github.com/kubeshop/testkube/pkg/mapper/testworkflows"
@@ -28,16 +29,24 @@ func NewGetTestWorkflowsCmd() *cobra.Command {
 		Aliases: []string{"testworkflows", "tw"},
 		Args:    cobra.MaximumNArgs(1),
 		Short:   "Get all available test workflows",
-		Long:    `Getting all available test workflows from given namespace - if no namespace given "testkube" namespace is used`,
+		Long:    `Get all available test workflows. In cloud context (API key) the CLI fetches them from the connected Control Plane environment and ignores the namespace flag. In kubeconfig context it fetches them from the agent in the given namespace (default "testkube").`,
 
 		Run: func(cmd *cobra.Command, args []string) {
 			namespace := cmd.Flag("namespace").Value.String()
 			client, _, err := common.GetClient(cmd)
 			ui.ExitOnError("getting client", err)
 
+			// Namespace only scopes the query in kubeconfig context, so keep it out of cloud-context error messages.
+			cfg, err := config.Load()
+			ui.ExitOnError("loading config file", err)
+			namespaceSuffix := " in namespace " + namespace
+			if cfg.ContextType == config.ContextTypeCloud {
+				namespaceSuffix = ""
+			}
+
 			if len(args) == 0 {
 				workflows, err := client.ListTestWorkflowWithExecutions(strings.Join(selectors, ","))
-				ui.ExitOnError("getting all test workflows in namespace "+namespace, err)
+				ui.ExitOnError("getting all test workflows"+namespaceSuffix, err)
 
 				if crdOnly {
 					uicrd.PrintCRDs(common2.MapSlice(workflows, func(t testkube.TestWorkflowWithExecution) testworkflowsv1.TestWorkflow {
@@ -52,7 +61,7 @@ func NewGetTestWorkflowsCmd() *cobra.Command {
 
 			name := args[0]
 			workflow, err := client.GetTestWorkflowWithExecution(name)
-			ui.ExitOnError("getting test workflow in namespace "+namespace, err)
+			ui.ExitOnError("getting test workflow"+namespaceSuffix, err)
 
 			if crdOnly {
 				uicrd.PrintCRD(testworkflows.MapTestWorkflowAPIToKube(*workflow.Workflow), "TestWorkflow", testworkflowsv1.GroupVersion)
@@ -70,7 +79,7 @@ func NewGetTestWorkflowsCmd() *cobra.Command {
 		},
 	}
 	cmd.Flags().StringSliceVarP(&selectors, "label", "l", nil, "label key value pair: --label key1=value1")
-	cmd.Flags().BoolVar(&crdOnly, "crd-only", false, "show only test workflow crd")
+	cmd.Flags().BoolVar(&crdOnly, "crd-only", false, "render the fetched test workflows as crd yaml; does not read crds from the cluster")
 
 	return cmd
 }

--- a/cmd/kubectl-testkube/commands/testworkflowtemplates/get.go
+++ b/cmd/kubectl-testkube/commands/testworkflowtemplates/get.go
@@ -10,6 +10,7 @@ import (
 	"github.com/kubeshop/testkube/cmd/kubectl-testkube/commands/common"
 	"github.com/kubeshop/testkube/cmd/kubectl-testkube/commands/common/render"
 	"github.com/kubeshop/testkube/cmd/kubectl-testkube/commands/testworkflowtemplates/renderer"
+	"github.com/kubeshop/testkube/cmd/kubectl-testkube/config"
 	"github.com/kubeshop/testkube/pkg/mapper/testworkflows"
 	"github.com/kubeshop/testkube/pkg/ui"
 	"github.com/kubeshop/testkube/pkg/ui/uicrd"
@@ -26,16 +27,24 @@ func NewGetTestWorkflowTemplatesCmd() *cobra.Command {
 		Aliases: []string{"testworkflowtemplates", "twt"},
 		Args:    cobra.MaximumNArgs(1),
 		Short:   "Get all available test workflow templates",
-		Long:    `Getting all available test workflow templates from given namespace - if no namespace given "testkube" namespace is used`,
+		Long:    `Get all available test workflow templates. In cloud context (API key) the CLI fetches them from the connected Control Plane environment and ignores the namespace flag. In kubeconfig context it fetches them from the agent in the given namespace (default "testkube").`,
 
 		Run: func(cmd *cobra.Command, args []string) {
 			namespace := cmd.Flag("namespace").Value.String()
 			client, _, err := common.GetClient(cmd)
 			ui.ExitOnError("getting client", err)
 
+			// Namespace only scopes the query in kubeconfig context, so keep it out of cloud-context error messages.
+			cfg, err := config.Load()
+			ui.ExitOnError("loading config file", err)
+			namespaceSuffix := " in namespace " + namespace
+			if cfg.ContextType == config.ContextTypeCloud {
+				namespaceSuffix = ""
+			}
+
 			if len(args) == 0 {
 				templates, err := client.ListTestWorkflowTemplates(strings.Join(selectors, ","))
-				ui.ExitOnError("getting all test workflow templates in namespace "+namespace, err)
+				ui.ExitOnError("getting all test workflow templates"+namespaceSuffix, err)
 
 				if crdOnly {
 					uicrd.PrintCRDs(testworkflows.MapTemplateListAPIToKube(templates).Items, "TestWorkflowTemplate", testworkflowsv1.GroupVersion)
@@ -48,7 +57,7 @@ func NewGetTestWorkflowTemplatesCmd() *cobra.Command {
 
 			name := args[0]
 			template, err := client.GetTestWorkflowTemplate(name)
-			ui.ExitOnError("getting test workflow in namespace "+namespace, err)
+			ui.ExitOnError("getting test workflow template"+namespaceSuffix, err)
 
 			if crdOnly {
 				uicrd.PrintCRD(testworkflows.MapTestWorkflowTemplateAPIToKube(template), "TestWorkflowTemplate", testworkflowsv1.GroupVersion)
@@ -59,7 +68,7 @@ func NewGetTestWorkflowTemplatesCmd() *cobra.Command {
 		},
 	}
 	cmd.Flags().StringSliceVarP(&selectors, "label", "l", nil, "label key value pair: --label key1=value1")
-	cmd.Flags().BoolVar(&crdOnly, "crd-only", false, "show only test workflow template crd")
+	cmd.Flags().BoolVar(&crdOnly, "crd-only", false, "render the fetched test workflow templates as crd yaml; does not read crds from the cluster")
 
 	return cmd
 }


### PR DESCRIPTION
Linear: https://linear.app/kubeshop/issue/TKC-6265

Rewords the help of `get testworkflows` and `get testworkflowtemplates`: `--crd-only` renders API results as CRD YAML and never reads cluster CRDs, and the namespace flag only applies in kubeconfig context. Error prefixes drop the namespace in cloud context since it does not scope queries there. Only help strings and messages change, behavior stays the same.