### PR TITLE
ci: use env indirection for expressions in workflow run scripts

### DIFF
--- a/.github/workflows/new-build.yaml
+++ b/.github/workflows/new-build.yaml
@@ -154,7 +154,7 @@ jobs:
 
       - name: Configure Docker for GAR
         if: ${{ github.ref_type == 'tag' }}
-        run: gcloud auth configure-docker ${{ env.GAR_LOCATION }}-docker.pkg.dev -q
+        run: gcloud auth configure-docker "${GAR_LOCATION}-docker.pkg.dev" -q
 
       - name: Login to DockerHub
         uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
@@ -164,24 +164,28 @@ jobs:
 
       - id: helm-publish
         name: Publish Helm Chart
+        env:
+          DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+          HELM_VERSION: ${{ steps.helm-version.outputs.result }}
         run: |
           REGISTRY=registry-1.docker.io
-          REGISTRY_GAR=${{ env.GAR_LOCATION }}-docker.pkg.dev
+          REGISTRY_GAR="${GAR_LOCATION}-docker.pkg.dev"
 
-          echo ${{ secrets.DOCKERHUB_TOKEN }} | helm registry login ${REGISTRY} --username ${{ secrets.DOCKERHUB_USERNAME }} --password-stdin
+          printf '%s' "$DOCKERHUB_TOKEN" | helm registry login "$REGISTRY" --username "$DOCKERHUB_USERNAME" --password-stdin
           helm repo add cloudnative-pg https://cloudnative-pg.github.io/charts --force-update
 
           # testkube chart
           helm dependency build k8s/helm/testkube
           helm package k8s/helm/testkube
-          helm push testkube-${{ steps.helm-version.outputs.result }}.tgz oci://${REGISTRY}/kubeshop
-          helm push testkube-${{ steps.helm-version.outputs.result }}.tgz oci://${REGISTRY_GAR}/${{ env.GAR_PROJECT_ID }}/${{ env.CHARTS_REPOSITORY }}
+          helm push "testkube-${HELM_VERSION}.tgz" "oci://${REGISTRY}/kubeshop"
+          helm push "testkube-${HELM_VERSION}.tgz" "oci://${REGISTRY_GAR}/${GAR_PROJECT_ID}/${CHARTS_REPOSITORY}"
 
           # testkube runner chart
           helm dependency build k8s/helm/testkube-runner
           helm package k8s/helm/testkube-runner
-          helm push testkube-runner-${{ steps.helm-version.outputs.result }}.tgz oci://${REGISTRY}/kubeshop
-          helm push testkube-runner-${{ steps.helm-version.outputs.result }}.tgz oci://${REGISTRY_GAR}/${{ env.GAR_PROJECT_ID }}/${{ env.CHARTS_REPOSITORY }}
+          helm push "testkube-runner-${HELM_VERSION}.tgz" "oci://${REGISTRY}/kubeshop"
+          helm push "testkube-runner-${HELM_VERSION}.tgz" "oci://${REGISTRY_GAR}/${GAR_PROJECT_ID}/${CHARTS_REPOSITORY}"
 
       - id: helm-index-update
         name: Dispatch update for legacy Helm index
@@ -222,9 +226,11 @@ jobs:
           echo "Using version from tag: $TAG"
 
       - name: Update server.json with version
+        env:
+          TAG: ${{ steps.tag.outputs.tag }}
         run: |
           cd build/mcp-server
-          jq --arg version "${{ steps.tag.outputs.tag }}" \
+          jq --arg version "$TAG" \
             '.version = $version | .packages[0].identifier = "docker.io/kubeshop/mcp-server:" + $version' \
             server.json > server.json.tmp
           mv server.json.tmp server.json
@@ -258,6 +264,8 @@ jobs:
             echo "Warning: Could not verify publication immediately. It may take a few minutes to appear."
 
       - name: Summary
+        env:
+          TAG: ${{ steps.tag.outputs.tag }}
         run: |
-          echo "MCP Server v${{ steps.tag.outputs.tag }} published to MCP Registry"
+          echo "MCP Server v${TAG} published to MCP Registry"
           echo "Registry URL: https://registry.modelcontextprotocol.io/v0/servers/io.github.kubeshop/testkube-mcp"

--- a/.github/workflows/release-cli-manual.yaml
+++ b/.github/workflows/release-cli-manual.yaml
@@ -109,9 +109,10 @@ jobs:
           permission-contents: write
       - name: Get GitHub App User ID
         id: get-user-id
-        run: echo "user-id=$(gh api "/users/${{ steps.app-token.outputs.app-slug }}[bot]" --jq .id)" >> "$GITHUB_OUTPUT"
+        run: echo "user-id=$(gh api "/users/${APP_SLUG}[bot]" --jq .id)" >> "$GITHUB_OUTPUT"
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          APP_SLUG: ${{ steps.app-token.outputs.app-slug }}
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -119,10 +120,14 @@ jobs:
           fetch-depth: 0
           token: ${{ steps.app-token.outputs.token }}
       - name: Configure git
+        env:
+          APP_SLUG: ${{ steps.app-token.outputs.app-slug }}
+          USER_ID: ${{ steps.get-user-id.outputs.user-id }}
+          APP_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
-          git config --global user.name '${{ steps.app-token.outputs.app-slug }}[bot]'
-          git config --global user.email '${{ steps.get-user-id.outputs.user-id }}+${{ steps.app-token.outputs.app-slug }}[bot]@users.noreply.github.com'
-          git config --global url."https://x-access-token:${{ steps.app-token.outputs.token }}@github.com/".insteadOf "https://github.com/"
+          git config --global user.name "${APP_SLUG}[bot]"
+          git config --global user.email "${USER_ID}+${APP_SLUG}[bot]@users.noreply.github.com"
+          git config --global url."https://x-access-token:${APP_TOKEN}@github.com/".insteadOf "https://github.com/"
       - uses: anchore/sbom-action/download-syft@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
       - name: Download Artifacts for Linux
         uses: actions/download-artifact@2a5974104b6d5dbdb2f9468a3e54da3bdd241578 # master as of 2026-07-15
@@ -166,8 +171,9 @@ jobs:
         id: release-check
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          TAG: ${{ steps.tag.outputs.tag }}
         run: |
-          if gh release view "${{ steps.tag.outputs.tag }}" --repo "${{ github.repository }}" >/dev/null 2>&1; then
+          if gh release view "$TAG" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
             echo "skip_publish=true" >> "$GITHUB_OUTPUT"
           else
             echo "skip_publish=false" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/release-create.yaml
+++ b/.github/workflows/release-create.yaml
@@ -41,9 +41,10 @@ jobs:
           permission-contents: write
       - name: Get GitHub App User ID
         id: get-user-id
-        run: echo "user-id=$(gh api "/users/${{ steps.app-token.outputs.app-slug }}[bot]" --jq .id)" >> "$GITHUB_OUTPUT"
+        run: echo "user-id=$(gh api "/users/${APP_SLUG}[bot]" --jq .id)" >> "$GITHUB_OUTPUT"
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          APP_SLUG: ${{ steps.app-token.outputs.app-slug }}
 
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -57,9 +58,12 @@ jobs:
       - name: Install dependencies packages
         run: npm install --prefix=js --workspace=tk-release
 
-      - run: |
-          git config --global user.name '${{ steps.app-token.outputs.app-slug }}[bot]'
-          git config --global user.email '${{ steps.get-user-id.outputs.user-id }}+${{ steps.app-token.outputs.app-slug }}[bot]@users.noreply.github.com'
+      - env:
+          APP_SLUG: ${{ steps.app-token.outputs.app-slug }}
+          USER_ID: ${{ steps.get-user-id.outputs.user-id }}
+        run: |
+          git config --global user.name "${APP_SLUG}[bot]"
+          git config --global user.email "${USER_ID}+${APP_SLUG}[bot]@users.noreply.github.com"
 
       - id: release-create
         name: Run release script

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -93,19 +93,24 @@ jobs:
           permission-contents: write
       - name: Get GitHub App User ID
         id: get-user-id
-        run: echo "user-id=$(gh api "/users/${{ steps.app-token.outputs.app-slug }}[bot]" --jq .id)" >> "$GITHUB_OUTPUT"
+        run: echo "user-id=$(gh api "/users/${APP_SLUG}[bot]" --jq .id)" >> "$GITHUB_OUTPUT"
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          APP_SLUG: ${{ steps.app-token.outputs.app-slug }}
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
           token: ${{ steps.app-token.outputs.token }}
       - name: Configure git
+        env:
+          APP_SLUG: ${{ steps.app-token.outputs.app-slug }}
+          USER_ID: ${{ steps.get-user-id.outputs.user-id }}
+          APP_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
-          git config --global user.name '${{ steps.app-token.outputs.app-slug }}[bot]'
-          git config --global user.email '${{ steps.get-user-id.outputs.user-id }}+${{ steps.app-token.outputs.app-slug }}[bot]@users.noreply.github.com'
-          git config --global url."https://x-access-token:${{ steps.app-token.outputs.token }}@github.com/".insteadOf "https://github.com/"
+          git config --global user.name "${APP_SLUG}[bot]"
+          git config --global user.email "${USER_ID}+${APP_SLUG}[bot]@users.noreply.github.com"
+          git config --global url."https://x-access-token:${APP_TOKEN}@github.com/".insteadOf "https://github.com/"
       - uses: anchore/sbom-action/download-syft@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
       - name: Download Artifacts for Linux
         uses: actions/download-artifact@2a5974104b6d5dbdb2f9468a3e54da3bdd241578 # master as of 2026-07-15

--- a/.github/workflows/update-release-notes.yaml
+++ b/.github/workflows/update-release-notes.yaml
@@ -28,13 +28,15 @@ jobs:
 
       - name: Read release notes
         id: read_notes
+        env:
+          NOTES_FILE: ${{ inputs.release_notes_file }}
         run: |
-          if [ -f "${{ inputs.release_notes_file }}" ]; then
-            echo "Reading release notes from ${{ inputs.release_notes_file }}"
+          if [ -f "$NOTES_FILE" ]; then
+            echo "Reading release notes from $NOTES_FILE"
             # Read the file and escape for GitHub Actions
             {
               echo 'RELEASE_NOTES<<EOF'
-              cat "${{ inputs.release_notes_file }}"
+              cat "$NOTES_FILE"
               echo EOF
             } >> "$GITHUB_ENV"
           else
@@ -45,12 +47,17 @@ jobs:
       - name: Update GitHub Release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ inputs.tag }}
+          REPO: ${{ github.repository }}
         run: |
-          gh release edit "${{ inputs.tag }}" \
-            --notes "${{ env.RELEASE_NOTES }}" \
-            --repo ${{ github.repository }}
+          gh release edit "$TAG" \
+            --notes "$RELEASE_NOTES" \
+            --repo "$REPO"
 
       - name: Success message
+        env:
+          TAG: ${{ inputs.tag }}
+          REPO: ${{ github.repository }}
         run: |
-          echo "✅ Release notes updated successfully for tag ${{ inputs.tag }}"
-          echo "View at: https://github.com/${{ github.repository }}/releases/tag/${{ inputs.tag }}"
+          echo "✅ Release notes updated successfully for tag $TAG"
+          echo "View at: https://github.com/$REPO/releases/tag/$TAG"


### PR DESCRIPTION
Moves `${{ }}` expressions out of `run:` script bodies into step-level `env:` blocks and references them as quoted shell variables, so untrusted values are no longer spliced into the script text that the shell parses. Registry login secrets are now piped to `helm registry login` via `--password-stdin` with `printf` instead of appearing on the command line.

Linear: TKC-6268