### PR TITLE
feat(git): add exported matchers package for cross-repo reuse

### DIFF
--- a/pkg/git/matchers/matchers.go
+++ b/pkg/git/matchers/matchers.go
@@ -1,0 +1,232 @@
+// Package matchers exports pure predicate helpers for evaluating whether a git
+// event should trigger a workflow. Callers pass primitive slices and strings
+// so the package stays free of provider-specific and control-plane-specific
+// types, making it consumable by both the OSS TestTrigger informer and by
+// external tools that need to reason about the same rules.
+package matchers
+
+import (
+	"path/filepath"
+	"strings"
+)
+
+// NormalizePaths trims whitespace and surrounding slashes from each path and
+// drops empty entries. Returns nil if the input is empty or entirely blank.
+func NormalizePaths(paths []string) []string {
+	if len(paths) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(paths))
+	for _, p := range paths {
+		p = strings.Trim(strings.TrimSpace(p), "/")
+		if p != "" {
+			out = append(out, p)
+		}
+	}
+	return out
+}
+
+// PathMatches reports whether file matches any of paths. Paths are normalized
+// before matching (whitespace and surrounding slashes trimmed).
+func PathMatches(paths []string, file string) bool {
+	return PathMatchesNormalized(NormalizePaths(paths), file)
+}
+
+// PathMatchesNormalized reports whether file matches any of paths. Paths must
+// already be normalized (see NormalizePaths).
+func PathMatchesNormalized(paths []string, file string) bool {
+	for _, p := range paths {
+		if MatchGlob(p, file) {
+			return true
+		}
+	}
+	return false
+}
+
+// PathIsIgnored returns true if file matches any of the ignore patterns.
+func PathIsIgnored(ignorePatterns []string, file string) bool {
+	if len(ignorePatterns) == 0 {
+		return false
+	}
+	for _, p := range ignorePatterns {
+		if MatchGlob(p, file) {
+			return true
+		}
+	}
+	return false
+}
+
+// BranchFromRef extracts the branch name from a full ref like
+// "refs/heads/main". Returns "" if ref is not a branch ref.
+func BranchFromRef(ref string) string {
+	const prefix = "refs/heads/"
+	if strings.HasPrefix(ref, prefix) {
+		return ref[len(prefix):]
+	}
+	return ""
+}
+
+// TagFromRef extracts the tag name from a full ref like "refs/tags/v1.0.0".
+// Returns "" if ref is not a tag ref.
+func TagFromRef(ref string) string {
+	const prefix = "refs/tags/"
+	if strings.HasPrefix(ref, prefix) {
+		return ref[len(prefix):]
+	}
+	return ""
+}
+
+// MatchGlob performs glob-style matching supporting * and ** patterns.
+// It matches file paths against patterns like "src/**", "*.md", "docs/*".
+// Malformed patterns are treated as non-matching (filepath.Match returns
+// ErrBadPattern).
+func MatchGlob(pattern, name string) bool {
+	matched, err := filepath.Match(pattern, name)
+	if err != nil {
+		return false
+	}
+	if matched {
+		return true
+	}
+	if strings.Contains(pattern, "**") {
+		pattern = filepath.ToSlash(strings.TrimSuffix(pattern, "/"))
+		name = filepath.ToSlash(strings.TrimSuffix(name, "/"))
+
+		pSegs := strings.Split(pattern, "/")
+		nSegs := strings.Split(name, "/")
+
+		type state struct{ i, j int }
+		memo := map[state]bool{}
+		var match func(i, j int) bool
+		match = func(i, j int) bool {
+			s := state{i, j}
+			if v, ok := memo[s]; ok {
+				return v
+			}
+
+			var res bool
+			switch {
+			case i == len(pSegs):
+				res = j == len(nSegs)
+			case pSegs[i] == "**":
+				res = match(i+1, j) || (j < len(nSegs) && match(i, j+1))
+			case j < len(nSegs):
+				ok, err := filepath.Match(pSegs[i], nSegs[j])
+				res = err == nil && ok && match(i+1, j+1)
+			default:
+				res = false
+			}
+
+			memo[s] = res
+			return res
+		}
+		return match(0, 0)
+	}
+
+	normalizedPattern := strings.TrimSuffix(pattern, "/")
+	if name == normalizedPattern || strings.HasPrefix(name, normalizedPattern+"/") {
+		return true
+	}
+	return false
+}
+
+// NameMatchesPatterns checks if a name (branch or tag) matches any of the given
+// glob patterns. Returns true if patterns is empty (matches all).
+func NameMatchesPatterns(name string, patterns []string) bool {
+	if len(patterns) == 0 {
+		return true
+	}
+	return NameMatchesAny(name, patterns)
+}
+
+// NameMatchesAny checks if a name matches any of the given glob patterns.
+// Returns false if patterns is empty.
+func NameMatchesAny(name string, patterns []string) bool {
+	for _, p := range patterns {
+		p = strings.TrimSpace(p)
+		if p == "" {
+			continue
+		}
+		matched, err := filepath.Match(p, name)
+		if err != nil {
+			continue
+		}
+		if matched {
+			return true
+		}
+	}
+	return false
+}
+
+// PRMatchesBaseBranch checks if a PR's base branch matches the branch filters.
+// branches is the allowlist (empty means match-all); branchesIgnore is the
+// denylist (takes precedence).
+func PRMatchesBaseBranch(baseBranch string, branches, branchesIgnore []string) bool {
+	if NameMatchesAny(baseBranch, branchesIgnore) {
+		return false
+	}
+	if len(branches) == 0 {
+		return true
+	}
+	return NameMatchesAny(baseBranch, branches)
+}
+
+// PRMatchesTypes checks if a PR action matches the configured types filter.
+// Returns true when types is empty (matches all).
+func PRMatchesTypes(action string, types []string) bool {
+	if len(types) == 0 {
+		return true
+	}
+	for _, t := range types {
+		if strings.EqualFold(strings.TrimSpace(t), action) {
+			return true
+		}
+	}
+	return false
+}
+
+// DeterminePRAction determines the PR action based on state transitions.
+// prevEncoded and currentEncoded are "sha:state" strings; headSHA is the
+// current head SHA of the PR.
+func DeterminePRAction(prevEncoded, currentEncoded, headSHA string) string {
+	prevParts := strings.SplitN(prevEncoded, ":", 2)
+	currParts := strings.SplitN(currentEncoded, ":", 2)
+
+	prevSHA := ""
+	prevState := ""
+	if len(prevParts) == 2 {
+		prevSHA = prevParts[0]
+		prevState = prevParts[1]
+	}
+
+	currState := ""
+	if len(currParts) == 2 {
+		currState = currParts[1]
+	}
+
+	if currState == "closed" && prevState != "closed" {
+		return "closed"
+	}
+	if currState == "open" && prevState == "closed" {
+		return "reopened"
+	}
+	if prevSHA != headSHA {
+		return "synchronize"
+	}
+	return "synchronize"
+}
+
+// PRPathsMatch checks if any changed file in a PR matches the path filters.
+// If paths is empty, any non-ignored file matches. pathsIgnore takes precedence
+// per-file.
+func PRPathsMatch(changedFiles, paths, pathsIgnore []string) bool {
+	for _, file := range changedFiles {
+		if PathIsIgnored(pathsIgnore, file) {
+			continue
+		}
+		if len(paths) == 0 || PathMatchesNormalized(paths, file) {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/git/matchers/matchers_test.go
+++ b/pkg/git/matchers/matchers_test.go
@@ -1,0 +1,257 @@
+package matchers_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/kubeshop/testkube/pkg/git/matchers"
+)
+
+func TestPathMatches(t *testing.T) {
+	cases := []struct {
+		paths []string
+		file  string
+		want  bool
+	}{
+		{[]string{"src"}, "src/main.go", true},
+		{[]string{"src"}, "src", true},
+		{[]string{"src/"}, "src/main.go", true},
+		{[]string{"other"}, "src/main.go", false},
+		{[]string{"src", "pkg"}, "pkg/util.go", true},
+		{[]string{""}, "anything.go", false},
+		{[]string{"src/sub"}, "src/sub/file.go", true},
+		{[]string{"src/sub"}, "src/other/file.go", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.file, func(t *testing.T) {
+			require.Equal(t, tc.want, matchers.PathMatches(tc.paths, tc.file))
+		})
+	}
+}
+
+func TestPathMatchesNormalized(t *testing.T) {
+	paths := matchers.NormalizePaths([]string{"src/", " pkg "})
+	require.True(t, matchers.PathMatchesNormalized(paths, "src/main.go"))
+	require.True(t, matchers.PathMatchesNormalized(paths, "pkg/util.go"))
+	require.False(t, matchers.PathMatchesNormalized(paths, "internal/main.go"))
+}
+
+func TestNormalizePaths(t *testing.T) {
+	paths := []string{" /a ", "/b/c", "", "///", "d/"}
+	require.Equal(t, []string{"a", "b/c", "d"}, matchers.NormalizePaths(paths))
+}
+
+func TestMatchGlob(t *testing.T) {
+	cases := []struct {
+		name    string
+		pattern string
+		input   string
+		want    bool
+	}{
+		{"exact match", "main.go", "main.go", true},
+		{"no match", "main.go", "other.go", false},
+		{"star matches extension", "*.go", "main.go", true},
+		{"doublestar matches nested", "src/**/*.go", "src/pkg/main.go", true},
+		{"doublestar matches multiple dirs", "src/**/*.go", "src/a/b/c.go", true},
+		{"doublestar no match outside prefix", "src/**/*.go", "pkg/main.go", false},
+		{"prefix directory match", "src", "src/main.go", true},
+		{"prefix directory exact", "src", "src", true},
+		{"prefix directory trailing slash", "src/", "src/main.go", true},
+		{"question mark single char", "?.go", "a.go", true},
+		{"question mark no match multi char", "?.go", "ab.go", false},
+		{"doublestar prefix only", "src/**", "src/a/b.go", true},
+		{"doublestar suffix only", "**/test.go", "a/b/test.go", true},
+		{"malformed pattern returns false", "[invalid", "anything", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.want, matchers.MatchGlob(tc.pattern, tc.input))
+		})
+	}
+}
+
+func TestNameMatchesPatterns(t *testing.T) {
+	cases := []struct {
+		name     string
+		input    string
+		patterns []string
+		want     bool
+	}{
+		{"empty patterns matches all", "main", nil, true},
+		{"exact match", "main", []string{"main"}, true},
+		{"no match", "develop", []string{"main"}, false},
+		{"glob star", "feature/foo", []string{"feature/*"}, true},
+		{"glob star no match", "bugfix/foo", []string{"feature/*"}, false},
+		{"multiple patterns first matches", "main", []string{"main", "develop"}, true},
+		{"multiple patterns second matches", "develop", []string{"main", "develop"}, true},
+		{"whitespace trimmed", "main", []string{"  main  "}, true},
+		{"empty pattern skipped", "main", []string{""}, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.want, matchers.NameMatchesPatterns(tc.input, tc.patterns))
+		})
+	}
+}
+
+func TestNameMatchesAny(t *testing.T) {
+	cases := []struct {
+		name     string
+		input    string
+		patterns []string
+		want     bool
+	}{
+		{"empty patterns returns false", "main", nil, false},
+		{"exact match", "main", []string{"main"}, true},
+		{"glob match", "v1.0.0", []string{"v*"}, true},
+		{"no match", "develop", []string{"main", "release/*"}, false},
+		{"glob question mark", "v1", []string{"v?"}, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.want, matchers.NameMatchesAny(tc.input, tc.patterns))
+		})
+	}
+}
+
+func TestPathIsIgnored(t *testing.T) {
+	cases := []struct {
+		name     string
+		patterns []string
+		file     string
+		want     bool
+	}{
+		{"empty patterns", nil, "any/file.go", false},
+		{"matches glob", []string{"*.md"}, "README.md", true},
+		{"does not match", []string{"*.md"}, "main.go", false},
+		{"directory pattern", []string{"docs"}, "docs/guide.md", true},
+		{"multiple patterns second matches", []string{"*.txt", "*.md"}, "notes.md", true},
+		{"doublestar ignore", []string{"**/*.test.js"}, "src/deep/file.test.js", true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.want, matchers.PathIsIgnored(tc.patterns, tc.file))
+		})
+	}
+}
+
+func TestBranchFromRef(t *testing.T) {
+	cases := []struct {
+		ref  string
+		want string
+	}{
+		{"refs/heads/main", "main"},
+		{"refs/heads/feature/foo", "feature/foo"},
+		{"refs/tags/v1.0", ""},
+		{"HEAD", ""},
+		{"", ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.ref, func(t *testing.T) {
+			require.Equal(t, tc.want, matchers.BranchFromRef(tc.ref))
+		})
+	}
+}
+
+func TestTagFromRef(t *testing.T) {
+	cases := []struct {
+		ref  string
+		want string
+	}{
+		{"refs/tags/v1.0", "v1.0"},
+		{"refs/tags/release/2.0", "release/2.0"},
+		{"refs/heads/main", ""},
+		{"HEAD", ""},
+		{"", ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.ref, func(t *testing.T) {
+			require.Equal(t, tc.want, matchers.TagFromRef(tc.ref))
+		})
+	}
+}
+
+func TestPRMatchesBaseBranch(t *testing.T) {
+	cases := []struct {
+		name           string
+		base           string
+		branches       []string
+		branchesIgnore []string
+		want           bool
+	}{
+		{"nil config matches all", "main", nil, nil, true},
+		{"empty branches matches all", "main", nil, nil, true},
+		{"branch matches", "main", []string{"main", "develop"}, nil, true},
+		{"branch does not match", "feature/x", []string{"main"}, nil, false},
+		{"glob match", "release/1.0", []string{"release/*"}, nil, true},
+		{"ignore takes precedence", "main", []string{"main"}, []string{"main"}, false},
+		{"ignore only", "main", nil, []string{"main"}, false},
+		{"ignore does not match", "develop", nil, []string{"main"}, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.want, matchers.PRMatchesBaseBranch(tc.base, tc.branches, tc.branchesIgnore))
+		})
+	}
+}
+
+func TestPRMatchesTypes(t *testing.T) {
+	cases := []struct {
+		name   string
+		action string
+		types  []string
+		want   bool
+	}{
+		{"nil types matches all", "opened", nil, true},
+		{"empty types matches all", "synchronize", []string{}, true},
+		{"type matches", "opened", []string{"opened", "synchronize"}, true},
+		{"type does not match", "closed", []string{"opened"}, false},
+		{"case insensitive", "Opened", []string{"opened"}, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.want, matchers.PRMatchesTypes(tc.action, tc.types))
+		})
+	}
+}
+
+func TestDeterminePRAction(t *testing.T) {
+	const headSHA = "new-sha"
+	cases := []struct {
+		name    string
+		prev    string
+		current string
+		want    string
+	}{
+		{"sha change is synchronize", "old-sha:open", "new-sha:open", "synchronize"},
+		{"state to closed", "old-sha:open", "new-sha:closed", "closed"},
+		{"state to open from closed", "old-sha:closed", "new-sha:open", "reopened"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.want, matchers.DeterminePRAction(tc.prev, tc.current, headSHA))
+		})
+	}
+}
+
+func TestPRPathsMatch(t *testing.T) {
+	cases := []struct {
+		name   string
+		files  []string
+		paths  []string
+		ignore []string
+		want   bool
+	}{
+		{"no filters matches all", []string{"src/main.go"}, nil, nil, true},
+		{"path matches", []string{"src/main.go", "docs/readme.md"}, []string{"src/**"}, nil, true},
+		{"path does not match", []string{"docs/readme.md"}, []string{"src/**"}, nil, false},
+		{"ignore takes precedence", []string{"src/vendor/lib.go"}, []string{"src/**"}, []string{"src/vendor/**"}, false},
+		{"mixed match after ignore", []string{"src/vendor/lib.go", "src/main.go"}, []string{"src/**"}, []string{"src/vendor/**"}, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.want, matchers.PRPathsMatch(tc.files, tc.paths, tc.ignore))
+		})
+	}
+}


### PR DESCRIPTION
## Changes

Adds a new package `pkg/git/matchers/` that exports pure predicate helpers for evaluating whether a git event should trigger a workflow: path globbing, ref-to-branch extraction, PR base-branch matching, PR action matching, PR path filtering, and PR action inference from state transitions.

These are the same predicates that already exist unexported inside `pkg/git/informer/{informer,github_pr}.go` (used by the git-triggers polling loop). The new package is a **copy**, not a move — the informer keeps its existing unexported helpers unchanged, so nothing about how git-triggers behaves changes with this PR.

## Why now

The Testkube Cloud Quality Loop is adding a webhook-driven path (TKC-6384) that evaluates the same matcher semantics customers already know from OSS `TestTrigger`. Rather than reinvent globbing/PR-matching rules, it should consume the same predicates. Making them exportable from OSS is the enabling step.

Today, Cloud has a **temporary internal copy** of these predicates (`internal/qualityloop/gitmatchers/` in the closed-source repo) with a TODO to replace with an import of this package once it lands.

## Approach

- **Additive only**: new files under `pkg/git/matchers/`, no changes to `informer.go` or `github_pr.go`
- **Decoupled signatures**: the exported functions take primitive slices and strings (no `testkube.*` types) so callers outside the informer can consume them without dragging in provider- or control-plane-specific dependencies
- **Table-driven tests** cover each predicate independently; all existing OSS tests continue to pass unchanged