### PR TITLE
perf: cache webhook secret resolution with a TTL cache

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,6 +61,7 @@
 - Agent behavior is driven by env vars defined in `internal/config/config.go` (scan for `envconfig:"..."` tags when researching a toggle).
 - Git trigger informer behavior is tuned via `TEST_TRIGGER_GIT_INFORMER_RECONCILE_INTERVAL`, `TEST_TRIGGER_GIT_INFORMER_REPO_DEPTH`, `TEST_TRIGGER_GIT_INFORMER_LIST_TIMEOUT`, `TEST_TRIGGER_GIT_INFORMER_MAX_COMMITS_SCAN`, `TEST_TRIGGER_GIT_INFORMER_PULL_RETRIES`, and `TEST_TRIGGER_GIT_INFORMER_PULL_RETRY_DELAY`.
 - Git trigger informer execution is leader-gated in `cmd/api-server/main.go` through the shared `leader` coordinator tasks, so only the active leader performs periodic git pulls/reconciliation.
+- Webhook secret resolution is cached in process by `secret.NewCachedClient` (`pkg/secret/cached_client.go`); `TESTKUBE_SECRET_CACHE_TTL` (Go duration, default `30s`) sets how long a resolved secret is reused, and `0` disables the cache so every lookup hits the Kubernetes API.
 - Helm chart values are the source of deployment defaults; `build/_local/values.dev.yaml` (shaped by the `values.dev.tpl.yaml` template) shows the local overrides used by `tk-dev` if you need a concrete reference.
 - CLI update-check toggle: set `TESTKUBE_DISABLE_UPDATE_CHECK=1` to suppress both the per-command hint and the `testkube version` status block. The CLI persists `lastUpdateCheckAt` and `latestKnownVersion` in `~/.testkube/config.json` to throttle the per-command hint to once per day.
 

--- a/cmd/api-server/main.go
+++ b/cmd/api-server/main.go
@@ -629,7 +629,7 @@ func main() {
 			log.DefaultLogger.Infow("webhooks control plane sync enabled", "envID", proContext.EnvID)
 		}
 		log.DefaultLogger.Infow("registering webhook loader", "envID", proContext.EnvID, "orgID", proContext.OrgID)
-		secretClient := secret.NewClientFor(clientset, cfg.TestkubeNamespace)
+		secretClient := secret.NewCachedClient(secret.NewClientFor(clientset, cfg.TestkubeNamespace), cfg.TestkubeNamespace, cfg.SecretCacheTTL)
 		webhookLoader := webhook.NewWebhookLoader(
 			webhooksLoaderClient,
 			webhook.WithTestWorkflowResultsRepository(testWorkflowResultsRepository),

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -149,6 +149,9 @@ type SecretManagementConfig struct {
 	EnableSecretsEndpoint   bool   `envconfig:"ENABLE_SECRETS_ENDPOINT" default:"false"`
 	EnableListingAllSecrets bool   `envconfig:"ENABLE_LISTING_ALL_SECRETS" default:"false"`
 	SecretCreationPrefix    string `envconfig:"SECRET_CREATION_PREFIX" default:"testkube-"`
+	// SecretCacheTTL is how long a resolved secret is reused, 0 disables the cache
+	// and every lookup hits the Kubernetes API.
+	SecretCacheTTL time.Duration `envconfig:"TESTKUBE_SECRET_CACHE_TTL" default:"30s"`
 }
 
 type ImageInspectorConfig struct {

--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -19,6 +19,12 @@ type Cache[T any] interface {
 	// Set stores the value in the cache with the given key.
 	// If ttl is 0, the item should not be cached and this method should return no error.
 	Set(ctx context.Context, key string, value T, ttl time.Duration) error
+	// Delete drops the cached value for the given key. Deleting a key that is not cached
+	// is not an error, since the caller wants it gone either way.
+	Delete(ctx context.Context, key string) error
+	// Clear drops every cached value. It is for callers that changed something they cannot
+	// map back to individual keys.
+	Clear(ctx context.Context) error
 }
 
 // IsCacheMiss returns true if the error is a cache miss error.

--- a/pkg/cache/inmem.go
+++ b/pkg/cache/inmem.go
@@ -21,12 +21,29 @@ type InMemoryCache[T any] struct {
 	timeGetter timeGetter
 }
 
+type InMemoryCacheOption[T any] func(*InMemoryCache[T])
+
+// WithTimeGetter replaces the time source used to set and check expiry, so that callers can
+// exercise TTL behavior without waiting on the wall clock.
+func WithTimeGetter[T any](now timeGetter) InMemoryCacheOption[T] {
+	return func(c *InMemoryCache[T]) {
+		if now != nil {
+			c.timeGetter = now
+		}
+	}
+}
+
 // NewInMemoryCache creates a new in-memory cache.
 // The underlying cache implementation uses a sync.Map so it is thread-safe.
-func NewInMemoryCache[T any]() *InMemoryCache[T] {
-	return &InMemoryCache[T]{
+func NewInMemoryCache[T any](opts ...InMemoryCacheOption[T]) *InMemoryCache[T] {
+	c := &InMemoryCache[T]{
 		timeGetter: time.Now,
 	}
+	for _, opt := range opts {
+		opt(c)
+	}
+
+	return c
 }
 
 func (c *InMemoryCache[T]) Get(ctx context.Context, key string) (T, error) {
@@ -64,6 +81,21 @@ func (c *InMemoryCache[T]) Set(ctx context.Context, key string, value T, ttl tim
 		i.expiresAt = &expiresAt
 	}
 	c.cache.Store(key, i)
+
+	return nil
+}
+
+func (c *InMemoryCache[T]) Delete(ctx context.Context, key string) error {
+	c.cache.Delete(key)
+
+	return nil
+}
+
+func (c *InMemoryCache[T]) Clear(ctx context.Context) error {
+	c.cache.Range(func(key, _ any) bool {
+		c.cache.Delete(key)
+		return true
+	})
 
 	return nil
 }

--- a/pkg/cache/inmem_test.go
+++ b/pkg/cache/inmem_test.go
@@ -206,3 +206,59 @@ func TestInMemoryCache_SetAndGet(t *testing.T) {
 		})
 	}
 }
+
+func TestInMemoryCache_DeleteAndClear(t *testing.T) {
+	ctx := context.Background()
+
+	tests := []struct {
+		name    string
+		drop    func(cache *InMemoryCache[string]) error
+		wantKey string
+		want    string
+		wantErr error
+	}{
+		{
+			name:    "delete drops the named key",
+			drop:    func(c *InMemoryCache[string]) error { return c.Delete(ctx, "first") },
+			wantKey: "first",
+			wantErr: ErrNotFound,
+		},
+		{
+			name:    "delete leaves the other keys alone",
+			drop:    func(c *InMemoryCache[string]) error { return c.Delete(ctx, "first") },
+			wantKey: "second",
+			want:    "second-value",
+		},
+		{
+			name:    "delete of an absent key is not an error",
+			drop:    func(c *InMemoryCache[string]) error { return c.Delete(ctx, "absent") },
+			wantKey: "first",
+			want:    "first-value",
+		},
+		{
+			name:    "clear drops every key",
+			drop:    func(c *InMemoryCache[string]) error { return c.Clear(ctx) },
+			wantKey: "second",
+			wantErr: ErrNotFound,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cache := NewInMemoryCache[string]()
+			require.NoError(t, cache.Set(ctx, "first", "first-value", time.Hour))
+			require.NoError(t, cache.Set(ctx, "second", "second-value", time.Hour))
+
+			require.NoError(t, tt.drop(cache))
+
+			got, err := cache.Get(ctx, tt.wantKey)
+			if tt.wantErr != nil {
+				assert.ErrorIs(t, err, tt.wantErr)
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/pkg/event/kind/webhook/listener_secret_test.go
+++ b/pkg/event/kind/webhook/listener_secret_test.go
@@ -1,0 +1,105 @@
+package webhook
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/fake"
+	ktesting "k8s.io/client-go/testing"
+
+	executorv1 "github.com/kubeshop/testkube/api/executor/v1"
+	v1 "github.com/kubeshop/testkube/internal/app/api/metrics"
+	"github.com/kubeshop/testkube/pkg/api/v1/testkube"
+	cloudwebhook "github.com/kubeshop/testkube/pkg/cloud/data/webhook"
+	"github.com/kubeshop/testkube/pkg/secret"
+)
+
+// A cache serving the wrong value fails silently here, since the webhook still delivers, so the
+// value is asserted on the real path rather than on the cache in isolation.
+func TestWebhookListener_NotifyWithSecretConfig(t *testing.T) {
+	const (
+		namespace   = "testkube"
+		secretName  = "webhook-token"
+		secretKey   = "token"
+		secretValue = "s3cr3t-value"
+	)
+
+	tests := []struct {
+		name string
+		ttl  time.Duration
+		// wantSecretGets is how often the Kubernetes API is read across two notifications.
+		// Without a cache this is not one read per notification: the config map is rebuilt for
+		// every templated field, so each notification resolves the secret once for the uri and
+		// once for the payload, and once more for every header.
+		wantSecretGets int32
+	}{
+		{
+			name:           "a cached client resolves the secret once for repeated notifications",
+			ttl:            30 * time.Second,
+			wantSecretGets: 1,
+		},
+		{
+			name:           "a disabled cache resolves the secret for every templated field",
+			ttl:            0,
+			wantSecretGets: 4,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var delivered atomic.Value
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				body, err := io.ReadAll(r.Body)
+				assert.NoError(t, err)
+				delivered.Store(string(body))
+			}))
+			defer server.Close()
+
+			var secretGets atomic.Int32
+			clientset := fake.NewClientset(&corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: secretName},
+				Data:       map[string][]byte{secretKey: []byte(secretValue)},
+			})
+			clientset.PrependReactor("get", "secrets", func(ktesting.Action) (bool, runtime.Object, error) {
+				secretGets.Add(1)
+				return false, nil, nil
+			})
+
+			mockCtrl := gomock.NewController(t)
+			defer mockCtrl.Finish()
+			mockWebhookRepository := cloudwebhook.NewMockWebhookRepository(mockCtrl)
+			mockWebhookRepository.EXPECT().CollectExecutionResult(gomock.Any(), gomock.Any(), "l1", gomock.Any(), gomock.Any()).AnyTimes()
+
+			secretClient := secret.NewCachedClient(secret.NewClientFor(clientset, namespace), namespace, tt.ttl)
+			listener := NewWebhookListener("l1", server.URL, "", testEventTypes, "", "{{ .Config.token }}", nil, false,
+				map[string]executorv1.WebhookConfigValue{
+					secretKey: {Secret: &executorv1.SecretRef{Name: secretName, Key: secretKey}},
+				},
+				nil,
+				listenerWithMetrics(v1.NewMetrics()),
+				listenerWithWebhookResultsRepository(mockWebhookRepository),
+				listenerWithSecretClient(secretClient))
+
+			for range 2 {
+				result := listener.Notify(testkube.Event{
+					Type_:                 testkube.EventStartTestWorkflow,
+					TestWorkflowExecution: exampleExecution(),
+				})
+				require.Equal(t, "", result.Error())
+				assert.Equal(t, secretValue, delivered.Load(), "the webhook must receive the secret value")
+			}
+
+			assert.Equal(t, tt.wantSecretGets, secretGets.Load())
+		})
+	}
+}

--- a/pkg/imageinspector/secretfetcher_test.go
+++ b/pkg/imageinspector/secretfetcher_test.go
@@ -100,3 +100,13 @@ func (n *noCache) Get(ctx context.Context, key string) (*corev1.Secret, error) {
 	n.t.Fatalf("get method should not be invoked when cache is disabled")
 	return nil, nil
 }
+
+func (n *noCache) Delete(ctx context.Context, key string) error {
+	n.t.Fatalf("delete method should not be invoked when cache is disabled")
+	return nil
+}
+
+func (n *noCache) Clear(ctx context.Context) error {
+	n.t.Fatalf("clear method should not be invoked when cache is disabled")
+	return nil
+}

--- a/pkg/secret/cached_client.go
+++ b/pkg/secret/cached_client.go
@@ -1,0 +1,232 @@
+package secret
+
+import (
+	"context"
+	"maps"
+	"strconv"
+	"sync"
+	"time"
+
+	"golang.org/x/sync/singleflight"
+
+	v1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+
+	"github.com/kubeshop/testkube/pkg/cache"
+)
+
+// negativeCacheTTLDivisor shortens the lifetime of cached not found results, so that a secret
+// created after a failed lookup is picked up sooner than a regular refresh.
+const negativeCacheTTLDivisor = 3
+
+// readCache adds what the store it writes into does not provide: a shorter lifetime for not
+// found results, coalescing of concurrent misses, and a revision that lets a mutation discard
+// reads it superseded.
+type readCache[T any] struct {
+	store       cache.Cache[cacheEntry[T]]
+	ttl         time.Duration
+	negativeTTL time.Duration
+	reads       singleflight.Group
+
+	mu       sync.Mutex
+	revision uint64
+}
+
+// cacheEntry keeps the error alongside the value, since the store holds values rather than
+// call results and a missing secret is worth remembering.
+type cacheEntry[T any] struct {
+	value T
+	err   error
+}
+
+func newReadCache[T any](ttl time.Duration, now func() time.Time) *readCache[T] {
+	return &readCache[T]{
+		store:       cache.NewInMemoryCache[cacheEntry[T]](cache.WithTimeGetter[cacheEntry[T]](now)),
+		ttl:         ttl,
+		negativeTTL: ttl / negativeCacheTTLDivisor,
+	}
+}
+
+func (c *readCache[T]) load(ctx context.Context, key string, read func() (T, error)) (T, error) {
+	entry, revision, ok := c.get(ctx, key)
+	if ok {
+		return entry.value, entry.err
+	}
+
+	// The revision is part of the flight identity, not just of the decision to cache the
+	// result. A caller that missed after an invalidation must not join a read that started
+	// before it, because that read answers a question the mutation has already changed.
+	shared, err, _ := c.reads.Do(strconv.FormatUint(revision, 10)+"/"+key, func() (any, error) {
+		// A read that finished between the miss above and here has already populated the entry.
+		if entry, _, ok := c.get(ctx, key); ok {
+			return entry, entry.err
+		}
+
+		value, readErr := read()
+		entry := cacheEntry[T]{value: value, err: readErr}
+		c.set(ctx, key, revision, entry)
+
+		return entry, readErr
+	})
+
+	result, _ := shared.(cacheEntry[T])
+
+	return result.value, err
+}
+
+func (c *readCache[T]) get(ctx context.Context, key string) (cacheEntry[T], uint64, bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	entry, err := c.store.Get(ctx, key)
+	if err != nil {
+		return cacheEntry[T]{}, c.revision, false
+	}
+
+	return entry, c.revision, true
+}
+
+// set caches a missing secret too, but never any other failure, which may be transient.
+func (c *readCache[T]) set(ctx context.Context, key string, revision uint64, entry cacheEntry[T]) {
+	if entry.err != nil && !k8serrors.IsNotFound(entry.err) {
+		return
+	}
+
+	ttl := c.ttl
+	if entry.err != nil {
+		ttl = c.negativeTTL
+	}
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	// A result read before an invalidation describes a value the mutation already replaced.
+	if c.revision != revision {
+		return
+	}
+
+	_ = c.store.Set(ctx, key, entry, ttl)
+}
+
+func (c *readCache[T]) delete(ctx context.Context, key string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	c.revision++
+	_ = c.store.Delete(ctx, key)
+}
+
+func (c *readCache[T]) clear(ctx context.Context) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	c.revision++
+	_ = c.store.Clear(ctx)
+}
+
+// cachedClient decorates a secret client with a short lived read cache. Mutating methods are
+// passed through and invalidate the entries they affect.
+type cachedClient struct {
+	inner     Interface
+	namespace string
+	values    *readCache[map[string]string]
+	objects   *readCache[*v1.Secret]
+}
+
+// NewCachedClient wraps inner with a TTL cache for reads. A zero or negative ttl disables
+// caching and returns inner unchanged. namespace must be the one inner falls back to, so that a
+// read with an explicit namespace and one without share a cache entry.
+func NewCachedClient(inner Interface, namespace string, ttl time.Duration) Interface {
+	if ttl <= 0 {
+		return inner
+	}
+
+	return newCachedClient(inner, namespace, ttl, time.Now)
+}
+
+func newCachedClient(inner Interface, namespace string, ttl time.Duration, now func() time.Time) *cachedClient {
+	return &cachedClient{
+		inner:     inner,
+		namespace: namespace,
+		values:    newReadCache[map[string]string](ttl, now),
+		objects:   newReadCache[*v1.Secret](ttl, now),
+	}
+}
+
+func (c *cachedClient) Get(id string, namespace ...string) (map[string]string, error) {
+	ctx := context.Background()
+	data, err := c.values.load(ctx, c.key(id, namespace...), func() (map[string]string, error) {
+		return c.inner.Get(id, namespace...)
+	})
+
+	// Copy on the way out, so that neither the cache nor another caller sharing this read can
+	// be mutated through the returned map.
+	return maps.Clone(data), err
+}
+
+func (c *cachedClient) GetObject(id string) (*v1.Secret, error) {
+	ctx := context.Background()
+	object, err := c.objects.load(ctx, c.key(id), func() (*v1.Secret, error) {
+		return c.inner.GetObject(id)
+	})
+
+	return object.DeepCopy(), err
+}
+
+// List is not cached: it does not resolve a single key, so there is nothing to key a cache
+// entry by.
+func (c *cachedClient) List(all bool, namespace string) (map[string]map[string]string, error) {
+	return c.inner.List(all, namespace)
+}
+
+func (c *cachedClient) Create(id string, labels, stringData map[string]string, namespace ...string) error {
+	defer c.invalidate(c.key(id, namespace...))
+
+	return c.inner.Create(id, labels, stringData, namespace...)
+}
+
+func (c *cachedClient) Apply(id string, labels, stringData map[string]string) error {
+	defer c.invalidate(c.key(id))
+
+	return c.inner.Apply(id, labels, stringData)
+}
+
+func (c *cachedClient) Update(id string, labels, stringData map[string]string) error {
+	defer c.invalidate(c.key(id))
+
+	return c.inner.Update(id, labels, stringData)
+}
+
+func (c *cachedClient) Delete(id string) error {
+	defer c.invalidate(c.key(id))
+
+	return c.inner.Delete(id)
+}
+
+// DeleteAll drops the whole cache rather than invalidating individual keys, since the selector
+// it applies to the inner client can affect names it never resolved a key for.
+func (c *cachedClient) DeleteAll(selector string) error {
+	defer func() {
+		ctx := context.Background()
+		c.values.clear(ctx)
+		c.objects.clear(ctx)
+	}()
+
+	return c.inner.DeleteAll(selector)
+}
+
+// key resolves the namespace the way the inner client does for the same arguments.
+func (c *cachedClient) key(id string, namespace ...string) string {
+	ns := c.namespace
+	if len(namespace) != 0 {
+		ns = namespace[0]
+	}
+
+	return ns + "/" + id
+}
+
+func (c *cachedClient) invalidate(key string) {
+	ctx := context.Background()
+	c.values.delete(ctx, key)
+	c.objects.delete(ctx, key)
+}

--- a/pkg/secret/cached_client_test.go
+++ b/pkg/secret/cached_client_test.go
@@ -1,0 +1,465 @@
+package secret
+
+import (
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+	v1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+const (
+	testCacheTTL  = 30 * time.Second
+	testNamespace = "testkube"
+)
+
+type fakeClock struct {
+	current time.Time
+}
+
+func (c *fakeClock) Now() time.Time {
+	return c.current
+}
+
+func (c *fakeClock) advance(d time.Duration) {
+	c.current = c.current.Add(d)
+}
+
+func TestCachedClient_Get(t *testing.T) {
+	notFound := k8serrors.NewNotFound(schema.GroupResource{Resource: "secrets"}, "secret")
+	throttled := k8serrors.NewTooManyRequestsError("try again later")
+
+	type step struct {
+		advance   time.Duration
+		namespace []string
+	}
+
+	tests := []struct {
+		name      string
+		innerErr  error
+		steps     []step
+		wantCalls int
+	}{
+		{
+			name:      "second read within the ttl is served from the cache",
+			steps:     []step{{}, {advance: 10 * time.Second}},
+			wantCalls: 1,
+		},
+		{
+			name:      "read after the ttl reaches the inner client again",
+			steps:     []step{{}, {advance: testCacheTTL + time.Second}},
+			wantCalls: 2,
+		},
+		{
+			name:      "explicit default namespace shares the entry with the implicit one",
+			steps:     []step{{}, {namespace: []string{testNamespace}}},
+			wantCalls: 1,
+		},
+		{
+			name:      "a different namespace does not collide with the default one",
+			steps:     []step{{}, {namespace: []string{"other"}}, {namespace: []string{"other"}}},
+			wantCalls: 2,
+		},
+		{
+			name:      "missing secret is remembered for the negative ttl",
+			innerErr:  notFound,
+			steps:     []step{{}, {advance: 5 * time.Second}},
+			wantCalls: 1,
+		},
+		{
+			name:      "missing secret is looked up again after the negative ttl",
+			innerErr:  notFound,
+			steps:     []step{{}, {advance: 11 * time.Second}},
+			wantCalls: 2,
+		},
+		{
+			name:      "transport failure is not cached",
+			innerErr:  throttled,
+			steps:     []step{{}, {advance: time.Second}},
+			wantCalls: 2,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			inner := NewMockInterface(gomock.NewController(t))
+			clock := &fakeClock{current: time.Now()}
+			calls := 0
+			inner.EXPECT().Get(gomock.Any(), gomock.Any()).DoAndReturn(func(id string, namespace ...string) (map[string]string, error) {
+				calls++
+				if tt.innerErr != nil {
+					return nil, tt.innerErr
+				}
+
+				return map[string]string{"key": "value"}, nil
+			}).AnyTimes()
+
+			client := newCachedClient(inner, testNamespace, testCacheTTL, clock.Now)
+			for _, s := range tt.steps {
+				clock.advance(s.advance)
+
+				data, err := client.Get("secret", s.namespace...)
+				if tt.innerErr != nil {
+					assert.Equal(t, tt.innerErr, err)
+					continue
+				}
+
+				require.NoError(t, err)
+				assert.Equal(t, map[string]string{"key": "value"}, data)
+				// Poisoning the returned map must not reach the next read.
+				data["key"] = "poisoned"
+			}
+
+			assert.Equal(t, tt.wantCalls, calls)
+		})
+	}
+}
+
+func TestCachedClient_GetObject(t *testing.T) {
+	tests := []struct {
+		name      string
+		advance   time.Duration
+		wantCalls int
+	}{
+		{
+			name:      "second read within the ttl is served from the cache",
+			advance:   10 * time.Second,
+			wantCalls: 1,
+		},
+		{
+			name:      "read after the ttl reaches the inner client again",
+			advance:   testCacheTTL + time.Second,
+			wantCalls: 2,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			inner := NewMockInterface(gomock.NewController(t))
+			clock := &fakeClock{current: time.Now()}
+			calls := 0
+			inner.EXPECT().GetObject(gomock.Any()).DoAndReturn(func(id string) (*v1.Secret, error) {
+				calls++
+				return &v1.Secret{ObjectMeta: metav1.ObjectMeta{Name: id}}, nil
+			}).AnyTimes()
+
+			client := newCachedClient(inner, testNamespace, testCacheTTL, clock.Now)
+
+			first, err := client.GetObject("secret")
+			require.NoError(t, err)
+			first.StringData = map[string]string{"changed": "true"}
+
+			clock.advance(tt.advance)
+
+			second, err := client.GetObject("secret")
+			require.NoError(t, err)
+			assert.Equal(t, "secret", second.Name)
+			assert.Nil(t, second.StringData, "callers must not be able to modify the cached object")
+			assert.Equal(t, tt.wantCalls, calls)
+		})
+	}
+}
+
+func TestCachedClient_Invalidation(t *testing.T) {
+	tests := []struct {
+		name      string
+		expect    func(inner *MockInterface)
+		mutate    func(client Interface) error
+		wantCalls int
+	}{
+		{
+			name:      "update drops the cached secret",
+			expect:    func(inner *MockInterface) { inner.EXPECT().Update("secret", gomock.Any(), gomock.Any()).Return(nil) },
+			mutate:    func(client Interface) error { return client.Update("secret", nil, nil) },
+			wantCalls: 2,
+		},
+		{
+			name:      "delete drops the cached secret",
+			expect:    func(inner *MockInterface) { inner.EXPECT().Delete("secret").Return(nil) },
+			mutate:    func(client Interface) error { return client.Delete("secret") },
+			wantCalls: 2,
+		},
+		{
+			name:      "apply drops the cached secret",
+			expect:    func(inner *MockInterface) { inner.EXPECT().Apply("secret", gomock.Any(), gomock.Any()).Return(nil) },
+			mutate:    func(client Interface) error { return client.Apply("secret", nil, nil) },
+			wantCalls: 2,
+		},
+		{
+			name: "create drops the cached secret",
+			expect: func(inner *MockInterface) {
+				inner.EXPECT().Create("secret", gomock.Any(), gomock.Any()).Return(nil)
+			},
+			mutate:    func(client Interface) error { return client.Create("secret", nil, nil) },
+			wantCalls: 2,
+		},
+		{
+			name: "create in another namespace keeps the cached secret",
+			expect: func(inner *MockInterface) {
+				inner.EXPECT().Create("secret", gomock.Any(), gomock.Any(), "other").Return(nil)
+			},
+			mutate:    func(client Interface) error { return client.Create("secret", nil, nil, "other") },
+			wantCalls: 1,
+		},
+		{
+			name:      "delete all drops the whole cache",
+			expect:    func(inner *MockInterface) { inner.EXPECT().DeleteAll("").Return(nil) },
+			mutate:    func(client Interface) error { return client.DeleteAll("") },
+			wantCalls: 2,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			inner := NewMockInterface(gomock.NewController(t))
+			clock := &fakeClock{current: time.Now()}
+			calls := 0
+			inner.EXPECT().Get(gomock.Any(), gomock.Any()).DoAndReturn(func(id string, namespace ...string) (map[string]string, error) {
+				calls++
+				return map[string]string{"key": "value"}, nil
+			}).AnyTimes()
+			tt.expect(inner)
+
+			client := newCachedClient(inner, testNamespace, testCacheTTL, clock.Now)
+
+			_, err := client.Get("secret")
+			require.NoError(t, err)
+			require.NoError(t, tt.mutate(client))
+
+			_, err = client.Get("secret")
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantCalls, calls)
+		})
+	}
+}
+
+func TestCachedClient_InvalidationDuringRead(t *testing.T) {
+	tests := []struct {
+		name   string
+		expect func(inner *MockInterface)
+		mutate func(client Interface) error
+	}{
+		{
+			name:   "update while a read is in flight discards the read result",
+			expect: func(inner *MockInterface) { inner.EXPECT().Update("secret", gomock.Any(), gomock.Any()).Return(nil) },
+			mutate: func(client Interface) error { return client.Update("secret", nil, nil) },
+		},
+		{
+			name:   "delete while a read is in flight discards the read result",
+			expect: func(inner *MockInterface) { inner.EXPECT().Delete("secret").Return(nil) },
+			mutate: func(client Interface) error { return client.Delete("secret") },
+		},
+		{
+			name:   "delete all while a read is in flight discards the read result",
+			expect: func(inner *MockInterface) { inner.EXPECT().DeleteAll("").Return(nil) },
+			mutate: func(client Interface) error { return client.DeleteAll("") },
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			inner := NewMockInterface(gomock.NewController(t))
+			clock := &fakeClock{current: time.Now()}
+			client := newCachedClient(inner, testNamespace, testCacheTTL, clock.Now)
+
+			calls := 0
+			inner.EXPECT().Get(gomock.Any(), gomock.Any()).DoAndReturn(func(id string, namespace ...string) (map[string]string, error) {
+				calls++
+				// The mutation lands between the inner read and the write into the cache.
+				if calls == 1 {
+					require.NoError(t, tt.mutate(client))
+				}
+
+				return map[string]string{"key": "value"}, nil
+			}).AnyTimes()
+			tt.expect(inner)
+
+			_, err := client.Get("secret")
+			require.NoError(t, err)
+
+			_, err = client.Get("secret")
+			require.NoError(t, err)
+			assert.Equal(t, 2, calls)
+		})
+	}
+}
+
+func TestNewCachedClient(t *testing.T) {
+	tests := []struct {
+		name      string
+		ttl       time.Duration
+		wantCalls int
+	}{
+		{
+			name:      "zero ttl bypasses the cache",
+			ttl:       0,
+			wantCalls: 2,
+		},
+		{
+			name:      "negative ttl bypasses the cache",
+			ttl:       -time.Second,
+			wantCalls: 2,
+		},
+		{
+			name:      "positive ttl caches reads",
+			ttl:       testCacheTTL,
+			wantCalls: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			inner := NewMockInterface(gomock.NewController(t))
+			calls := 0
+			inner.EXPECT().Get(gomock.Any(), gomock.Any()).DoAndReturn(func(id string, namespace ...string) (map[string]string, error) {
+				calls++
+				return map[string]string{"key": "value"}, nil
+			}).AnyTimes()
+
+			client := NewCachedClient(inner, testNamespace, tt.ttl)
+			if tt.ttl <= 0 {
+				assert.Same(t, inner, client)
+			}
+
+			for range 2 {
+				_, err := client.Get("secret")
+				require.NoError(t, err)
+			}
+
+			assert.Equal(t, tt.wantCalls, calls)
+		})
+	}
+}
+
+// TestCachedClient_CoalescesConcurrentMisses covers the burst this cache exists for: webhook
+// listeners resolve the same parameter at once, so a cold key must produce one read rather
+// than one per caller.
+func TestCachedClient_CoalescesConcurrentMisses(t *testing.T) {
+	const callers = 5
+
+	tests := []struct {
+		name   string
+		expect func(inner *MockInterface, block func())
+		read   func(client Interface) error
+	}{
+		{
+			name: "Get",
+			expect: func(inner *MockInterface, block func()) {
+				inner.EXPECT().Get(gomock.Any(), gomock.Any()).DoAndReturn(func(id string, namespace ...string) (map[string]string, error) {
+					block()
+					return map[string]string{"key": "value"}, nil
+				}).AnyTimes()
+			},
+			read: func(client Interface) error {
+				_, err := client.Get("secret")
+				return err
+			},
+		},
+		{
+			name: "GetObject",
+			expect: func(inner *MockInterface, block func()) {
+				inner.EXPECT().GetObject(gomock.Any()).DoAndReturn(func(id string) (*v1.Secret, error) {
+					block()
+					return &v1.Secret{ObjectMeta: metav1.ObjectMeta{Name: id}}, nil
+				}).AnyTimes()
+			},
+			read: func(client Interface) error {
+				_, err := client.GetObject("secret")
+				return err
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var calls atomic.Int32
+			entered := make(chan struct{}, 1)
+			release := make(chan struct{})
+
+			inner := NewMockInterface(gomock.NewController(t))
+			tt.expect(inner, func() {
+				if calls.Add(1) == 1 {
+					entered <- struct{}{}
+					<-release
+				}
+			})
+
+			client := newCachedClient(inner, testNamespace, testCacheTTL, time.Now)
+
+			var wg sync.WaitGroup
+			read := func() {
+				defer wg.Done()
+				assert.NoError(t, tt.read(client))
+			}
+
+			wg.Add(1)
+			go read()
+			// The first caller is now inside the inner client, so its read is registered and
+			// the callers started below can join it instead of starting their own.
+			<-entered
+
+			for range callers - 1 {
+				wg.Add(1)
+				go read()
+			}
+
+			// Let those callers reach the in-flight read before it completes.
+			time.Sleep(20 * time.Millisecond)
+			close(release)
+			wg.Wait()
+
+			assert.Equal(t, int32(1), calls.Load())
+		})
+	}
+}
+
+// TestCachedClient_ReadAfterInvalidationDoesNotJoinOlderFlight pins the ordering that coalescing
+// makes possible: a mutation completes while a read is still in flight, and the read that arrives
+// afterwards must see the mutation rather than the value the older read is about to return.
+func TestCachedClient_ReadAfterInvalidationDoesNotJoinOlderFlight(t *testing.T) {
+	var reads atomic.Int32
+	entered := make(chan struct{}, 1)
+	release := make(chan struct{})
+
+	inner := NewMockInterface(gomock.NewController(t))
+	inner.EXPECT().Get(gomock.Any(), gomock.Any()).DoAndReturn(func(id string, namespace ...string) (map[string]string, error) {
+		if reads.Add(1) == 1 {
+			entered <- struct{}{}
+			<-release
+			return map[string]string{"key": "before"}, nil
+		}
+
+		return map[string]string{"key": "after"}, nil
+	}).AnyTimes()
+	inner.EXPECT().Update("secret", gomock.Any(), gomock.Any()).Return(nil)
+
+	client := newCachedClient(inner, testNamespace, testCacheTTL, time.Now)
+
+	var first sync.WaitGroup
+	first.Add(1)
+	go func() {
+		defer first.Done()
+		data, err := client.Get("secret")
+		assert.NoError(t, err)
+		assert.Equal(t, map[string]string{"key": "before"}, data, "the in-flight read keeps the value it started with")
+	}()
+
+	// The first read is now inside the inner client and its flight is registered.
+	<-entered
+	require.NoError(t, client.Update("secret", nil, nil))
+
+	data, err := client.Get("secret")
+	require.NoError(t, err)
+	assert.Equal(t, map[string]string{"key": "after"}, data, "a read starting after the update must not receive the superseded value")
+
+	close(release)
+	first.Wait()
+	assert.Equal(t, int32(2), reads.Load())
+}


### PR DESCRIPTION
## How

Adds a caching decorator in `pkg/secret` and wraps the one client the webhook loader builds. Webhook parameters are resolved on every notification, so an event burst previously turned into one uncached secret GET per event per parameter.

Only `Get` and `GetObject` are cached. Every mutating method passes through to the inner client and invalidates the affected key. Entries are keyed by name plus the namespace the call resolves to, so a read with an explicit namespace and a read that falls back to the default share one entry. Returned maps and objects are copies, so a caller cannot mutate what the cache holds.

`TESTKUBE_SECRET_CACHE_TTL` sets the lifetime and defaults to 30s. A zero value returns the inner client unchanged, which disables caching completely.

Missing secrets are cached too, for a third of the TTL, so a webhook pointing at a secret that does not exist does not hammer the API server either. Every other error is treated as possibly transient and is never cached.

A read that started before an invalidation does not repopulate the cache afterwards, so a mutation cannot be overwritten by an older in flight result.

The saving is larger than one read per event. `processTemplate` rebuilds the resolved config map for every templated field, so an uncached notification reads the same secret once for the uri, once for the payload and once more for every header. A webhook with a templated uri and a payload resolves it twice per event before this change and once per TTL window after it.

Storage is the shared `pkg/cache`, rather than another map with an expiry sweep next to it. That package needed two things it did not have: `Delete`, without which a mutation cannot invalidate what it replaced, and a way to substitute the time source, without which TTL behavior can only be tested by waiting. Both are added here, and `Clear` comes with `Delete` for `DeleteAll`, which changes secrets it cannot map back to individual keys.

What stays in `pkg/secret` is the part that is specific to reading secrets: a shorter lifetime for not found results, coalescing of concurrent misses, and the revision that lets a mutation discard reads it superseded.

## Notes for review

This trades immediacy for request volume, and the staleness bound is worth an explicit decision: rotating a secret takes up to the TTL to reach webhook parameters, and creating a secret that was just looked up and missing takes up to a third of the TTL to become visible. Setting the TTL to zero restores the current behavior for anyone who needs rotation to apply immediately.

This branch includes the `Get` clock fix from #8053, since injecting a time source is pointless while `Get` reads the wall clock. Merge that first and this diff shrinks accordingly.

Widening `cache.Cache` touches every implementer. In this repository that is `InMemoryCache` and one test fake in `pkg/imageinspector`, both updated here.

The decorator is applied at exactly one construction site. Other `pkg/secret` callers are unchanged, and adopting it elsewhere is now a one line change per site.

Concurrent misses for the same key are coalesced with `singleflight`, so a burst arriving on a cold key produces one read rather than one per listener. Without that the cache only helps after the first read completes, which is not the case the change exists for.
