### PR TITLE
fix: accept large numeric config values in TestWorkflow CRDs

### DIFF
--- a/api/testworkflows/v1/config_value.go
+++ b/api/testworkflows/v1/config_value.go
@@ -1,0 +1,90 @@
+package v1
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"strconv"
+
+	"gopkg.in/yaml.v3"
+)
+
+// ConfigValue accepts an integer or a string and keeps the raw scalar
+// text of the value. A type that stores numbers as int32, such as
+// intstr.IntOrString, fails to unmarshal a larger number. One bad value
+// then causes a full informer list to fail.
+
+// +kubebuilder:validation:XIntOrString
+type ConfigValue string
+
+func NewConfigValue(value string) *ConfigValue {
+	result := ConfigValue(value)
+	return &result
+}
+
+func (v ConfigValue) String() string {
+	return string(v)
+}
+
+func (ConfigValue) OpenAPISchemaType() []string {
+	return []string{"string"}
+}
+
+func (ConfigValue) OpenAPISchemaFormat() string {
+	return "int-or-string"
+}
+
+func (ConfigValue) OpenAPIV3OneOfTypes() []string {
+	return []string{"integer", "string"}
+}
+
+func (v ConfigValue) MarshalJSON() ([]byte, error) {
+	value := v.String()
+	// Emit a number only when the value is a canonical integer in the
+	// int32 range. Older clients decode this field with
+	// intstr.IntOrString, which stores numbers as int32. For a larger
+	// number, the string form prevents a decode error in those clients.
+	if parsed, err := strconv.ParseInt(value, 10, 32); err == nil && strconv.FormatInt(parsed, 10) == value {
+		return []byte(value), nil
+	}
+	return json.Marshal(value)
+}
+
+func (v *ConfigValue) UnmarshalJSON(data []byte) error {
+	trimmed := bytes.TrimSpace(data)
+	if len(trimmed) == 0 || bytes.Equal(trimmed, []byte("null")) {
+		return nil
+	}
+
+	// json.Number keeps the raw literal, so numbers of any size keep
+	// their full precision.
+	decoder := json.NewDecoder(bytes.NewReader(trimmed))
+	decoder.UseNumber()
+	var value any
+	if err := decoder.Decode(&value); err != nil {
+		return err
+	}
+
+	switch value := value.(type) {
+	case string:
+		*v = ConfigValue(value)
+	case json.Number:
+		*v = ConfigValue(value.String())
+	case bool:
+		*v = ConfigValue(strconv.FormatBool(value))
+	default:
+		return fmt.Errorf("configuration value must be a scalar")
+	}
+	return nil
+}
+
+func (v *ConfigValue) UnmarshalYAML(node *yaml.Node) error {
+	if node.Kind != yaml.ScalarNode {
+		return fmt.Errorf("configuration value must be a scalar")
+	}
+	if node.Tag == "!!null" {
+		return nil
+	}
+	*v = ConfigValue(node.Value)
+	return nil
+}

--- a/api/testworkflows/v1/config_value_test.go
+++ b/api/testworkflows/v1/config_value_test.go
@@ -1,0 +1,134 @@
+package v1
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+	sigsyaml "sigs.k8s.io/yaml"
+)
+
+func TestConfigValue_UnmarshalJSON(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  ConfigValue
+	}{
+		{name: "number above int32 range", input: `873760302410822`, want: "873760302410822"},
+		{name: "number above int64 range", input: `18446744073709551615`, want: "18446744073709551615"},
+		{name: "number in int32 range", input: `1024`, want: "1024"},
+		{name: "negative number", input: `-5`, want: "-5"},
+		{name: "float number", input: `1.5`, want: "1.5"},
+		{name: "string", input: `"some value"`, want: "some value"},
+		{name: "numeric string", input: `"873760302410822"`, want: "873760302410822"},
+		{name: "template string", input: `"{{ config.id }}"`, want: "{{ config.id }}"},
+		{name: "boolean", input: `true`, want: "true"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var value ConfigValue
+			err := json.Unmarshal([]byte(tt.input), &value)
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, value)
+		})
+	}
+
+	t.Run("null keeps the value empty", func(t *testing.T) {
+		var value struct {
+			Default *ConfigValue `json:"default"`
+		}
+		err := json.Unmarshal([]byte(`{"default":null}`), &value)
+		require.NoError(t, err)
+		assert.Nil(t, value.Default)
+	})
+
+	t.Run("object is an error", func(t *testing.T) {
+		var value ConfigValue
+		err := json.Unmarshal([]byte(`{"a":1}`), &value)
+		assert.Error(t, err)
+	})
+}
+
+func TestConfigValue_MarshalJSON(t *testing.T) {
+	tests := []struct {
+		name  string
+		input ConfigValue
+		want  string
+	}{
+		{name: "number in int32 range stays a number", input: "1024", want: `1024`},
+		{name: "number above int32 range becomes a string", input: "873760302410822", want: `"873760302410822"`},
+		{name: "number with a leading zero becomes a string", input: "007", want: `"007"`},
+		{name: "plain string", input: "some value", want: `"some value"`},
+		{name: "template string", input: "{{ config.id }}", want: `"{{ config.id }}"`},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			data, err := json.Marshal(tt.input)
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, string(data))
+		})
+	}
+}
+
+func TestConfigValue_UnmarshalYAML(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  ConfigValue
+	}{
+		{name: "number above int32 range", input: "default: 873760302410822", want: "873760302410822"},
+		{name: "string", input: "default: 'some value'", want: "some value"},
+		{name: "template string", input: "default: '{{ config.id }}'", want: "{{ config.id }}"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var value struct {
+				Default *ConfigValue `yaml:"default"`
+			}
+			err := yaml.Unmarshal([]byte(tt.input), &value)
+			require.NoError(t, err)
+			require.NotNil(t, value.Default)
+			assert.Equal(t, tt.want, *value.Default)
+		})
+	}
+}
+
+func TestTestWorkflow_UnmarshalLargeNumericConfigDefault(t *testing.T) {
+	workflowJSON := []byte(`{
+		"apiVersion": "testworkflows.testkube.io/v1",
+		"kind": "TestWorkflow",
+		"metadata": {"name": "big-number"},
+		"spec": {
+			"config": {
+				"id": {"type": "string", "default": 873760302410822}
+			},
+			"use": [{"name": "tpl", "config": {"id": 873760302410822}}]
+		}
+	}`)
+
+	var workflow TestWorkflow
+	err := json.Unmarshal(workflowJSON, &workflow)
+	require.NoError(t, err)
+	require.NotNil(t, workflow.Spec.Config["id"].Default)
+	assert.Equal(t, "873760302410822", workflow.Spec.Config["id"].Default.String())
+	assert.Equal(t, ConfigValue("873760302410822"), workflow.Spec.Use[0].Config["id"])
+
+	workflowYAML := []byte(`
+apiVersion: testworkflows.testkube.io/v1
+kind: TestWorkflow
+metadata:
+  name: big-number
+spec:
+  config:
+    id:
+      type: string
+      default: 873760302410822
+`)
+	var workflowFromYAML TestWorkflow
+	err = sigsyaml.Unmarshal(workflowYAML, &workflowFromYAML)
+	require.NoError(t, err)
+	require.NotNil(t, workflowFromYAML.Spec.Config["id"].Default)
+	assert.Equal(t, "873760302410822", workflowFromYAML.Spec.Config["id"].Default.String())
+}

--- a/api/testworkflows/v1/parameter_types.go
+++ b/api/testworkflows/v1/parameter_types.go
@@ -1,9 +1,5 @@
 package v1
 
-import (
-	"k8s.io/apimachinery/pkg/util/intstr"
-)
-
 // +kubebuilder:validation:Enum=string;integer;number;boolean
 type ParameterType string
 
@@ -47,10 +43,10 @@ type ParameterSchema struct {
 	// the list of allowed values, when limited
 	Enum []string `json:"enum,omitempty"`
 	// exemplary value
-	Example *intstr.IntOrString `json:"example,omitempty"`
+	Example *ConfigValue `json:"example,omitempty"`
 	// default value - if not provided, the parameter is required
 	// +kubebuilder:validation:XIntOrString
-	Default *intstr.IntOrString `json:"default,omitempty" expr:"template"`
+	Default *ConfigValue `json:"default,omitempty" expr:"template"`
 	// whether this value should be stored in the secret
 	Sensitive bool `json:"sensitive,omitempty"`
 

--- a/api/testworkflows/v1/step_types.go
+++ b/api/testworkflows/v1/step_types.go
@@ -224,7 +224,7 @@ type StepExecuteWorkflow struct {
 	Tarball map[string]TarballRequest `json:"tarball,omitempty" expr:"template,include"`
 
 	// configuration to pass for the workflow
-	Config map[string]intstr.IntOrString `json:"config,omitempty" expr:"template"`
+	Config map[string]ConfigValue `json:"config,omitempty" expr:"template"`
 
 	// instructions for downloading artifacts produced by executed test workflows
 	Fetch []StepExecuteFetch `json:"fetch,omitempty" expr:"include"`

--- a/api/testworkflows/v1/step_types.go
+++ b/api/testworkflows/v1/step_types.go
@@ -221,7 +221,7 @@ type StepExecuteWorkflow struct {
 	Tarball map[string]TarballRequest `json:"tarball,omitempty" expr:"template,include"`
 
 	// configuration to pass for the workflow
-	Config map[string]intstr.IntOrString `json:"config,omitempty" expr:"template"`
+	Config map[string]ConfigValue `json:"config,omitempty" expr:"template"`
 
 	// Targets helps decide on which runner the execution is scheduled.
 	Target *commonv1.Target `json:"target,omitempty" expr:"include"`

--- a/api/testworkflows/v1/testworkflow_types.go
+++ b/api/testworkflows/v1/testworkflow_types.go
@@ -16,7 +16,6 @@ package v1
 import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
 // TestWorkflowSpec defines the desired state of TestWorkflow
@@ -49,7 +48,7 @@ type TemplateRef struct {
 	// name of the template to include
 	Name string `json:"name"`
 	// trait configuration values if needed
-	Config map[string]intstr.IntOrString `json:"config,omitempty" expr:"template"`
+	Config map[string]ConfigValue `json:"config,omitempty" expr:"template"`
 }
 
 // TestWorkflowStatusSummary contains information about the TestWorkflow status.

--- a/api/testworkflows/v1/testworkflowexecution_types.go
+++ b/api/testworkflows/v1/testworkflowexecution_types.go
@@ -16,7 +16,6 @@ package v1
 import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/util/intstr"
 
 	commonv1 "github.com/kubeshop/testkube/api/common/v1"
 )
@@ -33,8 +32,8 @@ type TestWorkflowExecutionSpec struct {
 // TestWorkflowExecutionRequest contains TestWorkflow execution parameters
 type TestWorkflowExecutionRequest struct {
 	// custom execution name
-	Name   string                        `json:"name,omitempty" expr:"template"`
-	Config map[string]intstr.IntOrString `json:"config,omitempty" expr:"template"`
+	Name   string                 `json:"name,omitempty" expr:"template"`
+	Config map[string]ConfigValue `json:"config,omitempty" expr:"template"`
 	// test workflow execution name started the test workflow execution
 	TestWorkflowExecutionName string `json:"testWorkflowExecutionName,omitempty" expr:"template"`
 	// whether webhooks should be disabled for this execution

--- a/api/testworkflows/v1/types.go
+++ b/api/testworkflows/v1/types.go
@@ -235,7 +235,7 @@ type CronJobConfig struct {
 	// annotations to attach to the cron job
 	Annotations map[string]string `json:"annotations,omitempty" expr:"template,template"`
 	// configuration to pass for the workflow
-	Config map[string]intstr.IntOrString `json:"config,omitempty" expr:"template,template"`
+	Config map[string]ConfigValue `json:"config,omitempty" expr:"template,template"`
 	// Targets helps decide on which runner the execution is scheduled.
 	Target *commonv1.Target `json:"target,omitempty" expr:"include"`
 	// cron timezone

--- a/api/testworkflows/v1/zz_generated.deepcopy.go
+++ b/api/testworkflows/v1/zz_generated.deepcopy.go
@@ -245,7 +245,7 @@ func (in *CronJobConfig) DeepCopyInto(out *CronJobConfig) {
 	}
 	if in.Config != nil {
 		in, out := &in.Config, &out.Config
-		*out = make(map[string]intstr.IntOrString, len(*in))
+		*out = make(map[string]ConfigValue, len(*in))
 		for key, val := range *in {
 			(*out)[key] = val
 		}
@@ -547,12 +547,12 @@ func (in *ParameterSchema) DeepCopyInto(out *ParameterSchema) {
 	}
 	if in.Example != nil {
 		in, out := &in.Example, &out.Example
-		*out = new(intstr.IntOrString)
+		*out = new(ConfigValue)
 		**out = **in
 	}
 	if in.Default != nil {
 		in, out := &in.Default, &out.Default
-		*out = new(intstr.IntOrString)
+		*out = new(ConfigValue)
 		**out = **in
 	}
 	in.ParameterStringSchema.DeepCopyInto(&out.ParameterStringSchema)
@@ -1029,7 +1029,7 @@ func (in *StepExecuteWorkflow) DeepCopyInto(out *StepExecuteWorkflow) {
 	}
 	if in.Config != nil {
 		in, out := &in.Config, &out.Config
-		*out = make(map[string]intstr.IntOrString, len(*in))
+		*out = make(map[string]ConfigValue, len(*in))
 		for key, val := range *in {
 			(*out)[key] = val
 		}
@@ -1347,7 +1347,7 @@ func (in *TemplateRef) DeepCopyInto(out *TemplateRef) {
 	*out = *in
 	if in.Config != nil {
 		in, out := &in.Config, &out.Config
-		*out = make(map[string]intstr.IntOrString, len(*in))
+		*out = make(map[string]ConfigValue, len(*in))
 		for key, val := range *in {
 			(*out)[key] = val
 		}
@@ -1599,7 +1599,7 @@ func (in *TestWorkflowExecutionRequest) DeepCopyInto(out *TestWorkflowExecutionR
 	*out = *in
 	if in.Config != nil {
 		in, out := &in.Config, &out.Config
-		*out = make(map[string]intstr.IntOrString, len(*in))
+		*out = make(map[string]ConfigValue, len(*in))
 		for key, val := range *in {
 			(*out)[key] = val
 		}

--- a/api/testworkflows/v1/zz_generated.deepcopy.go
+++ b/api/testworkflows/v1/zz_generated.deepcopy.go
@@ -270,7 +270,7 @@ func (in *CronJobConfig) DeepCopyInto(out *CronJobConfig) {
 	}
 	if in.Config != nil {
 		in, out := &in.Config, &out.Config
-		*out = make(map[string]intstr.IntOrString, len(*in))
+		*out = make(map[string]ConfigValue, len(*in))
 		for key, val := range *in {
 			(*out)[key] = val
 		}
@@ -572,12 +572,12 @@ func (in *ParameterSchema) DeepCopyInto(out *ParameterSchema) {
 	}
 	if in.Example != nil {
 		in, out := &in.Example, &out.Example
-		*out = new(intstr.IntOrString)
+		*out = new(ConfigValue)
 		**out = **in
 	}
 	if in.Default != nil {
 		in, out := &in.Default, &out.Default
-		*out = new(intstr.IntOrString)
+		*out = new(ConfigValue)
 		**out = **in
 	}
 	in.ParameterStringSchema.DeepCopyInto(&out.ParameterStringSchema)
@@ -1074,7 +1074,7 @@ func (in *StepExecuteWorkflow) DeepCopyInto(out *StepExecuteWorkflow) {
 	}
 	if in.Config != nil {
 		in, out := &in.Config, &out.Config
-		*out = make(map[string]intstr.IntOrString, len(*in))
+		*out = make(map[string]ConfigValue, len(*in))
 		for key, val := range *in {
 			(*out)[key] = val
 		}
@@ -1399,7 +1399,7 @@ func (in *TemplateRef) DeepCopyInto(out *TemplateRef) {
 	*out = *in
 	if in.Config != nil {
 		in, out := &in.Config, &out.Config
-		*out = make(map[string]intstr.IntOrString, len(*in))
+		*out = make(map[string]ConfigValue, len(*in))
 		for key, val := range *in {
 			(*out)[key] = val
 		}
@@ -1651,7 +1651,7 @@ func (in *TestWorkflowExecutionRequest) DeepCopyInto(out *TestWorkflowExecutionR
 	*out = *in
 	if in.Config != nil {
 		in, out := &in.Config, &out.Config
-		*out = make(map[string]intstr.IntOrString, len(*in))
+		*out = make(map[string]ConfigValue, len(*in))
 		for key, val := range *in {
 			(*out)[key] = val
 		}

--- a/cmd/tcl/testworkflow-toolkit/commands/execute_test.go
+++ b/cmd/tcl/testworkflow-toolkit/commands/execute_test.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"k8s.io/apimachinery/pkg/util/intstr"
 
 	testworkflowsv1 "github.com/kubeshop/testkube/api/testworkflows/v1"
 	"github.com/kubeshop/testkube/pkg/executiondata"
@@ -26,8 +25,8 @@ import (
 func TestDeferredSpecFinalization(t *testing.T) {
 	spec := &testworkflowsv1.StepExecuteWorkflow{
 		Name: "consumer",
-		Config: map[string]intstr.IntOrString{
-			"token": intstr.FromString(`{{ execution("p").outputs.token }}`),
+		Config: map[string]testworkflowsv1.ConfigValue{
+			"token": `{{ execution("p").outputs.token }}`,
 		},
 	}
 
@@ -50,7 +49,7 @@ func TestDeferredSpecFinalization(t *testing.T) {
 
 		workflow := *spec.DeepCopy()
 		require.NoError(t, expressions.Finalize(&workflow, machine))
-		assert.Equal(t, "abc123", workflow.Config["token"].StrVal)
+		assert.Equal(t, testworkflowsv1.ConfigValue("abc123"), workflow.Config["token"])
 	})
 }
 
@@ -65,8 +64,8 @@ func TestDeferredSpecFinalization(t *testing.T) {
 func TestWithheldOutputStopsTheExecution(t *testing.T) {
 	spec := &testworkflowsv1.StepExecuteWorkflow{
 		Name: "consumer",
-		Config: map[string]intstr.IntOrString{
-			"token": intstr.FromString(`{{ execution("p").outputs.token }}`),
+		Config: map[string]testworkflowsv1.ConfigValue{
+			"token": `{{ execution("p").outputs.token }}`,
 		},
 	}
 
@@ -85,7 +84,7 @@ func TestWithheldOutputStopsTheExecution(t *testing.T) {
 
 	markers := executiondata.WithheldMarkersIn(&workflow)
 	require.Len(t, markers, 1, "the marker reaches the configuration of the scheduled execution")
-	assert.NotEmpty(t, workflow.Config["token"].StrVal,
+	assert.NotEmpty(t, workflow.Config["token"].String(),
 		"the consumer must not resolve a withheld output to an empty value")
 
 	err := executiondata.WithheldError("this execution", markers)

--- a/k8s/crd/testworkflows.testkube.io_testworkflows.yaml
+++ b/k8s/crd/testworkflows.testkube.io_testworkflows.yaml
@@ -3429,10 +3429,10 @@ spec:
                   additionalProperties:
                     properties:
                       default:
+                        description: default value - if not provided, the parameter is required
                         anyOf:
                           - type: integer
                           - type: string
-                        description: default value - if not provided, the parameter is required
                         x-kubernetes-int-or-string: true
                       description:
                         description: parameter description
@@ -3443,10 +3443,10 @@ spec:
                           type: string
                         type: array
                       example:
+                        description: exemplary value
                         anyOf:
                           - type: integer
                           - type: string
-                        description: exemplary value
                         x-kubernetes-int-or-string: true
                       exclusiveMaximum:
                         description: maximum value for the number (exclusive)

--- a/k8s/crd/testworkflows.testkube.io_testworkflows.yaml
+++ b/k8s/crd/testworkflows.testkube.io_testworkflows.yaml
@@ -3533,10 +3533,10 @@ spec:
                   additionalProperties:
                     properties:
                       default:
+                        description: default value - if not provided, the parameter is required
                         anyOf:
                           - type: integer
                           - type: string
-                        description: default value - if not provided, the parameter is required
                         x-kubernetes-int-or-string: true
                       description:
                         description: parameter description
@@ -3547,10 +3547,10 @@ spec:
                           type: string
                         type: array
                       example:
+                        description: exemplary value
                         anyOf:
                           - type: integer
                           - type: string
-                        description: exemplary value
                         x-kubernetes-int-or-string: true
                       exclusiveMaximum:
                         description: maximum value for the number (exclusive)

--- a/k8s/crd/testworkflows.testkube.io_testworkflowtemplates.yaml
+++ b/k8s/crd/testworkflows.testkube.io_testworkflowtemplates.yaml
@@ -3307,10 +3307,10 @@ spec:
                   additionalProperties:
                     properties:
                       default:
+                        description: default value - if not provided, the parameter is required
                         anyOf:
                           - type: integer
                           - type: string
-                        description: default value - if not provided, the parameter is required
                         x-kubernetes-int-or-string: true
                       description:
                         description: parameter description
@@ -3321,10 +3321,10 @@ spec:
                           type: string
                         type: array
                       example:
+                        description: exemplary value
                         anyOf:
                           - type: integer
                           - type: string
-                        description: exemplary value
                         x-kubernetes-int-or-string: true
                       exclusiveMaximum:
                         description: maximum value for the number (exclusive)

--- a/k8s/crd/testworkflows.testkube.io_testworkflowtemplates.yaml
+++ b/k8s/crd/testworkflows.testkube.io_testworkflowtemplates.yaml
@@ -3411,10 +3411,10 @@ spec:
                   additionalProperties:
                     properties:
                       default:
+                        description: default value - if not provided, the parameter is required
                         anyOf:
                           - type: integer
                           - type: string
-                        description: default value - if not provided, the parameter is required
                         x-kubernetes-int-or-string: true
                       description:
                         description: parameter description
@@ -3425,10 +3425,10 @@ spec:
                           type: string
                         type: array
                       example:
+                        description: exemplary value
                         anyOf:
                           - type: integer
                           - type: string
-                        description: exemplary value
                         x-kubernetes-int-or-string: true
                       exclusiveMaximum:
                         description: maximum value for the number (exclusive)

--- a/k8s/helm/testkube-crds/templates/_generated_crds.tpl
+++ b/k8s/helm/testkube-crds/templates/_generated_crds.tpl
@@ -11439,10 +11439,10 @@ spec:
                   additionalProperties:
                     properties:
                       default:
+                        description: default value - if not provided, the parameter is required
                         anyOf:
                           - type: integer
                           - type: string
-                        description: default value - if not provided, the parameter is required
                         x-kubernetes-int-or-string: true
                       description:
                         description: parameter description
@@ -11453,10 +11453,10 @@ spec:
                           type: string
                         type: array
                       example:
+                        description: exemplary value
                         anyOf:
                           - type: integer
                           - type: string
-                        description: exemplary value
                         x-kubernetes-int-or-string: true
                       exclusiveMaximum:
                         description: maximum value for the number (exclusive)
@@ -23918,10 +23918,10 @@ spec:
                   additionalProperties:
                     properties:
                       default:
+                        description: default value - if not provided, the parameter is required
                         anyOf:
                           - type: integer
                           - type: string
-                        description: default value - if not provided, the parameter is required
                         x-kubernetes-int-or-string: true
                       description:
                         description: parameter description
@@ -23932,10 +23932,10 @@ spec:
                           type: string
                         type: array
                       example:
+                        description: exemplary value
                         anyOf:
                           - type: integer
                           - type: string
-                        description: exemplary value
                         x-kubernetes-int-or-string: true
                       exclusiveMaximum:
                         description: maximum value for the number (exclusive)

--- a/k8s/helm/testkube-crds/templates/_generated_crds.tpl
+++ b/k8s/helm/testkube-crds/templates/_generated_crds.tpl
@@ -11617,10 +11617,10 @@ spec:
                   additionalProperties:
                     properties:
                       default:
+                        description: default value - if not provided, the parameter is required
                         anyOf:
                           - type: integer
                           - type: string
-                        description: default value - if not provided, the parameter is required
                         x-kubernetes-int-or-string: true
                       description:
                         description: parameter description
@@ -11631,10 +11631,10 @@ spec:
                           type: string
                         type: array
                       example:
+                        description: exemplary value
                         anyOf:
                           - type: integer
                           - type: string
-                        description: exemplary value
                         x-kubernetes-int-or-string: true
                       exclusiveMaximum:
                         description: maximum value for the number (exclusive)
@@ -24463,10 +24463,10 @@ spec:
                   additionalProperties:
                     properties:
                       default:
+                        description: default value - if not provided, the parameter is required
                         anyOf:
                           - type: integer
                           - type: string
-                        description: default value - if not provided, the parameter is required
                         x-kubernetes-int-or-string: true
                       description:
                         description: parameter description
@@ -24477,10 +24477,10 @@ spec:
                           type: string
                         type: array
                       example:
+                        description: exemplary value
                         anyOf:
                           - type: integer
                           - type: string
-                        description: exemplary value
                         x-kubernetes-int-or-string: true
                       exclusiveMaximum:
                         description: maximum value for the number (exclusive)

--- a/k8s/helm/testkube-operator/charts/testkube-crds/templates/_generated_crds.tpl
+++ b/k8s/helm/testkube-operator/charts/testkube-crds/templates/_generated_crds.tpl
@@ -11439,10 +11439,10 @@ spec:
                   additionalProperties:
                     properties:
                       default:
+                        description: default value - if not provided, the parameter is required
                         anyOf:
                           - type: integer
                           - type: string
-                        description: default value - if not provided, the parameter is required
                         x-kubernetes-int-or-string: true
                       description:
                         description: parameter description
@@ -11453,10 +11453,10 @@ spec:
                           type: string
                         type: array
                       example:
+                        description: exemplary value
                         anyOf:
                           - type: integer
                           - type: string
-                        description: exemplary value
                         x-kubernetes-int-or-string: true
                       exclusiveMaximum:
                         description: maximum value for the number (exclusive)
@@ -23918,10 +23918,10 @@ spec:
                   additionalProperties:
                     properties:
                       default:
+                        description: default value - if not provided, the parameter is required
                         anyOf:
                           - type: integer
                           - type: string
-                        description: default value - if not provided, the parameter is required
                         x-kubernetes-int-or-string: true
                       description:
                         description: parameter description
@@ -23932,10 +23932,10 @@ spec:
                           type: string
                         type: array
                       example:
+                        description: exemplary value
                         anyOf:
                           - type: integer
                           - type: string
-                        description: exemplary value
                         x-kubernetes-int-or-string: true
                       exclusiveMaximum:
                         description: maximum value for the number (exclusive)

--- a/k8s/helm/testkube-operator/charts/testkube-crds/templates/_generated_crds.tpl
+++ b/k8s/helm/testkube-operator/charts/testkube-crds/templates/_generated_crds.tpl
@@ -11617,10 +11617,10 @@ spec:
                   additionalProperties:
                     properties:
                       default:
+                        description: default value - if not provided, the parameter is required
                         anyOf:
                           - type: integer
                           - type: string
-                        description: default value - if not provided, the parameter is required
                         x-kubernetes-int-or-string: true
                       description:
                         description: parameter description
@@ -11631,10 +11631,10 @@ spec:
                           type: string
                         type: array
                       example:
+                        description: exemplary value
                         anyOf:
                           - type: integer
                           - type: string
-                        description: exemplary value
                         x-kubernetes-int-or-string: true
                       exclusiveMaximum:
                         description: maximum value for the number (exclusive)
@@ -24463,10 +24463,10 @@ spec:
                   additionalProperties:
                     properties:
                       default:
+                        description: default value - if not provided, the parameter is required
                         anyOf:
                           - type: integer
                           - type: string
-                        description: default value - if not provided, the parameter is required
                         x-kubernetes-int-or-string: true
                       description:
                         description: parameter description
@@ -24477,10 +24477,10 @@ spec:
                           type: string
                         type: array
                       example:
+                        description: exemplary value
                         anyOf:
                           - type: integer
                           - type: string
-                        description: exemplary value
                         x-kubernetes-int-or-string: true
                       exclusiveMaximum:
                         description: maximum value for the number (exclusive)

--- a/k8s/helm/testkube-runner/charts/testkube-crds/templates/_generated_crds.tpl
+++ b/k8s/helm/testkube-runner/charts/testkube-crds/templates/_generated_crds.tpl
@@ -11439,10 +11439,10 @@ spec:
                   additionalProperties:
                     properties:
                       default:
+                        description: default value - if not provided, the parameter is required
                         anyOf:
                           - type: integer
                           - type: string
-                        description: default value - if not provided, the parameter is required
                         x-kubernetes-int-or-string: true
                       description:
                         description: parameter description
@@ -11453,10 +11453,10 @@ spec:
                           type: string
                         type: array
                       example:
+                        description: exemplary value
                         anyOf:
                           - type: integer
                           - type: string
-                        description: exemplary value
                         x-kubernetes-int-or-string: true
                       exclusiveMaximum:
                         description: maximum value for the number (exclusive)
@@ -23918,10 +23918,10 @@ spec:
                   additionalProperties:
                     properties:
                       default:
+                        description: default value - if not provided, the parameter is required
                         anyOf:
                           - type: integer
                           - type: string
-                        description: default value - if not provided, the parameter is required
                         x-kubernetes-int-or-string: true
                       description:
                         description: parameter description
@@ -23932,10 +23932,10 @@ spec:
                           type: string
                         type: array
                       example:
+                        description: exemplary value
                         anyOf:
                           - type: integer
                           - type: string
-                        description: exemplary value
                         x-kubernetes-int-or-string: true
                       exclusiveMaximum:
                         description: maximum value for the number (exclusive)

--- a/k8s/helm/testkube-runner/charts/testkube-crds/templates/_generated_crds.tpl
+++ b/k8s/helm/testkube-runner/charts/testkube-crds/templates/_generated_crds.tpl
@@ -11617,10 +11617,10 @@ spec:
                   additionalProperties:
                     properties:
                       default:
+                        description: default value - if not provided, the parameter is required
                         anyOf:
                           - type: integer
                           - type: string
-                        description: default value - if not provided, the parameter is required
                         x-kubernetes-int-or-string: true
                       description:
                         description: parameter description
@@ -11631,10 +11631,10 @@ spec:
                           type: string
                         type: array
                       example:
+                        description: exemplary value
                         anyOf:
                           - type: integer
                           - type: string
-                        description: exemplary value
                         x-kubernetes-int-or-string: true
                       exclusiveMaximum:
                         description: maximum value for the number (exclusive)
@@ -24463,10 +24463,10 @@ spec:
                   additionalProperties:
                     properties:
                       default:
+                        description: default value - if not provided, the parameter is required
                         anyOf:
                           - type: integer
                           - type: string
-                        description: default value - if not provided, the parameter is required
                         x-kubernetes-int-or-string: true
                       description:
                         description: parameter description
@@ -24477,10 +24477,10 @@ spec:
                           type: string
                         type: array
                       example:
+                        description: exemplary value
                         anyOf:
                           - type: integer
                           - type: string
-                        description: exemplary value
                         x-kubernetes-int-or-string: true
                       exclusiveMaximum:
                         description: maximum value for the number (exclusive)

--- a/pkg/expressions/generic.go
+++ b/pkg/expressions/generic.go
@@ -38,8 +38,11 @@ func hasUnexportedFields(v reflect.Value) bool {
 
 func clone(v reflect.Value) reflect.Value {
 	if v.Kind() == reflect.String {
-		s := v.String()
-		return reflect.ValueOf(&s).Elem()
+		// Keep the named type, so the caller can assign the clone
+		// back into a typed map or slice.
+		r := reflect.New(v.Type()).Elem()
+		r.SetString(v.String())
+		return r
 	} else if v.Kind() == reflect.Struct {
 		r := reflect.New(v.Type()).Elem()
 		t := v.Type()

--- a/pkg/mapper/testworkflows/kube_openapi.go
+++ b/pkg/mapper/testworkflows/kube_openapi.go
@@ -422,8 +422,8 @@ func MapLocalObjectReferenceKubeToAPI(v corev1.LocalObjectReference) testkube.Lo
 	return testkube.LocalObjectReference{Name: v.Name}
 }
 
-func MapConfigValueKubeToAPI(v map[string]intstr.IntOrString) map[string]string {
-	return common.MapMap(v, MapIntOrStringToString)
+func MapConfigValueKubeToAPI(v map[string]testworkflowsv1.ConfigValue) map[string]string {
+	return common.MapMap(v, testworkflowsv1.ConfigValue.String)
 }
 
 func MapParameterTypeKubeToAPI(v testworkflowsv1.ParameterType) *testkube.TestWorkflowParameterType {
@@ -470,8 +470,8 @@ func MapParameterSchemaKubeToAPI(v testworkflowsv1.ParameterSchema) testkube.Tes
 		Description:      v.Description,
 		Type_:            MapParameterTypeKubeToAPI(v.Type),
 		Enum:             v.Enum,
-		Example:          common.ResolvePtr(common.MapPtr(v.Example, MapIntOrStringToString), ""),
-		Default_:         MapStringToBoxedString(MapIntOrStringPtrToStringPtr(v.Default)),
+		Example:          common.ResolvePtr(common.MapPtr(v.Example, testworkflowsv1.ConfigValue.String), ""),
+		Default_:         MapStringTypeToBoxedString(v.Default),
 		Format:           v.Format,
 		Pattern:          v.Pattern,
 		MinLength:        MapInt64ToBoxedInteger(v.MinLength),

--- a/pkg/mapper/testworkflows/kube_openapi.go
+++ b/pkg/mapper/testworkflows/kube_openapi.go
@@ -422,8 +422,8 @@ func MapLocalObjectReferenceKubeToAPI(v corev1.LocalObjectReference) testkube.Lo
 	return testkube.LocalObjectReference{Name: v.Name}
 }
 
-func MapConfigValueKubeToAPI(v map[string]intstr.IntOrString) map[string]string {
-	return common.MapMap(v, MapIntOrStringToString)
+func MapConfigValueKubeToAPI(v map[string]testworkflowsv1.ConfigValue) map[string]string {
+	return common.MapMap(v, testworkflowsv1.ConfigValue.String)
 }
 
 func MapParameterTypeKubeToAPI(v testworkflowsv1.ParameterType) *testkube.TestWorkflowParameterType {
@@ -452,8 +452,8 @@ func MapParameterSchemaKubeToAPI(v testworkflowsv1.ParameterSchema) testkube.Tes
 		Description:      v.Description,
 		Type_:            MapParameterTypeKubeToAPI(v.Type),
 		Enum:             v.Enum,
-		Example:          common.ResolvePtr(common.MapPtr(v.Example, MapIntOrStringToString), ""),
-		Default_:         MapStringToBoxedString(MapIntOrStringPtrToStringPtr(v.Default)),
+		Example:          common.ResolvePtr(common.MapPtr(v.Example, testworkflowsv1.ConfigValue.String), ""),
+		Default_:         MapStringTypeToBoxedString(v.Default),
 		Format:           v.Format,
 		Pattern:          v.Pattern,
 		MinLength:        MapInt64ToBoxedInteger(v.MinLength),

--- a/pkg/mapper/testworkflows/mappers_test.go
+++ b/pkg/mapper/testworkflows/mappers_test.go
@@ -250,8 +250,8 @@ var (
 			Workflows: []testworkflowsv1.StepExecuteWorkflow{{
 				Name: "some-workflow",
 				As:   "some-alias",
-				Config: map[string]intstr.IntOrString{
-					"id": {Type: intstr.String, StrVal: "xyzz"},
+				Config: map[string]testworkflowsv1.ConfigValue{
+					"id": "xyzz",
 				},
 				Fetch: []testworkflowsv1.StepExecuteFetch{{
 					From:  "some-alias",
@@ -274,14 +274,14 @@ var (
 		StepOperations: stepBaseOperations,
 		StepDefaults:   stepBaseDefaults,
 		Use: []testworkflowsv1.TemplateRef{
-			{Name: "/abc", Config: map[string]intstr.IntOrString{
-				"xxx": {Type: intstr.Int, IntVal: 322},
+			{Name: "/abc", Config: map[string]testworkflowsv1.ConfigValue{
+				"xxx": "322",
 			}},
 		},
 		Template: &testworkflowsv1.TemplateRef{
 			Name: "other-one",
-			Config: map[string]intstr.IntOrString{
-				"foo": {Type: intstr.String, StrVal: "bar"},
+			Config: map[string]testworkflowsv1.ConfigValue{
+				"foo": "bar",
 			},
 		},
 		Steps: []testworkflowsv1.Step{
@@ -304,14 +304,8 @@ var (
 				Description: "some-description",
 				Type:        "integer",
 				Enum:        []string{"en", "um"},
-				Example: &intstr.IntOrString{
-					Type:   intstr.String,
-					StrVal: "some-vale",
-				},
-				Default: &intstr.IntOrString{
-					Type:   intstr.Int,
-					IntVal: 233,
-				},
+				Example:     testworkflowsv1.NewConfigValue("some-vale"),
+				Default:     testworkflowsv1.NewConfigValue("233"),
 				ParameterStringSchema: testworkflowsv1.ParameterStringSchema{
 					Format:    "url",
 					Pattern:   "^abc$",
@@ -374,9 +368,9 @@ func TestMapTestWorkflowBackAndForth(t *testing.T) {
 			Use: []testworkflowsv1.TemplateRef{
 				{
 					Name: "some-name",
-					Config: map[string]intstr.IntOrString{
-						"some-key":   {Type: intstr.String, StrVal: "some-value"},
-						"some-key-2": {Type: intstr.Int, IntVal: 444},
+					Config: map[string]testworkflowsv1.ConfigValue{
+						"some-key":   "some-value",
+						"some-key-2": "444",
 					},
 				},
 			},

--- a/pkg/mapper/testworkflows/mappers_test.go
+++ b/pkg/mapper/testworkflows/mappers_test.go
@@ -247,8 +247,8 @@ var (
 			Parallelism: 880,
 			Async:       false,
 			Tests:       []testworkflowsv1.StepExecuteTest{{Name: "some-name-test"}},
-			Workflows: []testworkflowsv1.StepExecuteWorkflow{{Name: "some-workflow", Config: map[string]intstr.IntOrString{
-				"id": {Type: intstr.String, StrVal: "xyzz"},
+			Workflows: []testworkflowsv1.StepExecuteWorkflow{{Name: "some-workflow", Config: map[string]testworkflowsv1.ConfigValue{
+				"id": "xyzz",
 			}}},
 		},
 		Artifacts: &testworkflowsv1.StepArtifacts{
@@ -265,14 +265,14 @@ var (
 		StepOperations: stepBaseOperations,
 		StepDefaults:   stepBaseDefaults,
 		Use: []testworkflowsv1.TemplateRef{
-			{Name: "/abc", Config: map[string]intstr.IntOrString{
-				"xxx": {Type: intstr.Int, IntVal: 322},
+			{Name: "/abc", Config: map[string]testworkflowsv1.ConfigValue{
+				"xxx": "322",
 			}},
 		},
 		Template: &testworkflowsv1.TemplateRef{
 			Name: "other-one",
-			Config: map[string]intstr.IntOrString{
-				"foo": {Type: intstr.String, StrVal: "bar"},
+			Config: map[string]testworkflowsv1.ConfigValue{
+				"foo": "bar",
 			},
 		},
 		Steps: []testworkflowsv1.Step{
@@ -295,14 +295,8 @@ var (
 				Description: "some-description",
 				Type:        "integer",
 				Enum:        []string{"en", "um"},
-				Example: &intstr.IntOrString{
-					Type:   intstr.String,
-					StrVal: "some-vale",
-				},
-				Default: &intstr.IntOrString{
-					Type:   intstr.Int,
-					IntVal: 233,
-				},
+				Example:     testworkflowsv1.NewConfigValue("some-vale"),
+				Default:     testworkflowsv1.NewConfigValue("233"),
 				ParameterStringSchema: testworkflowsv1.ParameterStringSchema{
 					Format:    "url",
 					Pattern:   "^abc$",
@@ -365,9 +359,9 @@ func TestMapTestWorkflowBackAndForth(t *testing.T) {
 			Use: []testworkflowsv1.TemplateRef{
 				{
 					Name: "some-name",
-					Config: map[string]intstr.IntOrString{
-						"some-key":   {Type: intstr.String, StrVal: "some-value"},
-						"some-key-2": {Type: intstr.Int, IntVal: 444},
+					Config: map[string]testworkflowsv1.ConfigValue{
+						"some-key":   "some-value",
+						"some-key-2": "444",
 					},
 				},
 			},

--- a/pkg/mapper/testworkflows/openapi_kube.go
+++ b/pkg/mapper/testworkflows/openapi_kube.go
@@ -48,6 +48,17 @@ func MapStringPtrToIntOrStringPtr(i *string) *intstr.IntOrString {
 	return common.Ptr(MapStringToIntOrString(*i))
 }
 
+func MapStringToConfigValue(v string) testworkflowsv1.ConfigValue {
+	return testworkflowsv1.ConfigValue(v)
+}
+
+func MapBoxedStringToConfigValue(v *testkube.BoxedString) *testworkflowsv1.ConfigValue {
+	if v == nil {
+		return nil
+	}
+	return testworkflowsv1.NewConfigValue(v.Value)
+}
+
 func MapBoxedStringToString(v *testkube.BoxedString) *string {
 	if v == nil {
 		return nil
@@ -238,8 +249,8 @@ func MapLocalObjectReferenceAPIToKube(v testkube.LocalObjectReference) corev1.Lo
 	return corev1.LocalObjectReference{Name: v.Name}
 }
 
-func MapConfigValueAPIToKube(v map[string]string) map[string]intstr.IntOrString {
-	return common.MapMap(v, MapStringToIntOrString)
+func MapConfigValueAPIToKube(v map[string]string) map[string]testworkflowsv1.ConfigValue {
+	return common.MapMap(v, MapStringToConfigValue)
 }
 
 func MapParameterTypeAPIToKube(v *testkube.TestWorkflowParameterType) testworkflowsv1.ParameterType {
@@ -279,16 +290,16 @@ func MapTimeoutsAPIToKube(v testkube.TestWorkflowTimeouts) testworkflowsv1.TestW
 }
 
 func MapParameterSchemaAPIToKube(v testkube.TestWorkflowParameterSchema) testworkflowsv1.ParameterSchema {
-	var example *intstr.IntOrString
+	var example *testworkflowsv1.ConfigValue
 	if v.Example != "" {
-		example = common.Ptr(MapStringToIntOrString(v.Example))
+		example = testworkflowsv1.NewConfigValue(v.Example)
 	}
 	return testworkflowsv1.ParameterSchema{
 		Description: v.Description,
 		Type:        MapParameterTypeAPIToKube(v.Type_),
 		Enum:        v.Enum,
 		Example:     example,
-		Default:     MapStringPtrToIntOrStringPtr(MapBoxedStringToString(v.Default_)),
+		Default:     MapBoxedStringToConfigValue(v.Default_),
 		ParameterStringSchema: testworkflowsv1.ParameterStringSchema{
 			Format:    v.Format,
 			Pattern:   v.Pattern,

--- a/pkg/mapper/testworkflows/openapi_kube.go
+++ b/pkg/mapper/testworkflows/openapi_kube.go
@@ -48,6 +48,17 @@ func MapStringPtrToIntOrStringPtr(i *string) *intstr.IntOrString {
 	return common.Ptr(MapStringToIntOrString(*i))
 }
 
+func MapStringToConfigValue(v string) testworkflowsv1.ConfigValue {
+	return testworkflowsv1.ConfigValue(v)
+}
+
+func MapBoxedStringToConfigValue(v *testkube.BoxedString) *testworkflowsv1.ConfigValue {
+	if v == nil {
+		return nil
+	}
+	return testworkflowsv1.NewConfigValue(v.Value)
+}
+
 func MapBoxedStringToString(v *testkube.BoxedString) *string {
 	if v == nil {
 		return nil
@@ -238,8 +249,8 @@ func MapLocalObjectReferenceAPIToKube(v testkube.LocalObjectReference) corev1.Lo
 	return corev1.LocalObjectReference{Name: v.Name}
 }
 
-func MapConfigValueAPIToKube(v map[string]string) map[string]intstr.IntOrString {
-	return common.MapMap(v, MapStringToIntOrString)
+func MapConfigValueAPIToKube(v map[string]string) map[string]testworkflowsv1.ConfigValue {
+	return common.MapMap(v, MapStringToConfigValue)
 }
 
 func MapParameterTypeAPIToKube(v *testkube.TestWorkflowParameterType) testworkflowsv1.ParameterType {
@@ -297,16 +308,16 @@ func MapTimeoutsAPIToKube(v testkube.TestWorkflowTimeouts) testworkflowsv1.TestW
 }
 
 func MapParameterSchemaAPIToKube(v testkube.TestWorkflowParameterSchema) testworkflowsv1.ParameterSchema {
-	var example *intstr.IntOrString
+	var example *testworkflowsv1.ConfigValue
 	if v.Example != "" {
-		example = common.Ptr(MapStringToIntOrString(v.Example))
+		example = testworkflowsv1.NewConfigValue(v.Example)
 	}
 	return testworkflowsv1.ParameterSchema{
 		Description: v.Description,
 		Type:        MapParameterTypeAPIToKube(v.Type_),
 		Enum:        v.Enum,
 		Example:     example,
-		Default:     MapStringPtrToIntOrStringPtr(MapBoxedStringToString(v.Default_)),
+		Default:     MapBoxedStringToConfigValue(v.Default_),
 		ParameterStringSchema: testworkflowsv1.ParameterStringSchema{
 			Format:    v.Format,
 			Pattern:   v.Pattern,

--- a/pkg/testworkflows/testworkflowprocessor/presets/processor_test.go
+++ b/pkg/testworkflows/testworkflowprocessor/presets/processor_test.go
@@ -4,12 +4,12 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
 
 	"k8s.io/apimachinery/pkg/api/resource"
-	"k8s.io/apimachinery/pkg/util/intstr"
 
 	"github.com/stretchr/testify/assert"
 	batchv1 "k8s.io/api/batch/v1"
@@ -130,8 +130,8 @@ func getSpec(actions actiontypes.ActionGroups) string {
 	return string(v)
 }
 
-func workflowInt(v int32) *intstr.IntOrString {
-	return &intstr.IntOrString{Type: intstr.Int, IntVal: v}
+func workflowInt(v int) *testworkflowsv1.ConfigValue {
+	return testworkflowsv1.NewConfigValue(strconv.Itoa(v))
 }
 
 func TestProcessEmpty(t *testing.T) {

--- a/pkg/testworkflows/testworkflowresolver/apply.go
+++ b/pkg/testworkflows/testworkflowresolver/apply.go
@@ -13,7 +13,6 @@ import (
 	"reflect"
 
 	"github.com/pkg/errors"
-	"k8s.io/apimachinery/pkg/util/intstr"
 
 	testworkflowsv1 "github.com/kubeshop/testkube/api/testworkflows/v1"
 	"github.com/kubeshop/testkube/internal/common"
@@ -21,7 +20,7 @@ import (
 	"github.com/kubeshop/testkube/pkg/rand"
 )
 
-func buildTemplate(template *testworkflowsv1.TestWorkflowTemplate, cfg map[string]intstr.IntOrString,
+func buildTemplate(template *testworkflowsv1.TestWorkflowTemplate, cfg map[string]testworkflowsv1.ConfigValue,
 	externalize func(key, value string) (expressions.Expression, error)) (*testworkflowsv1.TestWorkflowTemplate, error) {
 	v, err := ApplyWorkflowTemplateConfig(template.DeepCopy(), cfg, externalize)
 	if err != nil {
@@ -44,7 +43,7 @@ func getTemplate(name string, templates map[string]*testworkflowsv1.TestWorkflow
 	return tpl, fmt.Errorf(`template "%s" not found`, name)
 }
 
-func getConfiguredTemplate(name string, cfg map[string]intstr.IntOrString, templates map[string]*testworkflowsv1.TestWorkflowTemplate,
+func getConfiguredTemplate(name string, cfg map[string]testworkflowsv1.ConfigValue, templates map[string]*testworkflowsv1.TestWorkflowTemplate,
 	externalize func(key, value string) (expressions.Expression, error)) (tpl *testworkflowsv1.TestWorkflowTemplate, err error) {
 	tpl, err = getTemplate(name, templates)
 	if err != nil {

--- a/pkg/testworkflows/testworkflowresolver/apply_test.go
+++ b/pkg/testworkflows/testworkflowresolver/apply_test.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/util/intstr"
 
 	testworkflowsv1 "github.com/kubeshop/testkube/api/testworkflows/v1"
 	"github.com/kubeshop/testkube/internal/common"
@@ -118,22 +117,22 @@ var (
 	tplPodRef       = testworkflowsv1.TemplateRef{Name: "pod"}
 	tplPodConfigRef = testworkflowsv1.TemplateRef{
 		Name: "podConfig",
-		Config: map[string]intstr.IntOrString{
-			"department": {Type: intstr.String, StrVal: "test-department"},
+		Config: map[string]testworkflowsv1.ConfigValue{
+			"department": "test-department",
 		},
 	}
 	tplPodConfigRefEmpty = testworkflowsv1.TemplateRef{Name: "podConfig"}
 	tplEnvRef            = testworkflowsv1.TemplateRef{Name: "env"}
 	tplStepsRef          = testworkflowsv1.TemplateRef{Name: "steps"}
 	tplStepsEnvRef       = testworkflowsv1.TemplateRef{Name: "stepsEnv"}
-	tplStepsConfigRef    = testworkflowsv1.TemplateRef{Name: "stepsConfig", Config: map[string]intstr.IntOrString{
-		"index": {Type: intstr.Int, IntVal: 20},
+	tplStepsConfigRef    = testworkflowsv1.TemplateRef{Name: "stepsConfig", Config: map[string]testworkflowsv1.ConfigValue{
+		"index": "20",
 	}}
-	tplStepsConfigRefStringInvalid = testworkflowsv1.TemplateRef{Name: "stepsConfig", Config: map[string]intstr.IntOrString{
-		"index": {Type: intstr.String, StrVal: "text"},
+	tplStepsConfigRefStringInvalid = testworkflowsv1.TemplateRef{Name: "stepsConfig", Config: map[string]testworkflowsv1.ConfigValue{
+		"index": "text",
 	}}
-	tplStepsConfigRefStringValid = testworkflowsv1.TemplateRef{Name: "stepsConfig", Config: map[string]intstr.IntOrString{
-		"index": {Type: intstr.String, StrVal: "10"},
+	tplStepsConfigRefStringValid = testworkflowsv1.TemplateRef{Name: "stepsConfig", Config: map[string]testworkflowsv1.ConfigValue{
+		"index": "10",
 	}}
 	workflowPod = testworkflowsv1.TestWorkflow{
 		Spec: testworkflowsv1.TestWorkflowSpec{
@@ -585,8 +584,8 @@ func TestApplyTemplatesConfigOverflow(t *testing.T) {
 	wf := workflowPod.DeepCopy()
 	wf.Spec.Use = []testworkflowsv1.TemplateRef{{
 		Name: "podConfig",
-		Config: map[string]intstr.IntOrString{
-			"department": {Type: intstr.String, StrVal: "{{config.value}}"},
+		Config: map[string]testworkflowsv1.ConfigValue{
+			"department": "{{config.value}}",
 		},
 	}}
 	err := ApplyTemplates(wf, templates, nil)
@@ -606,7 +605,7 @@ func TestApplyTemplates_ConditionAlways(t *testing.T) {
 					Config: map[string]testworkflowsv1.ParameterSchema{
 						"result": {
 							Type:    testworkflowsv1.ParameterTypeString,
-							Default: &intstr.IntOrString{Type: intstr.String, StrVal: ""},
+							Default: testworkflowsv1.NewConfigValue(""),
 						},
 					},
 				},
@@ -634,8 +633,8 @@ func TestApplyTemplates_ConditionAlways(t *testing.T) {
 				{StepOperations: testworkflowsv1.StepOperations{Shell: "exit 0"}},
 				{Template: &testworkflowsv1.TemplateRef{
 					Name: "example",
-					Config: map[string]intstr.IntOrString{
-						"result": {Type: intstr.String, StrVal: "{{ passed }}"},
+					Config: map[string]testworkflowsv1.ConfigValue{
+						"result": "{{ passed }}",
 					},
 				}},
 			},

--- a/pkg/testworkflows/testworkflowresolver/apply_test.go
+++ b/pkg/testworkflows/testworkflowresolver/apply_test.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/util/intstr"
 
 	testworkflowsv1 "github.com/kubeshop/testkube/api/testworkflows/v1"
 	"github.com/kubeshop/testkube/internal/common"
@@ -118,22 +117,22 @@ var (
 	tplPodRef       = testworkflowsv1.TemplateRef{Name: "pod"}
 	tplPodConfigRef = testworkflowsv1.TemplateRef{
 		Name: "podConfig",
-		Config: map[string]intstr.IntOrString{
-			"department": {Type: intstr.String, StrVal: "test-department"},
+		Config: map[string]testworkflowsv1.ConfigValue{
+			"department": "test-department",
 		},
 	}
 	tplPodConfigRefEmpty = testworkflowsv1.TemplateRef{Name: "podConfig"}
 	tplEnvRef            = testworkflowsv1.TemplateRef{Name: "env"}
 	tplStepsRef          = testworkflowsv1.TemplateRef{Name: "steps"}
 	tplStepsEnvRef       = testworkflowsv1.TemplateRef{Name: "stepsEnv"}
-	tplStepsConfigRef    = testworkflowsv1.TemplateRef{Name: "stepsConfig", Config: map[string]intstr.IntOrString{
-		"index": {Type: intstr.Int, IntVal: 20},
+	tplStepsConfigRef    = testworkflowsv1.TemplateRef{Name: "stepsConfig", Config: map[string]testworkflowsv1.ConfigValue{
+		"index": "20",
 	}}
-	tplStepsConfigRefStringInvalid = testworkflowsv1.TemplateRef{Name: "stepsConfig", Config: map[string]intstr.IntOrString{
-		"index": {Type: intstr.String, StrVal: "text"},
+	tplStepsConfigRefStringInvalid = testworkflowsv1.TemplateRef{Name: "stepsConfig", Config: map[string]testworkflowsv1.ConfigValue{
+		"index": "text",
 	}}
-	tplStepsConfigRefStringValid = testworkflowsv1.TemplateRef{Name: "stepsConfig", Config: map[string]intstr.IntOrString{
-		"index": {Type: intstr.String, StrVal: "10"},
+	tplStepsConfigRefStringValid = testworkflowsv1.TemplateRef{Name: "stepsConfig", Config: map[string]testworkflowsv1.ConfigValue{
+		"index": "10",
 	}}
 	workflowPod = testworkflowsv1.TestWorkflow{
 		Spec: testworkflowsv1.TestWorkflowSpec{
@@ -737,8 +736,8 @@ func TestApplyTemplatesConfigOverflow(t *testing.T) {
 	wf := workflowPod.DeepCopy()
 	wf.Spec.Use = []testworkflowsv1.TemplateRef{{
 		Name: "podConfig",
-		Config: map[string]intstr.IntOrString{
-			"department": {Type: intstr.String, StrVal: "{{config.value}}"},
+		Config: map[string]testworkflowsv1.ConfigValue{
+			"department": "{{config.value}}",
 		},
 	}}
 	err := ApplyTemplates(wf, templates, nil)
@@ -758,7 +757,7 @@ func TestApplyTemplates_ConditionAlways(t *testing.T) {
 					Config: map[string]testworkflowsv1.ParameterSchema{
 						"result": {
 							Type:    testworkflowsv1.ParameterTypeString,
-							Default: &intstr.IntOrString{Type: intstr.String, StrVal: ""},
+							Default: testworkflowsv1.NewConfigValue(""),
 						},
 					},
 				},
@@ -786,8 +785,8 @@ func TestApplyTemplates_ConditionAlways(t *testing.T) {
 				{StepOperations: testworkflowsv1.StepOperations{Shell: "exit 0"}},
 				{Template: &testworkflowsv1.TemplateRef{
 					Name: "example",
-					Config: map[string]intstr.IntOrString{
-						"result": {Type: intstr.String, StrVal: "{{ passed }}"},
+					Config: map[string]testworkflowsv1.ConfigValue{
+						"result": "{{ passed }}",
 					},
 				}},
 			},

--- a/pkg/testworkflows/testworkflowresolver/config.go
+++ b/pkg/testworkflows/testworkflowresolver/config.go
@@ -10,11 +10,9 @@ package testworkflowresolver
 
 import (
 	"fmt"
-	"strconv"
 
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/util/intstr"
 
 	testworkflowsv1 "github.com/kubeshop/testkube/api/testworkflows/v1"
 	"github.com/kubeshop/testkube/pkg/expressions"
@@ -22,12 +20,8 @@ import (
 
 var configFinalizer = expressions.PrefixMachine("config.", expressions.FinalizerFail)
 
-func castParameter(value intstr.IntOrString, schema testworkflowsv1.ParameterSchema) (expressions.Expression, error) {
-	v := value.StrVal
-	if value.Type == intstr.Int {
-		v = strconv.Itoa(int(value.IntVal))
-	}
-	expr, err := expressions.CompileTemplate(v)
+func castParameter(value testworkflowsv1.ConfigValue, schema testworkflowsv1.ParameterSchema) (expressions.Expression, error) {
+	expr, err := expressions.CompileTemplate(value.String())
 	if err != nil {
 		return nil, err
 	}
@@ -42,7 +36,7 @@ func castParameter(value intstr.IntOrString, schema testworkflowsv1.ParameterSch
 	return expressions.CastToString(expr).Resolve()
 }
 
-func createConfigMachine(cfg map[string]intstr.IntOrString, schema map[string]testworkflowsv1.ParameterSchema,
+func createConfigMachine(cfg map[string]testworkflowsv1.ConfigValue, schema map[string]testworkflowsv1.ParameterSchema,
 	externalize func(key, value string) (expressions.Expression, error)) (expressions.Machine, error) {
 	machine := expressions.NewMachine()
 	for k, v := range cfg {
@@ -91,7 +85,7 @@ func EnvVarSourceToSecretExpression(fn func(key, value string) (*corev1.EnvVarSo
 	}
 }
 
-func ApplyWorkflowConfig(t *testworkflowsv1.TestWorkflow, cfg map[string]intstr.IntOrString,
+func ApplyWorkflowConfig(t *testworkflowsv1.TestWorkflow, cfg map[string]testworkflowsv1.ConfigValue,
 	externalize func(key, value string) (expressions.Expression, error)) (*testworkflowsv1.TestWorkflow, error) {
 	if t == nil {
 		return t, nil
@@ -104,7 +98,7 @@ func ApplyWorkflowConfig(t *testworkflowsv1.TestWorkflow, cfg map[string]intstr.
 	return t, err
 }
 
-func ApplyWorkflowTemplateConfig(t *testworkflowsv1.TestWorkflowTemplate, cfg map[string]intstr.IntOrString,
+func ApplyWorkflowTemplateConfig(t *testworkflowsv1.TestWorkflowTemplate, cfg map[string]testworkflowsv1.ConfigValue,
 	externalize func(key, value string) (expressions.Expression, error)) (*testworkflowsv1.TestWorkflowTemplate, error) {
 	if t == nil {
 		return t, nil

--- a/pkg/testworkflows/testworkflowresolver/config_test.go
+++ b/pkg/testworkflows/testworkflowresolver/config_test.go
@@ -12,18 +12,17 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"k8s.io/apimachinery/pkg/util/intstr"
 
 	testworkflowsv1 "github.com/kubeshop/testkube/api/testworkflows/v1"
 	"github.com/kubeshop/testkube/internal/common"
 )
 
 func TestApplyConfigTestWorkflow(t *testing.T) {
-	cfg := map[string]intstr.IntOrString{
-		"foo":    {Type: intstr.Int, IntVal: 30},
-		"bar":    {Type: intstr.String, StrVal: "some value"},
-		"baz":    {Type: intstr.String, StrVal: "some {{ 30 }} value"},
-		"foobar": {Type: intstr.String, StrVal: "some {{ unknown(300) }} value"},
+	cfg := map[string]testworkflowsv1.ConfigValue{
+		"foo":    "30",
+		"bar":    "some value",
+		"baz":    "some {{ 30 }} value",
+		"foobar": "some {{ unknown(300) }} value",
 	}
 	want := &testworkflowsv1.TestWorkflow{
 		Description: "{{some description here }}",
@@ -77,10 +76,10 @@ func TestApplyConfigTestWorkflow(t *testing.T) {
 }
 
 func TestApplyMissingConfig(t *testing.T) {
-	cfg := map[string]intstr.IntOrString{
-		"foo":    {Type: intstr.Int, IntVal: 30},
-		"bar":    {Type: intstr.String, StrVal: "some value"},
-		"foobar": {Type: intstr.String, StrVal: "some {{ unknown(300) }} value"},
+	cfg := map[string]testworkflowsv1.ConfigValue{
+		"foo":    "30",
+		"bar":    "some value",
+		"foobar": "some {{ unknown(300) }} value",
 	}
 	_, err := ApplyWorkflowConfig(&testworkflowsv1.TestWorkflow{
 		Description: "{{some description here }}",
@@ -111,17 +110,17 @@ func TestApplyMissingConfig(t *testing.T) {
 }
 
 func TestApplyConfigDefaults(t *testing.T) {
-	cfg := map[string]intstr.IntOrString{
-		"foo":    {Type: intstr.Int, IntVal: 30},
-		"bar":    {Type: intstr.String, StrVal: "some value"},
-		"foobar": {Type: intstr.String, StrVal: "some {{ unknown(300) }} value"},
+	cfg := map[string]testworkflowsv1.ConfigValue{
+		"foo":    "30",
+		"bar":    "some value",
+		"foobar": "some {{ unknown(300) }} value",
 	}
 	want := &testworkflowsv1.TestWorkflow{
 		Description: "{{some description here }}",
 		Spec: testworkflowsv1.TestWorkflowSpec{
 			TestWorkflowSpecBase: testworkflowsv1.TestWorkflowSpecBase{
 				Config: map[string]testworkflowsv1.ParameterSchema{
-					"baz": {Default: &intstr.IntOrString{Type: intstr.String, StrVal: "something"}},
+					"baz": {Default: testworkflowsv1.NewConfigValue("something")},
 				},
 				Pod: &testworkflowsv1.PodConfig{
 					ServiceAccountName: "abra 30",
@@ -146,7 +145,7 @@ func TestApplyConfigDefaults(t *testing.T) {
 		Spec: testworkflowsv1.TestWorkflowSpec{
 			TestWorkflowSpecBase: testworkflowsv1.TestWorkflowSpecBase{
 				Config: map[string]testworkflowsv1.ParameterSchema{
-					"baz": {Default: &intstr.IntOrString{Type: intstr.String, StrVal: "something"}},
+					"baz": {Default: testworkflowsv1.NewConfigValue("something")},
 				},
 				Pod: &testworkflowsv1.PodConfig{
 					ServiceAccountName: "abra {{config.foo}}",
@@ -172,8 +171,8 @@ func TestApplyConfigDefaults(t *testing.T) {
 }
 
 func TestInvalidInteger(t *testing.T) {
-	cfg := map[string]intstr.IntOrString{
-		"foo": {Type: intstr.String, StrVal: "some value"},
+	cfg := map[string]testworkflowsv1.ConfigValue{
+		"foo": "some value",
 	}
 	_, err := ApplyWorkflowConfig(&testworkflowsv1.TestWorkflow{
 		Description: "{{some description here }}",
@@ -195,11 +194,11 @@ func TestInvalidInteger(t *testing.T) {
 }
 
 func TestApplyConfigTestWorkflowTemplate(t *testing.T) {
-	cfg := map[string]intstr.IntOrString{
-		"foo":    {Type: intstr.Int, IntVal: 30},
-		"bar":    {Type: intstr.String, StrVal: "some value"},
-		"baz":    {Type: intstr.String, StrVal: "some {{ 30 }} value"},
-		"foobar": {Type: intstr.String, StrVal: "some {{ unknown(300) }} value"},
+	cfg := map[string]testworkflowsv1.ConfigValue{
+		"foo":    "30",
+		"bar":    "some value",
+		"baz":    "some {{ 30 }} value",
+		"foobar": "some {{ unknown(300) }} value",
 	}
 	want := &testworkflowsv1.TestWorkflowTemplate{
 		Description: "{{some description here }}",
@@ -257,11 +256,11 @@ func TestApplyConfigTestWorkflowTemplateIntegerSecurityContext(t *testing.T) {
 				Config: map[string]testworkflowsv1.ParameterSchema{
 					"runAsUser": {
 						Type:    testworkflowsv1.ParameterTypeInteger,
-						Default: &intstr.IntOrString{Type: intstr.Int, IntVal: 65532},
+						Default: testworkflowsv1.NewConfigValue("65532"),
 					},
 					"runAsGroup": {
 						Type:    testworkflowsv1.ParameterTypeInteger,
-						Default: &intstr.IntOrString{Type: intstr.Int, IntVal: 65532},
+						Default: testworkflowsv1.NewConfigValue("65532"),
 					},
 				},
 				Container: &testworkflowsv1.ContainerConfig{


### PR DESCRIPTION
A TestWorkflow with a numeric `config.default` above the int32 range, for example `873760302410822`, breaks every client that reads the CRD with `intstr.IntOrString`. The whole informer list fails to decode, the agent stops the sync of all workflows, and the UI shows none. (TKC-6402)

How:
- The config fields of the TestWorkflow CRDs (`config.default`, `config.example`, and the `config` maps on template refs, steps, cron jobs, and execution requests) now use a new `ConfigValue` type. The type keeps the raw scalar text, so a number of any size decodes without loss. The CRD schema stays `x-kubernetes-int-or-string`.
- `ConfigValue` emits a JSON number only when the value is a canonical integer in the int32 range. A larger number becomes a string, so an older client that still decodes with `intstr.IntOrString` does not fail on data from a new agent.
- The `clone` helper in the expressions engine now keeps the named type of a string value, so template resolution can write the result back into a `map[string]ConfigValue`.

Resource limits and requests, `count` and `maxCount`, and the service `port` still use `intstr.IntOrString` and have the same failure mode. This change does not cover them.