### PR TITLE
fix(testkube-runner): grant CRD read to listener-capable agents

### DIFF
--- a/k8s/helm/testkube-runner/templates/crd-reader-rbac.yaml
+++ b/k8s/helm/testkube-runner/templates/crd-reader-rbac.yaml
@@ -1,0 +1,60 @@
+{{- /*
+Cluster-scoped CRD read for the agent's cluster-resources inventory
+(internal/inventory), which backs the TestTrigger resourceRef picker. CRDs are
+cluster-scoped, so a namespaced Role cannot grant it.
+
+Gated on the same listener/gitops condition as watchers-role: a runner-only
+agent never starts the CRD informer, so it must not hold cluster-wide read on
+every CRD.
+*/}}
+{{- $watchersEnabled := or .Values.listener.enabled .Values.gitops.enabled }}
+{{- if and .Values.pod.serviceAccount.autoCreate $watchersEnabled }}
+apiVersion: {{ include "global.capabilities.rbac.apiVersion" . }}
+kind: ClusterRole
+metadata:
+  name: "crd-reader-{{ .Release.Name }}"
+  labels:
+    {{- if .Values.global.labels }}
+    {{- toYaml .Values.global.labels | nindent 4 }}
+    {{- end }}
+  {{- if .Values.global.annotations }}
+  annotations:
+    {{- toYaml .Values.global.annotations | nindent 4 }}
+  {{- end }}
+rules:
+- apiGroups:
+    - "apiextensions.k8s.io"
+  resources:
+    - customresourcedefinitions
+  verbs:
+    - get
+    - list
+    - watch
+
+---
+
+apiVersion: {{ include "global.capabilities.rbac.apiVersion" . }}
+kind: ClusterRoleBinding
+metadata:
+  name: "crd-reader-rb-{{ .Release.Name }}"
+  labels:
+    {{- if .Values.global.labels }}
+    {{- toYaml .Values.global.labels | nindent 4 }}
+    {{- end }}
+  {{- if .Values.global.annotations }}
+  annotations:
+    {{- toYaml .Values.global.annotations | nindent 4 }}
+  {{- end }}
+subjects:
+- kind: ServiceAccount
+  namespace: "{{ .Release.Namespace }}"
+  {{- if .Values.pod.serviceAccount.name }}
+  name: "{{ .Values.pod.serviceAccount.name }}"
+  {{- else }}
+  name: "agent-sa-{{ .Release.Name }}"
+  {{- end }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: "crd-reader-{{ .Release.Name }}"
+{{- end }}

--- a/k8s/helm/testkube-runner/tests/README.md
+++ b/k8s/helm/testkube-runner/tests/README.md
@@ -9,7 +9,7 @@ helm plugin install https://github.com/helm-unittest/helm-unittest.git  # once
 helm unittest k8s/helm/testkube-runner
 ```
 
-Expected: `Test Suites: 8 passed, 8 total` / `Tests: 75 passed`.
+Expected: `Test Suites: 9 passed, 9 total` / `Tests: 83 passed`.
 
 ## Suites
 
@@ -19,10 +19,11 @@ Expected: `Test Suites: 8 passed, 8 total` / `Tests: 75 passed`.
 | `servicemonitor_test.yaml` | `servicemonitor.yaml` | 13 | gating by `prometheus.enabled`, targetPort sync with Service, interval/monitoringLabels/matchLabels/sampleLimit |
 | `serviceaccount_test.yaml` | `serviceaccount.yaml` | 8 | auto-create branches (`pod.serviceAccount.autoCreate`, `execution.default.serviceAccount.autoCreate`), name/namespace overrides, annotations |
 | `poddisruptionbudget_test.yaml` | `poddisruptionbudget.yaml` | 7 | local vs `global.podDisruptionBudget` fallback, `minAvailable`/`maxUnavailable`, selector, K8s ≥1.21 apiVersion |
-| `role_test.yaml` | `role.yaml` | 10 | the 4 base Roles + watchers ClusterRole/Role per `watchAllNamespaces`; gating via `listener.enabled` / `gitops.enabled` |
+| `role_test.yaml` | `role.yaml` | 11 | the 4 base Roles + watchers ClusterRole/Role per `watchAllNamespaces`; gating via `listener.enabled` / `gitops.enabled` |
 | `rolebinding_test.yaml` | `rolebinding.yaml` | 10 | RoleBinding subjects + roleRef wiring (`agent-sa` → exec-role for jobs, `exec-sa` → exec-role), namespace propagation, watchers ClusterRoleBinding |
-| `deployment_test.yaml` | `deployment.yaml` | 15 | port 8088, ServiceAccount, runner credentials (inline & via secretRef), TLS, listener/gitops toggles, registration token, image references |
+| `deployment_test.yaml` | `deployment.yaml` | 17 | port 8088, ServiceAccount, runner credentials (inline & via secretRef), TLS, listener/gitops toggles, registration token, image references |
 | `crds_test.yaml` | `crds.yaml` | 1 | CRDs are rendered when `gitops.enabled && gitops.installCRD` |
+| `crd_reader_rbac_test.yaml` | `crd-reader-rbac.yaml` | 5 | cluster-wide CRD read is granted only to listener/gitops-enabled agents, and only when the agent ServiceAccount is auto-created |
 
 CI does not run these yet — they are local-dev guardrails. Wiring into a workflow is a separate follow-up.
 

--- a/k8s/helm/testkube-runner/tests/crd_reader_rbac_test.yaml
+++ b/k8s/helm/testkube-runner/tests/crd_reader_rbac_test.yaml
@@ -1,0 +1,77 @@
+suite: testkube-runner crd reader rbac
+templates:
+  - crd-reader-rbac.yaml
+release:
+  name: tk
+  namespace: testkube-dev
+tests:
+  - it: grants nothing to a runner-only agent
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: grants read on customresourcedefinitions when listener.enabled=true
+    set:
+      listener.enabled: true
+    documentSelector:
+      path: metadata.name
+      value: crd-reader-tk
+    asserts:
+      - isKind:
+          of: ClusterRole
+      - equal:
+          path: rules
+          value:
+            - apiGroups:
+                - apiextensions.k8s.io
+              resources:
+                - customresourcedefinitions
+              verbs:
+                - get
+                - list
+                - watch
+
+  - it: grants the same when gitops.enabled=true and listener is off
+    set:
+      gitops.enabled: true
+    asserts:
+      - hasDocuments:
+          count: 2
+      - equal:
+          path: metadata.name
+          value: crd-reader-tk
+        documentIndex: 0
+      - equal:
+          path: metadata.name
+          value: crd-reader-rb-tk
+        documentIndex: 1
+
+  - it: binds the agent service account
+    set:
+      listener.enabled: true
+    documentSelector:
+      path: metadata.name
+      value: crd-reader-rb-tk
+    asserts:
+      - isKind:
+          of: ClusterRoleBinding
+      - equal:
+          path: roleRef.kind
+          value: ClusterRole
+      - equal:
+          path: roleRef.name
+          value: crd-reader-tk
+      - equal:
+          path: subjects[0].name
+          value: agent-sa-tk
+      - equal:
+          path: subjects[0].namespace
+          value: testkube-dev
+
+  - it: grants nothing when the service account is not auto-created
+    set:
+      listener.enabled: true
+      pod.serviceAccount.autoCreate: false
+    asserts:
+      - hasDocuments:
+          count: 0


### PR DESCRIPTION
## How

The `testkube-runner` chart never granted `apiextensions.k8s.io/customresourcedefinitions`, so agents deployed from it log a recurring `Failed to watch ... CustomResourceDefinition ... forbidden` and retry forever. The sibling `testkube-api` chart has had `crd-reader-rbac.yaml` for this; the runner chart did not.

Adds the equivalent ClusterRole and ClusterRoleBinding, scoped to the same `listener.enabled or gitops.enabled` condition that already gates `watchers-role`, and to `pod.serviceAccount.autoCreate` like the rest of the chart's RBAC.

Scoped rather than unconditional because a runner-only agent has no reason to hold cluster-wide read on every CRD in the cluster. It never starts the CRD informer once #8033 lands, and the Control Plane refuses its inventory push regardless. The two conditions cover both worlds: against a capability-reporting control plane `listener.enabled` is what earns the agent the listener capability, and against an older one `gitops.enabled` is what trips the agent's local fallback.

This supersedes #8023, which grants the same access to every runner unconditionally.

A `crd_reader_rbac_test.yaml` suite covers the gate in both directions, the rule contents, and the binding subject. Chart suite goes from 8 files / 75 tests to 9 / 83.

## Note for review

The ClusterRole is named `crd-reader-{{ .Release.Name }}`, matching the one in `testkube-api`. Two releases sharing a name would collide on this cluster-scoped object. The existing `watchers-role-{{ .Release.Name }}` has the same exposure, so this follows the chart family's convention rather than diverging, but it is worth deciding deliberately.
