### PR TITLE
ci: reduce cache

### DIFF
--- a/.github/workflows/new-build.yaml
+++ b/.github/workflows/new-build.yaml
@@ -99,6 +99,23 @@ jobs:
         with:
           length: 7
 
+      - name: Define platform overrides
+        id: platform-overrides
+        run: |
+          if [[ "${GITHUB_REF_TYPE}" != "tag" ]]; then
+            {
+              echo "value<<EOF"
+              echo "api.platform=linux/amd64"
+              echo "cli.platform=linux/amd64"
+              echo "tw-init.platform=linux/amd64"
+              echo "tw-toolkit.platform=linux/amd64"
+              echo "mcp-server.platform=linux/amd64"
+              echo "EOF"
+            } >> "$GITHUB_OUTPUT"
+          else
+            echo "value=" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Build
         uses: depot/bake-action@1d58c2668346981089b088b7ef36755b206b20e9 # v1.13.0
         with:
@@ -110,6 +127,8 @@ jobs:
             ${{ steps.tw-toolkit-meta.outputs.bake-file }}
             ${{ steps.mcp-server-meta.outputs.bake-file }}
           targets: api,cli,tw-init,tw-toolkit,mcp-server
+          set: |
+            ${{ steps.platform-overrides.outputs.value }}
           provenance: mode=max
           sbom: true
           # Only tags are pushed, pushes to branches test whether app can be built.

--- a/.github/workflows/new-build.yaml
+++ b/.github/workflows/new-build.yaml
@@ -99,25 +99,9 @@ jobs:
         with:
           length: 7
 
-      - name: Define platform overrides
-        id: platform-overrides
-        run: |
-          if [[ "${GITHUB_REF_TYPE}" != "tag" ]]; then
-            {
-              echo "value<<EOF"
-              echo "api.platform=linux/amd64"
-              echo "cli.platform=linux/amd64"
-              echo "tw-init.platform=linux/amd64"
-              echo "tw-toolkit.platform=linux/amd64"
-              echo "mcp-server.platform=linux/amd64"
-              echo "EOF"
-            } >> "$GITHUB_OUTPUT"
-          else
-            echo "value=" >> "$GITHUB_OUTPUT"
-          fi
-
-      - name: Build
+      - name: Build for branches
         uses: depot/bake-action@1d58c2668346981089b088b7ef36755b206b20e9 # v1.13.0
+        if: ${{ github.ref_type != 'tag' }}
         with:
           files: |
             ./docker-bake.hcl
@@ -128,11 +112,33 @@ jobs:
             ${{ steps.mcp-server-meta.outputs.bake-file }}
           targets: api,cli,tw-init,tw-toolkit,mcp-server
           set: |
-            ${{ steps.platform-overrides.outputs.value }}
+            api.platform=linux/amd64
+            cli.platform=linux/amd64
+            tw-init.platform=linux/amd64
+            tw-toolkit.platform=linux/amd64
+            mcp-server.platform=linux/amd64
           provenance: mode=max
           sbom: true
           # Only tags are pushed, pushes to branches test whether app can be built.
-          push: ${{github.ref_type == 'tag'}}
+          push: false
+          save: true
+          save-tag: ${{ steps.short-sha.outputs.sha }}
+
+      - name: Build for tags
+        uses: depot/bake-action@1d58c2668346981089b088b7ef36755b206b20e9 # v1.13.0
+        if: ${{ github.ref_type == 'tag' }}
+        with:
+          files: |
+            ./docker-bake.hcl
+            ${{ steps.api-meta.outputs.bake-file }}
+            ${{ steps.cli-meta.outputs.bake-file }}
+            ${{ steps.tw-init-meta.outputs.bake-file }}
+            ${{ steps.tw-toolkit-meta.outputs.bake-file }}
+            ${{ steps.mcp-server-meta.outputs.bake-file }}
+          targets: api,cli,tw-init,tw-toolkit,mcp-server
+          provenance: mode=max
+          sbom: true
+          push: true
           save: true
           save-tag: ${{ steps.short-sha.outputs.sha }}
         env:


### PR DESCRIPTION
## Pull request description 

Reduce Depot container layer cache churn for branch builds by keeping branch CI on `linux/amd64` only, while preserving multi-arch (`linux/amd64` + `linux/arm64`) builds for release.


## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [ ] tested locally
- [ ] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Breaking changes

-

## Changes

-

## Fixes

-