### PR TITLE
feat(cli): Air Gapped Legacy Usage Command

### DIFF
--- a/cmd/kubectl-testkube/commands/common/helper.go
+++ b/cmd/kubectl-testkube/commands/common/helper.go
@@ -1583,3 +1583,23 @@ func CheckLegacyName(commandName string) {
 		ui.Alert("! -------------------------------------------------------------------------------------------------------------- !")
 	}
 }
+
+// LookupHelmPath returns the path to the helm binary or a structured CLI error.
+func LookupHelmPath() (string, *CLIError) {
+	return lookupHelmPath()
+}
+
+// RunHelmCommand executes helm with the given args.
+func RunHelmCommand(helmPath string, args []string, dryRun bool) (string, *CLIError) {
+	return runHelmCommand(helmPath, args, dryRun)
+}
+
+// LookupKubectlPath returns the path to the kubectl binary or a structured CLI error.
+func LookupKubectlPath() (string, *CLIError) {
+	return lookupKubectlPath()
+}
+
+// RunKubectlCommand executes kubectl with the given args.
+func RunKubectlCommand(kubectlPath string, args []string) (string, *CLIError) {
+	return runKubectlCommand(kubectlPath, args)
+}

--- a/cmd/kubectl-testkube/commands/pro.go
+++ b/cmd/kubectl-testkube/commands/pro.go
@@ -4,6 +4,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/kubeshop/testkube/cmd/kubectl-testkube/commands/pro"
+	exportcmd "github.com/kubeshop/testkube/cmd/kubectl-testkube/commands/pro/export"
 )
 
 func NewProCmd() *cobra.Command {
@@ -19,6 +20,7 @@ func NewProCmd() *cobra.Command {
 	cmd.AddCommand(pro.NewDisconnectCmd())
 	cmd.AddCommand(pro.NewInitCmd())
 	cmd.AddCommand(pro.NewLoginCmd())
+	cmd.AddCommand(exportcmd.NewExportCmd())
 
 	return cmd
 }

--- a/cmd/kubectl-testkube/commands/pro/export/discover.go
+++ b/cmd/kubectl-testkube/commands/pro/export/discover.go
@@ -1,0 +1,428 @@
+package export
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/kubeshop/testkube/cmd/kubectl-testkube/commands/common"
+	"github.com/kubeshop/testkube/cmd/kubectl-testkube/config"
+	"github.com/kubeshop/testkube/pkg/ui"
+)
+
+const (
+	cloudAPINameLabel        = "app.kubernetes.io/name=testkube-cloud-api"
+	cloudAPIContainerName    = "testkube-cloud-api"
+	envEnterpriseLicense     = "ENTERPRISE_LICENSE_KEY"
+	envEnterpriseLicenseFile = "ENTERPRISE_LICENSE_FILE"
+	envCredentialsMaster     = "CREDENTIALS_MASTER_PASSWORD"
+	envPostgresURL           = "API_POSTGRES_URL"
+	envMongoDSN              = "API_MONGO_DSN"
+	envMongoDB               = "API_MONGO_DB"
+	envMongoReadPref         = "API_MONGO_READ_PREFERENCE"
+	envDatabaseUsername      = "DATABASE_USERNAME"
+	envDatabasePassword      = "DATABASE_PASSWORD"
+	envDatabaseHost          = "DATABASE_HOST"
+	envDatabaseName          = "DATABASE_NAME"
+	envSSLCertDir            = "SSL_CERT_DIR"
+)
+
+type discoveredConfig struct {
+	HelmSet      map[string]string
+	Deployment   string
+	SourceDetail string
+}
+
+type kubeDeployment struct {
+	Items []kubeDeploymentItem `json:"items"`
+}
+
+type kubeDeploymentItem struct {
+	Metadata kubeObjectMeta     `json:"metadata"`
+	Spec     kubeDeploymentSpec `json:"spec"`
+}
+
+type kubeObjectMeta struct {
+	Name string `json:"name"`
+}
+
+type kubeDeploymentSpec struct {
+	Template kubePodTemplateSpec `json:"template"`
+}
+
+type kubePodTemplateSpec struct {
+	Spec kubePodSpec `json:"spec"`
+}
+
+type kubePodSpec struct {
+	Containers []kubeContainer `json:"containers"`
+	Volumes    []kubeVolume    `json:"volumes"`
+}
+
+type kubeContainer struct {
+	Name         string            `json:"name"`
+	Env          []kubeEnvVar      `json:"env"`
+	VolumeMounts []kubeVolumeMount `json:"volumeMounts"`
+}
+
+type kubeEnvVar struct {
+	Name      string          `json:"name"`
+	Value     string          `json:"value"`
+	ValueFrom *kubeEnvVarFrom `json:"valueFrom"`
+}
+
+type kubeEnvVarFrom struct {
+	SecretKeyRef *kubeSecretKeyRef `json:"secretKeyRef"`
+}
+
+type kubeSecretKeyRef struct {
+	Name string `json:"name"`
+	Key  string `json:"key"`
+}
+
+type kubeVolume struct {
+	Name   string            `json:"name"`
+	Secret *kubeVolumeSecret `json:"secret"`
+}
+
+type kubeVolumeSecret struct {
+	SecretName string `json:"secretName"`
+}
+
+type kubeVolumeMount struct {
+	Name      string `json:"name"`
+	MountPath string `json:"mountPath"`
+	SubPath   string `json:"subPath"`
+}
+
+// DiscoverConfig reads the Testkube Enterprise cloud-api deployment in the target
+// namespace and maps its env/volume wiring to testkube-usage-export Helm values.
+func DiscoverConfig(opts Options) (discoveredConfig, *common.CLIError) {
+	kubectlPath, cliErr := common.LookupKubectlPath()
+	if cliErr != nil {
+		return discoveredConfig{}, cliErr
+	}
+
+	args := kubectlBaseArgs(opts, "get", "deploy", "-l", cloudAPINameLabel, "-o", "json")
+	raw, cliErr := common.RunKubectlCommand(kubectlPath, args)
+	if cliErr != nil {
+		return discoveredConfig{}, cliErr
+	}
+
+	var list kubeDeployment
+	if err := json.Unmarshal([]byte(raw), &list); err != nil {
+		return discoveredConfig{}, common.NewCLIError(
+			common.TKErrKubectlCommandFailed,
+			"Failed to parse cloud-api deployment",
+			"Verify kubectl access to the target namespace",
+			err,
+		)
+	}
+
+	deploy := pickCloudAPIDeployment(list.Items)
+	if deploy == nil {
+		args = kubectlBaseArgs(opts, "get", "deploy", config.EnterpriseApiName, "-o", "json")
+		raw, cliErr = common.RunKubectlCommand(kubectlPath, args)
+		if cliErr != nil {
+			return discoveredConfig{}, common.NewCLIError(
+				common.TKErrKubectlCommandFailed,
+				"Testkube Enterprise cloud-api deployment not found",
+				fmt.Sprintf("Install enterprise in namespace %q or pass -f values.yaml with --no-auto-config", opts.Namespace),
+				fmt.Errorf("no deployment labeled %s", cloudAPINameLabel),
+			)
+		}
+		var single kubeDeploymentItem
+		if err := json.Unmarshal([]byte(raw), &single); err != nil {
+			return discoveredConfig{}, common.NewCLIError(
+				common.TKErrKubectlCommandFailed,
+				"Failed to parse cloud-api deployment",
+				"Verify kubectl access to the target namespace",
+				err,
+			)
+		}
+		deploy = &single
+	}
+
+	container := pickCloudAPIContainer(deploy.Spec.Template.Spec.Containers)
+	if container == nil {
+		return discoveredConfig{}, common.NewCLIError(
+			common.TKErrKubectlCommandFailed,
+			"cloud-api container not found",
+			"Expected a container named testkube-cloud-api on the enterprise deployment",
+			fmt.Errorf("deployment %q has no cloud-api container", deploy.Metadata.Name),
+		)
+	}
+
+	helmSet, err := helmSetFromCloudAPI(container.Env, deploy.Spec.Template.Spec.Volumes, container.VolumeMounts)
+	if err != nil {
+		return discoveredConfig{}, common.NewCLIError(
+			common.TKErrInvalidRuntimeParameter,
+			"Could not derive usage-export config from cloud-api",
+			"Provide -f values.yaml with --no-auto-config, or ensure cloud-api has database and license env configured",
+			err,
+		)
+	}
+
+	return discoveredConfig{
+		HelmSet:      helmSet,
+		Deployment:   deploy.Metadata.Name,
+		SourceDetail: fmt.Sprintf("deployment/%s", deploy.Metadata.Name),
+	}, nil
+}
+
+func pickCloudAPIDeployment(items []kubeDeploymentItem) *kubeDeploymentItem {
+	if len(items) == 0 {
+		return nil
+	}
+	for i := range items {
+		if items[i].Metadata.Name == config.EnterpriseApiName {
+			return &items[i]
+		}
+	}
+	return &items[0]
+}
+
+func pickCloudAPIContainer(containers []kubeContainer) *kubeContainer {
+	for i := range containers {
+		if containers[i].Name == cloudAPIContainerName {
+			return &containers[i]
+		}
+	}
+	if len(containers) == 0 {
+		return nil
+	}
+	return &containers[0]
+}
+
+func helmSetFromCloudAPI(envVars []kubeEnvVar, volumes []kubeVolume, mounts []kubeVolumeMount) (map[string]string, error) {
+	env := envVarsByName(envVars)
+	out := map[string]string{}
+
+	if err := applyPostgresHelmSet(env, out); err != nil {
+		return nil, err
+	}
+	if _, ok := out["postgres.enabled"]; !ok {
+		if err := applyMongoHelmSet(env, out); err != nil {
+			return nil, err
+		}
+	}
+	if _, ok := out["postgres.enabled"]; !ok {
+		if _, ok := out["mongo.enabled"]; !ok {
+			return nil, fmt.Errorf("cloud-api has neither postgres nor mongo configuration")
+		}
+	}
+
+	if err := applyCredentialsHelmSet(env, out); err != nil {
+		return nil, err
+	}
+	if err := applyLicenseHelmSet(env, out); err != nil {
+		return nil, err
+	}
+	applyCustomCAHelmSet(env, volumes, mounts, out)
+
+	return out, nil
+}
+
+func envVarsByName(envVars []kubeEnvVar) map[string]kubeEnvVar {
+	out := make(map[string]kubeEnvVar, len(envVars))
+	for _, e := range envVars {
+		out[e.Name] = e
+	}
+	return out
+}
+
+func applyPostgresHelmSet(env map[string]kubeEnvVar, out map[string]string) error {
+	if ref, ok := secretRef(env, envPostgresURL); ok {
+		out["postgres.enabled"] = "true"
+		out["postgres.dsnSecretRef"] = ref.name
+		out["postgres.dsnSecretKey"] = ref.key
+		return nil
+	}
+	if literal, ok := literalValue(env, envPostgresURL); ok && !isPostgresURLTemplate(literal) {
+		out["postgres.enabled"] = "true"
+		out["postgres.dsn"] = literal
+		return nil
+	}
+
+	pgSecret, ok := postgresComponentSecret(env)
+	if !ok {
+		return nil
+	}
+
+	out["postgres.enabled"] = "true"
+	out["postgres.secretRef.name"] = pgSecret
+	if ref, ok := secretRef(env, envDatabaseUsername); ok {
+		out["postgres.secretRef.usernameKey"] = ref.key
+	} else if v, ok := literalValue(env, envDatabaseUsername); ok {
+		out["postgres.username"] = v
+	}
+	if ref, ok := secretRef(env, envDatabasePassword); ok {
+		out["postgres.secretRef.passwordKey"] = ref.key
+	}
+	if ref, ok := secretRef(env, envDatabaseHost); ok {
+		out["postgres.secretRef.endpointKey"] = ref.key
+	} else if v, ok := literalValue(env, envDatabaseHost); ok {
+		out["postgres.endpoint"] = v
+	}
+	if v, ok := literalValue(env, envDatabaseName); ok {
+		out["postgres.database"] = v
+	}
+	return nil
+}
+
+func postgresComponentSecret(env map[string]kubeEnvVar) (string, bool) {
+	for _, name := range []string{envDatabaseUsername, envDatabasePassword, envDatabaseHost} {
+		if ref, ok := secretRef(env, name); ok {
+			return ref.name, true
+		}
+	}
+	return "", false
+}
+
+func applyMongoHelmSet(env map[string]kubeEnvVar, out map[string]string) error {
+	if ref, ok := secretRef(env, envMongoDSN); ok {
+		out["mongo.enabled"] = "true"
+		out["mongo.dsnSecretRef"] = ref.name
+	} else if literal, ok := literalValue(env, envMongoDSN); ok {
+		out["mongo.enabled"] = "true"
+		out["mongo.dsn"] = literal
+	} else {
+		return nil
+	}
+	if v, ok := literalValue(env, envMongoDB); ok {
+		out["mongo.database"] = v
+	}
+	if v, ok := literalValue(env, envMongoReadPref); ok {
+		out["mongo.readPreference"] = v
+	}
+	return nil
+}
+
+func applyCredentialsHelmSet(env map[string]kubeEnvVar, out map[string]string) error {
+	if ref, ok := secretRef(env, envCredentialsMaster); ok {
+		out["credentials.masterPassword.secretKeyRef.name"] = ref.name
+		out["credentials.masterPassword.secretKeyRef.key"] = ref.key
+		return nil
+	}
+	if v, ok := literalValue(env, envCredentialsMaster); ok {
+		out["credentials.masterPassword.value"] = v
+		ui.Warn("Auto-config copied inline CREDENTIALS_MASTER_PASSWORD from cloud-api; prefer secret refs in production")
+		return nil
+	}
+	return fmt.Errorf("CREDENTIALS_MASTER_PASSWORD not found on cloud-api deployment")
+}
+
+func applyLicenseHelmSet(env map[string]kubeEnvVar, out map[string]string) error {
+	if _, hasFile := env[envEnterpriseLicenseFile]; hasFile {
+		if _, hasKey := secretRef(env, envEnterpriseLicense); !hasKey {
+			if _, hasLiteral := literalValue(env, envEnterpriseLicense); !hasLiteral {
+				return fmt.Errorf("offline license file installs require ENTERPRISE_LICENSE_KEY for usage export")
+			}
+		}
+	}
+	if ref, ok := secretRef(env, envEnterpriseLicense); ok {
+		out["enterpriseLicenseSecretRef"] = ref.name
+		return nil
+	}
+	if v, ok := literalValue(env, envEnterpriseLicense); ok {
+		out["enterpriseLicenseKey"] = v
+		ui.Warn("Auto-config copied inline ENTERPRISE_LICENSE_KEY from cloud-api; prefer enterpriseLicenseSecretRef in production")
+		return nil
+	}
+	return fmt.Errorf("ENTERPRISE_LICENSE_KEY not found on cloud-api deployment")
+}
+
+func applyCustomCAHelmSet(env map[string]kubeEnvVar, volumes []kubeVolume, mounts []kubeVolumeMount, out map[string]string) {
+	if _, ok := literalValue(env, envSSLCertDir); !ok {
+		return
+	}
+	volumeSecrets := map[string]string{}
+	for _, vol := range volumes {
+		if vol.Secret != nil && vol.Secret.SecretName != "" {
+			volumeSecrets[vol.Name] = vol.Secret.SecretName
+		}
+	}
+	for _, mount := range mounts {
+		if secretName, ok := volumeSecrets[mount.Name]; ok && mount.SubPath != "" {
+			out["customCaSecretRef"] = secretName
+			out["customCaSecretKey"] = mount.SubPath
+			return
+		}
+	}
+}
+
+type secretRefValue struct {
+	name string
+	key  string
+}
+
+func secretRef(env map[string]kubeEnvVar, name string) (secretRefValue, bool) {
+	e, ok := env[name]
+	if !ok || e.ValueFrom == nil || e.ValueFrom.SecretKeyRef == nil {
+		return secretRefValue{}, false
+	}
+	ref := e.ValueFrom.SecretKeyRef
+	if strings.TrimSpace(ref.Name) == "" || strings.TrimSpace(ref.Key) == "" {
+		return secretRefValue{}, false
+	}
+	return secretRefValue{name: ref.Name, key: ref.Key}, true
+}
+
+func literalValue(env map[string]kubeEnvVar, name string) (string, bool) {
+	e, ok := env[name]
+	if !ok {
+		return "", false
+	}
+	v := strings.TrimSpace(e.Value)
+	if v == "" {
+		return "", false
+	}
+	return v, true
+}
+
+func isPostgresURLTemplate(dsn string) bool {
+	return strings.Contains(dsn, "$(")
+}
+
+func mergeHelmSets(base, overrides map[string]string) map[string]string {
+	out := make(map[string]string, len(base)+len(overrides))
+	for k, v := range base {
+		out[k] = v
+	}
+	for k, v := range overrides {
+		out[k] = v
+	}
+	return out
+}
+
+func shouldAutoConfig(valuesFiles []string, autoConfig, noAutoConfig bool) bool {
+	if noAutoConfig {
+		return false
+	}
+	if autoConfig {
+		return true
+	}
+	return len(valuesFiles) == 0
+}
+
+func applyAutoConfig(opts *Options, autoConfig, noAutoConfig bool) *common.CLIError {
+	if !shouldAutoConfig(opts.ValuesFiles, autoConfig, noAutoConfig) {
+		return nil
+	}
+
+	discovered, cliErr := DiscoverConfig(*opts)
+	if cliErr != nil {
+		return cliErr
+	}
+
+	opts.HelmSet = mergeHelmSets(discovered.HelmSet, opts.HelmSet)
+	opts.CreateNamespace = false
+
+	ui.Info("Auto-configured usage export from", discovered.SourceDetail)
+	if ui.IsVerbose() {
+		for k, v := range discovered.HelmSet {
+			ui.Debug(fmt.Sprintf("  %s=%s", k, v))
+		}
+	}
+	return nil
+}

--- a/cmd/kubectl-testkube/commands/pro/export/discover.go
+++ b/cmd/kubectl-testkube/commands/pro/export/discover.go
@@ -421,7 +421,7 @@ func applyAutoConfig(opts *Options, autoConfig, noAutoConfig bool) *common.CLIEr
 	ui.Info("Auto-configured usage export from", discovered.SourceDetail)
 	if ui.IsVerbose() {
 		for k, v := range discovered.HelmSet {
-			ui.Debug(fmt.Sprintf("  %s=%s", k, v))
+			ui.Debug(fmt.Sprintf("  %s=%s", k, redactHelmSetValueForLog(k, v)))
 		}
 	}
 	return nil

--- a/cmd/kubectl-testkube/commands/pro/export/discover_test.go
+++ b/cmd/kubectl-testkube/commands/pro/export/discover_test.go
@@ -1,0 +1,123 @@
+package export
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestHelmSetFromCloudAPI_PostgresSecretRef(t *testing.T) {
+	t.Parallel()
+
+	env := []kubeEnvVar{
+		{Name: envDatabaseUsername, ValueFrom: secretRefFrom("pg-creds", "username")},
+		{Name: envDatabasePassword, ValueFrom: secretRefFrom("pg-creds", "password")},
+		{Name: envDatabaseHost, ValueFrom: secretRefFrom("pg-creds", "host")},
+		{Name: envDatabaseName, Value: "backend"},
+		{Name: envPostgresURL, Value: "postgresql://$(DATABASE_USERNAME):$(DATABASE_PASSWORD)@$(DATABASE_HOST)/$(DATABASE_NAME)?sslmode=require"},
+		{Name: envCredentialsMaster, ValueFrom: secretRefFrom("testkube-credentials-master", "password")},
+		{Name: envEnterpriseLicense, ValueFrom: secretRefFrom("testkube-enterprise-license", "LICENSE_KEY")},
+	}
+
+	got, err := helmSetFromCloudAPI(env, nil, nil)
+	require.NoError(t, err)
+
+	assert.Equal(t, "true", got["postgres.enabled"])
+	assert.Equal(t, "pg-creds", got["postgres.secretRef.name"])
+	assert.Equal(t, "username", got["postgres.secretRef.usernameKey"])
+	assert.Equal(t, "password", got["postgres.secretRef.passwordKey"])
+	assert.Equal(t, "host", got["postgres.secretRef.endpointKey"])
+	assert.Equal(t, "backend", got["postgres.database"])
+	assert.Equal(t, "testkube-credentials-master", got["credentials.masterPassword.secretKeyRef.name"])
+	assert.Equal(t, "testkube-enterprise-license", got["enterpriseLicenseSecretRef"])
+}
+
+func TestHelmSetFromCloudAPI_PostgresDSNSecret(t *testing.T) {
+	t.Parallel()
+
+	env := []kubeEnvVar{
+		{Name: envPostgresURL, ValueFrom: secretRefFrom("pg-dsn", "API_POSTGRES_URL")},
+		{Name: envCredentialsMaster, ValueFrom: secretRefFrom("testkube-credentials-master", "password")},
+		{Name: envEnterpriseLicense, ValueFrom: secretRefFrom("testkube-enterprise-license", "LICENSE_KEY")},
+	}
+
+	got, err := helmSetFromCloudAPI(env, nil, nil)
+	require.NoError(t, err)
+
+	assert.Equal(t, "true", got["postgres.enabled"])
+	assert.Equal(t, "pg-dsn", got["postgres.dsnSecretRef"])
+	assert.Equal(t, "API_POSTGRES_URL", got["postgres.dsnSecretKey"])
+}
+
+func TestHelmSetFromCloudAPI_MongoSecretRef(t *testing.T) {
+	t.Parallel()
+
+	env := []kubeEnvVar{
+		{Name: envMongoDSN, ValueFrom: secretRefFrom("mongo-dsn", "MONGO_DSN")},
+		{Name: envMongoDB, Value: "testkubeEnterpriseDB"},
+		{Name: envCredentialsMaster, ValueFrom: secretRefFrom("testkube-credentials-master", "password")},
+		{Name: envEnterpriseLicense, ValueFrom: secretRefFrom("testkube-enterprise-license", "LICENSE_KEY")},
+	}
+
+	got, err := helmSetFromCloudAPI(env, nil, nil)
+	require.NoError(t, err)
+
+	assert.Equal(t, "true", got["mongo.enabled"])
+	assert.Equal(t, "mongo-dsn", got["mongo.dsnSecretRef"])
+	assert.Equal(t, "testkubeEnterpriseDB", got["mongo.database"])
+}
+
+func TestHelmSetFromCloudAPI_CustomCA(t *testing.T) {
+	t.Parallel()
+
+	env := []kubeEnvVar{
+		{Name: envPostgresURL, Value: "postgresql://u:p@db:5432/t"},
+		{Name: envCredentialsMaster, ValueFrom: secretRefFrom("testkube-credentials-master", "password")},
+		{Name: envEnterpriseLicense, ValueFrom: secretRefFrom("testkube-enterprise-license", "LICENSE_KEY")},
+		{Name: envSSLCertDir, Value: "/etc/testkube/certs"},
+	}
+	volumes := []kubeVolume{{Name: "custom-ca", Secret: &kubeVolumeSecret{SecretName: "custom-ca"}}}
+	mounts := []kubeVolumeMount{{Name: "custom-ca", SubPath: "ca.crt"}}
+
+	got, err := helmSetFromCloudAPI(env, volumes, mounts)
+	require.NoError(t, err)
+
+	assert.Equal(t, "custom-ca", got["customCaSecretRef"])
+	assert.Equal(t, "ca.crt", got["customCaSecretKey"])
+}
+
+func TestHelmSetFromCloudAPI_OfflineLicenseFileWithoutKey(t *testing.T) {
+	t.Parallel()
+
+	env := []kubeEnvVar{
+		{Name: envPostgresURL, Value: "postgresql://u:p@db:5432/t"},
+		{Name: envCredentialsMaster, ValueFrom: secretRefFrom("testkube-credentials-master", "password")},
+		{Name: envEnterpriseLicenseFile, Value: "/testkube/license.lic"},
+	}
+
+	_, err := helmSetFromCloudAPI(env, nil, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "offline license")
+}
+
+func TestShouldAutoConfig(t *testing.T) {
+	t.Parallel()
+
+	assert.True(t, shouldAutoConfig(nil, false, false))
+	assert.False(t, shouldAutoConfig([]string{"values.yaml"}, false, false))
+	assert.True(t, shouldAutoConfig([]string{"values.yaml"}, true, false))
+	assert.False(t, shouldAutoConfig(nil, true, true))
+}
+
+func TestMergeHelmSets(t *testing.T) {
+	t.Parallel()
+
+	got := mergeHelmSets(map[string]string{"postgres.enabled": "true", "usageExport.weeks": "4"}, map[string]string{"usageExport.weeks": "8"})
+	assert.Equal(t, "true", got["postgres.enabled"])
+	assert.Equal(t, "8", got["usageExport.weeks"])
+}
+
+func secretRefFrom(name, key string) *kubeEnvVarFrom {
+	return &kubeEnvVarFrom{SecretKeyRef: &kubeSecretKeyRef{Name: name, Key: key}}
+}

--- a/cmd/kubectl-testkube/commands/pro/export/download.go
+++ b/cmd/kubectl-testkube/commands/pro/export/download.go
@@ -15,6 +15,8 @@ import (
 	"github.com/kubeshop/testkube/cmd/kubectl-testkube/commands/common"
 )
 
+const usageExportContainer = "usage-export"
+
 var (
 	outputPathJSONPattern = regexp.MustCompile(`"outputPath"\s*:\s*"([^"]+)"`)
 	outputPathLogPattern  = regexp.MustCompile(`outputPath[=:\s]+(/[^\s",]+)`)
@@ -59,7 +61,7 @@ func WaitAndDownload(ctx context.Context, opts Options, jobName string) (string,
 
 	podName, remotePath, cliErr := waitForExportComplete(waitCtx, kubectlPath, opts, jobName)
 	if cliErr != nil {
-		return "", "", cliErr
+		return "", podName, cliErr
 	}
 
 	localPath := opts.Output
@@ -75,7 +77,7 @@ func WaitAndDownload(ctx context.Context, opts Options, jobName string) (string,
 		)
 	}
 
-	cpArgs := kubectlBaseArgs(opts, "cp", fmt.Sprintf("%s:%s", podName, remotePath), localPath)
+	cpArgs := kubectlBaseArgs(opts, "cp", "-c", usageExportContainer, fmt.Sprintf("%s:%s", podName, remotePath), localPath)
 	if _, cliErr := common.RunKubectlCommand(kubectlPath, cpArgs); cliErr != nil {
 		return "", "", cliErr
 	}
@@ -89,7 +91,7 @@ func waitForExportComplete(ctx context.Context, kubectlPath string, opts Options
 		return "", "", cliErr
 	}
 
-	logArgs := kubectlBaseArgs(opts, "logs", "-f", podName)
+	logArgs := kubectlBaseArgs(opts, "logs", "-f", podName, "-c", usageExportContainer)
 	cmd := exec.CommandContext(ctx, kubectlPath, logArgs...)
 	stdout, err := cmd.StdoutPipe()
 	if err != nil {
@@ -125,7 +127,7 @@ func waitForExportComplete(ctx context.Context, kubectlPath string, opts Options
 	select {
 	case <-ctx.Done():
 		_ = cmd.Process.Kill()
-		return "", "", common.NewCLIError(
+		return podName, "", common.NewCLIError(
 			common.TKErrKubectlCommandFailed,
 			"Timed out waiting for usage export",
 			fmt.Sprintf("Increase --timeout (current %s) or inspect logs: kubectl logs %s", opts.Timeout, podName),
@@ -137,7 +139,7 @@ func waitForExportComplete(ctx context.Context, kubectlPath string, opts Options
 		if exportPath == "" {
 			exportPath, cliErr = discoverOutputPath(kubectlPath, opts, podName)
 			if cliErr != nil {
-				return "", "", cliErr
+				return podName, "", exportFailureCLIError(opts, podName, cliErr)
 			}
 			return podName, exportPath, nil
 		}
@@ -152,11 +154,14 @@ func waitForJobPod(ctx context.Context, kubectlPath string, opts Options, jobNam
 	for {
 		args := kubectlBaseArgs(opts, "get", "pods",
 			"-l", fmt.Sprintf("job-name=%s", jobName),
-			"-o", "jsonpath={.items[0].metadata.name}",
+			"-o", "jsonpath={.items[0].metadata.name}{\"\\t\"}{.items[0].status.phase}",
 		)
-		podName, cliErr := common.RunKubectlCommand(kubectlPath, args)
-		if cliErr == nil && strings.TrimSpace(podName) != "" {
-			return strings.TrimSpace(podName), nil
+		raw, cliErr := common.RunKubectlCommand(kubectlPath, args)
+		if cliErr == nil {
+			podName, phase, ok := parsePodNamePhase(raw)
+			if ok && podIsReadyForExport(phase) {
+				return podName, nil
+			}
 		}
 
 		select {
@@ -172,8 +177,25 @@ func waitForJobPod(ctx context.Context, kubectlPath string, opts Options, jobNam
 	}
 }
 
+func parsePodNamePhase(raw string) (podName, phase string, ok bool) {
+	parts := strings.Split(strings.TrimSpace(raw), "\t")
+	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+		return "", "", false
+	}
+	return parts[0], parts[1], true
+}
+
+func podIsReadyForExport(phase string) bool {
+	switch phase {
+	case "Running", "Succeeded", "Failed":
+		return true
+	default:
+		return false
+	}
+}
+
 func discoverOutputPath(kubectlPath string, opts Options, podName string) (string, *common.CLIError) {
-	args := kubectlBaseArgs(opts, "exec", podName, "--", "sh", "-c", "ls -1 /output/*.zip 2>/dev/null | head -1")
+	args := kubectlBaseArgs(opts, "exec", podName, "-c", usageExportContainer, "--", "sh", "-c", "ls -1 /output/*.zip 2>/dev/null | head -1")
 	output, cliErr := common.RunKubectlCommand(kubectlPath, args)
 	if cliErr != nil {
 		return "", cliErr
@@ -188,6 +210,21 @@ func discoverOutputPath(kubectlPath string, opts Options, podName string) (strin
 		)
 	}
 	return path, nil
+}
+
+func exportFailureCLIError(opts Options, podName string, cause *common.CLIError) *common.CLIError {
+	hint := fmt.Sprintf("Inspect pod logs: kubectl -n %s logs %s -c %s", opts.Namespace, podName, usageExportContainer)
+	return common.NewCLIError(
+		common.TKErrKubectlCommandFailed,
+		"Usage export did not produce a downloadable zip",
+		hint,
+		cause,
+	)
+}
+
+func podLogs(kubectlPath string, opts Options, podName string) (string, *common.CLIError) {
+	args := kubectlBaseArgs(opts, "logs", podName, "-c", usageExportContainer)
+	return common.RunKubectlCommand(kubectlPath, args)
 }
 
 func defaultLocalOutput(remotePath string) string {

--- a/cmd/kubectl-testkube/commands/pro/export/download.go
+++ b/cmd/kubectl-testkube/commands/pro/export/download.go
@@ -1,0 +1,199 @@
+package export
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/kubeshop/testkube/cmd/kubectl-testkube/commands/common"
+)
+
+var (
+	outputPathJSONPattern = regexp.MustCompile(`"outputPath"\s*:\s*"([^"]+)"`)
+	outputPathLogPattern  = regexp.MustCompile(`outputPath[=:\s]+(/[^\s",]+)`)
+	downloadLinePattern   = regexp.MustCompile(`Download:\s+kubectl\s+-n\s+\S+\s+cp\s+\S+:(\S+)`)
+)
+
+func ParseOutputPath(logLine string) (string, bool) {
+	if matches := outputPathJSONPattern.FindStringSubmatch(logLine); len(matches) == 2 {
+		return matches[1], true
+	}
+	if matches := outputPathLogPattern.FindStringSubmatch(logLine); len(matches) == 2 {
+		return matches[1], true
+	}
+	if matches := downloadLinePattern.FindStringSubmatch(logLine); len(matches) == 2 {
+		return matches[1], true
+	}
+	return "", false
+}
+
+func WaitAndDownload(ctx context.Context, opts Options, jobName string) (string, string, *common.CLIError) {
+	kubectlPath, cliErr := common.LookupKubectlPath()
+	if cliErr != nil {
+		return "", "", cliErr
+	}
+
+	if opts.DryRun {
+		return opts.Output, "dry-run-pod", nil
+	}
+
+	timeout, err := time.ParseDuration(opts.Timeout)
+	if err != nil {
+		return "", "", common.NewCLIError(
+			common.TKErrInvalidRuntimeParameter,
+			"Invalid timeout",
+			"Provide a valid duration such as 15m or 30m",
+			err,
+		)
+	}
+
+	waitCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	podName, remotePath, cliErr := waitForExportComplete(waitCtx, kubectlPath, opts, jobName)
+	if cliErr != nil {
+		return "", "", cliErr
+	}
+
+	localPath := opts.Output
+	if localPath == "" {
+		localPath = defaultLocalOutput(remotePath)
+	}
+	if err := os.MkdirAll(filepath.Dir(localPath), 0o755); err != nil {
+		return "", "", common.NewCLIError(
+			common.TKErrKubectlCommandFailed,
+			"Failed to create output directory",
+			"Choose a writable --output path",
+			err,
+		)
+	}
+
+	cpArgs := kubectlBaseArgs(opts, "cp", fmt.Sprintf("%s:%s", podName, remotePath), localPath)
+	if _, cliErr := common.RunKubectlCommand(kubectlPath, cpArgs); cliErr != nil {
+		return "", "", cliErr
+	}
+
+	return localPath, podName, nil
+}
+
+func waitForExportComplete(ctx context.Context, kubectlPath string, opts Options, jobName string) (podName, remotePath string, cliErr *common.CLIError) {
+	podName, cliErr = waitForJobPod(ctx, kubectlPath, opts, jobName)
+	if cliErr != nil {
+		return "", "", cliErr
+	}
+
+	logArgs := kubectlBaseArgs(opts, "logs", "-f", podName)
+	cmd := exec.CommandContext(ctx, kubectlPath, logArgs...)
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return "", "", common.NewCLIError(common.TKErrKubectlCommandFailed, "Failed to stream pod logs", "Retry the command or inspect the Job manually with kubectl logs", err)
+	}
+	stderr, err := cmd.StderrPipe()
+	if err != nil {
+		return "", "", common.NewCLIError(common.TKErrKubectlCommandFailed, "Failed to stream pod logs", "Retry the command or inspect the Job manually with kubectl logs", err)
+	}
+
+	if err := cmd.Start(); err != nil {
+		return "", "", common.NewCLIError(common.TKErrKubectlCommandFailed, "Failed to stream pod logs", "Retry the command or inspect the Job manually with kubectl logs", err)
+	}
+
+	done := make(chan string, 1)
+	go func() {
+		defer close(done)
+		var exportPath string
+		scanner := bufio.NewScanner(io.MultiReader(stdout, stderr))
+		for scanner.Scan() {
+			line := scanner.Text()
+			if path, ok := ParseOutputPath(line); ok {
+				exportPath = path
+			}
+			if strings.Contains(line, "usage export complete") && exportPath != "" {
+				done <- exportPath
+				return
+			}
+		}
+		done <- exportPath
+	}()
+
+	select {
+	case <-ctx.Done():
+		_ = cmd.Process.Kill()
+		return "", "", common.NewCLIError(
+			common.TKErrKubectlCommandFailed,
+			"Timed out waiting for usage export",
+			fmt.Sprintf("Increase --timeout (current %s) or inspect logs: kubectl logs %s", opts.Timeout, podName),
+			ctx.Err(),
+		)
+	case exportPath := <-done:
+		_ = cmd.Process.Kill()
+		_ = cmd.Wait()
+		if exportPath == "" {
+			exportPath, cliErr = discoverOutputPath(kubectlPath, opts, podName)
+			if cliErr != nil {
+				return "", "", cliErr
+			}
+			return podName, exportPath, nil
+		}
+		return podName, exportPath, nil
+	}
+}
+
+func waitForJobPod(ctx context.Context, kubectlPath string, opts Options, jobName string) (string, *common.CLIError) {
+	ticker := time.NewTicker(2 * time.Second)
+	defer ticker.Stop()
+
+	for {
+		args := kubectlBaseArgs(opts, "get", "pods",
+			"-l", fmt.Sprintf("job-name=%s", jobName),
+			"-o", "jsonpath={.items[0].metadata.name}",
+		)
+		podName, cliErr := common.RunKubectlCommand(kubectlPath, args)
+		if cliErr == nil && strings.TrimSpace(podName) != "" {
+			return strings.TrimSpace(podName), nil
+		}
+
+		select {
+		case <-ctx.Done():
+			return "", common.NewCLIError(
+				common.TKErrKubectlCommandFailed,
+				"Timed out waiting for usage export pod",
+				fmt.Sprintf("Inspect the Job: kubectl describe job %s", jobName),
+				ctx.Err(),
+			)
+		case <-ticker.C:
+		}
+	}
+}
+
+func discoverOutputPath(kubectlPath string, opts Options, podName string) (string, *common.CLIError) {
+	args := kubectlBaseArgs(opts, "exec", podName, "--", "sh", "-c", "ls -1 /output/*.zip 2>/dev/null | head -1")
+	output, cliErr := common.RunKubectlCommand(kubectlPath, args)
+	if cliErr != nil {
+		return "", cliErr
+	}
+	path := strings.TrimSpace(output)
+	if path == "" {
+		return "", common.NewCLIError(
+			common.TKErrKubectlCommandFailed,
+			"Could not locate usage export zip in pod",
+			"Inspect pod logs and copy manually from /output",
+			fmt.Errorf("no zip found in /output"),
+		)
+	}
+	return path, nil
+}
+
+func defaultLocalOutput(remotePath string) string {
+	base := filepath.Base(remotePath)
+	if base == "" || base == "." {
+		base = fmt.Sprintf("plan-usage-%s.zip", time.Now().UTC().Format("20060102T150405Z"))
+	}
+	return base
+}

--- a/cmd/kubectl-testkube/commands/pro/export/download_test.go
+++ b/cmd/kubectl-testkube/commands/pro/export/download_test.go
@@ -57,3 +57,30 @@ func TestDefaultLocalOutput(t *testing.T) {
 		t.Fatalf("defaultLocalOutput() = %q", got)
 	}
 }
+
+func TestParsePodNamePhase(t *testing.T) {
+	t.Parallel()
+
+	pod, phase, ok := parsePodNamePhase("export-pod-1\tRunning")
+	if !ok || pod != "export-pod-1" || phase != "Running" {
+		t.Fatalf("parsePodNamePhase() = (%q, %q, %v)", pod, phase, ok)
+	}
+
+	_, _, ok = parsePodNamePhase("")
+	if ok {
+		t.Fatal("expected empty input to be invalid")
+	}
+}
+
+func TestPodIsReadyForExport(t *testing.T) {
+	t.Parallel()
+
+	for _, phase := range []string{"Running", "Succeeded", "Failed"} {
+		if !podIsReadyForExport(phase) {
+			t.Fatalf("phase %q should be ready", phase)
+		}
+	}
+	if podIsReadyForExport("Pending") {
+		t.Fatal("Pending should not be ready")
+	}
+}

--- a/cmd/kubectl-testkube/commands/pro/export/download_test.go
+++ b/cmd/kubectl-testkube/commands/pro/export/download_test.go
@@ -1,0 +1,59 @@
+package export
+
+import "testing"
+
+func TestParseOutputPath(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		line   string
+		want   string
+		wantOK bool
+	}{
+		{
+			name:   "json structured log",
+			line:   `{"level":"info","msg":"usage export complete","outputPath":"/output/plan-usage-acme-20260101T120000Z.zip"}`,
+			want:   "/output/plan-usage-acme-20260101T120000Z.zip",
+			wantOK: true,
+		},
+		{
+			name:   "logfmt style",
+			line:   `usage export complete outputPath=/output/plan-usage.zip sizeBytes=1234`,
+			want:   "/output/plan-usage.zip",
+			wantOK: true,
+		},
+		{
+			name:   "download hint line",
+			line:   "Download: kubectl -n testkube cp usage-export-pod:/output/plan-usage.zip ./plan-usage.zip",
+			want:   "/output/plan-usage.zip",
+			wantOK: true,
+		},
+		{
+			name:   "unrelated line",
+			line:   "connected to postgres",
+			wantOK: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got, ok := ParseOutputPath(tt.line)
+			if ok != tt.wantOK {
+				t.Fatalf("ParseOutputPath() ok = %v, want %v", ok, tt.wantOK)
+			}
+			if got != tt.want {
+				t.Fatalf("ParseOutputPath() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestDefaultLocalOutput(t *testing.T) {
+	t.Parallel()
+
+	if got := defaultLocalOutput("/output/plan-usage-acme.zip"); got != "plan-usage-acme.zip" {
+		t.Fatalf("defaultLocalOutput() = %q", got)
+	}
+}

--- a/cmd/kubectl-testkube/commands/pro/export/helm.go
+++ b/cmd/kubectl-testkube/commands/pro/export/helm.go
@@ -1,0 +1,135 @@
+package export
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/kubeshop/testkube/cmd/kubectl-testkube/commands/common"
+	"github.com/kubeshop/testkube/pkg/ui"
+)
+
+const (
+	chartRepoName  = "testkubeenterprise"
+	chartRepoURL   = "https://kubeshop.github.io/testkube-cloud-charts"
+	chartName      = "testkube-usage-export"
+	defaultRelease = "testkube-usage-export"
+)
+
+type Options struct {
+	Namespace       string
+	KubeContext     string
+	Release         string
+	ValuesFiles     []string
+	HelmSet         map[string]string
+	HelmArg         map[string]string
+	ChartVersion    string
+	ChartPath       string
+	Output          string
+	Timeout         string
+	CreateNamespace bool
+	KeepRelease     bool
+	DryRun          bool
+}
+
+func Install(opts Options) (string, *common.CLIError) {
+	helmPath, cliErr := common.LookupHelmPath()
+	if cliErr != nil {
+		return "", cliErr
+	}
+
+	if opts.ChartPath == "" {
+		if cliErr := updateChartRepo(helmPath, opts.DryRun); cliErr != nil {
+			return "", cliErr
+		}
+	}
+
+	args := []string{"upgrade", "--install", opts.Release}
+	if opts.ChartPath != "" {
+		args = append(args, opts.ChartPath)
+	} else {
+		args = append(args, fmt.Sprintf("%s/%s", chartRepoName, chartName))
+	}
+
+	if opts.Namespace != "" {
+		args = append(args, "--namespace", opts.Namespace)
+	}
+	if opts.CreateNamespace {
+		args = append(args, "--create-namespace")
+	}
+	if opts.KubeContext != "" {
+		args = append(args, "--kube-context", opts.KubeContext)
+	}
+	if opts.ChartVersion != "" {
+		args = append(args, "--version", opts.ChartVersion)
+	}
+	for _, valuesFile := range opts.ValuesFiles {
+		args = append(args, "-f", valuesFile)
+	}
+	for key, value := range opts.HelmSet {
+		args = append(args, "--set", fmt.Sprintf("%s=%s", key, value))
+	}
+	for key, value := range opts.HelmArg {
+		args = append(args, fmt.Sprintf("--%s", key))
+		if value != "" {
+			args = append(args, value)
+		}
+	}
+
+	output, cliErr := common.RunHelmCommand(helmPath, args, opts.DryRun)
+	if cliErr != nil {
+		return "", cliErr
+	}
+	ui.Debug("Helm install usage-export output", output)
+	return resolveJobName(opts)
+}
+
+func resolveJobName(opts Options) (string, *common.CLIError) {
+	if opts.DryRun {
+		return fmt.Sprintf("%s-usage-export-1", opts.Release), nil
+	}
+
+	kubectlPath, cliErr := common.LookupKubectlPath()
+	if cliErr != nil {
+		return "", cliErr
+	}
+
+	args := kubectlBaseArgs(opts, "get", "jobs",
+		"-l", fmt.Sprintf("app.kubernetes.io/instance=%s,app.kubernetes.io/component=usage-export", opts.Release),
+		"-o", "jsonpath={.items[-1].metadata.name}",
+	)
+	jobName, cliErr := common.RunKubectlCommand(kubectlPath, args)
+	if cliErr != nil {
+		return "", cliErr
+	}
+	jobName = strings.TrimSpace(jobName)
+	if jobName == "" {
+		return "", common.NewCLIError(
+			common.TKErrKubectlCommandFailed,
+			"Usage export Job not found",
+			"Check helm install output and verify the release created a Job in the target namespace",
+			fmt.Errorf("no job for release %q", opts.Release),
+		)
+	}
+	return jobName, nil
+}
+
+func updateChartRepo(helmPath string, dryRun bool) *common.CLIError {
+	_, err := common.RunHelmCommand(helmPath, []string{"repo", "add", chartRepoName, chartRepoURL}, dryRun)
+	if err != nil && !strings.Contains(err.Error(), "already exists") {
+		return err
+	}
+	_, err = common.RunHelmCommand(helmPath, []string{"repo", "update"}, dryRun)
+	return err
+}
+
+func kubectlBaseArgs(opts Options, args ...string) []string {
+	out := make([]string, 0, len(args)+4)
+	if opts.KubeContext != "" {
+		out = append(out, "--context", opts.KubeContext)
+	}
+	if opts.Namespace != "" {
+		out = append(out, "-n", opts.Namespace)
+	}
+	out = append(out, args...)
+	return out
+}

--- a/cmd/kubectl-testkube/commands/pro/export/helm.go
+++ b/cmd/kubectl-testkube/commands/pro/export/helm.go
@@ -84,6 +84,24 @@ func Install(opts Options) (string, *common.CLIError) {
 	return resolveJobName(opts)
 }
 
+func Uninstall(opts Options) *common.CLIError {
+	helmPath, cliErr := common.LookupHelmPath()
+	if cliErr != nil {
+		return cliErr
+	}
+
+	args := []string{"uninstall", opts.Release}
+	if opts.Namespace != "" {
+		args = append(args, "--namespace", opts.Namespace)
+	}
+	if opts.KubeContext != "" {
+		args = append(args, "--kube-context", opts.KubeContext)
+	}
+
+	_, cliErr = runHelmCommand(helmPath, args, opts.DryRun)
+	return cliErr
+}
+
 func runHelmCommand(helmPath string, args []string, dryRun bool) (string, *common.CLIError) {
 	logArgs := redactHelmArgsForLog(append([]string{helmPath}, args...))
 	ui.DebugNL()

--- a/cmd/kubectl-testkube/commands/pro/export/helm.go
+++ b/cmd/kubectl-testkube/commands/pro/export/helm.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/kubeshop/testkube/cmd/kubectl-testkube/commands/common"
+	"github.com/kubeshop/testkube/pkg/process"
 	"github.com/kubeshop/testkube/pkg/ui"
 )
 
@@ -66,7 +67,7 @@ func Install(opts Options) (string, *common.CLIError) {
 		args = append(args, "-f", valuesFile)
 	}
 	for key, value := range opts.HelmSet {
-		args = append(args, "--set", fmt.Sprintf("%s=%s", key, value))
+		args = append(args, "--set", formatHelmSetArg(key, value))
 	}
 	for key, value := range opts.HelmArg {
 		args = append(args, fmt.Sprintf("--%s", key))
@@ -75,12 +76,33 @@ func Install(opts Options) (string, *common.CLIError) {
 		}
 	}
 
-	output, cliErr := common.RunHelmCommand(helmPath, args, opts.DryRun)
+	output, cliErr := runHelmCommand(helmPath, args, opts.DryRun)
 	if cliErr != nil {
 		return "", cliErr
 	}
 	ui.Debug("Helm install usage-export output", output)
 	return resolveJobName(opts)
+}
+
+func runHelmCommand(helmPath string, args []string, dryRun bool) (string, *common.CLIError) {
+	logArgs := redactHelmArgsForLog(append([]string{helmPath}, args...))
+	ui.DebugNL()
+	ui.Debug("Helm command:")
+	ui.Debug(strings.Join(logArgs, " "))
+
+	output, err := process.ExecuteWithOptions(process.Options{Command: helmPath, Args: args, DryRun: dryRun})
+	ui.DebugNL()
+	ui.Debug("Helm output:")
+	ui.Debug(string(output))
+	if err != nil {
+		return "", common.NewCLIError(
+			common.TKErrHelmCommandFailed,
+			"Helm command failed",
+			"Retry the command with a bigger timeout by setting --helm-arg timeout=30m, if the error still persists, reach out to Testkube support",
+			err,
+		).WithExecutedCommand(strings.Join(logArgs, " "))
+	}
+	return string(output), nil
 }
 
 func resolveJobName(opts Options) (string, *common.CLIError) {
@@ -114,11 +136,11 @@ func resolveJobName(opts Options) (string, *common.CLIError) {
 }
 
 func updateChartRepo(helmPath string, dryRun bool) *common.CLIError {
-	_, err := common.RunHelmCommand(helmPath, []string{"repo", "add", chartRepoName, chartRepoURL}, dryRun)
+	_, err := runHelmCommand(helmPath, []string{"repo", "add", chartRepoName, chartRepoURL}, dryRun)
 	if err != nil && !strings.Contains(err.Error(), "already exists") {
 		return err
 	}
-	_, err = common.RunHelmCommand(helmPath, []string{"repo", "update"}, dryRun)
+	_, err = runHelmCommand(helmPath, []string{"repo", "update"}, dryRun)
 	return err
 }
 

--- a/cmd/kubectl-testkube/commands/pro/export/helm_set.go
+++ b/cmd/kubectl-testkube/commands/pro/export/helm_set.go
@@ -1,0 +1,54 @@
+package export
+
+import (
+	"regexp"
+	"strings"
+)
+
+var sensitiveHelmSetKey = regexp.MustCompile(`(?i)(password|dsn|license|credential|token|secretkey)`)
+
+// formatHelmSetArg builds a Helm --set argument with value characters escaped per strvals rules.
+func formatHelmSetArg(key, value string) string {
+	return key + "=" + escapeHelmSetValue(value)
+}
+
+func escapeHelmSetValue(value string) string {
+	if value == "" {
+		return value
+	}
+	var b strings.Builder
+	b.Grow(len(value) + 8)
+	for _, r := range value {
+		switch r {
+		case '\\', ',':
+			b.WriteByte('\\')
+		}
+		b.WriteRune(r)
+	}
+	return b.String()
+}
+
+func redactHelmSetValueForLog(key, value string) string {
+	if sensitiveHelmSetKey.MatchString(key) {
+		return "[REDACTED]"
+	}
+	return value
+}
+
+func redactHelmArgsForLog(args []string) []string {
+	out := make([]string, len(args))
+	copy(out, args)
+	for i := 0; i < len(out); i++ {
+		if out[i] != "--set" || i+1 >= len(out) {
+			continue
+		}
+		setArg := out[i+1]
+		key, value, ok := strings.Cut(setArg, "=")
+		if !ok {
+			continue
+		}
+		out[i+1] = key + "=" + redactHelmSetValueForLog(key, value)
+		i++
+	}
+	return out
+}

--- a/cmd/kubectl-testkube/commands/pro/export/helm_set_test.go
+++ b/cmd/kubectl-testkube/commands/pro/export/helm_set_test.go
@@ -1,0 +1,62 @@
+package export
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestEscapeHelmSetValue(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		value string
+		want  string
+	}{
+		{name: "plain dsn", value: "postgresql://user:pass@host:5432/db?sslmode=require", want: "postgresql://user:pass@host:5432/db?sslmode=require"},
+		{name: "comma", value: "a,b", want: `a\,b`},
+		{name: "backslash", value: `a\b`, want: `a\\b`},
+		{name: "comma and backslash", value: `a\,b`, want: `a\\\,b`},
+		{name: "mongo dsn with query", value: "mongodb://user:pass@host/db?replicaSet=rs0&authSource=admin", want: "mongodb://user:pass@host/db?replicaSet=rs0&authSource=admin"},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, escapeHelmSetValue(tt.value))
+		})
+	}
+}
+
+func TestFormatHelmSetArg(t *testing.T) {
+	t.Parallel()
+
+	got := formatHelmSetArg("mongo.dsn", "mongodb://user:pass@host/db?opt=a,b")
+	assert.Equal(t, `mongo.dsn=mongodb://user:pass@host/db?opt=a\,b`, got)
+}
+
+func TestRedactHelmSetValueForLog(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t, "[REDACTED]", redactHelmSetValueForLog("postgres.dsn", "postgresql://secret"))
+	assert.Equal(t, "[REDACTED]", redactHelmSetValueForLog("credentials.masterPassword.value", "secret"))
+	assert.Equal(t, "[REDACTED]", redactHelmSetValueForLog("enterpriseLicenseKey", "lic"))
+	assert.Equal(t, "true", redactHelmSetValueForLog("postgres.enabled", "true"))
+	assert.Equal(t, "pg-creds", redactHelmSetValueForLog("postgres.secretRef.name", "pg-creds"))
+}
+
+func TestRedactHelmArgsForLog(t *testing.T) {
+	t.Parallel()
+
+	args := []string{
+		"upgrade", "--install", "rel", "chart",
+		"--set", "postgres.enabled=true",
+		"--set", "postgres.dsn=postgresql://user:pass@host/db",
+	}
+
+	got := redactHelmArgsForLog(args)
+	assert.Equal(t, "postgres.enabled=true", got[5])
+	assert.Equal(t, "postgres.dsn=[REDACTED]", got[7])
+}

--- a/cmd/kubectl-testkube/commands/pro/export/instructions.go
+++ b/cmd/kubectl-testkube/commands/pro/export/instructions.go
@@ -9,13 +9,12 @@ import (
 func PrintInstructions(opts Options, localPath string) {
 	ui.NL()
 	ui.H2("Usage export complete")
-	ui.Info("Saved export to:", localPath)
 	ui.NL()
 	ui.H2("Next steps")
-	ui.Info("1. Upload the zip via the Testkube backoffice license usage import.")
-	ui.Info("2. Review the import preview and confirm manifest checks pass.")
-	if !opts.KeepRelease {
-		ui.Info("3. Clean up the export Job release when finished:")
+	ui.Info(fmt.Sprintf("1. Your usage export is saved at: %s", localPath))
+	ui.Info("2. Send this file to Testkube staff for processing.")
+	if opts.KeepRelease {
+		ui.Info("3. When you are finished, uninstall the export release:")
 		uninstall := fmt.Sprintf("   helm uninstall %s", opts.Release)
 		if opts.Namespace != "" {
 			uninstall += fmt.Sprintf(" -n %s", opts.Namespace)
@@ -25,10 +24,7 @@ func PrintInstructions(opts Options, localPath string) {
 		}
 		ui.Info(uninstall)
 	} else {
-		ui.Info("3. Release kept (--keep-release). Uninstall manually when finished.")
+		ui.Info(fmt.Sprintf("3. Helm release %q was removed from the cluster.", opts.Release))
 	}
-	ui.NL()
-	ui.Info("Chart values reference:")
-	ui.Info("  https://github.com/kubeshop/testkube-cloud-api/tree/main/helm/testkube-usage-export")
 	ui.NL()
 }

--- a/cmd/kubectl-testkube/commands/pro/export/instructions.go
+++ b/cmd/kubectl-testkube/commands/pro/export/instructions.go
@@ -1,0 +1,34 @@
+package export
+
+import (
+	"fmt"
+
+	"github.com/kubeshop/testkube/pkg/ui"
+)
+
+func PrintInstructions(opts Options, localPath string) {
+	ui.NL()
+	ui.H2("Usage export complete")
+	ui.Info("Saved export to:", localPath)
+	ui.NL()
+	ui.H2("Next steps")
+	ui.Info("1. Upload the zip via the Testkube backoffice license usage import.")
+	ui.Info("2. Review the import preview and confirm manifest checks pass.")
+	if !opts.KeepRelease {
+		ui.Info("3. Clean up the export Job release when finished:")
+		uninstall := fmt.Sprintf("   helm uninstall %s", opts.Release)
+		if opts.Namespace != "" {
+			uninstall += fmt.Sprintf(" -n %s", opts.Namespace)
+		}
+		if opts.KubeContext != "" {
+			uninstall += fmt.Sprintf(" --kube-context %s", opts.KubeContext)
+		}
+		ui.Info(uninstall)
+	} else {
+		ui.Info("3. Release kept (--keep-release). Uninstall manually when finished.")
+	}
+	ui.NL()
+	ui.Info("Chart values reference:")
+	ui.Info("  https://github.com/kubeshop/testkube-cloud-api/tree/main/helm/testkube-usage-export")
+	ui.NL()
+}

--- a/cmd/kubectl-testkube/commands/pro/export/usage.go
+++ b/cmd/kubectl-testkube/commands/pro/export/usage.go
@@ -46,7 +46,7 @@ func NewUsageCmd() *cobra.Command {
 		Use:   "usage",
 		Short: "Install the usage-export chart, download the zip, and print follow-up steps",
 		Long: `Installs the standalone testkube-usage-export Helm chart, waits for the export Job,
-copies the resulting zip locally, and prints instructions for uploading it to Testkube.
+copies the resulting zip locally, removes the release, and prints follow-up steps.
 
 When no -f values file is provided, configuration is auto-detected from the Testkube Enterprise
 cloud-api deployment in the target namespace (database, credentials, license).`,
@@ -83,13 +83,13 @@ cloud-api deployment in the target namespace (database, credentials, license).`,
 			}
 
 			if cliErr := applyAutoConfig(&opts, autoConfig, noAutoConfig); cliErr != nil {
-				common.HandleCLIError(cliErr)
+				finishUsageExport(opts, "", "", cliErr)
 			}
 
 			if !dryRun {
 				currentContext, cliErr := common.GetCurrentKubernetesContext()
 				if cliErr != nil {
-					common.HandleCLIError(cliErr)
+					finishUsageExport(opts, "", "", cliErr)
 				}
 				ui.Info("Kubernetes context:", currentContext)
 				if kubeContext != "" {
@@ -103,24 +103,35 @@ cloud-api deployment in the target namespace (database, credentials, license).`,
 			jobName, cliErr := Install(opts)
 			if cliErr != nil {
 				spinner.Fail()
-				common.HandleCLIError(cliErr)
+				finishUsageExport(opts, jobName, "", cliErr)
 			}
 			spinner.Success("Chart installed, Job:", jobName)
 
 			spinner = ui.NewSpinner("Waiting for usage export and downloading zip...")
-			localPath, _, cliErr := WaitAndDownload(context.Background(), opts, jobName)
+			localPath, podName, cliErr := WaitAndDownload(context.Background(), opts, jobName)
 			if cliErr != nil {
 				spinner.Fail()
-				common.HandleCLIError(cliErr)
+				finishUsageExport(opts, jobName, podName, cliErr)
 			}
 			spinner.Success("Downloaded:", localPath)
 
+			if !keepRelease {
+				spinner = ui.NewSpinner("Cleaning up usage export release...")
+				if cliErr := Uninstall(opts); cliErr != nil {
+					spinner.Fail()
+					finishUsageExport(opts, jobName, podName, cliErr)
+				}
+				spinner.Success("Removed Helm release:", opts.Release)
+			}
+
 			if dryRun {
+				printRunVersions(opts)
 				ui.Info("Dry run complete — no resources were created.")
 				os.Exit(0)
 			}
 
 			PrintInstructions(opts, localPath)
+			printRunVersions(opts)
 		},
 	}
 
@@ -134,7 +145,7 @@ cloud-api deployment in the target namespace (database, credentials, license).`,
 	cmd.Flags().StringVar(&output, "output", "", "Local path for the downloaded zip")
 	cmd.Flags().StringVar(&timeout, "timeout", "15m", "Maximum time to wait for export completion")
 	cmd.Flags().BoolVar(&createNamespace, "create-namespace", true, "Create namespace if it does not exist")
-	cmd.Flags().BoolVar(&keepRelease, "keep-release", false, "Skip cleanup instructions for the Helm release")
+	cmd.Flags().BoolVar(&keepRelease, "keep-release", false, "Keep the Helm release after download (default: uninstall when finished)")
 	cmd.Flags().BoolVar(&dryRun, "dry-run", false, "Print helm/kubectl commands only")
 	cmd.Flags().BoolVar(&autoConfig, "auto-config", false, "Discover DB/license config from the enterprise cloud-api deployment (default when no -f is passed)")
 	cmd.Flags().BoolVar(&noAutoConfig, "no-auto-config", false, "Disable auto-config; requires -f values.yaml")

--- a/cmd/kubectl-testkube/commands/pro/export/usage.go
+++ b/cmd/kubectl-testkube/commands/pro/export/usage.go
@@ -1,0 +1,143 @@
+package export
+
+import (
+	"context"
+	"os"
+
+	"github.com/spf13/cobra"
+
+	"github.com/kubeshop/testkube/cmd/kubectl-testkube/commands/common"
+	"github.com/kubeshop/testkube/cmd/kubectl-testkube/commands/common/validator"
+	"github.com/kubeshop/testkube/pkg/ui"
+)
+
+func NewExportCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "export",
+		Short: "Export Testkube Enterprise usage data",
+		Run: func(cmd *cobra.Command, args []string) {
+			_ = cmd.Help()
+		},
+	}
+
+	cmd.AddCommand(NewUsageCmd())
+	return cmd
+}
+
+func NewUsageCmd() *cobra.Command {
+	var (
+		kubeContext     string
+		release         string
+		valuesFiles     []string
+		helmSet         map[string]string
+		helmArg         map[string]string
+		chartVersion    string
+		chartPath       string
+		output          string
+		timeout         string
+		createNamespace bool
+		keepRelease     bool
+		dryRun          bool
+		autoConfig      bool
+		noAutoConfig    bool
+	)
+
+	cmd := &cobra.Command{
+		Use:   "usage",
+		Short: "Install the usage-export chart, download the zip, and print follow-up steps",
+		Long: `Installs the standalone testkube-usage-export Helm chart, waits for the export Job,
+copies the resulting zip locally, and prints instructions for uploading it to Testkube.
+
+When no -f values file is provided, configuration is auto-detected from the Testkube Enterprise
+cloud-api deployment in the target namespace (database, credentials, license).`,
+		PreRun: func(cmd *cobra.Command, args []string) {
+			validator.PersistentPreRunVersionCheck(cmd, common.Version)
+		},
+		Run: func(cmd *cobra.Command, args []string) {
+			ns, err := cmd.Flags().GetString("namespace")
+			if err != nil || ns == "" {
+				ns, _ = cmd.Root().PersistentFlags().GetString("namespace")
+			}
+
+			opts := Options{
+				Namespace:       ns,
+				KubeContext:     kubeContext,
+				Release:         release,
+				ValuesFiles:     valuesFiles,
+				HelmSet:         helmSet,
+				HelmArg:         helmArg,
+				ChartVersion:    chartVersion,
+				ChartPath:       chartPath,
+				Output:          output,
+				Timeout:         timeout,
+				CreateNamespace: createNamespace,
+				KeepRelease:     keepRelease,
+				DryRun:          dryRun,
+			}
+
+			if opts.Namespace == "" {
+				opts.Namespace = "testkube"
+			}
+			if opts.Release == "" {
+				opts.Release = defaultRelease
+			}
+
+			if cliErr := applyAutoConfig(&opts, autoConfig, noAutoConfig); cliErr != nil {
+				common.HandleCLIError(cliErr)
+			}
+
+			if !dryRun {
+				currentContext, cliErr := common.GetCurrentKubernetesContext()
+				if cliErr != nil {
+					common.HandleCLIError(cliErr)
+				}
+				ui.Info("Kubernetes context:", currentContext)
+				if kubeContext != "" {
+					ui.Info("Using kube context override:", kubeContext)
+				}
+				ui.Info("Namespace:", opts.Namespace)
+				ui.NL()
+			}
+
+			spinner := ui.NewSpinner("Installing usage export chart...")
+			jobName, cliErr := Install(opts)
+			if cliErr != nil {
+				spinner.Fail()
+				common.HandleCLIError(cliErr)
+			}
+			spinner.Success("Chart installed, Job:", jobName)
+
+			spinner = ui.NewSpinner("Waiting for usage export and downloading zip...")
+			localPath, _, cliErr := WaitAndDownload(context.Background(), opts, jobName)
+			if cliErr != nil {
+				spinner.Fail()
+				common.HandleCLIError(cliErr)
+			}
+			spinner.Success("Downloaded:", localPath)
+
+			if dryRun {
+				ui.Info("Dry run complete — no resources were created.")
+				os.Exit(0)
+			}
+
+			PrintInstructions(opts, localPath)
+		},
+	}
+
+	cmd.Flags().StringVar(&kubeContext, "context", "", "Kubernetes context")
+	cmd.Flags().StringVar(&release, "release", defaultRelease, "Helm release name")
+	cmd.Flags().StringArrayVarP(&valuesFiles, "values", "f", nil, "Helm values file(s)")
+	cmd.Flags().StringToStringVar(&helmSet, "helm-set", nil, "Helm --set key=value")
+	cmd.Flags().StringToStringVar(&helmArg, "helm-arg", nil, "Extra Helm argument in form key=value")
+	cmd.Flags().StringVar(&chartVersion, "chart-version", "", "Pin the testkube-usage-export chart version")
+	cmd.Flags().StringVar(&chartPath, "chart-path", "", "Local chart path (dev only; skips remote repo)")
+	cmd.Flags().StringVar(&output, "output", "", "Local path for the downloaded zip")
+	cmd.Flags().StringVar(&timeout, "timeout", "15m", "Maximum time to wait for export completion")
+	cmd.Flags().BoolVar(&createNamespace, "create-namespace", true, "Create namespace if it does not exist")
+	cmd.Flags().BoolVar(&keepRelease, "keep-release", false, "Skip cleanup instructions for the Helm release")
+	cmd.Flags().BoolVar(&dryRun, "dry-run", false, "Print helm/kubectl commands only")
+	cmd.Flags().BoolVar(&autoConfig, "auto-config", false, "Discover DB/license config from the enterprise cloud-api deployment (default when no -f is passed)")
+	cmd.Flags().BoolVar(&noAutoConfig, "no-auto-config", false, "Disable auto-config; requires -f values.yaml")
+
+	return cmd
+}

--- a/cmd/kubectl-testkube/commands/pro/export/version.go
+++ b/cmd/kubectl-testkube/commands/pro/export/version.go
@@ -1,0 +1,168 @@
+package export
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/kubeshop/testkube/cmd/kubectl-testkube/commands/common"
+	"github.com/kubeshop/testkube/pkg/ui"
+)
+
+const (
+	defaultImageRegistry   = "docker.io"
+	defaultImageRepository = "kubeshop/testkube-usage-export"
+	defaultImageTag        = "2.12.0-rc.0"
+)
+
+type runVersions struct {
+	CLI   string
+	Chart string
+	Image string
+}
+
+type chartFileMeta struct {
+	Version    string `yaml:"version"`
+	AppVersion string `yaml:"appVersion"`
+}
+
+func resolveRunVersions(opts Options) runVersions {
+	versions := runVersions{
+		CLI:   strings.TrimSpace(common.Version),
+		Chart: resolveChartVersion(opts),
+		Image: resolveImageReference(opts, chartAppVersion(opts)),
+	}
+	if versions.CLI == "" {
+		versions.CLI = "unknown"
+	}
+	return versions
+}
+
+func chartAppVersion(opts Options) string {
+	if meta, ok := readChartMeta(opts.ChartPath); ok && meta.AppVersion != "" {
+		return meta.AppVersion
+	}
+	return defaultImageTag
+}
+
+func resolveChartVersion(opts Options) string {
+	if opts.ChartVersion != "" {
+		return opts.ChartVersion
+	}
+	if meta, ok := readChartMeta(opts.ChartPath); ok {
+		if meta.Version != "" {
+			if opts.ChartPath != "" {
+				return fmt.Sprintf("%s (%s)", meta.Version, filepath.Base(opts.ChartPath))
+			}
+			return meta.Version
+		}
+	}
+	if opts.ChartPath != "" {
+		return fmt.Sprintf("local (%s)", filepath.Base(opts.ChartPath))
+	}
+	return fmt.Sprintf("%s/%s (latest)", chartRepoName, chartName)
+}
+
+func readChartMeta(chartPath string) (chartFileMeta, bool) {
+	if chartPath == "" {
+		return chartFileMeta{}, false
+	}
+	raw, err := os.ReadFile(filepath.Join(chartPath, "Chart.yaml"))
+	if err != nil {
+		return chartFileMeta{}, false
+	}
+	var meta chartFileMeta
+	if err := yaml.Unmarshal(raw, &meta); err != nil {
+		return chartFileMeta{}, false
+	}
+	return meta, true
+}
+
+func resolveImageReference(opts Options, defaultTag string) string {
+	registry := helmSetValue(opts.HelmSet, "image.registry", defaultImageRegistry)
+	repository := helmSetValue(opts.HelmSet, "image.repository", defaultImageRepository)
+	tag := helmSetValue(opts.HelmSet, "image.tag", defaultTag)
+	tagSuffix := helmSetValue(opts.HelmSet, "image.tagSuffix", "")
+	digest := helmSetValue(opts.HelmSet, "image.digest", "")
+
+	if digest != "" {
+		return fmt.Sprintf("%s/%s@%s", registry, repository, digest)
+	}
+	return fmt.Sprintf("%s/%s:%s%s", registry, repository, tag, tagSuffix)
+}
+
+func helmSetValue(set map[string]string, key, fallback string) string {
+	if set == nil {
+		return fallback
+	}
+	if v, ok := set[key]; ok && strings.TrimSpace(v) != "" {
+		return v
+	}
+	return fallback
+}
+
+func printRunVersions(opts Options) {
+	v := resolveRunVersions(opts)
+	ui.NL()
+	ui.H2("Versions")
+	ui.Info("CLI:", v.CLI)
+	ui.Info("Chart:", v.Chart)
+	ui.Info("Image:", v.Image)
+	ui.NL()
+}
+
+func finishUsageExport(opts Options, jobName, podName string, cliErr *common.CLIError) {
+	printRunVersions(opts)
+	printExportLogs(opts, jobName, podName)
+	common.HandleCLIError(cliErr)
+}
+
+func printExportLogs(opts Options, jobName, podName string) {
+	if opts.DryRun {
+		return
+	}
+	logs, source := exportLogs(opts, jobName, podName)
+	if logs == "" {
+		return
+	}
+	ui.H2("Export logs")
+	if source != "" {
+		ui.Info(source)
+	}
+	ui.Info(logs)
+	ui.NL()
+}
+
+func exportLogs(opts Options, jobName, podName string) (logs, source string) {
+	kubectlPath, cliErr := common.LookupKubectlPath()
+	if cliErr != nil {
+		return "", ""
+	}
+	if podName == "" && jobName != "" {
+		podName = exportPodNameForJob(kubectlPath, opts, jobName)
+	}
+	if podName == "" {
+		return "", ""
+	}
+	logs, cliErr = podLogs(kubectlPath, opts, podName)
+	if cliErr != nil || strings.TrimSpace(logs) == "" {
+		return "", ""
+	}
+	source = fmt.Sprintf("From pod %s:", podName)
+	return strings.TrimSpace(logs), source
+}
+
+func exportPodNameForJob(kubectlPath string, opts Options, jobName string) string {
+	args := kubectlBaseArgs(opts, "get", "pods",
+		"-l", fmt.Sprintf("job-name=%s", jobName),
+		"-o", "jsonpath={.items[0].metadata.name}",
+	)
+	podName, cliErr := common.RunKubectlCommand(kubectlPath, args)
+	if cliErr != nil {
+		return ""
+	}
+	return strings.TrimSpace(podName)
+}

--- a/cmd/kubectl-testkube/commands/pro/export/version_test.go
+++ b/cmd/kubectl-testkube/commands/pro/export/version_test.go
@@ -1,0 +1,54 @@
+package export
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestResolveImageReference(t *testing.T) {
+	t.Parallel()
+
+	opts := Options{
+		HelmSet: map[string]string{
+			"image.registry":   "registry.depot.dev",
+			"image.repository": "8m4mpphf9g",
+			"image.tag":        "ecd4d87",
+			"image.tagSuffix":  "-usage-export",
+		},
+	}
+	got := resolveImageReference(opts, "2.12.0-rc.0")
+	want := "registry.depot.dev/8m4mpphf9g:ecd4d87-usage-export"
+	if got != want {
+		t.Fatalf("resolveImageReference() = %q, want %q", got, want)
+	}
+}
+
+func TestResolveChartVersionFromPath(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "Chart.yaml"), []byte(`version: 1.2.3
+appVersion: 9.9.9
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	got := resolveChartVersion(Options{ChartPath: dir})
+	if !strings.HasPrefix(got, "1.2.3 (") {
+		t.Fatalf("resolveChartVersion() = %q", got)
+	}
+}
+
+func TestHelmSetValue(t *testing.T) {
+	t.Parallel()
+
+	set := map[string]string{"image.tag": "dev"}
+	if got := helmSetValue(set, "image.tag", "fallback"); got != "dev" {
+		t.Fatalf("helmSetValue() = %q", got)
+	}
+	if got := helmSetValue(set, "image.registry", "fallback"); got != "fallback" {
+		t.Fatalf("helmSetValue() = %q", got)
+	}
+}


### PR DESCRIPTION
## Pull request description

Adds `testkube pro export usage` for air-gapped Testkube Enterprise installs: installs the `testkube-usage-export` Helm chart, waits for the export Job, downloads the usage zip locally, and prints backoffice upload steps. When no `-f` values file is passed, DB/credentials/license config is auto-discovered from the enterprise `cloud-api` deployment.

## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [ ] tested locally
- [ ] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [x] added a test

## Breaking changes

- None — new `pro export usage` subcommand only.

## Changes

- Register `testkube pro export usage` under the Pro command group.
- Install `testkube-usage-export` via Helm (remote chart or `--chart-path` for dev).
- Auto-config from `cloud-api` deployment env/volumes → Helm `--set` (Postgres/Mongo, credentials master password, enterprise license, custom CA).
- Stream Job logs, parse `outputPath`, `kubectl cp` the zip to `--output` (default derived from remote path).
- Export `LookupHelmPath` / `RunHelmCommand` / `LookupKubectlPath` / `RunKubectlCommand` from `commands/common` for reuse.
- Unit tests for config discovery mapping and log output-path parsing.

## Fixes

- TKC-5726 — air-gapped customers had no CLI path to produce a usage export zip for backoffice import.
