### PR TITLE
fix: prevent runner panic when recovering TestWorkflow result with nil error

### DIFF
--- a/pkg/api/v1/testkube/model_test_workflow_result_extended.go
+++ b/pkg/api/v1/testkube/model_test_workflow_result_extended.go
@@ -229,7 +229,14 @@ func (r *TestWorkflowResult) Equal(r2 *TestWorkflowResult) bool {
 }
 
 func (r *TestWorkflowResult) Fatal(err error, aborted bool, ts time.Time) {
-	r.Initialization.ErrorMessage = err.Error()
+	if r.Initialization == nil {
+		r.Initialization = &TestWorkflowStepResult{}
+	}
+	if err != nil {
+		r.Initialization.ErrorMessage = err.Error()
+	} else if r.Initialization.ErrorMessage == "" {
+		r.Initialization.ErrorMessage = "fatal error without details"
+	}
 	r.Status = common.Ptr(FAILED_TestWorkflowStatus)
 	r.PredictedStatus = r.Status
 	if aborted {

--- a/pkg/api/v1/testkube/model_test_workflow_result_extended_test.go
+++ b/pkg/api/v1/testkube/model_test_workflow_result_extended_test.go
@@ -61,3 +61,62 @@ func TestHealDuration(t *testing.T) {
 		})
 	}
 }
+
+func TestTestWorkflowResult_Fatal(t *testing.T) {
+	ts := time.Date(2026, 7, 22, 15, 20, 0, 0, time.UTC)
+
+	tests := []struct {
+		name             string
+		result           *TestWorkflowResult
+		err              error
+		aborted          bool
+		wantStatus       TestWorkflowStatus
+		wantInitStatus   TestWorkflowStepStatus
+		wantErrorMessage string
+	}{
+		{
+			name:             "handles nil error and nil initialization without panicking",
+			result:           &TestWorkflowResult{},
+			err:              nil,
+			aborted:          true,
+			wantStatus:       ABORTED_TestWorkflowStatus,
+			wantInitStatus:   ABORTED_TestWorkflowStepStatus,
+			wantErrorMessage: "fatal error without details",
+		},
+		{
+			name: "keeps existing initialization error message when error is nil",
+			result: &TestWorkflowResult{
+				Initialization: &TestWorkflowStepResult{ErrorMessage: "original failure"},
+			},
+			err:              nil,
+			aborted:          false,
+			wantStatus:       FAILED_TestWorkflowStatus,
+			wantInitStatus:   FAILED_TestWorkflowStepStatus,
+			wantErrorMessage: "original failure",
+		},
+		{
+			name: "stores error message and marks result failed",
+			result: &TestWorkflowResult{
+				Initialization: &TestWorkflowStepResult{},
+			},
+			err:              assert.AnError,
+			aborted:          false,
+			wantStatus:       FAILED_TestWorkflowStatus,
+			wantInitStatus:   FAILED_TestWorkflowStepStatus,
+			wantErrorMessage: assert.AnError.Error(),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.result.Fatal(tt.err, tt.aborted, ts)
+
+			assert.Equal(t, tt.wantStatus, *tt.result.Status)
+			assert.Equal(t, tt.wantInitStatus, *tt.result.Initialization.Status)
+			assert.Equal(t, tt.wantErrorMessage, tt.result.Initialization.ErrorMessage)
+			assert.Equal(t, ts, tt.result.QueuedAt)
+			assert.Equal(t, ts, tt.result.StartedAt)
+			assert.Equal(t, ts, tt.result.FinishedAt)
+		})
+	}
+}

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -242,9 +242,12 @@ func (r *runner) monitor(ctx context.Context, organizationId string, environment
 		if lastResult == nil {
 			lastResult = execution.Result
 		}
+		if lastResult == nil {
+			lastResult = &testkube.TestWorkflowResult{}
+		}
 		if !lastResult.IsFinished() {
 			logger.Errorw("failed to recover TestWorkflow result, marking as fatal error...")
-			lastResult.Fatal(err, true, time.Now())
+			lastResult.Fatal(errors.New("failed to recover TestWorkflow result"), true, time.Now())
 		}
 	}
 


### PR DESCRIPTION
## What

Fixes an agent panic (SIGSEGV) seen in customer logs: after `failed to recover TestWorkflow result, marking as fatal error...`, the runner crashed in `TestWorkflowResult.Fatal` and restarted the agent pod.

## How

The recovery path in the runner monitor passed a stale, usually nil, error variable into `Fatal`, which dereferenced it unconditionally. The monitor now passes a real error describing the recovery failure, and `Fatal` tolerates a nil error and a nil `Initialization` so no caller can crash the process through it. A nil recovered result is also replaced with an empty one before use, since `IsFinished` is not nil-safe.