### PR TITLE
fix: do not print SaaS dashboard links when the API URI targets another control plane

### DIFF
--- a/cmd/kubectl-testkube/commands/common/flags.go
+++ b/cmd/kubectl-testkube/commands/common/flags.go
@@ -178,24 +178,55 @@ func ProcessMasterFlags(cmd *cobra.Command, opts *HelmOptions, cfg *config.Data)
 		opts.Master.Insecure)
 
 	// override whole URIs usually composed from prefix - host parts
-	if cmd.Flag("agent-uri-override") != nil && cmd.Flags().Changed("agent-uri-override") {
+	if flagChanged(cmd, "agent-uri-override") {
 		uris.WithAgentURI(cmd.Flag("agent-uri-override").Value.String())
 	}
 
-	if cmd.Flag("api-uri-override") != nil && cmd.Flags().Changed("api-uri-override") {
+	if flagChanged(cmd, "api-uri-override") {
 		uris.WithApiURI(cmd.Flag("api-uri-override").Value.String())
+
+		// The composed UI URI points to the SaaS dashboard by default. That
+		// default is wrong when the API URI targets a different control plane.
+		// The CLI cannot derive the dashboard host from the API URI, so it
+		// clears the UI URI instead.
+		if !uiConfigured(cmd, cfg) {
+			uris.WithUiURI("")
+		}
 	}
 
-	if cmd.Flag("ui-uri-override") != nil && cmd.Flags().Changed("ui-uri-override") {
+	if flagChanged(cmd, "ui-uri-override") {
 		uris.WithUiURI(cmd.Flag("ui-uri-override").Value.String())
 	}
 
-	if cmd.Flag("auth-uri-override") != nil && cmd.Flags().Changed("auth-uri-override") {
+	if flagChanged(cmd, "auth-uri-override") {
 		uris.WithAuthURI(cmd.Flag("auth-uri-override").Value.String())
 	}
 
 	opts.Master.URIs = uris
 
+}
+
+// uiConfigured reports whether any input defines the dashboard location.
+// The input can be a UI URI override, a UI prefix, or a root domain,
+// from the command line or from the saved configuration.
+func uiConfigured(cmd *cobra.Command, cfg *config.Data) bool {
+	for _, name := range []string{
+		"ui-uri-override",
+		"ui-prefix",
+		"cloud-ui-prefix",
+		"root-domain",
+		"pro-root-domain",
+		"cloud-root-domain",
+	} {
+		if flagChanged(cmd, name) {
+			return true
+		}
+	}
+	return cfg != nil && (cfg.Master.UiUrlPrefix != "" || cfg.Master.RootDomain != "")
+}
+
+func flagChanged(cmd *cobra.Command, name string) bool {
+	return cmd != nil && cmd.Flag(name) != nil && cmd.Flags().Changed(name)
 }
 
 // ResolveSkipTLS returns the effective skip-TLS value with precedence:

--- a/cmd/kubectl-testkube/commands/common/flags_test.go
+++ b/cmd/kubectl-testkube/commands/common/flags_test.go
@@ -1,0 +1,76 @@
+package common
+
+import (
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/kubeshop/testkube/cmd/kubectl-testkube/config"
+)
+
+func TestProcessMasterFlags_UiUri(t *testing.T) {
+	tests := []struct {
+		name       string
+		args       []string
+		cfg        *config.Data
+		expectedUi string
+	}{
+		{
+			name:       "no flags keep the default UI URI",
+			args:       nil,
+			expectedUi: "https://app.testkube.io",
+		},
+		{
+			name:       "api uri override alone clears the UI URI",
+			args:       []string{"--api-uri-override", "https://api.onprem.example.com"},
+			expectedUi: "",
+		},
+		{
+			name: "api uri override with ui uri override keeps the UI URI",
+			args: []string{
+				"--api-uri-override", "https://api.onprem.example.com",
+				"--ui-uri-override", "https://dashboard.onprem.example.com",
+			},
+			expectedUi: "https://dashboard.onprem.example.com",
+		},
+		{
+			name: "api uri override with root domain keeps the composed UI URI",
+			args: []string{
+				"--api-uri-override", "https://api.onprem.example.com",
+				"--root-domain", "onprem.example.com",
+			},
+			expectedUi: "https://app.onprem.example.com",
+		},
+		{
+			name: "api uri override with ui prefix keeps the composed UI URI",
+			args: []string{
+				"--api-uri-override", "https://api.onprem.example.com",
+				"--ui-prefix", "dashboard",
+			},
+			expectedUi: "https://dashboard.testkube.io",
+		},
+		{
+			name: "api uri override with a saved root domain keeps the composed UI URI",
+			args: []string{"--api-uri-override", "https://api.onprem.example.com"},
+			cfg: &config.Data{
+				Master: config.Master{RootDomain: "onprem.example.com"},
+			},
+			expectedUi: "https://app.onprem.example.com",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var opts HelmOptions
+			cmd := &cobra.Command{Use: "test"}
+			PopulateMasterFlags(cmd, &opts, false)
+			require.NoError(t, cmd.Flags().Parse(tt.args))
+
+			ProcessMasterFlags(cmd, &opts, tt.cfg)
+
+			assert.Equal(t, tt.expectedUi, opts.Master.URIs.Ui)
+		})
+	}
+}

--- a/cmd/kubectl-testkube/commands/common/render/common.go
+++ b/cmd/kubectl-testkube/commands/common/render/common.go
@@ -73,6 +73,12 @@ func PrintTestWorkflowExecutionURIs(execution *testkube.TestWorkflowExecution) {
 		return
 	}
 
+	// An empty UI URI means the context has no known dashboard location,
+	// for example an on-prem context created with --api-uri-override only.
+	if cfg.CloudContext.UiUri == "" {
+		return
+	}
+
 	if execution.Result == nil || !execution.Result.IsFinished() {
 		return
 	}

--- a/cmd/kubectl-testkube/commands/dashboard.go
+++ b/cmd/kubectl-testkube/commands/dashboard.go
@@ -59,6 +59,10 @@ func NewDashboardCmd() *cobra.Command {
 }
 
 func openCloudDashboard(cfg config.Data) {
+	if cfg.CloudContext.UiUri == "" {
+		ui.Failf("The context has no dashboard URI. Pass `--ui-uri-override <url>` to `testkube set context` or `testkube login`.")
+	}
+
 	// open browser
 	uri := fmt.Sprintf("%s/organization/%s/environment/%s", cfg.CloudContext.UiUri, cfg.CloudContext.OrganizationId, cfg.CloudContext.EnvironmentId)
 	err := open.Run(uri)


### PR DESCRIPTION
## How

- `ProcessMasterFlags` clears the composed UI URI when `--api-uri-override` targets another control plane and no flag or saved configuration defines the dashboard location. The CLI cannot derive the dashboard host from the API URI, so it stores an empty value instead of the SaaS default.
- The execution output skips the dashboard links when the context has no UI URI.
- `testkube dashboard` fails with a hint to pass `--ui-uri-override` when the context has no UI URI.

An explicit `--ui-uri-override`, `--ui-prefix`, or `--root-domain` keeps the current behavior.