### PR TITLE
feat: [TKC-6266] hint about disabled CRD sync when test workflow lookup returns 404

### DIFF
--- a/cmd/kubectl-testkube/commands/common/errors.go
+++ b/cmd/kubectl-testkube/commands/common/errors.go
@@ -71,6 +71,11 @@ const (
 	// is malformed or references an unknown key, or the parameter values
 	// could not be re-applied to the workflow YAML.
 	TKErrMarketplaceInvalidParameter ErrorCode = "TKERR-1603"
+
+	// TKERR-17xx errors are related to resource lookup operations.
+
+	// TKErrResourceNotFound is returned when a requested resource does not exist on the API server.
+	TKErrResourceNotFound ErrorCode = "TKERR-1701"
 )
 
 const helpUrl = "https://testkubeworkspace.slack.com"

--- a/cmd/kubectl-testkube/commands/testworkflows/get.go
+++ b/cmd/kubectl-testkube/commands/testworkflows/get.go
@@ -1,6 +1,7 @@
 package testworkflows
 
 import (
+	"fmt"
 	"os"
 	"strings"
 
@@ -12,6 +13,7 @@ import (
 	"github.com/kubeshop/testkube/cmd/kubectl-testkube/commands/testworkflows/renderer"
 	"github.com/kubeshop/testkube/cmd/kubectl-testkube/config"
 	common2 "github.com/kubeshop/testkube/internal/common"
+	"github.com/kubeshop/testkube/pkg/api/v1/client"
 	"github.com/kubeshop/testkube/pkg/api/v1/testkube"
 	"github.com/kubeshop/testkube/pkg/mapper/testworkflows"
 	"github.com/kubeshop/testkube/pkg/ui"
@@ -61,6 +63,7 @@ func NewGetTestWorkflowsCmd() *cobra.Command {
 
 			name := args[0]
 			workflow, err := client.GetTestWorkflowWithExecution(name)
+			common.HandleCLIError(testWorkflowNotFoundError(name, namespace, err))
 			ui.ExitOnError("getting test workflow"+namespaceSuffix, err)
 
 			if crdOnly {
@@ -82,4 +85,24 @@ func NewGetTestWorkflowsCmd() *cobra.Command {
 	cmd.Flags().BoolVar(&crdOnly, "crd-only", false, "render the fetched test workflows as crd yaml; does not read crds from the cluster")
 
 	return cmd
+}
+
+// testWorkflowNotFoundError returns a CLIError with a CRD-sync hint when a test
+// workflow lookup returns a 404, or nil for a nil or non-404 error.
+func testWorkflowNotFoundError(name, namespace string, err error) *common.CLIError {
+	if !client.IsNotFound(err) {
+		return nil
+	}
+
+	moreInfo := fmt.Sprintf("The workflow may exist only as a Kubernetes CRD in your cluster. "+
+		"When CRD-to-Control Plane synchronization is disabled, workflows created from CRDs are not visible to the API. "+
+		"Check with: kubectl get testworkflows.testworkflows.testkube.io -n %s. "+
+		"Verify you are targeting the right environment with: testkube get context.", namespace)
+
+	return common.NewCLIError(
+		common.TKErrResourceNotFound,
+		fmt.Sprintf("test workflow '%s' not found", name),
+		moreInfo,
+		err,
+	)
 }

--- a/cmd/kubectl-testkube/commands/testworkflows/get_test.go
+++ b/cmd/kubectl-testkube/commands/testworkflows/get_test.go
@@ -1,0 +1,37 @@
+package testworkflows
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/kubeshop/testkube/cmd/kubectl-testkube/commands/common"
+	"github.com/kubeshop/testkube/pkg/api/v1/client"
+)
+
+func TestTestWorkflowNotFoundError(t *testing.T) {
+	t.Run("returns CLIError with hint for not found errors", func(t *testing.T) {
+		notFound := fmt.Errorf("problem: no test workflow found my-wf: %w", &client.HTTPStatusError{StatusCode: http.StatusNotFound})
+
+		cliErr := testWorkflowNotFoundError("my-wf", "testkube", notFound)
+
+		assert.NotNil(t, cliErr)
+		assert.Equal(t, common.TKErrResourceNotFound, cliErr.Code)
+		assert.Contains(t, cliErr.Title, "my-wf")
+		assert.Contains(t, cliErr.MoreInfo, "kubectl get testworkflows")
+		assert.Contains(t, cliErr.MoreInfo, "testkube")
+		assert.Contains(t, cliErr.MoreInfo, "Control Plane")
+	})
+
+	t.Run("returns nil for non-404 errors", func(t *testing.T) {
+		serverErr := fmt.Errorf("problem: boom: %w", &client.HTTPStatusError{StatusCode: http.StatusInternalServerError})
+
+		assert.Nil(t, testWorkflowNotFoundError("my-wf", "testkube", serverErr))
+	})
+
+	t.Run("returns nil for nil error", func(t *testing.T) {
+		assert.Nil(t, testWorkflowNotFoundError("my-wf", "testkube", nil))
+	})
+}


### PR DESCRIPTION
Linear: https://linear.app/kubeshop/issue/TKC-6266

When `testkube get testworkflow <name>` gets a 404, the CLI now prints a structured CLIError (TKERR-1701). The hint explains that the workflow may exist only as a cluster CRD while synchronization to the Control Plane is disabled, and points at kubectl and `testkube get context` to check. Non-404 errors keep the existing path.