### PR TITLE
fix(testworkflowexecutor): stop double-wrapping JSON config values

### DIFF
--- a/pkg/testworkflows/testworkflowexecutor/prepared.go
+++ b/pkg/testworkflows/testworkflowexecutor/prepared.go
@@ -256,14 +256,7 @@ func (e *IntermediateExecution) ApplyDynamicConfig(config map[string]string) err
 func (e *IntermediateExecution) ApplyConfig(config map[string]string) error {
 	dynamicConfig := make(map[string]string)
 	for k, v := range config {
-		// Detect JSON values (start with { or [ but NOT {{) and wrap in tojson(json()) to prevent colon tokenization
-		isJSON := len(v) > 0 && ((v[0] == '{' && (len(v) < 2 || v[1] != '{')) || v[0] == '[')
-
-		if isJSON {
-			dynamicConfig[k] = "tojson(json(" + expressions.NewStringValue(v).String() + "))"
-		} else {
-			dynamicConfig[k] = expressions.NewStringValue(v).Template()
-		}
+		dynamicConfig[k] = expressions.NewStringValue(v).Template()
 	}
 	return e.ApplyDynamicConfig(dynamicConfig)
 }

--- a/pkg/testworkflows/testworkflowexecutor/prepared_config_test.go
+++ b/pkg/testworkflows/testworkflowexecutor/prepared_config_test.go
@@ -1,84 +1,94 @@
 package testworkflowexecutor
 
 import (
-	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/kubeshop/testkube/pkg/expressions"
+	testworkflowsv1 "github.com/kubeshop/testkube/api/testworkflows/v1"
 )
 
-func TestApplyConfig_JSONHandling(t *testing.T) {
+// TestApplyConfig_JSONConfigReadableByJSONFunction guards against a bug where
+// ApplyConfig wrapped JSON-shaped values as `tojson(json("<escaped>"))`. The
+// wrapped string flowed through castParameter's CompileTemplate as a literal
+// (no `{{...}}` interpolation to trigger), so config.<key> ended up registered
+// as the plain text "tojson(json(...))". A workflow expression like
+// json(config.jobs) then received that text and failed to parse it as JSON.
+func TestApplyConfig_JSONConfigReadableByJSONFunction(t *testing.T) {
+	workflow := &testworkflowsv1.TestWorkflow{
+		Spec: testworkflowsv1.TestWorkflowSpec{
+			TestWorkflowSpecBase: testworkflowsv1.TestWorkflowSpecBase{
+				Config: map[string]testworkflowsv1.ParameterSchema{
+					"jobs": {Type: testworkflowsv1.ParameterTypeString},
+				},
+				Pod: &testworkflowsv1.PodConfig{
+					ServiceAccountName: `{{ json(config.jobs).0.name }}`,
+				},
+			},
+		},
+	}
+
+	ie := NewIntermediateExecution().SetWorkflow(workflow)
+	err := ie.ApplyConfig(map[string]string{
+		"jobs": `[{"name":"go"},{"name":"node"}]`,
+	})
+
+	assert.NoError(t, err)
+	assert.Equal(t, "go", ie.cr.Spec.Pod.ServiceAccountName)
+}
+
+// TestApplyConfig_JSONConfigColonsSurviveJSONReparse verifies that colons and
+// other special chars (`+`, `=`) inside a JSON config value survive ApplyConfig
+// and can be pulled back out via json(config.<key>).<field>. Preventing colon
+// splitting in JSON config values was the original motivation for PR #6952;
+// this test covers that intent at the resolve-time level.
+func TestApplyConfig_JSONConfigColonsSurviveJSONReparse(t *testing.T) {
 	tests := []struct {
-		name     string
-		input    string
-		expected string
+		name      string
+		configVal string
+		template  string
+		expected  string
 	}{
 		{
-			name:     "simple string value",
-			input:    "production",
-			expected: "production",
+			name:      "URL with port read back via json()",
+			configVal: `{"url":"https://api.example.com:8080/v1"}`,
+			template:  `{{ json(config.data).url }}`,
+			expected:  "https://api.example.com:8080/v1",
 		},
 		{
-			name:     "simple value with equals",
-			input:    "key=value",
-			expected: "key=value",
-		},
-		{
-			name:     "JSON object with URL",
-			input:    `{"agency":{"url":"https://test.com"}}`,
-			expected: `tojson(json("{\"agency\":{\"url\":\"https://test.com\"}}"))`,
-		},
-		{
-			name:     "JSON object with multiple fields",
-			input:    `{"name":"Test","url":"https://example.com","port":8080}`,
-			expected: `tojson(json("{\"name\":\"Test\",\"url\":\"https://example.com\",\"port\":8080}"))`,
-		},
-		{
-			name:     "JSON array",
-			input:    `["value1","value2","value3"]`,
-			expected: `tojson(json("[\"value1\",\"value2\",\"value3\"]"))`,
-		},
-		{
-			name:     "nested JSON object",
-			input:    `{"agency":{"name":"Test Agency","url":"https://test.com","config":{"timeout":30}}}`,
-			expected: `tojson(json("{\"agency\":{\"name\":\"Test Agency\",\"url\":\"https://test.com\",\"config\":{\"timeout\":30}}}"))`,
+			name:      "base64 secret with +/= read back via json()",
+			configVal: `{"secret":"aGVsbG8rd29ybGQ+c2VjcmV0PQ=="}`,
+			template:  `{{ json(config.data).secret }}`,
+			expected:  "aGVsbG8rd29ybGQ+c2VjcmV0PQ==",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			var result string
-
-			isJSON := len(tt.input) > 0 && ((tt.input[0] == '{' && (len(tt.input) < 2 || tt.input[1] != '{')) || tt.input[0] == '[')
-			if isJSON {
-				result = "tojson(json(" + expressions.NewStringValue(tt.input).String() + "))"
-			} else {
-				result = expressions.NewStringValue(tt.input).Template()
+			workflow := &testworkflowsv1.TestWorkflow{
+				Spec: testworkflowsv1.TestWorkflowSpec{
+					TestWorkflowSpecBase: testworkflowsv1.TestWorkflowSpecBase{
+						Config: map[string]testworkflowsv1.ParameterSchema{
+							"data": {Type: testworkflowsv1.ParameterTypeString},
+						},
+						Pod: &testworkflowsv1.PodConfig{
+							ServiceAccountName: tt.template,
+						},
+					},
+				},
 			}
 
-			assert.Equal(t, tt.expected, result)
+			ie := NewIntermediateExecution().SetWorkflow(workflow)
+			err := ie.ApplyConfig(map[string]string{"data": tt.configVal})
+
+			assert.NoError(t, err)
+			assert.Equal(t, tt.expected, ie.cr.Spec.Pod.ServiceAccountName)
 		})
 	}
 }
 
-func TestApplyConfig_PreservesColonsInJSON(t *testing.T) {
-	input := `{"url":"https://test.com","port":8080}`
-
-	var result string
-	isJSON := len(input) > 0 && ((input[0] == '{' && (len(input) < 2 || input[1] != '{')) || input[0] == '[')
-	if isJSON {
-		result = "tojson(json(" + expressions.NewStringValue(input).String() + "))"
-	}
-
-	assert.Contains(t, result, "tojson(json(")
-	assert.Contains(t, result, `\"url\":`)
-	assert.Contains(t, result, `\"https:`)
-	assert.NotContains(t, result, "agency:url")
-	assert.NotContains(t, result, "url:https")
-}
-
+// TestApplyConfig_SimpleValuesUnchanged verifies that plain string values pass
+// through ApplyConfig untouched into a `{{ config.<key> }}` substitution site.
 func TestApplyConfig_SimpleValuesUnchanged(t *testing.T) {
 	tests := []string{
 		"production",
@@ -87,352 +97,34 @@ func TestApplyConfig_SimpleValuesUnchanged(t *testing.T) {
 		"https://example.com",
 		"123",
 		"true",
+		"https://api.example.com:8080",
+		"key=value&another=value2",
+		"opt1;opt2;opt3",
+		"value1,value2,value3",
 	}
 
 	for _, input := range tests {
 		t.Run(input, func(t *testing.T) {
-			if len(input) > 0 && (input[0] == '{' || input[0] == '[') {
-				t.Fatal("test data should not start with { or [")
+			workflow := &testworkflowsv1.TestWorkflow{
+				Spec: testworkflowsv1.TestWorkflowSpec{
+					TestWorkflowSpecBase: testworkflowsv1.TestWorkflowSpecBase{
+						Config: map[string]testworkflowsv1.ParameterSchema{
+							"v": {Type: testworkflowsv1.ParameterTypeString},
+						},
+						Pod: &testworkflowsv1.PodConfig{
+							ServiceAccountName: `{{ config.v }}`,
+						},
+					},
+				},
 			}
 
-			result := expressions.NewStringValue(input).Template()
-			assert.Equal(t, input, result)
+			ie := NewIntermediateExecution().SetWorkflow(workflow)
+			err := ie.ApplyConfig(map[string]string{"v": input})
+
+			assert.NoError(t, err)
+			assert.Equal(t, input, ie.cr.Spec.Pod.ServiceAccountName)
 		})
 	}
 }
 
-func TestApplyConfig_EdgeCases(t *testing.T) {
-	tests := []struct {
-		name         string
-		input        string
-		shouldBeJSON bool
-	}{
-		{
-			name:         "template expression",
-			input:        "{{config.value}}",
-			shouldBeJSON: false,
-		},
-		{
-			name:         "invalid JSON",
-			input:        "{notjson",
-			shouldBeJSON: true,
-		},
-		{
-			name:         "empty string",
-			input:        "",
-			shouldBeJSON: false,
-		},
-		{
-			name:         "whitespace before JSON",
-			input:        " {\"key\":\"value\"}",
-			shouldBeJSON: false,
-		},
-		{
-			name:         "JSON with template expression inside",
-			input:        `{"url":"{{config.baseUrl}}/api"}`,
-			shouldBeJSON: true,
-		},
-		{
-			name:         "ternary expression",
-			input:        "{{condition ? 'true' : 'false'}}",
-			shouldBeJSON: false,
-		},
-		{
-			name:         "URL with port",
-			input:        "https://example.com:8080/path",
-			shouldBeJSON: false,
-		},
-	}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			isJSON := len(tt.input) > 0 && ((tt.input[0] == '{' && (len(tt.input) < 2 || tt.input[1] != '{')) || tt.input[0] == '[')
-			assert.Equal(t, tt.shouldBeJSON, isJSON)
-
-			var result string
-			if isJSON {
-				result = "tojson(json(" + expressions.NewStringValue(tt.input).String() + "))"
-				assert.Contains(t, result, "tojson(json(")
-			} else {
-				result = expressions.NewStringValue(tt.input).Template()
-				assert.NotContains(t, result, "tojson(json(")
-			}
-		})
-	}
-}
-
-func TestApplyConfig_BackwardCompatibility(t *testing.T) {
-	tests := []struct {
-		name  string
-		input string
-	}{
-		{"environment variable", "production"},
-		{"numeric string", "123"},
-		{"boolean string", "true"},
-		{"URL with port", "https://api.example.com:8080"},
-		{"path", "/path/to/resource"},
-		{"template expression", "{{config.value}}"},
-		{"complex template", "{{env.ENV}}-{{config.region}}"},
-		{"value with equals", "key=value&another=value2"},
-		{"semicolon separated", "opt1;opt2;opt3"},
-		{"comma separated", "value1,value2,value3"},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			isJSON := len(tt.input) > 0 && ((tt.input[0] == '{' && (len(tt.input) < 2 || tt.input[1] != '{')) || tt.input[0] == '[')
-			assert.False(t, isJSON)
-
-			result := expressions.NewStringValue(tt.input).Template()
-
-			if !strings.Contains(tt.input, "{{") {
-				assert.Equal(t, tt.input, result)
-			} else {
-				assert.NotContains(t, result, "tojson(json(")
-			}
-		})
-	}
-}
-
-func TestApplyConfig_JSONValidation(t *testing.T) {
-	tests := []struct {
-		name  string
-		input string
-	}{
-		{"valid JSON object", `{"key":"value"}`},
-		{"valid JSON array", `["a","b","c"]`},
-		{"invalid JSON object", `{invalid}`},
-		{"invalid JSON array", `[invalid`},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			isJSON := len(tt.input) > 0 && ((tt.input[0] == '{' && (len(tt.input) < 2 || tt.input[1] != '{')) || tt.input[0] == '[')
-			assert.True(t, isJSON)
-
-			result := "tojson(json(" + expressions.NewStringValue(tt.input).String() + "))"
-			assert.Contains(t, result, "tojson(json(")
-		})
-	}
-}
-
-// TestApplyConfig_ColonHandling tests proper handling of colons in JSON config values
-func TestApplyConfig_ColonHandling(t *testing.T) {
-	tests := []struct {
-		name             string
-		configInput      map[string]string
-		expectedWrapping map[string]bool
-		shouldContain    map[string][]string
-		shouldNotContain map[string][]string
-	}{
-		{
-			name: "nested JSON object with URL fields",
-			configInput: map[string]string{
-				"customAgency": `{"agency":{"url":"https://test.com"}}`,
-			},
-			expectedWrapping: map[string]bool{
-				"customAgency": true,
-			},
-			shouldContain: map[string][]string{
-				"customAgency": {`tojson(json(`, `\"url\":`, `\"https:`},
-			},
-			shouldNotContain: map[string][]string{
-				"customAgency": {"agency:url", "url:https"},
-			},
-		},
-		{
-			name: "mixed config types",
-			configInput: map[string]string{
-				"env":       "production",
-				"apiConfig": `{"url":"https://api.test.com:8080"}`,
-			},
-			expectedWrapping: map[string]bool{
-				"env":       false,
-				"apiConfig": true,
-			},
-			shouldContain: map[string][]string{
-				"env":       {"production"},
-				"apiConfig": {`tojson(json(`},
-			},
-			shouldNotContain: map[string][]string{
-				"env":       {`tojson(json(`},
-				"apiConfig": {"url:https"},
-			},
-		},
-		{
-			name: "template expressions not wrapped",
-			configInput: map[string]string{
-				"baseUrl":   "{{config.apiUrl}}",
-				"condition": "{{env.DEBUG ? 'debug' : 'production'}}",
-			},
-			expectedWrapping: map[string]bool{
-				"baseUrl":   false,
-				"condition": false,
-			},
-			shouldNotContain: map[string][]string{
-				"baseUrl":   {`tojson(json(`},
-				"condition": {`tojson(json(`},
-			},
-		},
-		{
-			name: "plain URLs not wrapped",
-			configInput: map[string]string{
-				"apiUrl": "https://api.test.com:8080/v1",
-				"dbUrl":  "postgresql://user:pass@localhost:5432/db",
-			},
-			expectedWrapping: map[string]bool{
-				"apiUrl": false,
-				"dbUrl":  false,
-			},
-			shouldContain: map[string][]string{
-				"apiUrl": {"https://api.test.com:8080/v1"},
-			},
-			shouldNotContain: map[string][]string{
-				"apiUrl": {`tojson(json(`},
-			},
-		},
-		{
-			name: "complex nested JSON",
-			configInput: map[string]string{
-				"services": `{"database":{"host":"db.test.com:5432"},"api":{"endpoint":"https://api.test.com:8443"}}`,
-			},
-			expectedWrapping: map[string]bool{
-				"services": true,
-			},
-			shouldContain: map[string][]string{
-				"services": {`tojson(json(`, `\"host\":`},
-			},
-			shouldNotContain: map[string][]string{
-				"services": {"host:db"},
-			},
-		},
-		{
-			name: "JSON array with objects",
-			configInput: map[string]string{
-				"endpoints": `[{"name":"api","url":"https://api.test.com:8080"}]`,
-			},
-			expectedWrapping: map[string]bool{
-				"endpoints": true,
-			},
-			shouldContain: map[string][]string{
-				"endpoints": {`tojson(json(`},
-			},
-			shouldNotContain: map[string][]string{
-				"endpoints": {"url:https"},
-			},
-		},
-		{
-			name: "JSON with base64 secret containing special chars",
-			configInput: map[string]string{
-				"apiClient": `{"clientId":"AAAAAAAA-BBBB-CCCC","secret":"aGVsbG8rd29ybGQ+c2VjcmV0PQ=="}`,
-			},
-			expectedWrapping: map[string]bool{
-				"apiClient": true,
-			},
-			shouldContain: map[string][]string{
-				"apiClient": {`tojson(json(`, `+`, `=`},
-			},
-			shouldNotContain: map[string][]string{
-				"apiClient": {"secret:aGVs", "clientId:AAAA"},
-			},
-		},
-		{
-			name: "JSON with empty string values",
-			configInput: map[string]string{
-				"user": `{"id":"","username":"","password":""}`,
-			},
-			expectedWrapping: map[string]bool{
-				"user": true,
-			},
-			shouldContain: map[string][]string{
-				"user": {`tojson(json(`},
-			},
-		},
-		{
-			name: "real user scenario - full structure from bug report",
-			configInput: map[string]string{
-				"customAgency": `{"agency":{"url":"https://api.example.com","id":"AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEEE"},"apiClient":{"clientId":"FFFFFFFF-GGGG-HHHH-IIII-JJJJJJJJJJJJ","secret":"aGVsbG8rd29ybGQ+c2VjcmV0PQ=="},"user":{"id":"","username":"","password":""},"device":{"serial":""}}`,
-			},
-			expectedWrapping: map[string]bool{
-				"customAgency": true,
-			},
-			shouldContain: map[string][]string{
-				"customAgency": {`tojson(json(`, `api.example.com`, `aGVsbG8rd29ybGQ+`, `c2VjcmV0PQ==`},
-			},
-			shouldNotContain: map[string][]string{
-				"customAgency": {"url:https", "agency:url", "clientId:FFFF", "secret:aGVs"},
-			},
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			processedConfig := make(map[string]string)
-			for k, v := range tt.configInput {
-				isJSON := len(v) > 0 && ((v[0] == '{' && (len(v) < 2 || v[1] != '{')) || v[0] == '[')
-
-				if expectedWrapped, exists := tt.expectedWrapping[k]; exists {
-					assert.Equal(t, expectedWrapped, isJSON)
-				}
-
-				if isJSON {
-					processedConfig[k] = "tojson(json(" + expressions.NewStringValue(v).String() + "))"
-				} else {
-					processedConfig[k] = expressions.NewStringValue(v).Template()
-				}
-			}
-
-			for key, expectedStrings := range tt.shouldContain {
-				processedValue := processedConfig[key]
-				for _, expected := range expectedStrings {
-					assert.Contains(t, processedValue, expected)
-				}
-			}
-
-			for key, unwantedStrings := range tt.shouldNotContain {
-				processedValue := processedConfig[key]
-				for _, unwanted := range unwantedStrings {
-					assert.NotContains(t, processedValue, unwanted)
-				}
-			}
-		})
-	}
-}
-
-// TestApplyConfig_MultipleColonsInValue tests values with many colons are preserved
-func TestApplyConfig_MultipleColonsInValue(t *testing.T) {
-	tests := []struct {
-		name  string
-		input string
-		key   string
-		value string
-	}{
-		{
-			name:  "database connection strings",
-			input: `dbConfig={"primary":"postgresql://user:password@primary.db.com:5432/mydb"}`,
-			key:   "dbConfig",
-			value: `{"primary":"postgresql://user:password@primary.db.com:5432/mydb"}`,
-		},
-		{
-			name:  "service endpoint arrays",
-			input: `services=["https://service1.test.com:8080","https://service2.test.com:8081"]`,
-			key:   "services",
-			value: `["https://service1.test.com:8080","https://service2.test.com:8081"]`,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			parts := strings.SplitN(tt.input, "=", 2)
-			assert.Equal(t, tt.key, parts[0])
-			assert.Equal(t, tt.value, parts[1])
-
-			isJSON := len(parts[1]) > 0 && ((parts[1][0] == '{' && (len(parts[1]) < 2 || parts[1][1] != '{')) || parts[1][0] == '[')
-			assert.True(t, isJSON)
-
-			processedValue := "tojson(json(" + expressions.NewStringValue(parts[1]).String() + "))"
-			assert.Contains(t, processedValue, "tojson(json(")
-			assert.Greater(t, strings.Count(parts[1], ":"), 0)
-		})
-	}
-}

--- a/pkg/testworkflows/testworkflowexecutor/prepared_config_test.go
+++ b/pkg/testworkflows/testworkflowexecutor/prepared_config_test.go
@@ -126,5 +126,3 @@ func TestApplyConfig_SimpleValuesUnchanged(t *testing.T) {
 		})
 	}
 }
-
-


### PR DESCRIPTION
## Summary

`ApplyConfig` wraps JSON-shaped config values in `tojson(json("..."))` (added in #6952 to prevent colon tokenization). The wrap does not survive `castParameter`'s `CompileTemplate`: with no `{{...}}` interpolation to trigger, the wrapped text is registered on the config machine as a literal string. A workflow expression like `json(config.jobs)` then receives that literal text and fails to parse it as JSON.

Fix: drop the wrap and call `expressions.NewStringValue(v).Template()` for every value. `Template` already escapes single `{`, and text outside `{{...}}` is never tokenized, so colons and other special chars stay intact.

## Tests

The previous `prepared_config_test.go` cases asserted on the wrap format by replicating the branching logic inline instead of calling `ApplyConfig`; they pass regardless of what `ApplyConfig` does and no longer describe production behavior. Replaced with three resolve-time tests that go through `NewIntermediateExecution.SetWorkflow.ApplyConfig`:

- `TestApplyConfig_JSONConfigReadableByJSONFunction`: regression guard for the reported bug. `json(config.jobs).0.name` on a JSON array value must return the first entry's name.
- `TestApplyConfig_JSONConfigColonsSurviveJSONReparse`: URL with port and base64 secret with `+/=` inside JSON survive `ApplyConfig` and stay readable via `json(config.data).<field>`.
- `TestApplyConfig_SimpleValuesUnchanged`: plain strings, URLs, delimited values pass through `{{ config.v }}` untouched.

## Test plan

- [x] `go test ./pkg/testworkflows/...` green locally.