### PR TITLE
feat(cli): warn and confirm before testkube purge

### DIFF
--- a/cmd/kubectl-testkube/commands/purge.go
+++ b/cmd/kubectl-testkube/commands/purge.go
@@ -1,6 +1,8 @@
 package commands
 
 import (
+	"fmt"
+
 	"github.com/spf13/cobra"
 
 	"github.com/kubeshop/testkube/pkg/process"
@@ -9,6 +11,7 @@ import (
 
 func NewPurgeCmd() *cobra.Command {
 	var name, namespace string
+	var yes bool
 
 	cmd := &cobra.Command{
 		Use:     "purge",
@@ -16,6 +19,11 @@ func NewPurgeCmd() *cobra.Command {
 		Long:    `Uninstall Testkube from your current kubectl context`,
 		Aliases: []string{"uninstall"},
 		Run: func(cmd *cobra.Command, args []string) {
+			if !shouldPurge(name, namespace, yes, ui.Confirm) {
+				ui.Info("Purge cancelled")
+				return
+			}
+
 			originalVerbose := ui.Verbose
 			ui.Verbose = true
 
@@ -29,6 +37,20 @@ func NewPurgeCmd() *cobra.Command {
 
 	cmd.Flags().StringVar(&name, "name", "testkube", "installation name")
 	cmd.Flags().StringVar(&namespace, "namespace", "testkube", "namespace from where to uninstall")
+	cmd.Flags().BoolVarP(&yes, "yes", "y", false, "skip the confirmation prompt")
 
 	return cmd
+}
+
+// shouldPurge warns about the data loss and asks for confirmation, unless it was already given with --yes.
+func shouldPurge(name, namespace string, yes bool, confirm func(string) bool) bool {
+	if yes {
+		return true
+	}
+
+	ui.Warn(fmt.Sprintf("This will uninstall the Testkube release %q from namespace %q.", name, namespace))
+	ui.Warn("All Testkube data will be removed, including tests, test suites, triggers, webhooks and execution results.")
+	ui.NL()
+
+	return confirm("Do you want to continue?")
 }

--- a/cmd/kubectl-testkube/commands/purge_test.go
+++ b/cmd/kubectl-testkube/commands/purge_test.go
@@ -1,0 +1,47 @@
+package commands
+
+import (
+	"testing"
+)
+
+func TestShouldPurge(t *testing.T) {
+	t.Run("skips the prompt when --yes is set", func(t *testing.T) {
+		prompted := false
+		ok := shouldPurge("testkube", "testkube", true, func(string) bool {
+			prompted = true
+			return false
+		})
+
+		if !ok {
+			t.Fatal("expected purge to proceed when --yes is set")
+		}
+		if prompted {
+			t.Fatal("expected no confirmation prompt when --yes is set")
+		}
+	})
+
+	t.Run("stops when the confirmation is declined", func(t *testing.T) {
+		if shouldPurge("testkube", "testkube", false, func(string) bool { return false }) {
+			t.Fatal("expected purge to stop when the confirmation is declined")
+		}
+	})
+
+	t.Run("proceeds when the confirmation is accepted", func(t *testing.T) {
+		if !shouldPurge("testkube", "testkube", false, func(string) bool { return true }) {
+			t.Fatal("expected purge to proceed when the confirmation is accepted")
+		}
+	})
+}
+
+func TestPurgeCmdHasYesFlag(t *testing.T) {
+	flag := NewPurgeCmd().Flags().Lookup("yes")
+	if flag == nil {
+		t.Fatal("expected purge command to define a --yes flag")
+	}
+	if flag.Shorthand != "y" {
+		t.Fatalf("expected -y shorthand, got %q", flag.Shorthand)
+	}
+	if flag.DefValue != "false" {
+		t.Fatalf("expected --yes to default to false, got %q", flag.DefValue)
+	}
+}


### PR DESCRIPTION
## Pull request description

`testkube purge` (and its `uninstall` alias) runs `helm uninstall` immediately. That removes the whole installation along with every test, test suite, trigger, webhook and execution result, with no warning and no chance to back out — while `testkube init` does ask for confirmation first.

This adds the missing warning and confirmation, plus a `--yes`/`-y` escape hatch so scripted teardowns keep working non-interactively. The flag name and shorthand match the ones already used by the agent commands.

```
$ testkube purge
This will uninstall the Testkube release "testkube" from namespace "testkube".
All Testkube data will be removed, including tests, test suites, triggers, webhooks and execution results.

 WARNING  Do you want to continue? [Y/n]
```

## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [x] tested locally
- [ ] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [x] added a test

## Breaking changes

- None for interactive use. Anything running `testkube purge`/`testkube uninstall` unattended should add `--yes`.

## Changes

- Warn which release and namespace are about to be removed, and that all Testkube data goes with them, before uninstalling.
- Ask for confirmation and abort the purge when it is declined.
- Add `--yes`/`-y` to skip the prompt.
- Cover the confirmation gate and the flag wiring with unit tests.

## Fixes

- Fixes #3520
