### PR TITLE
fix: accept large numeric resource values in TestWorkflow CRDs

### DIFF
--- a/api/testworkflows/v1/config_value_test.go
+++ b/api/testworkflows/v1/config_value_test.go
@@ -95,6 +95,23 @@ func TestConfigValue_UnmarshalYAML(t *testing.T) {
 	}
 }
 
+func TestResources_UnmarshalLargeNumericMemory(t *testing.T) {
+	containerJSON := []byte(`{
+		"resources": {
+			"limits": {"memory": 8589934592},
+			"requests": {"cpu": "300m", "memory": 8589934592}
+		}
+	}`)
+
+	var container ContainerConfig
+	err := json.Unmarshal(containerJSON, &container)
+	require.NoError(t, err)
+	require.NotNil(t, container.Resources)
+	assert.Equal(t, ConfigValue("8589934592"), container.Resources.Limits["memory"])
+	assert.Equal(t, ConfigValue("300m"), container.Resources.Requests["cpu"])
+	assert.Equal(t, ConfigValue("8589934592"), container.Resources.Requests["memory"])
+}
+
 func TestTestWorkflow_UnmarshalLargeNumericConfigDefault(t *testing.T) {
 	workflowJSON := []byte(`{
 		"apiVersion": "testworkflows.testkube.io/v1",

--- a/api/testworkflows/v1/types.go
+++ b/api/testworkflows/v1/types.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/util/intstr"
 
 	commonv1 "github.com/kubeshop/testkube/api/common/v1"
 )
@@ -43,10 +42,10 @@ type ContainerConfig struct {
 
 type Resources struct {
 	// resource limits for the container
-	Limits map[corev1.ResourceName]intstr.IntOrString `json:"limits,omitempty" expr:"template,template"`
+	Limits map[corev1.ResourceName]ConfigValue `json:"limits,omitempty" expr:"template,template"`
 
 	// resource requests for the container
-	Requests map[corev1.ResourceName]intstr.IntOrString `json:"requests,omitempty" expr:"template,template"`
+	Requests map[corev1.ResourceName]ConfigValue `json:"requests,omitempty" expr:"template,template"`
 }
 
 type EnvVar struct {

--- a/api/testworkflows/v1/zz_generated.deepcopy.go
+++ b/api/testworkflows/v1/zz_generated.deepcopy.go
@@ -720,14 +720,14 @@ func (in *Resources) DeepCopyInto(out *Resources) {
 	*out = *in
 	if in.Limits != nil {
 		in, out := &in.Limits, &out.Limits
-		*out = make(map[corev1.ResourceName]intstr.IntOrString, len(*in))
+		*out = make(map[corev1.ResourceName]ConfigValue, len(*in))
 		for key, val := range *in {
 			(*out)[key] = val
 		}
 	}
 	if in.Requests != nil {
 		in, out := &in.Requests, &out.Requests
-		*out = make(map[corev1.ResourceName]intstr.IntOrString, len(*in))
+		*out = make(map[corev1.ResourceName]ConfigValue, len(*in))
 		for key, val := range *in {
 			(*out)[key] = val
 		}

--- a/api/testworkflows/v1/zz_generated.deepcopy.go
+++ b/api/testworkflows/v1/zz_generated.deepcopy.go
@@ -745,14 +745,14 @@ func (in *Resources) DeepCopyInto(out *Resources) {
 	*out = *in
 	if in.Limits != nil {
 		in, out := &in.Limits, &out.Limits
-		*out = make(map[corev1.ResourceName]intstr.IntOrString, len(*in))
+		*out = make(map[corev1.ResourceName]ConfigValue, len(*in))
 		for key, val := range *in {
 			(*out)[key] = val
 		}
 	}
 	if in.Requests != nil {
 		in, out := &in.Requests, &out.Requests
-		*out = make(map[corev1.ResourceName]intstr.IntOrString, len(*in))
+		*out = make(map[corev1.ResourceName]ConfigValue, len(*in))
 		for key, val := range *in {
 			(*out)[key] = val
 		}

--- a/pkg/mapper/testworkflows/kube_openapi.go
+++ b/pkg/mapper/testworkflows/kube_openapi.go
@@ -551,16 +551,15 @@ func MapContentFileKubeToAPI(v testworkflowsv1.ContentFile) testkube.TestWorkflo
 	}
 }
 
-func MapResourcesListKubeToAPI(v map[corev1.ResourceName]intstr.IntOrString) *testkube.TestWorkflowResourcesList {
+func MapResourcesListKubeToAPI(v map[corev1.ResourceName]testworkflowsv1.ConfigValue) *testkube.TestWorkflowResourcesList {
 	if len(v) == 0 {
 		return nil
 	}
-	empty := intstr.IntOrString{Type: intstr.String, StrVal: ""}
 	return &testkube.TestWorkflowResourcesList{
-		Cpu:              MapIntOrStringToString(common.GetMapValue(v, corev1.ResourceCPU, empty)),
-		Memory:           MapIntOrStringToString(common.GetMapValue(v, corev1.ResourceMemory, empty)),
-		Storage:          MapIntOrStringToString(common.GetMapValue(v, corev1.ResourceStorage, empty)),
-		EphemeralStorage: MapIntOrStringToString(common.GetMapValue(v, corev1.ResourceEphemeralStorage, empty)),
+		Cpu:              common.GetMapValue(v, corev1.ResourceCPU, "").String(),
+		Memory:           common.GetMapValue(v, corev1.ResourceMemory, "").String(),
+		Storage:          common.GetMapValue(v, corev1.ResourceStorage, "").String(),
+		EphemeralStorage: common.GetMapValue(v, corev1.ResourceEphemeralStorage, "").String(),
 	}
 }
 

--- a/pkg/mapper/testworkflows/kube_openapi.go
+++ b/pkg/mapper/testworkflows/kube_openapi.go
@@ -531,16 +531,15 @@ func MapContentFileKubeToAPI(v testworkflowsv1.ContentFile) testkube.TestWorkflo
 	}
 }
 
-func MapResourcesListKubeToAPI(v map[corev1.ResourceName]intstr.IntOrString) *testkube.TestWorkflowResourcesList {
+func MapResourcesListKubeToAPI(v map[corev1.ResourceName]testworkflowsv1.ConfigValue) *testkube.TestWorkflowResourcesList {
 	if len(v) == 0 {
 		return nil
 	}
-	empty := intstr.IntOrString{Type: intstr.String, StrVal: ""}
 	return &testkube.TestWorkflowResourcesList{
-		Cpu:              MapIntOrStringToString(common.GetMapValue(v, corev1.ResourceCPU, empty)),
-		Memory:           MapIntOrStringToString(common.GetMapValue(v, corev1.ResourceMemory, empty)),
-		Storage:          MapIntOrStringToString(common.GetMapValue(v, corev1.ResourceStorage, empty)),
-		EphemeralStorage: MapIntOrStringToString(common.GetMapValue(v, corev1.ResourceEphemeralStorage, empty)),
+		Cpu:              common.GetMapValue(v, corev1.ResourceCPU, "").String(),
+		Memory:           common.GetMapValue(v, corev1.ResourceMemory, "").String(),
+		Storage:          common.GetMapValue(v, corev1.ResourceStorage, "").String(),
+		EphemeralStorage: common.GetMapValue(v, corev1.ResourceEphemeralStorage, "").String(),
 	}
 }
 

--- a/pkg/mapper/testworkflows/mappers_test.go
+++ b/pkg/mapper/testworkflows/mappers_test.go
@@ -7,7 +7,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/util/intstr"
 
 	testworkflowsv1 "github.com/kubeshop/testkube/api/testworkflows/v1"
 	"github.com/kubeshop/testkube/internal/common"
@@ -58,13 +57,13 @@ var (
 		Command: common.Ptr([]string{"c", "d"}),
 		Args:    common.Ptr([]string{"ar", "gs"}),
 		Resources: &testworkflowsv1.Resources{
-			Limits: map[corev1.ResourceName]intstr.IntOrString{
-				corev1.ResourceCPU:    {Type: intstr.String, StrVal: "300m"},
-				corev1.ResourceMemory: {Type: intstr.Int, IntVal: 1024},
+			Limits: map[corev1.ResourceName]testworkflowsv1.ConfigValue{
+				corev1.ResourceCPU:    "300m",
+				corev1.ResourceMemory: "1024",
 			},
-			Requests: map[corev1.ResourceName]intstr.IntOrString{
-				corev1.ResourceCPU:    {Type: intstr.String, StrVal: "3800m"},
-				corev1.ResourceMemory: {Type: intstr.Int, IntVal: 10204},
+			Requests: map[corev1.ResourceName]testworkflowsv1.ConfigValue{
+				corev1.ResourceCPU:    "3800m",
+				corev1.ResourceMemory: "10204",
 			},
 		},
 		SecurityContext: testworkflowsv1.WorkflowSecurityContextFromKube(&corev1.SecurityContext{
@@ -203,8 +202,8 @@ var (
 			Command:         common.Ptr([]string{"ab"}),
 			Args:            common.Ptr([]string{"abrgs"}),
 			Resources: &testworkflowsv1.Resources{
-				Requests: map[corev1.ResourceName]intstr.IntOrString{
-					corev1.ResourceMemory: {Type: intstr.String, StrVal: "300m"},
+				Requests: map[corev1.ResourceName]testworkflowsv1.ConfigValue{
+					corev1.ResourceMemory: "300m",
 				},
 			},
 			SecurityContext: testworkflowsv1.WorkflowSecurityContextFromKube(&corev1.SecurityContext{
@@ -230,8 +229,8 @@ var (
 				Command: common.Ptr([]string{"c", "m", "d"}),
 				Args:    common.Ptr([]string{"arg", "s", "d"}),
 				Resources: &testworkflowsv1.Resources{
-					Limits: map[corev1.ResourceName]intstr.IntOrString{
-						corev1.ResourceCPU: {Type: intstr.Int, IntVal: 444},
+					Limits: map[corev1.ResourceName]testworkflowsv1.ConfigValue{
+						corev1.ResourceCPU: "444",
 					},
 				},
 				SecurityContext: testworkflowsv1.WorkflowSecurityContextFromKube(&corev1.SecurityContext{

--- a/pkg/mapper/testworkflows/openapi_kube.go
+++ b/pkg/mapper/testworkflows/openapi_kube.go
@@ -366,22 +366,22 @@ func MapContentFileAPIToKube(v testkube.TestWorkflowContentFile) testworkflowsv1
 	}
 }
 
-func MapResourcesListAPIToKube(v *testkube.TestWorkflowResourcesList) map[corev1.ResourceName]intstr.IntOrString {
+func MapResourcesListAPIToKube(v *testkube.TestWorkflowResourcesList) map[corev1.ResourceName]testworkflowsv1.ConfigValue {
 	if v == nil {
 		return nil
 	}
-	res := make(map[corev1.ResourceName]intstr.IntOrString)
+	res := make(map[corev1.ResourceName]testworkflowsv1.ConfigValue)
 	if v.Cpu != "" {
-		res[corev1.ResourceCPU] = MapStringToIntOrString(v.Cpu)
+		res[corev1.ResourceCPU] = MapStringToConfigValue(v.Cpu)
 	}
 	if v.Memory != "" {
-		res[corev1.ResourceMemory] = MapStringToIntOrString(v.Memory)
+		res[corev1.ResourceMemory] = MapStringToConfigValue(v.Memory)
 	}
 	if v.Storage != "" {
-		res[corev1.ResourceStorage] = MapStringToIntOrString(v.Storage)
+		res[corev1.ResourceStorage] = MapStringToConfigValue(v.Storage)
 	}
 	if v.EphemeralStorage != "" {
-		res[corev1.ResourceEphemeralStorage] = MapStringToIntOrString(v.EphemeralStorage)
+		res[corev1.ResourceEphemeralStorage] = MapStringToConfigValue(v.EphemeralStorage)
 	}
 	return res
 }

--- a/pkg/mapper/testworkflows/openapi_kube.go
+++ b/pkg/mapper/testworkflows/openapi_kube.go
@@ -386,22 +386,22 @@ func MapContentFileAPIToKube(v testkube.TestWorkflowContentFile) testworkflowsv1
 	}
 }
 
-func MapResourcesListAPIToKube(v *testkube.TestWorkflowResourcesList) map[corev1.ResourceName]intstr.IntOrString {
+func MapResourcesListAPIToKube(v *testkube.TestWorkflowResourcesList) map[corev1.ResourceName]testworkflowsv1.ConfigValue {
 	if v == nil {
 		return nil
 	}
-	res := make(map[corev1.ResourceName]intstr.IntOrString)
+	res := make(map[corev1.ResourceName]testworkflowsv1.ConfigValue)
 	if v.Cpu != "" {
-		res[corev1.ResourceCPU] = MapStringToIntOrString(v.Cpu)
+		res[corev1.ResourceCPU] = MapStringToConfigValue(v.Cpu)
 	}
 	if v.Memory != "" {
-		res[corev1.ResourceMemory] = MapStringToIntOrString(v.Memory)
+		res[corev1.ResourceMemory] = MapStringToConfigValue(v.Memory)
 	}
 	if v.Storage != "" {
-		res[corev1.ResourceStorage] = MapStringToIntOrString(v.Storage)
+		res[corev1.ResourceStorage] = MapStringToConfigValue(v.Storage)
 	}
 	if v.EphemeralStorage != "" {
-		res[corev1.ResourceEphemeralStorage] = MapStringToIntOrString(v.EphemeralStorage)
+		res[corev1.ResourceEphemeralStorage] = MapStringToConfigValue(v.EphemeralStorage)
 	}
 	return res
 }

--- a/pkg/testworkflows/testworkflowprocessor/processor_test.go
+++ b/pkg/testworkflows/testworkflowprocessor/processor_test.go
@@ -8,7 +8,6 @@ import (
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
-	"k8s.io/apimachinery/pkg/util/intstr"
 
 	testworkflowsv1 "github.com/kubeshop/testkube/api/testworkflows/v1"
 	"github.com/kubeshop/testkube/pkg/imageinspector"
@@ -396,9 +395,9 @@ func TestBundle_DefaultRunnerResources_DoesNotOverrideExplicitResources(t *testi
 							ContainerConfig: testworkflowsv1.ContainerConfig{
 								Image: "custom-image:latest",
 								Resources: &testworkflowsv1.Resources{
-									Requests: map[corev1.ResourceName]intstr.IntOrString{
-										corev1.ResourceCPU:    intstr.FromString("200m"),
-										corev1.ResourceMemory: intstr.FromString("256Mi"),
+									Requests: map[corev1.ResourceName]testworkflowsv1.ConfigValue{
+										corev1.ResourceCPU:    "200m",
+										corev1.ResourceMemory: "256Mi",
 									},
 								},
 							},
@@ -461,8 +460,8 @@ func TestBundle_DefaultRunnerResources_AppliesLimitsWhenOnlyRequestsSet(t *testi
 			TestWorkflowSpecBase: testworkflowsv1.TestWorkflowSpecBase{
 				Container: &testworkflowsv1.ContainerConfig{
 					Resources: &testworkflowsv1.Resources{
-						Requests: map[corev1.ResourceName]intstr.IntOrString{
-							corev1.ResourceCPU: intstr.FromString("50m"),
+						Requests: map[corev1.ResourceName]testworkflowsv1.ConfigValue{
+							corev1.ResourceCPU: "50m",
 						},
 					},
 				},

--- a/test/integration/components/toolkit/parallel_test.go
+++ b/test/integration/components/toolkit/parallel_test.go
@@ -422,13 +422,13 @@ func TestParallelLifecycle_Integration(t *testing.T) {
 				{EnvVar: corev1.EnvVar{Name: "TOTAL", Value: "{{count}}"}},
 			},
 			Resources: &testworkflowsv1.Resources{
-				Requests: map[corev1.ResourceName]intstr.IntOrString{
-					corev1.ResourceCPU:    intstr.FromString("100m"),
-					corev1.ResourceMemory: intstr.FromString("128Mi"),
+				Requests: map[corev1.ResourceName]testworkflowsv1.ConfigValue{
+					corev1.ResourceCPU:    "100m",
+					corev1.ResourceMemory: "128Mi",
 				},
-				Limits: map[corev1.ResourceName]intstr.IntOrString{
-					corev1.ResourceCPU:    intstr.FromString("200m"),
-					corev1.ResourceMemory: intstr.FromString("256Mi"),
+				Limits: map[corev1.ResourceName]testworkflowsv1.ConfigValue{
+					corev1.ResourceCPU:    "200m",
+					corev1.ResourceMemory: "256Mi",
 				},
 			},
 		},

--- a/test/integration/components/toolkit/services_oomkill_test.go
+++ b/test/integration/components/toolkit/services_oomkill_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/util/intstr"
 
 	testworkflowsv1 "github.com/kubeshop/testkube/api/testworkflows/v1"
 	"github.com/kubeshop/testkube/cmd/tcl/testworkflow-toolkit/commands"
@@ -58,8 +57,8 @@ func oomService() map[string]testworkflowsv1.ServiceSpec {
 					ContainerConfig: testworkflowsv1.ContainerConfig{
 						Image: "python:3.14.3-slim-trixie",
 						Resources: &testworkflowsv1.Resources{
-							Limits: map[corev1.ResourceName]intstr.IntOrString{
-								corev1.ResourceMemory: intstr.FromString(oomTestMemoryLimit),
+							Limits: map[corev1.ResourceName]testworkflowsv1.ConfigValue{
+								corev1.ResourceMemory: oomTestMemoryLimit,
 							},
 						},
 					},


### PR DESCRIPTION
Stacked on #8076; merge that PR first, then retarget this one to `main`.

An unquoted numeric resource value above the int32 range, for example `memory: 8589934592`, breaks the TestWorkflow informer list the same way as the config values in #8076. This PR migrates `resources.limits` and `resources.requests` to the `ConfigValue` type from #8076.

How:
- `Resources.Limits` and `Resources.Requests` change from `map[corev1.ResourceName]intstr.IntOrString` to `map[corev1.ResourceName]ConfigValue`.
- The mappers convert with plain string casts instead of int sniffing.
- The generated CRD schema is unchanged; only the deepcopy file regenerates.

The last int-or-string fields, `count` and `maxCount`, migrate in the next PR of the stack.