### PR TITLE
fix(testkube-runner): grant CRD read access to agent ServiceAccount

### DIFF
--- a/k8s/helm/testkube-runner/templates/role.yaml
+++ b/k8s/helm/testkube-runner/templates/role.yaml
@@ -37,6 +37,34 @@ rules:
 
 ---
 
+# Allow Agent to discover installed CRDs at startup (cluster-scoped, so this
+# must be a ClusterRole regardless of the listener/gitops watchers feature).
+{{- if .Values.pod.serviceAccount.autoCreate }}
+apiVersion: {{ include "global.capabilities.rbac.apiVersion" . }}
+kind: ClusterRole
+metadata:
+  name: "crd-reader-{{ .Release.Name }}"
+  labels:
+    {{- if .Values.global.labels }}
+    {{- toYaml .Values.global.labels | nindent 4 }}
+    {{- end }}
+  annotations:
+    {{- if .Values.global.annotations }}
+    {{- toYaml .Values.global.annotations | nindent 4 }}
+    {{- end }}
+rules:
+- apiGroups:
+    - "apiextensions.k8s.io"
+  resources:
+    - customresourcedefinitions
+  verbs:
+    - get
+    - list
+    - watch
+{{- end }}
+
+---
+
 # Allow Agent to access leases for leader election
 {{- if .Values.pod.serviceAccount.autoCreate }}
 apiVersion: {{ include "global.capabilities.rbac.apiVersion" . }}

--- a/k8s/helm/testkube-runner/templates/rolebinding.yaml
+++ b/k8s/helm/testkube-runner/templates/rolebinding.yaml
@@ -29,6 +29,34 @@ roleRef:
 
 ---
 
+# Apply CRD discovery role (cluster-scoped)
+apiVersion: {{ include "global.capabilities.rbac.apiVersion" . }}
+kind: ClusterRoleBinding
+metadata:
+  name: "crd-reader-rb-{{ .Release.Name }}"
+  labels:
+    {{- if .Values.global.labels }}
+    {{- toYaml .Values.global.labels | nindent 4 }}
+    {{- end }}
+  annotations:
+    {{- if .Values.global.annotations }}
+    {{- toYaml .Values.global.annotations | nindent 4 }}
+    {{- end }}
+subjects:
+- kind: ServiceAccount
+  namespace: "{{ .Release.Namespace }}"
+  {{- if .Values.pod.serviceAccount.name }}
+  name: "{{ .Values.pod.serviceAccount.name }}"
+  {{- else }}
+  name: "agent-sa-{{ .Release.Name }}"
+  {{- end }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: "crd-reader-{{ .Release.Name }}"
+
+---
+
 # Apply agent lease access role
 apiVersion: {{ include "global.capabilities.rbac.apiVersion" . }}
 kind: RoleBinding

--- a/k8s/helm/testkube-runner/tests/role_test.yaml
+++ b/k8s/helm/testkube-runner/tests/role_test.yaml
@@ -5,22 +5,26 @@ release:
   name: tk
   namespace: testkube-dev
 tests:
-  - it: renders agent-role, agent-lease-access and exec-role by default
+  - it: renders agent-role, crd-reader, agent-lease-access and exec-role by default
     asserts:
       - hasDocuments:
-          count: 3
+          count: 4
       - equal:
           path: metadata.name
           value: agent-role-tk
         documentIndex: 0
       - equal:
           path: metadata.name
-          value: agent-lease-access-tk
+          value: crd-reader-tk
         documentIndex: 1
       - equal:
           path: metadata.name
-          value: exec-role-tk
+          value: agent-lease-access-tk
         documentIndex: 2
+      - equal:
+          path: metadata.name
+          value: exec-role-tk
+        documentIndex: 3
 
   - it: agent-role grants the expected verbs on secrets and configmaps
     documentSelector:
@@ -142,7 +146,27 @@ tests:
           path: kind
           value: ClusterRole
 
+  - it: crd-reader is a ClusterRole with CRD get/list/watch
+    documentSelector:
+      path: metadata.name
+      value: crd-reader-tk
+    asserts:
+      - equal:
+          path: kind
+          value: ClusterRole
+      - contains:
+          path: rules
+          content:
+            apiGroups:
+              - apiextensions.k8s.io
+            resources:
+              - customresourcedefinitions
+            verbs:
+              - get
+              - list
+              - watch
+
   - it: no watchers role when listener and gitops both disabled
     asserts:
       - hasDocuments:
-          count: 3
+          count: 4

--- a/k8s/helm/testkube-runner/tests/rolebinding_test.yaml
+++ b/k8s/helm/testkube-runner/tests/rolebinding_test.yaml
@@ -5,10 +5,10 @@ release:
   name: tk
   namespace: testkube-dev
 tests:
-  - it: renders the 4 base RoleBindings by default
+  - it: renders the 5 base RoleBindings by default
     asserts:
       - hasDocuments:
-          count: 4
+          count: 5
 
   - it: agent-rb binds agent-sa to agent-role
     documentSelector:
@@ -30,6 +30,24 @@ tests:
       - equal:
           path: subjects[0].namespace
           value: testkube-dev
+
+  - it: crd-reader-rb binds agent-sa to crd-reader ClusterRole
+    documentSelector:
+      path: metadata.name
+      value: crd-reader-rb-tk
+    asserts:
+      - equal:
+          path: kind
+          value: ClusterRoleBinding
+      - equal:
+          path: roleRef.kind
+          value: ClusterRole
+      - equal:
+          path: roleRef.name
+          value: crd-reader-tk
+      - equal:
+          path: subjects[0].name
+          value: agent-sa-tk
 
   - it: agent-lease-access-rb binds agent-sa to agent-lease-access role
     documentSelector:


### PR DESCRIPTION
## Summary

- The testkube-runner agent watches CustomResourceDefinition (cluster-scoped) at startup unconditionally, but the chart never granted that permission to the agent's ServiceAccount, not even when listener.enabled: true or gitops.enabled: true.
- The existing watchers-role-* (Cluster)Role in templates/role.yaml is only created when listener.enabled or gitops.enabled is true, and its rules (from the testkube-runner.listener.watchers.rules helper) never cover apiextensions.k8s.io/customresourcedefinitions regardless.
- Result: every agent pod logs a recurring "Failed to watch ... CustomResourceDefinition ... forbidden" error, on every deployment of this chart. Confirmed reproducing on multiple GKE clusters, both a dev environment and production, all running 2.12.0, independent of listener/gitops config.
- Doesn't appear to break functionality (agent connects to control plane, recovers/executes workflows fine), but it's constant log noise and a wasted retry loop.

## Change

- templates/role.yaml: add a ClusterRole (crd-reader-{{ .Release.Name }}) granting get/list/watch on apiextensions.k8s.io/customresourcedefinitions, gated only by pod.serviceAccount.autoCreate (same gate as the base agent-role), independent of listener/gitops.
- templates/rolebinding.yaml: add the matching ClusterRoleBinding (crd-reader-rb-{{ .Release.Name }}) for the agent ServiceAccount.

No values.yaml changes needed, no new flags introduced.

## Test plan

- [x] helm lint . passes
- [x] helm template . renders the new ClusterRole/ClusterRoleBinding with default values
- [x] Renders correctly with listener.enabled=true too (existing watchers role/binding still render alongside)
- [x] pod.serviceAccount.autoCreate=false correctly omits the new resources, consistent with the rest of the agent RBAC
- [ ] After merge/release, confirm the "Failed to watch ... CustomResourceDefinition" error no longer appears in agent logs