### PR TITLE
fix: correct semver Lte semantic equality and GetNewest empty-input panic

### DIFF
--- a/pkg/semver/version.go
+++ b/pkg/semver/version.go
@@ -109,12 +109,18 @@ func Lt(version1, version2 string) (bool, error) {
 
 // Lte checks if version1 is less-than or equal version2, returns error in case of invalid version string
 func Lte(version1, version2 string) (bool, error) {
-	ok, err := Lt(version1, version2)
+	v1, err := semver.NewVersion(version1)
+	if err != nil {
+		return false, err
+	}
+	v2, err := semver.NewVersion(version2)
 	if err != nil {
 		return false, err
 	}
 
-	return ok || version1 == version2, nil
+	// Compare semantically, so equal versions with different string forms
+	// (e.g. "1.0" and "1.0.0", or "v1.2.3" and "1.2.3") are treated as equal.
+	return v1.Compare(v2) <= 0, nil
 }
 
 func validateVersionPostion(kind string) error {
@@ -125,7 +131,8 @@ func validateVersionPostion(kind string) error {
 	return fmt.Errorf("invalid version kind: %s: use one of major|minor|patch", kind)
 }
 
-// GetNewest returns greatest version from passed versions list
+// GetNewest returns greatest version from passed versions list,
+// or an empty string if the list contains no valid versions.
 func GetNewest(versions []string) string {
 	semversions := []*semver.Version{}
 	for _, ver := range versions {
@@ -134,6 +141,10 @@ func GetNewest(versions []string) string {
 		if err == nil {
 			semversions = append(semversions, v)
 		}
+	}
+
+	if len(semversions) == 0 {
+		return ""
 	}
 
 	sort.Slice(semversions, func(i, j int) bool {

--- a/pkg/semver/version_test.go
+++ b/pkg/semver/version_test.go
@@ -46,6 +46,47 @@ func TestVersioning(t *testing.T) {
 	})
 }
 
+func TestLte(t *testing.T) {
+	t.Run("equal versions in different string forms", func(t *testing.T) {
+		// Regression: "1.0" and "1.0.0" are semantically equal and must be <=.
+		ok, err := Lte("1.0", "1.0.0")
+		assert.NoError(t, err)
+		assert.True(t, ok)
+
+		ok, err = Lte("v1.2.3", "1.2.3")
+		assert.NoError(t, err)
+		assert.True(t, ok)
+	})
+
+	t.Run("strictly less-than", func(t *testing.T) {
+		ok, err := Lte("1.0.0", "1.0.1")
+		assert.NoError(t, err)
+		assert.True(t, ok)
+	})
+
+	t.Run("greater-than is not lte", func(t *testing.T) {
+		ok, err := Lte("2.0.0", "1.9.9")
+		assert.NoError(t, err)
+		assert.False(t, ok)
+	})
+
+	t.Run("invalid version returns error", func(t *testing.T) {
+		_, err := Lte("not-a-version", "1.0.0")
+		assert.Error(t, err)
+	})
+}
+
+func TestGetNewestEmpty(t *testing.T) {
+	t.Run("empty list returns empty string without panicking", func(t *testing.T) {
+		assert.Equal(t, "", GetNewest(nil))
+		assert.Equal(t, "", GetNewest([]string{}))
+	})
+
+	t.Run("no valid versions returns empty string", func(t *testing.T) {
+		assert.Equal(t, "", GetNewest([]string{"not-a-version", "also-bad"}))
+	})
+}
+
 func TestNextPrerelease(t *testing.T) {
 
 	t.Run("beta postfix", func(t *testing.T) {


### PR DESCRIPTION
## What

Two correctness fixes in `pkg/semver`:

### 1. `Lte` compared equality by string, not semantically

`Lte` fell back to raw string equality to decide the "or equal" case:

```go
return ok || version1 == version2, nil
```

So semantically-equal versions written differently were reported as **not** less-than-or-equal:

- `Lte("1.0", "1.0.0")` → `false` (should be `true`)
- `Lte("v1.2.3", "1.2.3")` → `false` (should be `true`)

This is used by the kubectl / Kubernetes dependency validator (`pkg/diagnostics/validators/deps`), where a required version like `1.0.0` compared against a client-reported `1.0` could incorrectly flag a valid install as too old.

`Lte` now compares versions semantically via `Compare(...) <= 0`.

### 2. `GetNewest` panicked on empty / all-invalid input

```go
return semversions[0].String()
```

If the input list is empty, or contains no parseable semver strings, `semversions` is empty and indexing `[0]` panics with an index-out-of-range. `GetNewest` now returns an empty string in that case.

## Tests

Added tests covering:
- `Lte` semantic equality across differing string forms, strict less-than, greater-than, and invalid-input error paths.
- `GetNewest` on `nil`, empty, and all-invalid input.

Existing tests continue to pass.