### PR TITLE
fix: generate zsh completion under the actual kubectl-testkube binary name

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,6 +16,7 @@
 - `cmd/api-server` is the main agent API server; agent personas (superagent, runner, listener, GitOps, etc.) are enabled through Helm values and env configuration.
 - `cmd/kubectl-testkube` is the Testkube CLI for managing tests, workflows, and interacting with Testkube installations.
 - `cmd/testworkflow-init` initializes TestWorkflow execution containers and orchestrates workflow step groups.
+- `cmd/kubectl-testkube/commands/completion.go` implements custom completion generation that ensures zsh completion works with the actual binary name (`kubectl-testkube`)
 - `cmd/testworkflow-toolkit` provides runtime utilities and commands for TestWorkflow containers (artifacts, services, parallel execution, etc.).
 - `cmd/tcl/devbox-mutating-webhook` is a Kubernetes mutating webhook for injecting devbox containers into pods.
 - `cmd/tcl/devbox-binary-storage` serves as a binary storage server for devbox dependencies and cached files.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -292,6 +292,9 @@ The Testkube CLI (`kubectl-testkube`, typically invoked as `testkube`) is a kube
 
 ### Architecture
 
+**Completion Command**: [`cmd/kubectl-testkube/commands/completion.go`] (custom implementation that generates zsh completion under the actual binary name `kubectl-testkube` instead of `testkube` to ensure proper shell integration)
+
+
 **Command Structure**: [`cmd/kubectl-testkube/commands/`](cmd/kubectl-testkube/commands/)
 
 - Root command and command groups (testworkflows, webhooks, artifacts, etc.)

--- a/cmd/kubectl-testkube/commands/completion.go
+++ b/cmd/kubectl-testkube/commands/completion.go
@@ -1,0 +1,57 @@
+package commands
+
+import (
+	"io"
+	"os"
+
+	"github.com/spf13/cobra"
+)
+
+// pluginBinaryName is the actual name the binary is invoked under (it ships
+// as a kubectl plugin, e.g. "kubectl-testkube"), as opposed to RootCmd.Use
+// ("testkube"), which is only used for help text.
+const pluginBinaryName = "kubectl-testkube"
+
+// NewCompletionCmd builds a "completion" command that mirrors Cobra's
+// built-in one for bash/fish/powershell, but generates the zsh script under
+// the actual invoked binary name instead of RootCmd.Use.
+//
+// Cobra's generated zsh script hardcodes RootCmd.Name() (the first word of
+// Use, i.e. "testkube") in its "#compdef" header and function names. Since
+// this binary is always invoked as "kubectl-testkube" (a kubectl plugin),
+// the installed script never matched the actual command name and zsh
+// completion silently did nothing. See #964.
+func NewCompletionCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:                   "completion [bash|zsh|fish|powershell]",
+		Short:                 "Generate the autocompletion script for the specified shell",
+		DisableFlagsInUseLine: true,
+		ValidArgs:             []string{"bash", "zsh", "fish", "powershell"},
+		Args:                  cobra.MatchAll(cobra.ExactArgs(1), cobra.OnlyValidArgs),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			root := cmd.Root()
+			switch args[0] {
+			case "bash":
+				return root.GenBashCompletionV2(os.Stdout, true)
+			case "zsh":
+				return genZshCompletionAs(root, pluginBinaryName, os.Stdout)
+			case "fish":
+				return root.GenFishCompletion(os.Stdout, true)
+			case "powershell":
+				return root.GenPowerShellCompletionWithDesc(os.Stdout)
+			}
+			return nil
+		},
+	}
+	return cmd
+}
+
+// genZshCompletionAs generates the zsh completion script as if the root
+// command's Use were `name`, without permanently changing it (which would
+// also affect --help output and other shells' generated scripts).
+func genZshCompletionAs(root *cobra.Command, name string, w io.Writer) error {
+	original := root.Use
+	root.Use = name
+	defer func() { root.Use = original }()
+	return root.GenZshCompletion(w)
+}

--- a/cmd/kubectl-testkube/commands/completion_test.go
+++ b/cmd/kubectl-testkube/commands/completion_test.go
@@ -1,0 +1,50 @@
+package commands
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+// TestZshCompletionUsesActualBinaryName guards against #964: the zsh
+// completion script must reference the binary's actual invoked name
+// ("kubectl-testkube"), not RootCmd.Use ("testkube"), or the installed
+// script never matches and zsh completion silently does nothing.
+func TestZshCompletionUsesActualBinaryName(t *testing.T) {
+	root := &cobra.Command{Use: "testkube"}
+	root.AddCommand(&cobra.Command{Use: "get"})
+
+	var buf bytes.Buffer
+	if err := genZshCompletionAs(root, pluginBinaryName, &buf); err != nil {
+		t.Fatalf("genZshCompletionAs returned error: %v", err)
+	}
+
+	out := buf.String()
+	if !strings.Contains(out, "#compdef kubectl-testkube") {
+		t.Fatalf("expected zsh script to declare #compdef kubectl-testkube, got:\n%s", out[:200])
+	}
+	if !strings.Contains(out, "_kubectl-testkube()") {
+		t.Fatalf("expected zsh script to define _kubectl-testkube(), got:\n%s", out[:400])
+	}
+	if strings.Contains(out, "_testkube()") {
+		t.Fatalf("zsh script should not define _testkube() when generated for kubectl-testkube")
+	}
+
+	// genZshCompletionAs must not leave Use mutated behind it.
+	if root.Use != "testkube" {
+		t.Fatalf("expected root.Use to be restored to %q, got %q", "testkube", root.Use)
+	}
+}
+
+func TestCompletionCmdRejectsUnknownShell(t *testing.T) {
+	cmd := NewCompletionCmd()
+	cmd.SetArgs([]string{"invalidshell"})
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&bytes.Buffer{})
+
+	if err := cmd.Execute(); err == nil {
+		t.Fatal("expected an error for an unsupported shell argument")
+	}
+}

--- a/cmd/kubectl-testkube/commands/root.go
+++ b/cmd/kubectl-testkube/commands/root.go
@@ -81,6 +81,7 @@ func init() {
 	RootCmd.AddCommand(devbox.NewDevBoxCommand())
 
 	RootCmd.SetHelpCommand(NewHelpCmd())
+	RootCmd.AddCommand(NewCompletionCmd())
 }
 
 var RootCmd = &cobra.Command{


### PR DESCRIPTION
## Summary

Cobra's built-in `completion zsh` command hardcodes `RootCmd.Name()`
(the first word of `Use`, i.e. `"testkube"`) in the generated script's
`#compdef` header and function names. This CLI ships and is invoked
as `kubectl-testkube` (a kubectl plugin), so the installed completion
script never matched the real command name:

```console
$ kubectl-testkube completion zsh > $fpath[1]/_kubectl-testkube
$ exec zsh
$ kubectl-testkube <TAB>   # nothing happens
```

Before:
```
#compdef _testkube testkube
...
_testkube() { ... }
...
if [ "$funcstack[1]" = "_testkube" ]; then
        _testkube
fi
```

After:
```
#compdef kubectl-testkube
compdef _kubectl-testkube kubectl-testkube
...
_kubectl-testkube() { ... }
...
if [ "$funcstack[1]" = "_kubectl-testkube" ]; then
        _kubectl-testkube
fi
```

## Approach

Added a custom `completion` command (`cmd/kubectl-testkube/commands/completion.go`)
that:
- delegates `bash`/`fish`/`powershell` to Cobra's standard generators, unchanged
- generates `zsh` under the actual binary name (`kubectl-testkube`) by
  temporarily swapping `RootCmd.Use` for the duration of that one call
  and restoring it immediately after (so `--help` output and the other
  shells are unaffected)

This mirrors the fix suggested directly in the issue.

## Test plan

- [x] Added `TestZshCompletionUsesActualBinaryName` and
      `TestCompletionCmdRejectsUnknownShell`
- [x] `go build ./cmd/kubectl-testkube/...` — clean
- [x] `go test ./cmd/kubectl-testkube/...` — full suite green
- [x] `golangci-lint run ./cmd/kubectl-testkube/commands/...` — 0 issues
- [x] Manually built the binary and diffed `completion zsh` / `completion bash` output before and after — bash unaffected, zsh now matches the working script from the issue

Fixes #964