### PR TITLE
fix: handle pod delete tombstones in trigger watcher

### DIFF
--- a/pkg/triggers/watcher.go
+++ b/pkg/triggers/watcher.go
@@ -533,8 +533,17 @@ func (s *Service) podEventHandler(ctx context.Context) cache.ResourceEventHandle
 		DeleteFunc: func(obj interface{}) {
 			pod, ok := obj.(*corev1.Pod)
 			if !ok {
-				s.logger.Errorf("failed to process delete pod event due to it being an unexpected type, received type %+v", obj)
-				return
+				tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
+				if !ok {
+					s.logger.Errorf("failed to process delete pod event due to it being an unexpected type, received type %+v", obj)
+					return
+				}
+
+				pod, ok = tombstone.Obj.(*corev1.Pod)
+				if !ok {
+					s.logger.Errorf("failed to process delete pod event due to tombstone containing an unexpected type, received type %+v", tombstone.Obj)
+					return
+				}
 			}
 			s.logger.Debugf("trigger service: watcher component: emiting event: pod %s/%s deleted", pod.Namespace, pod.Name)
 			event := s.newWatcherEvent(testtrigger.EventDeleted, &pod.ObjectMeta, pod, testtrigger.ResourcePod,


### PR DESCRIPTION
## Pull request description 
Fix pod delete event handling in the trigger watcher when k8s delivers the delete event as `cache.DeletedFinalStateUnknown` instead of a direct `*corev1.Pod`.
Previously, the pod DeleteFunc only accepted `*corev1.Pod`. In tombstone cases, Testkube logged the event as an unexpected type and skipped processing the delete event.

Reported by a customer after Testkube failed to process a pod deletion and logged the following error repeatedly:
`failed to process delete pod event due to it being an unexpected type, received type {Key:... Obj:&Pod{...}}`

## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [x] tested locally
- [ ] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Breaking changes

-

## Changes

-

## Fixes

-