### PR TITLE
ci: scope workflow permissions and GitHub App tokens to least privilege

### DIFF
--- a/.github/workflows/fips-oss.yaml
+++ b/.github/workflows/fips-oss.yaml
@@ -7,6 +7,9 @@ on:
     tags:
       - '[0-9]+.[0-9]+.[0-9]+'
 
+permissions:
+  contents: read
+
 jobs:
   trigger-fips-build:
     name: Trigger FIPS OSS build

--- a/.github/workflows/lint_pr.yaml
+++ b/.github/workflows/lint_pr.yaml
@@ -8,6 +8,10 @@ on:
       - synchronize
       - ready_for_review
 
+# pull_request_target lets the semantic title check run on fork PRs; the job never checks out PR code.
+permissions:
+  pull-requests: read
+
 jobs:
   prlint:
     name: Lint PR

--- a/.github/workflows/new-build.yaml
+++ b/.github/workflows/new-build.yaml
@@ -16,11 +16,14 @@ env:
   BUSYBOX_IMAGE: busybox:1.36.1-musl
 
 permissions:
-  id-token: write # needed for depot
+  contents: read
 
 jobs:
   build:
     runs-on: depot-ubuntu-22.04
+    permissions:
+      contents: read
+      id-token: write # needed for depot
     steps:
       - name: Checkout
         uses: actions/checkout@v7

--- a/.github/workflows/release-cli-manual.yaml
+++ b/.github/workflows/release-cli-manual.yaml
@@ -12,8 +12,7 @@ on:
           - 'yes'
 
 permissions:
-  id-token: write # needed for keyless signing
-  contents: write
+  contents: read
 
 env:
   TESTKUBE_CHOCO_REPO: https://chocolatey.kubeshop.io/
@@ -104,6 +103,10 @@ jobs:
           app-id: 253113
           private-key: ${{ secrets.TESTKUBE_GH_APP_GITOPS_KEY }}
           owner: kubeshop
+          repositories: |
+            testkube
+            homebrew-testkube
+          permission-contents: write
       - name: Get GitHub App User ID
         id: get-user-id
         run: echo "user-id=$(gh api "/users/${{ steps.app-token.outputs.app-slug }}[bot]" --jq .id)" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/release-create.yaml
+++ b/.github/workflows/release-create.yaml
@@ -19,6 +19,9 @@ on:
           - 'no'
           - 'yes'
 
+permissions:
+  contents: read
+
 jobs:
   release:
     name: Release
@@ -33,6 +36,9 @@ jobs:
         with:
           app-id: 253113
           private-key: ${{ secrets.TESTKUBE_GH_APP_GITOPS_KEY }}
+          owner: kubeshop
+          repositories: testkube
+          permission-contents: write
       - name: Get GitHub App User ID
         id: get-user-id
         run: echo "user-id=$(gh api "/users/${{ steps.app-token.outputs.app-slug }}[bot]" --jq .id)" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -6,8 +6,7 @@ on:
       - "[0-9]+.[0-9]+.[0-9]+"
 
 permissions:
-  id-token: write # needed for keyless signing
-  contents: write
+  contents: read
 
 env:
   TESTKUBE_CHOCO_REPO: https://chocolatey.kubeshop.io/
@@ -88,6 +87,10 @@ jobs:
           app-id: 253113
           private-key: ${{ secrets.TESTKUBE_GH_APP_GITOPS_KEY }}
           owner: kubeshop
+          repositories: |
+            testkube
+            homebrew-testkube
+          permission-contents: write
       - name: Get GitHub App User ID
         id: get-user-id
         run: echo "user-id=$(gh api "/users/${{ steps.app-token.outputs.app-slug }}[bot]" --jq .id)" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -12,14 +12,16 @@ on:
 
 permissions:
   contents: read
-  checks: write  # For test annotations
-  pull-requests: write  # For PR comments
 
 jobs:
   unit-tests:
     name: Unit Tests
     if: (github.event_name != 'pull_request' || github.event.pull_request.draft == false) && github.actor != 'renovate[bot]' && github.actor != 'dependabot[bot]'
     runs-on: depot-ubuntu-24.04
+    permissions:
+      contents: read
+      checks: write  # For test annotations
+      pull-requests: write  # For PR comments
 
     steps:
       - uses: actions/checkout@v7
@@ -77,6 +79,10 @@ jobs:
     name: Integration Tests
     if: (github.event_name != 'pull_request' || github.event.pull_request.draft == false) && github.actor != 'renovate[bot]' && github.actor != 'dependabot[bot]'
     runs-on: depot-ubuntu-24.04
+    permissions:
+      contents: read
+      checks: write  # For test annotations
+      pull-requests: write  # For PR comments
 
     services:
       mongo:
@@ -172,6 +178,8 @@ jobs:
     name: Verify generated protobuf
     if: (github.event_name != 'pull_request' || github.event.pull_request.draft == false) && github.actor != 'renovate[bot]' && github.actor != 'dependabot[bot]'
     runs-on: depot-ubuntu-24.04
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v7
 
@@ -198,6 +206,8 @@ jobs:
     name: Verify generated CRDs
     if: (github.event_name != 'pull_request' || github.event.pull_request.draft == false) && github.actor != 'renovate[bot]' && github.actor != 'dependabot[bot]'
     runs-on: depot-ubuntu-24.04
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v7
 

--- a/.github/workflows/update-release-notes.yaml
+++ b/.github/workflows/update-release-notes.yaml
@@ -13,11 +13,13 @@ on:
         default: 'docs/release-notes/2.6.1.md'
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   update-release-notes:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write  # gh release edit updates the GitHub release
     steps:
       - name: Checkout
         uses: actions/checkout@v7


### PR DESCRIPTION
Each workflow now declares an explicit minimal top-level permissions block (contents: read where jobs only read). Write permissions were moved down to the individual jobs that actually use them: checks/pull-requests write to the test-summary jobs in test.yaml, id-token to the depot build job in new-build.yaml, and contents: write to the release-editing job in update-release-notes.yaml. The GitHub App tokens created by actions/create-github-app-token are now scoped with an explicit owner, a repositories allowlist covering exactly the repos each token touches (testkube plus homebrew-testkube for the goreleaser brew tap in the two release workflows, testkube only in release-create), and permission-contents: write matching their real use. lint_pr keeps its pull_request_target trigger, which the semantic title check needs for forks, but gains an explicit pull-requests: read block so the token is no longer write-capable.

Linear: TKC-6268