### PR TITLE
fix: expose runner metrics

### DIFF
--- a/cmd/api-server/main.go
+++ b/cmd/api-server/main.go
@@ -554,6 +554,7 @@ func main() {
 		eventsEmitter,
 		metrics,
 		proContext,
+		cfg.DisableDefaultAgent,
 		runnerOpts.StorageSkipVerify,
 		cfg.TestWorkflowLogArchiveRequired,
 		runnerOpts.GlobalTemplate,

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -112,6 +112,9 @@ func (r *runner) observeExecutionMetrics(execution testkube.TestWorkflowExecutio
 	if !r.reportMetricsLocal || execution.Result == nil || !execution.Result.IsFinished() {
 		return
 	}
+	if execution.SilentMode != nil && execution.SilentMode.Metrics {
+		return
+	}
 
 	r.metrics.IncAndObserveExecuteTestWorkflow(execution, r.proContext.DashboardURI)
 }

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -73,6 +73,7 @@ type runner struct {
 	emitter            event.Interface
 	metrics            metrics.Metrics
 	proContext         config.ProContext // TODO: Include Agent ID in pro context
+	reportMetricsLocal bool
 	storageSkipVerify  bool
 	logArchiveRequired bool
 	getGlobalTemplate  GlobalTemplateFactory
@@ -88,6 +89,7 @@ func New(
 	emitter event.Interface,
 	metrics metrics.Metrics,
 	proContext config.ProContext,
+	reportMetricsLocal bool,
 	storageSkipVerify bool,
 	logArchiveRequired bool,
 	getGlobalTemplate GlobalTemplateFactory,
@@ -99,10 +101,19 @@ func New(
 		emitter:            emitter,
 		metrics:            metrics,
 		proContext:         proContext,
+		reportMetricsLocal: reportMetricsLocal,
 		storageSkipVerify:  storageSkipVerify,
 		logArchiveRequired: logArchiveRequired,
 		getGlobalTemplate:  getGlobalTemplate,
 	}
+}
+
+func (r *runner) observeExecutionMetrics(execution testkube.TestWorkflowExecution) {
+	if !r.reportMetricsLocal || execution.Result == nil || !execution.Result.IsFinished() {
+		return
+	}
+
+	r.metrics.IncAndObserveExecuteTestWorkflow(execution, r.proContext.DashboardURI)
 }
 
 func (r *runner) monitor(ctx context.Context, organizationId string, environmentId string, execution testkube.TestWorkflowExecution) error {
@@ -288,6 +299,9 @@ func (r *runner) monitor(ctx context.Context, organizationId string, environment
 		logger.Errorw("failed to save execution data", "error", err)
 		return errors.Wrapf(err, "failed to save execution '%s' data", execution.Id)
 	}
+
+	execution.Result = lastResult
+	r.observeExecutionMetrics(execution)
 
 	err = r.worker.Destroy(context.Background(), execution.Id, executionworkertypes.DestroyOptions{})
 	if err != nil {


### PR DESCRIPTION
## Pull request description 
This PR makes the runner publish workflow execution Prometheus metrics locally, so runner-only deployments now expose testkube_testworkflow_executions_count and related duration metrics on :8088/metrics.


## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [x] tested locally
- [ ] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Breaking changes

-

## Changes

-

## Fixes

-