### PR TITLE
fix: serialize the silentMode on execution summaries

### DIFF
--- a/pkg/repository/testworkflow/postgres/postgres.go
+++ b/pkg/repository/testworkflow/postgres/postgres.go
@@ -472,6 +472,7 @@ func (r *PostgresRepository) executionToSummary(row testkube.TestWorkflowExecuti
 		Runtime:              row.Runtime,
 		Reports:              row.Reports,
 		ResourceAggregations: row.ResourceAggregations,
+		SilentMode:           row.SilentMode,
 	}
 }
 


### PR DESCRIPTION
This field is projected via mongo but not from postgres. This change brings the two to parity.