### PR TITLE
fix: api server image CVEs

### DIFF
--- a/.github/workflows/new-build.yaml
+++ b/.github/workflows/new-build.yaml
@@ -12,7 +12,7 @@ on:
       - dependabot/**
       
 env:
-  ALPINE_IMAGE: alpine:3.23.3
+  ALPINE_IMAGE: alpine:3.24.1
   BUSYBOX_IMAGE: busybox:1.36.1-musl
 
 permissions:

--- a/.github/workflows/release-cli-manual.yaml
+++ b/.github/workflows/release-cli-manual.yaml
@@ -16,7 +16,7 @@ permissions:
 
 env:
   TESTKUBE_CHOCO_REPO: https://chocolatey.kubeshop.io/
-  ALPINE_IMAGE: alpine:3.23.3
+  ALPINE_IMAGE: alpine:3.24.1
   BUSYBOX_IMAGE: busybox:1.36.1-musl
 
 jobs:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -10,7 +10,7 @@ permissions:
 
 env:
   TESTKUBE_CHOCO_REPO: https://chocolatey.kubeshop.io/
-  ALPINE_IMAGE: alpine:3.23.3
+  ALPINE_IMAGE: alpine:3.24.1
   BUSYBOX_IMAGE: busybox:1.36.1-musl
 
 jobs:

--- a/Makefile
+++ b/Makefile
@@ -471,7 +471,7 @@ docker-build-api: ## Build API server Docker image
 	@env ANALYTICS_TRACKING_ID=** ANALYTICS_API_KEY=** \
 		SEGMENTIO_KEY=** CLOUD_SEGMENTIO_KEY=** \
 		DOCKER_BUILDX_CACHE_FROM=type=registry,ref=$(DOCKER_REGISTRY)/testkube-api-server:latest \
-		ALPINE_IMAGE=alpine:3.23.3 \
+		ALPINE_IMAGE=alpine:3.24.1 \
 		$(GORELEASER) release -f goreleaser_files/.goreleaser-docker-build-api.yml --clean --snapshot
 
 .PHONY: docker-build-cli
@@ -480,7 +480,7 @@ docker-build-cli: ## Build CLI Docker image
 	@env ANALYTICS_TRACKING_ID=** ANALYTICS_API_KEY=** \
 		SEGMENTIO_KEY=** CLOUD_SEGMENTIO_KEY=** \
 		DOCKER_BUILDX_CACHE_FROM=type=registry,ref=$(DOCKER_REGISTRY)/testkube-cli:latest \
-		ALPINE_IMAGE=alpine:3.23.3 \
+		ALPINE_IMAGE=alpine:3.24.1 \
 		$(GORELEASER) release -f .builds-linux.goreleaser.yml --clean --snapshot
 
 # ==================== Kubernetes ====================

--- a/cmd/kubectl-testkube/commands/common/client.go
+++ b/cmd/kubectl-testkube/commands/common/client.go
@@ -112,6 +112,20 @@ func GetClient(cmd *cobra.Command) (client.Client, string, error) {
 	return c, namespace, nil
 }
 
+func TelemetryUserID(cmd *cobra.Command, cfg *config.Data) string {
+	if cfg.CloudContext.EnvironmentId != "" {
+		return cfg.CloudContext.EnvironmentId
+	}
+	id := "command-cli-user"
+	client, _, err := GetClient(cmd)
+	if err == nil && client != nil {
+		if info, err := client.GetServerInfo(); err == nil && info.ClusterId != "" {
+			id = info.ClusterId
+		}
+	}
+	return id
+}
+
 func userAgent() string {
 	return fmt.Sprintf("%s/%s (%s; %s) Go/%s", UserAgentCLI, Version, runtime.GOOS, runtime.GOARCH, runtime.Version())
 }

--- a/cmd/kubectl-testkube/commands/docker/init.go
+++ b/cmd/kubectl-testkube/commands/docker/init.go
@@ -167,7 +167,7 @@ func sendErrTelemetry(cmd *cobra.Command, clientCfg config.Data, errType string,
 func sendAttemptTelemetry(cmd *cobra.Command, clientCfg config.Data) {
 	if clientCfg.TelemetryEnabled {
 		ui.Debug("collecting anonymous telemetry data, you can disable it by calling `testkube disable telemetry`")
-		out, err := telemetry.SendCmdAttemptEvent(cmd, common.Version)
+		out, err := telemetry.SendCmdAttemptEvent(cmd, common.Version, common.TelemetryUserID(cmd, &clientCfg))
 		if ui.Verbose && err != nil {
 			ui.Err(err)
 		}

--- a/cmd/kubectl-testkube/commands/init.go
+++ b/cmd/kubectl-testkube/commands/init.go
@@ -152,7 +152,7 @@ func NewInitCmdDemo() *cobra.Command {
 			if cliErr != nil {
 				if cfg.TelemetryEnabled {
 					cliErr.AddTelemetry(cmd, "kubeconfig not found", "kubeconfig_not_found", license)
-					_, _ = telemetry.HandleCLIErrorTelemetry(common.Version, cliErr)
+					_, _ = handleCLIErrorTelemetry(common.Version, cliErr)
 				}
 				common.HandleCLIError(cliErr)
 			}
@@ -167,7 +167,7 @@ func NewInitCmdDemo() *cobra.Command {
 						cliErr = common.NewCLIError(common.TKErrConfigInitFailed, "Error reading namespace from console", "Check does the current system have a console.", err)
 						if cfg.TelemetryEnabled {
 							cliErr.AddTelemetry(cmd, "input namespace", "reading_namespace_failed", license)
-							_, _ = telemetry.HandleCLIErrorTelemetry(common.Version, cliErr)
+							_, _ = handleCLIErrorTelemetry(common.Version, cliErr)
 						}
 						common.HandleCLIError(cliErr)
 					}
@@ -181,7 +181,7 @@ func NewInitCmdDemo() *cobra.Command {
 					cliErr = common.NewCLIError(common.TKErrConfigInitFailed, "Error reading namespace from console", "Check does the current system have a console.", err)
 					if cfg.TelemetryEnabled {
 						cliErr.AddTelemetry(cmd, "input license", "reading_license_failed", license)
-						_, _ = telemetry.HandleCLIErrorTelemetry(common.Version, cliErr)
+						_, _ = handleCLIErrorTelemetry(common.Version, cliErr)
 					}
 					common.HandleCLIError(cliErr)
 				}
@@ -201,7 +201,7 @@ func NewInitCmdDemo() *cobra.Command {
 				)
 				if cfg.TelemetryEnabled {
 					cliErr.AddTelemetry(cmd, "license validation", "install_license_invalid", license)
-					_, _ = telemetry.HandleCLIErrorTelemetry(common.Version, cliErr)
+					_, _ = handleCLIErrorTelemetry(common.Version, cliErr)
 				}
 				common.HandleCLIError(cliErr)
 			}
@@ -236,7 +236,7 @@ func NewInitCmdDemo() *cobra.Command {
 				spinner.Fail("Failed to install Testkube On-Prem Demo")
 				if cfg.TelemetryEnabled {
 					cliErr.AddTelemetry(cmd, "installing", "install_failed", license)
-					_, _ = telemetry.HandleCLIErrorTelemetry(common.Version, cliErr)
+					_, _ = handleCLIErrorTelemetry(common.Version, cliErr)
 				}
 				common.HandleCLIError(cliErr)
 			}
@@ -250,7 +250,7 @@ func NewInitCmdDemo() *cobra.Command {
 				spinner.Fail("Failed to install Testkube On-Prem Demo")
 				if cfg.TelemetryEnabled {
 					cliErr.AddTelemetry(cmd, "installing", "install_failed", license)
-					_, _ = telemetry.HandleCLIErrorTelemetry(common.Version, cliErr)
+					_, _ = handleCLIErrorTelemetry(common.Version, cliErr)
 				}
 				common.HandleCLIError(cliErr)
 			}
@@ -338,7 +338,7 @@ func sendErrTelemetry(cmd *cobra.Command, clientCfg config.Data, errType, licens
 
 func sendTelemetry(cmd *cobra.Command, clientCfg config.Data, license, step string) {
 	if clientCfg.TelemetryEnabled {
-		out, err := telemetry.SendCmdWithLicenseEvent(cmd, common.Version, license, step)
+		out, err := telemetry.SendCmdWithLicenseEvent(cmd, common.Version, common.TelemetryUserID(cmd, &clientCfg), license, step)
 		if ui.Verbose && err != nil {
 			ui.Err(err)
 		}

--- a/cmd/kubectl-testkube/commands/pro/init.go
+++ b/cmd/kubectl-testkube/commands/pro/init.go
@@ -159,7 +159,7 @@ func sendErrTelemetry(cmd *cobra.Command, clientCfg config.Data, errType string,
 func sendAttemptTelemetry(cmd *cobra.Command, clientCfg config.Data) {
 	if clientCfg.TelemetryEnabled {
 		ui.Debug("collecting anonymous telemetry data, you can disable it by calling `testkube disable telemetry`")
-		out, err := telemetry.SendCmdAttemptEvent(cmd, common.Version)
+		out, err := telemetry.SendCmdAttemptEvent(cmd, common.Version, common.TelemetryUserID(cmd, &clientCfg))
 		if ui.Verbose && err != nil {
 			ui.Err(err)
 		}

--- a/cmd/kubectl-testkube/commands/root.go
+++ b/cmd/kubectl-testkube/commands/root.go
@@ -176,7 +176,8 @@ func handleTelemetry(cmd *cobra.Command, cfg *config.Data, isPreRun bool) {
 	// Send telemetry early to ensure it's captured even if command fails
 	if cfg.TelemetryEnabled {
 		ui.Debug("collecting anonymous telemetry data, you can disable it by calling `testkube disable telemetry`")
-		out, err := telemetry.SendCmdEvent(cmd, common.Version)
+		userID := common.TelemetryUserID(cmd, cfg)
+		out, err := telemetry.SendCmdEvent(cmd, common.Version, userID)
 		if ui.Verbose && err != nil {
 			ui.Err(err)
 		}
@@ -190,13 +191,28 @@ func handleTelemetry(cmd *cobra.Command, cfg *config.Data, isPreRun bool) {
 
 			ui.Debug("sending 'init' event")
 
-			out, err := telemetry.SendCmdInitEvent(cmd, common.Version)
+			out, err := telemetry.SendCmdInitEvent(cmd, common.Version, userID)
 			if ui.Verbose && err != nil {
 				ui.Err(err)
 			}
 			ui.Debug("telemetry init event response", out)
 		}
 	}
+}
+
+func handleCLIErrorTelemetry(version string, err *common.CLIError) (string, error) {
+	if err.Telemetry == nil {
+		return "", nil
+	}
+	return telemetry.SendCmdErrorEventWithLicense(
+		err.Telemetry.Command,
+		version,
+		err.Telemetry.Type,
+		err.StackTrace,
+		err.Telemetry.License,
+		err.Telemetry.Step,
+		string(err.Code),
+	)
 }
 
 func Execute() {

--- a/cmd/kubectl-testkube/commands/telemetry/disable.go
+++ b/cmd/kubectl-testkube/commands/telemetry/disable.go
@@ -42,7 +42,7 @@ func NewDisableTelemetryCmd() *cobra.Command {
 			// update failed, the root post-run sync would re-enable the CLI
 			// config, so sending here would record a false opt-out.
 			if wasEnabled && apiDisabled {
-				if _, sendErr := telemetry.SendTelemetryOptOutEvent(cmd, common.Version); sendErr != nil {
+				if _, sendErr := telemetry.SendTelemetryOptOutEvent(cmd, common.Version, common.TelemetryUserID(cmd, &cfg)); sendErr != nil {
 					ui.Debug("sending telemetry opt-out event failed", sendErr.Error())
 				}
 			}

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -1,7 +1,7 @@
 variable "GOCACHE"       { default = "/go/pkg" }
 variable "GOMODCACHE"    { default = "/root/.cache/go-build" }
 variable "BUSYBOX_IMAGE" { default = "busybox:1.37.0-musl"}
-variable "ALPINE_IMAGE"  { default = "alpine:3.23.3" }
+variable "ALPINE_IMAGE"  { default = "alpine:3.24.1" }
 variable "VERSION"       { default = "0.0.0-unknown"}
 
 variable "GIT_SHA"                 { default = ""}

--- a/pkg/telemetry/telemetry.go
+++ b/pkg/telemetry/telemetry.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/kubeshop/testkube/cmd/kubectl-testkube/commands/common"
 	"github.com/kubeshop/testkube/cmd/kubectl-testkube/config"
 	"github.com/kubeshop/testkube/pkg/cliruntime"
 	httpclient "github.com/kubeshop/testkube/pkg/http"
@@ -33,34 +32,19 @@ func SendServerStartEvent(clusterId, version string, capabilities []string) (str
 }
 
 // SendCmdEvent will send CLI event to GA
-func SendCmdEvent(cmd *cobra.Command, version string) (string, error) {
+func SendCmdEvent(cmd *cobra.Command, version, userID string) (string, error) {
 	// get all sub-commands passed to cli
 	command := strings.TrimPrefix(cmd.CommandPath(), "kubectl-testkube ")
 	if command == "" {
 		command = "root"
 	}
 
-	payload := NewCLIPayload(getCurrentContext(), getUserID(cmd), command, version, "cli_command_execution", GetClusterType())
+	payload := NewCLIPayload(getCurrentContext(), userID, command, version, "cli_command_execution", GetClusterType())
 	return sendData(senders, payload)
 }
 
 func SendCmdErrorEvent(cmd *cobra.Command, version, errType string, errorStackTrace string) (string, error) {
 	return SendCmdErrorEventWithLicense(cmd, version, errType, errorStackTrace, "", "", "")
-}
-
-func HandleCLIErrorTelemetry(version string, err *common.CLIError) (string, error) {
-	if err.Telemetry != nil {
-		return SendCmdErrorEventWithLicense(
-			err.Telemetry.Command,
-			version,
-			err.Telemetry.Type,
-			err.StackTrace,
-			err.Telemetry.License,
-			err.Telemetry.Step,
-			string(err.Code),
-		)
-	}
-	return "", nil
 }
 
 // SendCmdErrorEventWithLicense will send CLI error event with license
@@ -103,29 +87,29 @@ func SendCmdErrorEventWithLicense(cmd *cobra.Command, version, errType, errorSta
 	return sendData(senders, payload)
 }
 
-func SendCmdAttemptEvent(cmd *cobra.Command, version string) (string, error) {
+func SendCmdAttemptEvent(cmd *cobra.Command, version, userID string) (string, error) {
 	// TODO pass error
-	payload := NewCLIPayload(getCurrentContext(), getUserID(cmd), getCommand(cmd), version, "cli_command_execution", GetClusterType())
+	payload := NewCLIPayload(getCurrentContext(), userID, getCommand(cmd), version, "cli_command_execution", GetClusterType())
 	return sendData(senders, payload)
 }
 
 // SendCmdWithLicenseEvent will send CLI command attempt event with license
-func SendCmdWithLicenseEvent(cmd *cobra.Command, version, license, step string) (string, error) {
-	payload := NewCLIWithLicensePayload(getCurrentContext(), getUserID(cmd), getCommandWithoutAttempt(cmd), version, "cli_command_execution", GetClusterType(), license, step)
+func SendCmdWithLicenseEvent(cmd *cobra.Command, version, userID, license, step string) (string, error) {
+	payload := NewCLIWithLicensePayload(getCurrentContext(), userID, getCommandWithoutAttempt(cmd), version, "cli_command_execution", GetClusterType(), license, step)
 	return sendData(senders, payload)
 }
 
 // SendCmdInitEvent will send CLI event to GA
-func SendCmdInitEvent(cmd *cobra.Command, version string) (string, error) {
-	payload := NewCLIPayload(getCurrentContext(), getUserID(cmd), "init", version, "cli_command_execution", GetClusterType())
+func SendCmdInitEvent(cmd *cobra.Command, version, userID string) (string, error) {
+	payload := NewCLIPayload(getCurrentContext(), userID, "init", version, "cli_command_execution", GetClusterType())
 	return sendData(senders, payload)
 }
 
 // SendTelemetryOptOutEvent records that the user disabled telemetry. It must be
 // called while telemetry is still enabled (before the opt-out is persisted), as
 // no further events may be sent once the user has opted out.
-func SendTelemetryOptOutEvent(cmd *cobra.Command, version string) (string, error) {
-	payload := NewCLIPayload(getCurrentContext(), getUserID(cmd), "telemetry_opt_out", version, "cli_command_execution", GetClusterType())
+func SendTelemetryOptOutEvent(cmd *cobra.Command, version, userID string) (string, error) {
+	payload := NewCLIPayload(getCurrentContext(), userID, "telemetry_opt_out", version, "cli_command_execution", GetClusterType())
 	return sendData(senders, payload)
 }
 
@@ -245,22 +229,6 @@ func getCurrentContext() RunContext {
 // GetCurrentContext returns the current run context, making it accessible from other packages
 func GetCurrentContext() RunContext {
 	return getCurrentContext()
-}
-
-func getUserID(cmd *cobra.Command) string {
-	id := "command-cli-user"
-	client, _, err := common.GetClient(cmd)
-	if err == nil && client != nil {
-		info, err := client.GetServerInfo()
-		if err == nil && info.ClusterId != "" {
-			id = info.ClusterId
-		}
-	}
-	data, err := config.Load()
-	if err != nil || data.CloudContext.EnvironmentId == "" {
-		return id
-	}
-	return data.CloudContext.EnvironmentId
 }
 
 // IsRunningInDocker detects if the CLI is running inside a Docker container.


### PR DESCRIPTION
## What changed

- update production and local release builds from Alpine 3.23.3 to 3.24.1
- keep CLI-only client lookup outside `pkg/telemetry`
- stop linking the unused Moby Docker client into the API server binary

## Why

The `kubeshop/testkube-api-server:2.11.2` image reported 2 critical and 22 high vulnerabilities. Alpine package updates resolve the OpenSSL, curl, musl, and Git findings. The API server also linked Moby unintentionally because the shared telemetry package imported CLI `common`; keeping that lookup in the CLI removes three additional high findings.

A rebuilt arm64 image reports 0 critical and 1 high vulnerability. The remaining Docker CLI finding, CVE-2025-15558, applies only to Windows plugin discovery and is not applicable to this Linux image.

## Validation

- `go test ./pkg/telemetry ./cmd/kubectl-testkube/commands/... ./cmd/api-server/...`
- verified `go list -deps ./cmd/api-server` no longer contains `github.com/docker/docker`
- rebuilt `build/new/api-server.Dockerfile` for linux/arm64
- `docker scout cves --only-severity critical,high testkube-api-server:cve-test`
