### PR TITLE
feat(cli): add --list flag to config command to show current values

### DIFF
--- a/cmd/kubectl-testkube/commands/config.go
+++ b/cmd/kubectl-testkube/commands/config.go
@@ -25,14 +25,14 @@ func NewConfigCmd() *cobra.Command {
 				ui.ExitOnError("loading config file", err)
 
 				ui.NL()
-				ui.InfoGrid(map[string]string{
-					"Context type     ": string(cfg.ContextType),
-					"Namespace        ": cfg.Namespace,
-					"API URI          ": cfg.APIURI,
-					"API Server Name  ": cfg.APIServerName,
-					"API Server Port  ": fmt.Sprintf("%d", cfg.APIServerPort),
-					"Headers          ": testkube.MapToString(cfg.Headers),
-					"Telemetry Enabled": fmt.Sprintf("%t", cfg.TelemetryEnabled),
+				ui.Properties([][]string{
+					{"Context type     ", string(cfg.ContextType)},
+					{"Namespace        ", cfg.Namespace},
+					{"API URI          ", cfg.APIURI},
+					{"API Server Name  ", cfg.APIServerName},
+					{"API Server Port  ", fmt.Sprintf("%d", cfg.APIServerPort)},
+					{"Headers          ", testkube.MapToString(cfg.Headers)},
+					{"Telemetry Enabled", fmt.Sprintf("%t", cfg.TelemetryEnabled)},
 				})
 				return
 			}

--- a/cmd/kubectl-testkube/commands/config.go
+++ b/cmd/kubectl-testkube/commands/config.go
@@ -1,20 +1,42 @@
 package commands
 
 import (
+	"fmt"
+
 	"github.com/spf13/cobra"
 
 	"github.com/kubeshop/testkube/cmd/kubectl-testkube/commands/common"
 	commands "github.com/kubeshop/testkube/cmd/kubectl-testkube/commands/config"
 	"github.com/kubeshop/testkube/cmd/kubectl-testkube/config"
+	"github.com/kubeshop/testkube/pkg/api/v1/testkube"
 	"github.com/kubeshop/testkube/pkg/ui"
 )
 
 func NewConfigCmd() *cobra.Command {
+	var list bool
+
 	cmd := &cobra.Command{
 		Use:     "config <feature> <value>",
 		Aliases: []string{"set", "configure"},
 		Short:   "Set feature configuration value",
 		Run: func(cmd *cobra.Command, args []string) {
+			if list {
+				cfg, err := config.Load()
+				ui.ExitOnError("loading config file", err)
+
+				ui.NL()
+				ui.InfoGrid(map[string]string{
+					"Context type     ": string(cfg.ContextType),
+					"Namespace        ": cfg.Namespace,
+					"API URI          ": cfg.APIURI,
+					"API Server Name  ": cfg.APIServerName,
+					"API Server Port  ": fmt.Sprintf("%d", cfg.APIServerPort),
+					"Headers          ": testkube.MapToString(cfg.Headers),
+					"Telemetry Enabled": fmt.Sprintf("%t", cfg.TelemetryEnabled),
+				})
+				return
+			}
+
 			err := cmd.Help()
 			ui.PrintOnError("Displaying help", err)
 		},
@@ -25,6 +47,8 @@ func NewConfigCmd() *cobra.Command {
 			common.UiContextHeader(cmd, cfg)
 		},
 	}
+
+	cmd.Flags().BoolVar(&list, "list", false, "list current configuration values")
 
 	cmd.AddCommand(commands.NewConfigureNamespaceCmd())
 	cmd.AddCommand(commands.NewConfigureAPIURICmd())


### PR DESCRIPTION
## Pull request description 

Adds a `--list` flag to `testkube config` that prints the current client configuration values (context type, namespace, API URI, API server name/port, headers, telemetry), so users can check the current value before changing it — e.g. after running `testkube config api-uri ...` there was previously no way to see what the value was.

```
$ testkube config --list

  Context type     :
  Namespace        : testkube
  API URI          : http://localhost:8088
  API Server Name  : testkube-api-server
  API Server Port  : 8088
  Headers          :
  Telemetry Enabled: true
```

Running `testkube config` without the flag still shows help, and all existing subcommands are unchanged.

## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [x] tested locally
- [ ] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Breaking changes

- none

## Changes

- `testkube config --list` prints current configuration values using the existing `ui.InfoGrid` style

## Fixes

- Closes #3771