### PR TITLE
fix(controlplane): correct the force cancel step queries in the Postgres scheduler

### DIFF
--- a/pkg/controlplane/scheduling/sqlc/execution_controller.sql
+++ b/pkg/controlplane/scheduling/sqlc/execution_controller.sql
@@ -134,60 +134,70 @@ WHERE execution_id = @execution_id
 -- name: ForceCancelExecutionSteps :exec
 -- Cancels all steps that are not already terminated (passed/failed)
 -- Sets missing timestamps (queuedat, startedat, finishedat) to the provided time
-UPDATE test_workflow_results 
-SET steps = (
+UPDATE test_workflow_results
+-- jsonb_object_agg returns NULL over zero rows, so a result that holds an
+-- empty steps object would lose the object. The COALESCE keeps it.
+SET steps = COALESCE((
     SELECT jsonb_object_agg(
         key,
-        CASE 
+        CASE
             -- If step is already passed or failed, keep it as is
             WHEN value->>'status' IN ('passed', 'failed') THEN value
-            -- Otherwise, cancel it and update timestamps
-            ELSE jsonb_build_object(
+            -- Otherwise, cancel it and update timestamps.
+            -- Both COALESCE branches must be jsonb; a text branch makes
+            -- Postgres reject the query with SQLSTATE 42804.
+            -- The new values go on the right side of || so they override
+            -- the old ones.
+            ELSE value || jsonb_build_object(
                 'status', 'canceled',
                 'queuedAt', COALESCE(
-                    NULLIF(value->>'queuedAt', '0001-01-01T00:00:00Z'),
+                    to_jsonb(NULLIF(value->>'queuedAt', '0001-01-01T00:00:00Z')),
                     to_jsonb(@finished_at::timestamptz)
                 ),
                 'startedAt', COALESCE(
-                    NULLIF(value->>'startedAt', '0001-01-01T00:00:00Z'),
+                    to_jsonb(NULLIF(value->>'startedAt', '0001-01-01T00:00:00Z')),
                     to_jsonb(@finished_at::timestamptz)
                 ),
                 'finishedAt', COALESCE(
-                    NULLIF(value->>'finishedAt', '0001-01-01T00:00:00Z'),
+                    to_jsonb(NULLIF(value->>'finishedAt', '0001-01-01T00:00:00Z')),
                     to_jsonb(@finished_at::timestamptz)
                 )
-            ) || (value - ARRAY['status', 'queuedat', 'startedat', 'finishedat'])
+            )
         END
     )
     FROM jsonb_each(COALESCE(steps, '{}'::jsonb))
-)
+), '{}'::jsonb)
 WHERE execution_id = @execution_id
   AND steps IS NOT NULL
   AND jsonb_typeof(steps) = 'object';
 
 -- name: ForceCancelExecutionInitialization :exec
 -- Cancels the initialization step if it's not already terminated
-UPDATE test_workflow_results 
+UPDATE test_workflow_results
 SET initialization = (
-    CASE 
+    CASE
         -- If initialization is already passed or failed, keep it as is
         WHEN initialization->>'status' IN ('passed', 'failed') THEN initialization
-        -- Otherwise, cancel it and update timestamps
-        ELSE jsonb_build_object(
+        -- Otherwise, cancel it and update timestamps.
+        -- Both COALESCE branches must be jsonb; a text branch makes
+        -- Postgres reject the query with SQLSTATE 42804.
+        -- The new values go on the right side of || so they override
+        -- the old ones.
+        ELSE initialization || jsonb_build_object(
             'status', 'canceled',
             'queuedAt', COALESCE(
-                NULLIF(initialization->>'queuedAt', '0001-01-01T00:00:00Z'),
+                to_jsonb(NULLIF(initialization->>'queuedAt', '0001-01-01T00:00:00Z')),
                 to_jsonb(@finished_at::timestamptz)
             ),
             'startedAt', COALESCE(
-                NULLIF(initialization->>'startedAt', '0001-01-01T00:00:00Z'),
+                to_jsonb(NULLIF(initialization->>'startedAt', '0001-01-01T00:00:00Z')),
                 to_jsonb(@finished_at::timestamptz)
             ),
-            'finishedaAt', COALESCE(
-                NULLIF(initialization->>'finishedAt', '0001-01-01T00:00:00Z'),
+            'finishedAt', COALESCE(
+                to_jsonb(NULLIF(initialization->>'finishedAt', '0001-01-01T00:00:00Z')),
                 to_jsonb(@finished_at::timestamptz)
             )
-        ) || (initialization - ARRAY['status', 'queuedat', 'startedat', 'finishedat'])
+        )
     END
 )
 WHERE execution_id = @execution_id

--- a/pkg/controlplane/scheduling/sqlc/execution_controller.sql.go
+++ b/pkg/controlplane/scheduling/sqlc/execution_controller.sql.go
@@ -179,27 +179,31 @@ func (q *Queries) ForceCancelExecution(ctx context.Context, arg ForceCancelExecu
 }
 
 const forceCancelExecutionInitialization = `-- name: ForceCancelExecutionInitialization :exec
-UPDATE test_workflow_results 
+UPDATE test_workflow_results
 SET initialization = (
-    CASE 
+    CASE
         -- If initialization is already passed or failed, keep it as is
         WHEN initialization->>'status' IN ('passed', 'failed') THEN initialization
-        -- Otherwise, cancel it and update timestamps
-        ELSE jsonb_build_object(
+        -- Otherwise, cancel it and update timestamps.
+        -- Both COALESCE branches must be jsonb; a text branch makes
+        -- Postgres reject the query with SQLSTATE 42804.
+        -- The new values go on the right side of || so they override
+        -- the old ones.
+        ELSE initialization || jsonb_build_object(
             'status', 'canceled',
             'queuedAt', COALESCE(
-                NULLIF(initialization->>'queuedAt', '0001-01-01T00:00:00Z'),
+                to_jsonb(NULLIF(initialization->>'queuedAt', '0001-01-01T00:00:00Z')),
                 to_jsonb($1::timestamptz)
             ),
             'startedAt', COALESCE(
-                NULLIF(initialization->>'startedAt', '0001-01-01T00:00:00Z'),
+                to_jsonb(NULLIF(initialization->>'startedAt', '0001-01-01T00:00:00Z')),
                 to_jsonb($1::timestamptz)
             ),
-            'finishedaAt', COALESCE(
-                NULLIF(initialization->>'finishedAt', '0001-01-01T00:00:00Z'),
+            'finishedAt', COALESCE(
+                to_jsonb(NULLIF(initialization->>'finishedAt', '0001-01-01T00:00:00Z')),
                 to_jsonb($1::timestamptz)
             )
-        ) || (initialization - ARRAY['status', 'queuedat', 'startedat', 'finishedat'])
+        )
     END
 )
 WHERE execution_id = $2
@@ -244,33 +248,37 @@ func (q *Queries) ForceCancelExecutionResult(ctx context.Context, arg ForceCance
 }
 
 const forceCancelExecutionSteps = `-- name: ForceCancelExecutionSteps :exec
-UPDATE test_workflow_results 
-SET steps = (
+UPDATE test_workflow_results
+SET steps = COALESCE((
     SELECT jsonb_object_agg(
         key,
-        CASE 
+        CASE
             -- If step is already passed or failed, keep it as is
             WHEN value->>'status' IN ('passed', 'failed') THEN value
-            -- Otherwise, cancel it and update timestamps
-            ELSE jsonb_build_object(
+            -- Otherwise, cancel it and update timestamps.
+            -- Both COALESCE branches must be jsonb; a text branch makes
+            -- Postgres reject the query with SQLSTATE 42804.
+            -- The new values go on the right side of || so they override
+            -- the old ones.
+            ELSE value || jsonb_build_object(
                 'status', 'canceled',
                 'queuedAt', COALESCE(
-                    NULLIF(value->>'queuedAt', '0001-01-01T00:00:00Z'),
+                    to_jsonb(NULLIF(value->>'queuedAt', '0001-01-01T00:00:00Z')),
                     to_jsonb($1::timestamptz)
                 ),
                 'startedAt', COALESCE(
-                    NULLIF(value->>'startedAt', '0001-01-01T00:00:00Z'),
+                    to_jsonb(NULLIF(value->>'startedAt', '0001-01-01T00:00:00Z')),
                     to_jsonb($1::timestamptz)
                 ),
                 'finishedAt', COALESCE(
-                    NULLIF(value->>'finishedAt', '0001-01-01T00:00:00Z'),
+                    to_jsonb(NULLIF(value->>'finishedAt', '0001-01-01T00:00:00Z')),
                     to_jsonb($1::timestamptz)
                 )
-            ) || (value - ARRAY['status', 'queuedat', 'startedat', 'finishedat'])
+            )
         END
     )
     FROM jsonb_each(COALESCE(steps, '{}'::jsonb))
-)
+), '{}'::jsonb)
 WHERE execution_id = $2
   AND steps IS NOT NULL
   AND jsonb_typeof(steps) = 'object'
@@ -283,6 +291,8 @@ type ForceCancelExecutionStepsParams struct {
 
 // Cancels all steps that are not already terminated (passed/failed)
 // Sets missing timestamps (queuedat, startedat, finishedat) to the provided time
+// jsonb_object_agg returns NULL over zero rows, so a result that holds an
+// empty steps object would lose the object. The COALESCE keeps it.
 func (q *Queries) ForceCancelExecutionSteps(ctx context.Context, arg ForceCancelExecutionStepsParams) error {
 	_, err := q.db.Exec(ctx, forceCancelExecutionSteps, arg.FinishedAt, arg.ExecutionID)
 	return err

--- a/pkg/controlplane/scheduling/sqlc/execution_controller_integration_test.go
+++ b/pkg/controlplane/scheduling/sqlc/execution_controller_integration_test.go
@@ -1,0 +1,123 @@
+package sqlc_test
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/kubeshop/testkube/pkg/controlplane/scheduling/sqlc"
+	database "github.com/kubeshop/testkube/pkg/database/postgres"
+	testpostgres "github.com/kubeshop/testkube/pkg/test/postgres"
+	"github.com/kubeshop/testkube/pkg/utils/test"
+)
+
+// seedResult writes one execution and one result row that carries the given
+// steps and initialization documents. It returns the execution id.
+func seedResult(t *testing.T, db *database.DB, ctx context.Context, steps, initialization string) string {
+	t.Helper()
+
+	executionID := uuid.NewString()
+	_, err := db.Pool.Exec(ctx,
+		`INSERT INTO test_workflow_executions (id, name) VALUES ($1, $2)`,
+		executionID, "wf-"+executionID)
+	require.NoError(t, err)
+
+	_, err = db.Pool.Exec(ctx,
+		`INSERT INTO test_workflow_results (execution_id, status, steps, initialization)
+		 VALUES ($1, 'running', $2, $3)`,
+		executionID, steps, initialization)
+	require.NoError(t, err)
+
+	return executionID
+}
+
+// TestForceCancelExecutionQueries_Integration is the first test of this
+// package. It pins the four defects that the control plane copy of these
+// queries already fixed: a COALESCE that mixed a text branch with a jsonb
+// branch, a concatenation that let the stale timestamps win, a key spelled
+// finishedaAt, and an aggregate that returned NULL over zero rows.
+func TestForceCancelExecutionQueries_Integration(t *testing.T) {
+	test.IntegrationTest(t)
+
+	db, cleanup := testpostgres.PreparePostgresTestDatabase(t, "force_cancel_queries")
+	t.Cleanup(cleanup)
+
+	ctx := context.Background()
+	queries := sqlc.New(db.Pool)
+
+	finishedAt := time.Date(2030, 1, 1, 0, 0, 0, 0, time.UTC)
+	zeroTime := "0001-01-01T00:00:00Z"
+
+	t.Run("steps cancel and keep every other key", func(t *testing.T) {
+		executionID := seedResult(t,
+			db, ctx,
+			`{"active":{"status":"running","queuedAt":"`+zeroTime+`","errorMessage":"keep-me"},
+			  "done":{"status":"passed","queuedAt":"2020-01-01T00:00:00Z"}}`,
+			`{"status":"running"}`)
+
+		require.NoError(t, queries.ForceCancelExecutionSteps(ctx, sqlc.ForceCancelExecutionStepsParams{
+			ExecutionID: executionID,
+			FinishedAt:  pgtype.Timestamptz{Time: finishedAt, Valid: true},
+		}))
+
+		steps := map[string]map[string]any{}
+		require.NoError(t, json.Unmarshal(readSteps(t, db, ctx, executionID), &steps))
+
+		assert.Equal(t, "canceled", steps["active"]["status"], "an active step must cancel")
+		assert.Equal(t, "keep-me", steps["active"]["errorMessage"], "the other keys must survive")
+		assert.NotEqual(t, zeroTime, steps["active"]["queuedAt"],
+			"the new timestamp must win over the zero value")
+		assert.Equal(t, "passed", steps["done"]["status"], "a terminated step must keep its status")
+	})
+
+	t.Run("an empty steps object stays an empty object", func(t *testing.T) {
+		executionID := seedResult(t, db, ctx, `{}`, `{"status":"running"}`)
+
+		require.NoError(t, queries.ForceCancelExecutionSteps(ctx, sqlc.ForceCancelExecutionStepsParams{
+			ExecutionID: executionID,
+			FinishedAt:  pgtype.Timestamptz{Time: finishedAt, Valid: true},
+		}))
+
+		raw := readSteps(t, db, ctx, executionID)
+		require.NotNil(t, raw, "steps must stay a jsonb object, never SQL NULL")
+		assert.JSONEq(t, `{}`, string(raw))
+	})
+
+	t.Run("initialization cancels and writes finishedAt", func(t *testing.T) {
+		executionID := seedResult(t, db, ctx, `{}`,
+			`{"status":"running","queuedAt":"`+zeroTime+`"}`)
+
+		require.NoError(t, queries.ForceCancelExecutionInitialization(ctx, sqlc.ForceCancelExecutionInitializationParams{
+			ExecutionID: executionID,
+			FinishedAt:  pgtype.Timestamptz{Time: finishedAt, Valid: true},
+		}))
+
+		var raw []byte
+		require.NoError(t, db.Pool.QueryRow(ctx,
+			`SELECT initialization FROM test_workflow_results WHERE execution_id = $1`,
+			executionID).Scan(&raw))
+
+		initialization := map[string]any{}
+		require.NoError(t, json.Unmarshal(raw, &initialization))
+
+		assert.Equal(t, "canceled", initialization["status"])
+		assert.Contains(t, initialization, "finishedAt", "the finish time must use the finishedAt key")
+		assert.NotContains(t, initialization, "finishedaAt", "the misspelled key must not appear")
+	})
+}
+
+func readSteps(t *testing.T, db *database.DB, ctx context.Context, executionID string) []byte {
+	t.Helper()
+
+	var raw []byte
+	require.NoError(t, db.Pool.QueryRow(ctx,
+		`SELECT steps FROM test_workflow_results WHERE execution_id = $1`,
+		executionID).Scan(&raw))
+	return raw
+}


### PR DESCRIPTION
Companion to kubeshop/testkube-cloud-api#4995.

`pkg/controlplane/scheduling/sqlc/execution_controller.sql` holds a copy of the force cancel queries that the control plane also carries. The copy never received the fixes, and `controller_postgres.go` wires it into the standalone control plane, so force cancel does not work there.

| Defect | Query | Effect |
|--------|-------|--------|
| `COALESCE` mixes a text branch and a jsonb branch | both | the query fails on every call with `SQLSTATE 42804` |
| the `-` key list uses lowercase names | both | the stale timestamps survive and override the new ones |
| the key is spelled `finishedaAt` | initialization | the finish time lands under a name no reader uses |
| `jsonb_object_agg` returns NULL over zero rows | steps | a result with an empty steps object loses the object |

The second defect needs the detail. The old form puts `jsonb_build_object(...)` on the left of `||` and `(value - ARRAY['status', 'queuedat', 'startedat', 'finishedat'])` on the right, and the right side of `||` wins. The removal list spells the timestamp keys in lowercase while the stored keys are camelCase, so only `status` goes and the stale `queuedAt` overrides the value the query just built.

Adopt the shape the control plane already uses. Wrap each `NULLIF` in `to_jsonb`, put the original value on the left of `||` so the new values win, correct the spelling, and wrap the steps aggregate in `COALESCE(..., '{}'::jsonb)`.

`execution_controller_integration_test.go` is the first test of this package. Each defect was reintroduced on its own to confirm the test catches it.

Both queries change from "always error" to "cancel the steps". No caller can regress, because no caller ever completed this call.
