### PR TITLE
fix(cli): make --crd-only emit pure YAML

### DIFF
--- a/cmd/kubectl-testkube/commands/common/cloudcontext.go
+++ b/cmd/kubectl-testkube/commands/common/cloudcontext.go
@@ -54,7 +54,7 @@ func UiCloudContextValidationError(err error) {
 
 func UiContextHeader(cmd *cobra.Command, cfg config.Data) {
 	// only show header when stdout is not carrying machine-readable output
-	if !outputIsPretty(cmd) {
+	if !OutputIsPretty(cmd) {
 		return
 	}
 

--- a/cmd/kubectl-testkube/commands/common/cloudcontext.go
+++ b/cmd/kubectl-testkube/commands/common/cloudcontext.go
@@ -58,6 +58,11 @@ func UiContextHeader(cmd *cobra.Command, cfg config.Data) {
 		return
 	}
 
+	// --crd-only output is meant to be piped into kubectl or a file, so keep stdout pure YAML
+	if flag := cmd.Flags().Lookup("crd-only"); flag != nil && flag.Value.String() == "true" {
+		return
+	}
+
 	// Check for legacy resource type and show deprecation warning
 	CheckLegacyName(cmd.Name())
 

--- a/cmd/kubectl-testkube/commands/common/cloudcontext.go
+++ b/cmd/kubectl-testkube/commands/common/cloudcontext.go
@@ -53,13 +53,8 @@ func UiCloudContextValidationError(err error) {
 }
 
 func UiContextHeader(cmd *cobra.Command, cfg config.Data) {
-	// only show header when output is pretty
-	if cmd.Flag("output") != nil && cmd.Flag("output").Value.String() != "pretty" {
-		return
-	}
-
-	// --crd-only output is meant to be piped into kubectl or a file, so keep stdout pure YAML
-	if flag := cmd.Flags().Lookup("crd-only"); flag != nil && flag.Value.String() == "true" {
+	// only show header when stdout is not carrying machine-readable output
+	if !outputIsPretty(cmd) {
 		return
 	}
 

--- a/cmd/kubectl-testkube/commands/common/update_check.go
+++ b/cmd/kubectl-testkube/commands/common/update_check.go
@@ -205,9 +205,16 @@ func updateCheckEnabled(cmd *cobra.Command) bool {
 	return outputIsPretty(cmd)
 }
 
+// outputIsPretty reports whether the command renders human-readable output, and so
+// whether decoration may be written to stdout alongside it.
 func outputIsPretty(cmd *cobra.Command) bool {
 	if cmd == nil {
 		return true
+	}
+	// --crd-only writes a manifest to stdout that is meant to be piped into kubectl
+	// or redirected to a file, so anything else printed there corrupts it
+	if crdOnlyFlag := cmd.Flags().Lookup("crd-only"); crdOnlyFlag != nil && crdOnlyFlag.Value.String() == "true" {
+		return false
 	}
 	outputFlag := cmd.Flag("output")
 	if outputFlag == nil {

--- a/cmd/kubectl-testkube/commands/common/update_check.go
+++ b/cmd/kubectl-testkube/commands/common/update_check.go
@@ -202,12 +202,13 @@ func updateCheckEnabled(cmd *cobra.Command) bool {
 	if v, _ := os.LookupEnv(updateCheckEnvDisable); v != "" {
 		return false
 	}
-	return outputIsPretty(cmd)
+	return OutputIsPretty(cmd)
 }
 
-// outputIsPretty reports whether the command renders human-readable output, and so
-// whether decoration may be written to stdout alongside it.
-func outputIsPretty(cmd *cobra.Command) bool {
+// OutputIsPretty reports whether the command renders human-readable output, and so
+// whether decoration (context header, version warnings, update hints) may be written
+// to stdout alongside it.
+func OutputIsPretty(cmd *cobra.Command) bool {
 	if cmd == nil {
 		return true
 	}

--- a/cmd/kubectl-testkube/commands/common/update_check_test.go
+++ b/cmd/kubectl-testkube/commands/common/update_check_test.go
@@ -121,6 +121,51 @@ func TestMaybeNotifyNewerRelease_SkipsNonPrettyOutput(t *testing.T) {
 	}
 }
 
+// OutputIsPretty gates every decoration written to stdout alongside a command's
+// real output: the context header, the version-mismatch warning and the update hint.
+func TestOutputIsPretty(t *testing.T) {
+	newCmd := func(output string, crdOnly *bool) *cobra.Command {
+		cmd := &cobra.Command{Use: "get"}
+		if output != "" {
+			cmd.Flags().StringP("output", "o", output, "")
+		}
+		if crdOnly != nil {
+			cmd.Flags().Bool("crd-only", false, "")
+			if *crdOnly {
+				if err := cmd.Flags().Set("crd-only", "true"); err != nil {
+					t.Fatalf("setting crd-only: %v", err)
+				}
+			}
+		}
+		return cmd
+	}
+	yes, no := true, false
+
+	tests := []struct {
+		name string
+		cmd  *cobra.Command
+		want bool
+	}{
+		{"nil command", nil, true},
+		{"no output flag", newCmd("", nil), true},
+		{"empty output value", newCmd("", nil), true},
+		{"pretty output", newCmd("pretty", nil), true},
+		{"json output", newCmd("json", nil), false},
+		{"yaml output", newCmd("yaml", nil), false},
+		{"crd-only unset", newCmd("pretty", &no), true},
+		// --crd-only coexists with a pretty --output, so it has to gate on its own
+		{"crd-only set", newCmd("pretty", &yes), false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := OutputIsPretty(tt.cmd); got != tt.want {
+				t.Errorf("OutputIsPretty() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestMaybeNotifyNewerRelease_SkipsCrdOnly(t *testing.T) {
 	withLocalRunContext(t)
 	stub := &fetcherStub{value: "2.1.140"}

--- a/cmd/kubectl-testkube/commands/common/update_check_test.go
+++ b/cmd/kubectl-testkube/commands/common/update_check_test.go
@@ -121,6 +121,29 @@ func TestMaybeNotifyNewerRelease_SkipsNonPrettyOutput(t *testing.T) {
 	}
 }
 
+func TestMaybeNotifyNewerRelease_SkipsCrdOnly(t *testing.T) {
+	withLocalRunContext(t)
+	stub := &fetcherStub{value: "2.1.140"}
+	withFetcher(t, stub)
+	withVersion(t, "2.1.130")
+
+	// create/get keep --crd-only alongside a pretty --output, so the hint has to be
+	// suppressed by the crd-only flag rather than by the output format
+	cmd := newCmdWithOutputFlag("create", "pretty")
+	cmd.Flags().Bool("crd-only", false, "")
+	if err := cmd.Flags().Set("crd-only", "true"); err != nil {
+		t.Fatalf("setting crd-only: %v", err)
+	}
+	cfg := &config.Data{}
+
+	if dirty := MaybeNotifyNewerRelease(cmd, cfg); dirty {
+		t.Fatal("expected dirty=false for --crd-only")
+	}
+	if stub.called != 0 {
+		t.Fatalf("fetcher should not be called for --crd-only, got %d calls", stub.called)
+	}
+}
+
 func TestMaybeNotifyNewerRelease_SkipsCIContext(t *testing.T) {
 	withRunContext(t, "github-actions")
 	stub := &fetcherStub{value: "2.1.140"}

--- a/cmd/kubectl-testkube/commands/common/validator/version.go
+++ b/cmd/kubectl-testkube/commands/common/validator/version.go
@@ -8,7 +8,6 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/kubeshop/testkube/cmd/kubectl-testkube/commands/common"
-	"github.com/kubeshop/testkube/cmd/kubectl-testkube/commands/common/render"
 	"github.com/kubeshop/testkube/pkg/ui"
 )
 
@@ -16,13 +15,9 @@ var ErrOldClientVersion = fmt.Errorf("client version is older than api version, 
 
 // PersistentPreRunVersionCheck will check versions based on commands client
 func PersistentPreRunVersionCheck(cmd *cobra.Command, clientVersion string) {
-	outputFlag := cmd.Flag("output")
-	outputType := render.OutputPretty
-	if outputFlag != nil {
-		outputType = render.OutputType(outputFlag.Value.String())
-	}
-
-	if outputType != render.OutputPretty {
+	// skip when stdout is carrying machine-readable output (-o json/yaml, --crd-only),
+	// so the warning never lands in the middle of a manifest
+	if !common.OutputIsPretty(cmd) {
 		return
 	}
 

--- a/cmd/kubectl-testkube/commands/webhooks/create.go
+++ b/cmd/kubectl-testkube/commands/webhooks/create.go
@@ -87,7 +87,7 @@ func NewCreateWebhookCmd() *cobra.Command {
 				data, err := crd.ExecuteTemplate(crd.TemplateWebhook, options)
 				ui.ExitOnError("executing crd template", err)
 
-				ui.Info(data)
+				fmt.Print(data)
 			}
 		},
 	}

--- a/cmd/kubectl-testkube/commands/webhooktemplates/create.go
+++ b/cmd/kubectl-testkube/commands/webhooktemplates/create.go
@@ -86,7 +86,7 @@ func NewCreateWebhookTemplateCmd() *cobra.Command {
 				data, err := crd.ExecuteTemplate(crd.TemplateWebhookTemplate, options)
 				ui.ExitOnError("executing crd template", err)
 
-				ui.Info(data)
+				fmt.Print(data)
 			}
 		},
 	}

--- a/pkg/api/v1/testkube/model_webhook_create_request_extended.go
+++ b/pkg/api/v1/testkube/model_webhook_create_request_extended.go
@@ -1,36 +1,10 @@
 package testkube
 
-import "fmt"
-
 func (w *WebhookCreateRequest) QuoteTextFields() {
 	if w.PayloadTemplate != "" {
 		w.PayloadTemplate, _ = printPayloadTemplate(w.PayloadTemplate)
 	}
 
-	for key, val := range w.Config {
-		if val.Value != nil && val.Value.Value != "" {
-			val.Value.Value = fmt.Sprintf("%q", val.Value.Value)
-		}
-		w.Config[key] = val
-	}
-
-	for key, value := range w.Parameters {
-		if value.Description != "" {
-			value.Description = fmt.Sprintf("%q", value.Description)
-		}
-
-		if value.Example != "" {
-			value.Example = fmt.Sprintf("%q", value.Example)
-		}
-
-		if value.Default_ != nil && value.Default_.Value != "" {
-			value.Pattern = fmt.Sprintf("%q", value.Pattern)
-		}
-
-		if value.Pattern != "" {
-			value.Pattern = fmt.Sprintf("%q", value.Pattern)
-		}
-
-		w.Parameters[key] = value
-	}
+	quoteWebhookConfig(w.Config)
+	quoteWebhookParameters(w.Parameters)
 }

--- a/pkg/api/v1/testkube/model_webhook_extended.go
+++ b/pkg/api/v1/testkube/model_webhook_extended.go
@@ -58,14 +58,24 @@ func (w *Webhook) QuoteTextFields() {
 		w.PayloadTemplate, _ = printPayloadTemplate(w.PayloadTemplate)
 	}
 
-	for key, val := range w.Config {
-		if val.Value != nil && val.Value.Value != "" {
-			val.Value.Value = fmt.Sprintf("%q", val.Value.Value)
-		}
-		w.Config[key] = val
-	}
+	quoteWebhookConfig(w.Config)
+	quoteWebhookParameters(w.Parameters)
+}
 
-	for key, value := range w.Parameters {
+// quoteWebhookConfig quotes config values in place so that the rendered CRD keeps them as strings.
+func quoteWebhookConfig(config map[string]WebhookConfigValue) {
+	for key, val := range config {
+		if val.Value != nil && val.Value.Value != "" {
+			val.Value = &BoxedString{Value: fmt.Sprintf("%q", val.Value.Value)}
+		}
+		config[key] = val
+	}
+}
+
+// quoteWebhookParameters quotes the free-form parameter fields in place. Without quoting, values
+// such as "yes", "1:2" or "*" are rendered as bare YAML scalars and no longer round-trip as strings.
+func quoteWebhookParameters(parameters []WebhookParameterSchema) {
+	for i, value := range parameters {
 		if value.Description != "" {
 			value.Description = fmt.Sprintf("%q", value.Description)
 		}
@@ -75,14 +85,14 @@ func (w *Webhook) QuoteTextFields() {
 		}
 
 		if value.Default_ != nil && value.Default_.Value != "" {
-			value.Pattern = fmt.Sprintf("%q", value.Pattern)
+			value.Default_ = &BoxedString{Value: fmt.Sprintf("%q", value.Default_.Value)}
 		}
 
 		if value.Pattern != "" {
 			value.Pattern = fmt.Sprintf("%q", value.Pattern)
 		}
 
-		w.Parameters[key] = value
+		parameters[i] = value
 	}
 }
 

--- a/pkg/api/v1/testkube/model_webhook_template_create_request_extended.go
+++ b/pkg/api/v1/testkube/model_webhook_template_create_request_extended.go
@@ -1,36 +1,10 @@
 package testkube
 
-import "fmt"
-
 func (w *WebhookTemplateCreateRequest) QuoteTextFields() {
 	if w.PayloadTemplate != "" {
 		w.PayloadTemplate, _ = printPayloadTemplate(w.PayloadTemplate)
 	}
 
-	for key, val := range w.Config {
-		if val.Value != nil && val.Value.Value != "" {
-			val.Value.Value = fmt.Sprintf("%q", val.Value.Value)
-		}
-		w.Config[key] = val
-	}
-
-	for key, value := range w.Parameters {
-		if value.Description != "" {
-			value.Description = fmt.Sprintf("%q", value.Description)
-		}
-
-		if value.Example != "" {
-			value.Example = fmt.Sprintf("%q", value.Example)
-		}
-
-		if value.Default_ != nil && value.Default_.Value != "" {
-			value.Pattern = fmt.Sprintf("%q", value.Pattern)
-		}
-
-		if value.Pattern != "" {
-			value.Pattern = fmt.Sprintf("%q", value.Pattern)
-		}
-
-		w.Parameters[key] = value
-	}
+	quoteWebhookConfig(w.Config)
+	quoteWebhookParameters(w.Parameters)
 }

--- a/pkg/api/v1/testkube/model_webhook_template_extended.go
+++ b/pkg/api/v1/testkube/model_webhook_template_extended.go
@@ -55,32 +55,8 @@ func (w *WebhookTemplate) QuoteTextFields() {
 		w.PayloadTemplate, _ = printPayloadTemplate(w.PayloadTemplate)
 	}
 
-	for key, val := range w.Config {
-		if val.Value != nil && val.Value.Value != "" {
-			val.Value.Value = fmt.Sprintf("%q", val.Value.Value)
-		}
-		w.Config[key] = val
-	}
-
-	for key, value := range w.Parameters {
-		if value.Description != "" {
-			value.Description = fmt.Sprintf("%q", value.Description)
-		}
-
-		if value.Example != "" {
-			value.Example = fmt.Sprintf("%q", value.Example)
-		}
-
-		if value.Default_ != nil && value.Default_.Value != "" {
-			value.Pattern = fmt.Sprintf("%q", value.Pattern)
-		}
-
-		if value.Pattern != "" {
-			value.Pattern = fmt.Sprintf("%q", value.Pattern)
-		}
-
-		w.Parameters[key] = value
-	}
+	quoteWebhookConfig(w.Config)
+	quoteWebhookParameters(w.Parameters)
 }
 
 func (w *WebhookTemplate) ConvertDots(fn func(string) string) *WebhookTemplate {

--- a/pkg/crd/crd_test.go
+++ b/pkg/crd/crd_test.go
@@ -164,6 +164,84 @@ func TestExecuteTemplateRendersContentSelectorGit(t *testing.T) {
 	}
 }
 
+func TestExecuteTemplateQuotesWebhookConfigAndParameters(t *testing.T) {
+	t.Parallel()
+
+	webhook := testkube.Webhook{
+		Name:            "sample-webhook",
+		Namespace:       "testkube",
+		Uri:             "http://localhost:8080/events",
+		PayloadTemplate: "{\"text\": \"event id {{ .Id }}\"}\n",
+		Config: map[string]testkube.WebhookConfigValue{
+			// "yes" parses as a boolean in YAML 1.1 unless it is quoted
+			"flag": {Value: &testkube.BoxedString{Value: "yes"}},
+		},
+		Parameters: []testkube.WebhookParameterSchema{
+			{
+				Name:        "var",
+				Description: "some: description",
+				Example:     "12345",
+				// "0" is a string in the API model, but renders as a YAML integer unless it is quoted
+				Default_: &testkube.BoxedString{Value: "0"},
+				Pattern:     "[0-9]*",
+			},
+		},
+	}
+
+	webhook.QuoteTextFields()
+
+	output, err := ExecuteTemplate(TemplateWebhook, webhook)
+	if err != nil {
+		t.Fatalf("execute template: %v", err)
+	}
+
+	var parsed struct {
+		Spec struct {
+			Config map[string]struct {
+				Value string `yaml:"value"`
+			} `yaml:"config"`
+			Parameters []struct {
+				Description string `yaml:"description"`
+				Example     string `yaml:"example"`
+				// decoded as any so that an unquoted scalar shows up as a non-string type
+				Default any    `yaml:"default"`
+				Pattern string `yaml:"pattern"`
+			} `yaml:"parameters"`
+			PayloadTemplate string `yaml:"payloadTemplate"`
+		} `yaml:"spec"`
+	}
+
+	if err := yaml.Unmarshal([]byte(output), &parsed); err != nil {
+		t.Fatalf("generated YAML does not parse: %v\n%s", err, output)
+	}
+
+	if got := parsed.Spec.Config["flag"].Value; got != "yes" {
+		t.Errorf("config flag value should round-trip as a string, got %q\n%s", got, output)
+	}
+
+	if got := parsed.Spec.PayloadTemplate; got != "{\"text\": \"event id {{ .Id }}\"}\n" {
+		t.Errorf("payload template should round-trip verbatim, got %q\n%s", got, output)
+	}
+
+	if len(parsed.Spec.Parameters) != 1 {
+		t.Fatalf("expected 1 parameter, got %d\n%s", len(parsed.Spec.Parameters), output)
+	}
+
+	parameter := parsed.Spec.Parameters[0]
+	if parameter.Description != "some: description" {
+		t.Errorf("parameter description should round-trip, got %q\n%s", parameter.Description, output)
+	}
+	if parameter.Example != "12345" {
+		t.Errorf("parameter example should round-trip, got %q\n%s", parameter.Example, output)
+	}
+	if parameter.Default != any("0") {
+		t.Errorf("parameter default should round-trip as the string \"0\", got %#v\n%s", parameter.Default, output)
+	}
+	if parameter.Pattern != "[0-9]*" {
+		t.Errorf("parameter pattern should round-trip without extra quoting, got %q\n%s", parameter.Pattern, output)
+	}
+}
+
 func TestExecuteTemplateRendersMatchAndListener(t *testing.T) {
 	action := testkube.RUN_TestTriggerActions
 	execution := testkube.TESTWORKFLOW_TestTriggerExecutions

--- a/pkg/crd/crd_test.go
+++ b/pkg/crd/crd_test.go
@@ -183,7 +183,7 @@ func TestExecuteTemplateQuotesWebhookConfigAndParameters(t *testing.T) {
 				Example:     "12345",
 				// "0" is a string in the API model, but renders as a YAML integer unless it is quoted
 				Default_: &testkube.BoxedString{Value: "0"},
-				Pattern:     "[0-9]*",
+				Pattern:  "[0-9]*",
 			},
 		},
 	}


### PR DESCRIPTION
## Pull request description

Fixes kubeshop/testkube#4428.

`--crd-only` is meant to produce YAML you can pipe into `kubectl` or redirect to a file, but its output was neither pure nor valid.

**Before** — `testkube create webhook --crd-only --name bruno-test --uri http://x/y --events start-test --payload-template payload.json --config 'var1=value=data' --parameter 'var3=descr;true;12345;0;[0-9]*'`, piped through `cat -A`:

```
$
^[[90mContext: ^[[0m^[[37m^[[0m^[[90m (999.0.0-dev)^[[0m   ^[[90mNamespace: ^[[0m^[[37mtestkube^[[0m$
---------------------------------------------$
^[[37mapiVersion: executor.testkube.io/v1$
kind: Webhook$
...
      default: 0$
      pattern: "\"[0-9]*\""$
^[[0m$
```

**After**:

```
apiVersion: executor.testkube.io/v1$
kind: Webhook$
...
      default: "0"$
      pattern: "[0-9]*"$
```

Three separate problems:

1. The context header banner was written to stdout even with `--crd-only`. `UiContextHeader` already suppresses itself for non-`pretty` output; `--crd-only` is machine-readable output too, so it now suppresses itself there as well. This covers `create` and `get`, whose `PersistentPreRun` both call it (`create` already guarded the version check behind `crdOnly` but not the header).
2. `create webhook` / `create webhooktemplate` printed the CRD with `ui.Info`, which wraps the whole document in ANSI colour codes and appends a newline. They now use `fmt.Print`, matching `common.UIPrintCRD` which the `get` commands already use.
3. `QuoteTextFields` had a copy-paste bug in the parameter loop:

   ```go
   if value.Default_ != nil && value.Default_.Value != "" {
       value.Pattern = fmt.Sprintf("%q", value.Pattern)   // quotes the wrong field
   }
   if value.Pattern != "" {
       value.Pattern = fmt.Sprintf("%q", value.Pattern)
   }
   ```

   `pattern` was quoted twice (`"\"[0-9]*\""` — the regex no longer round-trips) and `default` was never quoted, so it rendered as a bare scalar. `default` is a string in the API model, but `0` renders as a YAML integer and `yes`/`no` as booleans under the YAML 1.1 semantics Kubernetes uses, so the manifest fails to apply.

That loop was duplicated verbatim across `Webhook`, `WebhookCreateRequest`, `WebhookTemplate` and `WebhookTemplateCreateRequest` — all four carried the same bug. They now share `quoteWebhookParameters`/`quoteWebhookConfig`, so this cannot drift apart again.

Test triggers are named in the issue thread as also needing this, but `--crd-only` no longer exists on any test trigger command, so there is nothing left to fix there.

## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [X] tested locally
- [ ] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [X] added a test

## Breaking changes

* None. Only `--crd-only` output changes, and only to remove decoration and correct the quoting.

## Changes

* `UiContextHeader` returns early when `--crd-only` is set.
* `create webhook` and `create webhooktemplate` print the CRD with `fmt.Print` instead of `ui.Info`.
* Extracted `quoteWebhookConfig` and `quoteWebhookParameters`, replacing four duplicated copies.
* Quoting no longer mutates the caller's `BoxedString` in place; it assigns a new one.

## Fixes

* `--crd-only` no longer prints the context header banner or ANSI escape codes to stdout.
* Webhook parameter `pattern` is quoted once instead of twice, and `default` is quoted so it round-trips as a string.
* New test `TestExecuteTemplateQuotesWebhookConfigAndParameters` renders a webhook and asserts `config`, `description`, `example`, `default`, `pattern` and the multi-line `payloadTemplate` all survive a YAML round-trip. It fails on `main`:

  ```
  --- FAIL: TestExecuteTemplateQuotesWebhookConfigAndParameters
      crd_test.go:232: parameter default should round-trip as the string "0", got 0
      crd_test.go:235: parameter pattern should round-trip without extra quoting, got "\"[0-9]*\""
  ```