### PR TITLE
feat: add support for matchexpressions

### DIFF
--- a/pkg/triggers/executor.go
+++ b/pkg/triggers/executor.go
@@ -561,10 +561,10 @@ func (s *Service) getTestWorkflowsFromInternal(t *internalTrigger) ([]testworkfl
 			return nil, err
 		}
 		testWorkflowsList, err := s.testWorkflowsClient.List(context.Background(), s.getEnvironmentId(), testworkflowclient.ListOptions{})
-			if err != nil {
-				s.logger.Errorf("failed to list test workflows for trigger labelSelector filtering: %v", err)
-				return nil, err
-			}
+		if err != nil {
+			s.logger.Errorf("failed to list test workflows for trigger labelSelector filtering: %v", err)
+			return nil, err
+		}
 		for i := range testWorkflowsList {
 			workflowLabelSet := labels.Set(testWorkflowsList[i].Labels)
 			if !k8sSelector.Matches(workflowLabelSet) {

--- a/pkg/triggers/executor.go
+++ b/pkg/triggers/executor.go
@@ -561,10 +561,10 @@ func (s *Service) getTestWorkflowsFromInternal(t *internalTrigger) ([]testworkfl
 			return nil, err
 		}
 		testWorkflowsList, err := s.testWorkflowsClient.List(context.Background(), s.getEnvironmentId(), testworkflowclient.ListOptions{})
-		if err != nil {
-		    s.Logger.Errorf("failed to list test workflows for trigger labelSelector filtering: %v", err)
-			return nil, err
-		}
+			if err != nil {
+				s.logger.Errorf("failed to list test workflows for trigger labelSelector filtering: %v", err)
+				return nil, err
+			}
 		for i := range testWorkflowsList {
 			workflowLabelSet := labels.Set(testWorkflowsList[i].Labels)
 			if !k8sSelector.Matches(workflowLabelSet) {

--- a/pkg/triggers/executor.go
+++ b/pkg/triggers/executor.go
@@ -10,7 +10,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/pkg/errors"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/util/jsonpath"
 
 	commonv1 "github.com/kubeshop/testkube/api/common/v1"
@@ -553,17 +554,21 @@ func (s *Service) getTestWorkflowsFromInternal(t *internalTrigger) ([]testworkfl
 	}
 
 	if sel.LabelSelector != nil {
-		if len(sel.LabelSelector.MatchExpressions) > 0 {
-			return nil, errors.New("error creating selector from test resource label selector: MatchExpressions not supported")
+		s.logger.Debugf("trigger service: executor component: fetching TestWorkflow with label selector matchLabels=%v matchExpressions=%v",
+			sel.LabelSelector.MatchLabels, sel.LabelSelector.MatchExpressions)
+		k8sSelector, err := v1.LabelSelectorAsSelector(sel.LabelSelector)
+		if err != nil {
+			return nil, err
 		}
-		s.logger.Debugf("trigger service: executor component: fetching TestWorkflow with label %s", sel.LabelSelector.MatchLabels)
-		testWorkflowsList, err := s.testWorkflowsClient.List(context.Background(), s.getEnvironmentId(), testworkflowclient.ListOptions{
-			Labels: sel.LabelSelector.MatchLabels,
-		})
+		testWorkflowsList, err := s.testWorkflowsClient.List(context.Background(), s.getEnvironmentId(), testworkflowclient.ListOptions{})
 		if err != nil {
 			return nil, err
 		}
 		for i := range testWorkflowsList {
+			workflowLabelSet := labels.Set(testWorkflowsList[i].Labels)
+			if !k8sSelector.Matches(workflowLabelSet) {
+				continue
+			}
 			testWorkflows = append(testWorkflows, *testworkflows.MapAPIToKube(&testWorkflowsList[i]))
 		}
 	}

--- a/pkg/triggers/executor.go
+++ b/pkg/triggers/executor.go
@@ -562,6 +562,7 @@ func (s *Service) getTestWorkflowsFromInternal(t *internalTrigger) ([]testworkfl
 		}
 		testWorkflowsList, err := s.testWorkflowsClient.List(context.Background(), s.getEnvironmentId(), testworkflowclient.ListOptions{})
 		if err != nil {
+		    s.Logger.Errorf("failed to list test workflows for trigger labelSelector filtering: %v", err)
 			return nil, err
 		}
 		for i := range testWorkflowsList {

--- a/pkg/triggers/executor_test.go
+++ b/pkg/triggers/executor_test.go
@@ -4,11 +4,14 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"go.uber.org/mock/gomock"
+	"go.uber.org/zap"
 	appsv1 "k8s.io/api/apps/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/kubeshop/testkube/pkg/api/v1/testkube"
 	"github.com/kubeshop/testkube/pkg/cloud"
+	"github.com/kubeshop/testkube/pkg/newclients/testworkflowclient"
 	"github.com/kubeshop/testkube/pkg/testworkflows/testworkflowexecutor"
 )
 
@@ -156,6 +159,96 @@ func TestGetTemplateData_SimpleFields(t *testing.T) {
 			result, err := s.getTemplateData(e, tt.template)
 			assert.NoError(t, err)
 			assert.Equal(t, tt.expected, string(result))
+		})
+	}
+}
+
+// TestGetTestWorkflowsFromInternal_LabelSelectorMatchExpressions verifies that
+// TestTrigger workflow selection supports Kubernetes labelSelector.matchExpressions
+// and returns only the workflows whose labels satisfy the selector across the
+// standard Kubernetes operators supported for label selectors.
+func TestGetTestWorkflowsFromInternal_LabelSelectorMatchExpressions(t *testing.T) {
+	workflowsFixture := []testkube.TestWorkflow{
+		{Name: "alpha-workflow", Labels: map[string]string{"automation": "team-a"}},
+		{Name: "beta-workflow", Labels: map[string]string{"automation": "team-b"}},
+		{Name: "gamma-workflow", Labels: map[string]string{"region": "us-east-1"}},
+		{Name: "other-workflow", Labels: map[string]string{"automation": "other"}},
+	}
+
+	tests := []struct {
+		name         string
+		requirement  metav1.LabelSelectorRequirement
+		expectedName []string
+	}{
+		{
+			name: "in_operator",
+			requirement: metav1.LabelSelectorRequirement{
+				Key:      "automation",
+				Operator: metav1.LabelSelectorOpIn,
+				Values:   []string{"team-a", "team-b"},
+			},
+			expectedName: []string{"alpha-workflow", "beta-workflow"},
+		},
+		{
+			name: "notin_operator",
+			requirement: metav1.LabelSelectorRequirement{
+				Key:      "automation",
+				Operator: metav1.LabelSelectorOpNotIn,
+				Values:   []string{"other"},
+			},
+			expectedName: []string{"alpha-workflow", "beta-workflow", "gamma-workflow"},
+		},
+		{
+			name: "exists_operator",
+			requirement: metav1.LabelSelectorRequirement{
+				Key:      "automation",
+				Operator: metav1.LabelSelectorOpExists,
+			},
+			expectedName: []string{"alpha-workflow", "beta-workflow", "other-workflow"},
+		},
+		{
+			name: "does_not_exist_operator",
+			requirement: metav1.LabelSelectorRequirement{
+				Key:      "automation",
+				Operator: metav1.LabelSelectorOpDoesNotExist,
+			},
+			expectedName: []string{"gamma-workflow"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			mockTestWorkflowsClient := testworkflowclient.NewMockTestWorkflowClient(ctrl)
+			mockTestWorkflowsClient.EXPECT().
+				List(gomock.Any(), "", testworkflowclient.ListOptions{}).
+				Return(workflowsFixture, nil).
+				Times(1)
+
+			s := &Service{
+				testWorkflowsClient: mockTestWorkflowsClient,
+				logger:              zap.NewNop().Sugar(),
+			}
+
+			trigger := &internalTrigger{
+				WorkflowSelector: internalTriggerSelector{
+					LabelSelector: &metav1.LabelSelector{
+						MatchExpressions: []metav1.LabelSelectorRequirement{tt.requirement},
+					},
+				},
+			}
+
+			workflows, err := s.getTestWorkflowsFromInternal(trigger)
+
+			assert.NoError(t, err)
+			assert.Len(t, workflows, len(tt.expectedName))
+			actualNames := make([]string, 0, len(workflows))
+			for i := range workflows {
+				actualNames = append(actualNames, workflows[i].Name)
+			}
+			assert.ElementsMatch(t, tt.expectedName, actualNames)
 		})
 	}
 }


### PR DESCRIPTION
## Pull request description 
This PR introduces a support for matchExpressions: `In`, `NotIn`, `Exists`, and `DoesNotExist`.
 
Tested locally, using the following configuration of TestTrigger:
```
apiVersion: tests.testkube.io/v1
kind: TestTrigger
metadata:
  name: cm-match-expression
  namespace: testkube
spec:
  resource: configmap
  resourceSelector:
    name: "cm"
    namespace: "testkube"
  event: modified
  action: run
  execution: testworkflow
  testSelector:
    namespace: "testkube"
    labelSelector:
        matchExpressions:
          - key: automation
            operator: In
            values: [team-a team-b]
```


## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [x] tested locally
- [ ] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [x] added a test

## Breaking changes

-

## Changes

-

## Fixes

-