### PR TITLE
feat(6300): add silentMode to workflow execution metrics

### DIFF
--- a/api/v1/testkube.yaml
+++ b/api/v1/testkube.yaml
@@ -5469,6 +5469,8 @@ components:
           format: date-time
         runnerId:
           type: string
+        silentMode:
+          $ref: '#/components/schemas/SilentMode'
 
     Variables:
       type: object

--- a/pkg/api/v1/testkube/model_executions_metrics_executions.go
+++ b/pkg/api/v1/testkube/model_executions_metrics_executions.go
@@ -22,4 +22,5 @@ type ExecutionsMetricsExecutions struct {
 	Name        string    `json:"name,omitempty"`
 	StartTime   time.Time `json:"startTime,omitempty"`
 	RunnerId    string    `json:"runnerId,omitempty"`
+	SilentMode  *SilentMode `json:"silentMode,omitempty"`
 }

--- a/pkg/database/postgres/queries/executions.sql
+++ b/pkg/database/postgres/queries/executions.sql
@@ -958,7 +958,8 @@ SELECT
     r.status,
     e.name,
     e.scheduled_at as start_time,
-    e.runner_id
+    e.runner_id,
+    e.silent_mode
 FROM test_workflow_executions e
 LEFT JOIN test_workflow_results r ON e.id = r.execution_id
 WHERE e.workflow_name = @workflow_name::text AND (e.organization_id = @organization_id AND e.environment_id = @environment_id)

--- a/pkg/database/postgres/sqlc/executions.sql.go
+++ b/pkg/database/postgres/sqlc/executions.sql.go
@@ -3486,7 +3486,8 @@ SELECT
     r.status,
     e.name,
     e.scheduled_at as start_time,
-    e.runner_id
+    e.runner_id,
+    e.silent_mode
 FROM test_workflow_executions e
 LEFT JOIN test_workflow_results r ON e.id = r.execution_id
 WHERE e.workflow_name = $1::text AND (e.organization_id = $2 AND e.environment_id = $3)
@@ -3512,6 +3513,7 @@ type GetTestWorkflowMetricsRow struct {
 	Name        string             `db:"name" json:"name"`
 	StartTime   pgtype.Timestamptz `db:"start_time" json:"start_time"`
 	RunnerID    pgtype.Text        `db:"runner_id" json:"runner_id"`
+	SilentMode  []byte             `db:"silent_mode" json:"silent_mode"`
 }
 
 func (q *Queries) GetTestWorkflowMetrics(ctx context.Context, arg GetTestWorkflowMetricsParams) ([]GetTestWorkflowMetricsRow, error) {
@@ -3538,6 +3540,7 @@ func (q *Queries) GetTestWorkflowMetrics(ctx context.Context, arg GetTestWorkflo
 			&i.Name,
 			&i.StartTime,
 			&i.RunnerID,
+			&i.SilentMode,
 		); err != nil {
 			return nil, err
 		}

--- a/pkg/repository/testworkflow/mongo/mongo.go
+++ b/pkg/repository/testworkflow/mongo/mongo.go
@@ -821,6 +821,7 @@ func (r *MongoRepository) GetTestWorkflowMetrics(ctx context.Context, name strin
 			"name":        1,
 			"starttime":   "$scheduledat",
 			"runnerid":    1,
+			"silentmode":  1,
 		}},
 	}
 

--- a/pkg/repository/testworkflow/postgres/postgres.go
+++ b/pkg/repository/testworkflow/postgres/postgres.go
@@ -1777,6 +1777,13 @@ func (r *PostgresRepository) GetTestWorkflowMetrics(ctx context.Context, name st
 			StartTime:   fromPgTimestamp(row.StartTime),
 			RunnerId:    fromPgText(row.RunnerID),
 		}
+		if len(row.SilentMode) > 0 {
+			silentMode, err := fromJSONB[testkube.SilentMode](row.SilentMode)
+			if err != nil {
+				return metrics, err
+			}
+			executions[i].SilentMode = silentMode
+		}
 	}
 
 	metrics = common.CalculateMetrics(executions)


### PR DESCRIPTION
## Pull request description 

Adds `silentMode` to workflow execution metrics so the dashboard can identify silent runs.



## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [x] tested locally
- [ ] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Breaking changes

-

## Changes
- Add `SilentMode` to `ExecutionsMetricsExecutions` + schema, SQL query, and postgres mapping
## Fixes

-