### PR TITLE
feat(TKC-6504): rework init demo for new architecture

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,6 +57,13 @@
 - Adding a new CI/runtime detection: extend `pkg/cliruntime/context.go` so both telemetry and the update-check feature stay in sync.
 - Adding a new AI-tool detection: extend `DetectAITool` in `pkg/cliruntime/context.go` (add the env-var check and a `TestDetectAITool` case in `context_test.go`); no telemetry wiring changes are needed since payloads already read the `AITool` field.
 
+## On-prem demo install
+
+- `testkube init demo` (`cmd/kubectl-testkube/commands/init.go`) installs the On-Prem demo on the new architecture: the Control Plane (enterprise chart + `values.demo.v2.yaml`) plus a **separate** listener-enabled runner (`kubeshop/testkube-runner`). The bundled agent is gone.
+- The CLI generates one agent secret key per install (`common.GenerateDemoAgentSecretKey`) and passes the *same* key to both sides — injected into the Control Plane's `bootstrapConfig` runner so the CP provisions it, and into the runner install (`common.HelmUpgradeOrInstallTestkubeOnPremDemoRunner` → `demoRunnerHelmOptions`). No secret is baked into the binary or chart.
+- The runner identity (`demoRunnerID`/`OrgID`/`EnvID`) must stay in sync with the runner declared under `bootstrapConfig` in `values.demo.v2.yaml` (in `testkube-cloud-charts`).
+- The legacy `values.demo.yaml` profile (bundled agent, MongoDB) is deprecated but kept for older CLIs.
+
 ## Configuration references
 
 - Agent behavior is driven by env vars defined in `internal/config/config.go` (scan for `envconfig:"..."` tags when researching a toggle).

--- a/cmd/kubectl-testkube/commands/common/demo_runner_test.go
+++ b/cmd/kubectl-testkube/commands/common/demo_runner_test.go
@@ -1,0 +1,100 @@
+package common
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_GenerateDemoAgentSecretKey(t *testing.T) {
+	t.Parallel()
+
+	t.Run("has the correct tkckey_<type>_<32 chars> format", func(t *testing.T) {
+		t.Parallel()
+
+		key := GenerateDemoAgentSecretKey()
+
+		parts := strings.Split(key, "_")
+		assert.Len(t, parts, 3, "key should have three underscore-separated parts")
+		assert.Equal(t, "tkckey", parts[0], "key should start with the tkckey prefix")
+		assert.Equal(t, "agent", parts[1], "key type should be agent")
+		assert.Len(t, parts[2], 32, "random segment should be 32 characters")
+
+		for _, r := range parts[2] {
+			isLower := r >= 'a' && r <= 'z'
+			isDigit := r >= '0' && r <= '9'
+			assert.True(t, isLower || isDigit, "random segment must be lowercase alphanumeric, got %q", string(r))
+		}
+	})
+
+	t.Run("produces a unique key per call", func(t *testing.T) {
+		t.Parallel()
+
+		const iterations = 100
+		seen := make(map[string]struct{}, iterations)
+		for i := 0; i < iterations; i++ {
+			key := GenerateDemoAgentSecretKey()
+			_, exists := seen[key]
+			assert.False(t, exists, "generated a duplicate key: %s", key)
+			seen[key] = struct{}{}
+		}
+	})
+}
+
+func Test_demoRunnerHelmOptions(t *testing.T) {
+	t.Parallel()
+
+	const (
+		namespace = "testkube"
+		secretKey = "tkckey_agent_abcdefghijklmnopqrstuvwxyz012345"
+	)
+
+	opts := demoRunnerHelmOptions(namespace, secretKey, false)
+
+	t.Run("uses the published kubeshop/testkube-runner chart", func(t *testing.T) {
+		assert.Equal(t, "https://kubeshop.github.io/helm-charts", opts.RegistryURL)
+		assert.Equal(t, "kubeshop", opts.RepositoryName)
+		assert.Equal(t, "testkube-runner", opts.ChartName)
+		assert.Equal(t, "testkube-"+demoRunnerName, opts.ReleaseName)
+		assert.Equal(t, namespace, opts.Namespace)
+		assert.False(t, opts.DryRun)
+		assert.Equal(t, []string{"--wait"}, opts.Args)
+	})
+
+	t.Run("wires the runner identity to match the bootstrapped runner", func(t *testing.T) {
+		assert.Equal(t, demoRunnerID, opts.Values["runner.id"])
+		assert.Equal(t, demoRunnerName, opts.Values["runner.name"])
+		assert.Equal(t, demoRunnerOrgID, opts.Values["runner.orgId"])
+		assert.Equal(t, demoRunnerEnvID, opts.Values["runner.envId"])
+	})
+
+	t.Run("passes through the generated secret key", func(t *testing.T) {
+		assert.Equal(t, secretKey, opts.Values["runner.secret"])
+	})
+
+	t.Run("connects to the in-cluster control plane over plaintext gRPC", func(t *testing.T) {
+		assert.Equal(t,
+			"testkube-enterprise-api.testkube.svc.cluster.local:8089",
+			opts.Values["cloud.url"],
+		)
+		assert.Equal(t, false, opts.Values["cloud.tls.enabled"])
+	})
+
+	t.Run("advertises the listener capability", func(t *testing.T) {
+		assert.Equal(t, true, opts.Values["listener.enabled"])
+	})
+
+	t.Run("pins the deployment name via fullnameOverride", func(t *testing.T) {
+		assert.Equal(t, "testkube-demo-runner", opts.Values["fullnameOverride"])
+	})
+
+	t.Run("interpolates the namespace into the cloud url", func(t *testing.T) {
+		other := demoRunnerHelmOptions("custom-ns", secretKey, true)
+		assert.Equal(t,
+			"testkube-enterprise-api.custom-ns.svc.cluster.local:8089",
+			other.Values["cloud.url"],
+		)
+		assert.True(t, other.DryRun)
+	})
+}

--- a/cmd/kubectl-testkube/commands/common/demo_runner_test.go
+++ b/cmd/kubectl-testkube/commands/common/demo_runner_test.go
@@ -98,3 +98,48 @@ func Test_demoRunnerHelmOptions(t *testing.T) {
 		assert.True(t, other.DryRun)
 	})
 }
+
+func Test_decideDemoAgentSecretKey(t *testing.T) {
+	t.Parallel()
+
+	const (
+		namespace   = "testkube"
+		existingKey = "tkckey_agent_abcdefghijklmnopqrstuvwxyz012345"
+	)
+
+	t.Run("reuses the existing runner key on re-install", func(t *testing.T) {
+		t.Parallel()
+
+		reuseKey, generate, cliErr := decideDemoAgentSecretKey(true, existingKey, false, namespace)
+		assert.Nil(t, cliErr)
+		assert.False(t, generate, "should not mint a new key when one can be reused")
+		assert.Equal(t, existingKey, reuseKey)
+	})
+
+	t.Run("mints a fresh key on a clean namespace", func(t *testing.T) {
+		t.Parallel()
+
+		reuseKey, generate, cliErr := decideDemoAgentSecretKey(false, "", false, namespace)
+		assert.Nil(t, cliErr)
+		assert.True(t, generate, "should mint a new key when nothing is installed")
+		assert.Equal(t, "", reuseKey)
+	})
+
+	t.Run("errors when a runner exists but its key is unreadable", func(t *testing.T) {
+		t.Parallel()
+
+		reuseKey, generate, cliErr := decideDemoAgentSecretKey(true, "", false, namespace)
+		assert.NotNil(t, cliErr, "must not silently mint a mismatching key")
+		assert.False(t, generate)
+		assert.Equal(t, "", reuseKey)
+	})
+
+	t.Run("errors when the control plane exists but no runner to reuse from", func(t *testing.T) {
+		t.Parallel()
+
+		reuseKey, generate, cliErr := decideDemoAgentSecretKey(false, "", true, namespace)
+		assert.NotNil(t, cliErr, "a fresh key would be rejected by the existing control plane")
+		assert.False(t, generate)
+		assert.Equal(t, "", reuseKey)
+	})
+}

--- a/cmd/kubectl-testkube/commands/common/helper.go
+++ b/cmd/kubectl-testkube/commands/common/helper.go
@@ -134,10 +134,98 @@ const (
 	demoRunnerOrgID                  = "tkcorg_demo"
 	demoRunnerEnvID                  = "tkcenv_my-first-environment"
 	demoRunnerBootstrapSecretKeyPath = "testkube-cloud-api.api.features.bootstrapConfig.config.organizations[0].runners[0].secret_key"
+	demoRunnerDeploymentName         = "testkube-demo-runner"
+	demoControlPlaneDeploymentName   = "testkube-enterprise-api"
+	demoRunnerAPIKeyEnvVar           = "TESTKUBE_PRO_API_KEY"
 )
 
 func GenerateDemoAgentSecretKey() string {
 	return "tkckey_agent_" + utils.RandAlphanum(32)
+}
+
+func ResolveDemoAgentSecretKey(namespace string, dryRun bool) (string, *CLIError) {
+	if dryRun {
+		return GenerateDemoAgentSecretKey(), nil
+	}
+
+	runnerExists, err := KubectlResourceExists(namespace, "deployment", demoRunnerDeploymentName)
+	if err != nil {
+		return "", NewCLIError(
+			TKErrKubectlCommandFailed,
+			"Checking for an existing Testkube demo runner",
+			"Check that the kubeconfig (~/.kube/config) has correct permissions and the cluster is reachable by running 'kubectl get nodes'.",
+			err,
+		)
+	}
+
+	var runnerKey string
+	if runnerExists {
+		var keyErr *CLIError
+		runnerKey, keyErr = readDemoRunnerSecretKey(namespace)
+		if keyErr != nil {
+			return "", keyErr
+		}
+	}
+
+	cpExists := false
+	if !runnerExists {
+		cpExists, err = KubectlResourceExists(namespace, "deployment", demoControlPlaneDeploymentName)
+		if err != nil {
+			return "", NewCLIError(
+				TKErrKubectlCommandFailed,
+				"Checking for an existing Testkube Control Plane",
+				"Check that the kubeconfig (~/.kube/config) has correct permissions and the cluster is reachable by running 'kubectl get nodes'.",
+				err,
+			)
+		}
+	}
+
+	reuseKey, generate, cliErr := decideDemoAgentSecretKey(runnerExists, runnerKey, cpExists, namespace)
+	if cliErr != nil {
+		return "", cliErr
+	}
+	if generate {
+		return GenerateDemoAgentSecretKey(), nil
+	}
+	return reuseKey, nil
+}
+
+func decideDemoAgentSecretKey(runnerExists bool, runnerKey string, cpExists bool, namespace string) (reuseKey string, generate bool, cliErr *CLIError) {
+	if runnerExists {
+		if runnerKey != "" {
+			return runnerKey, false, nil
+		}
+		return "", false, NewCLIError(
+			TKErrInvalidInstallConfig,
+			"Existing Testkube demo runner has no readable agent key",
+			fmt.Sprintf("To fix: recreate the cluster, or delete the %q namespace, then run 'testkube init demo' once. (A demo runner already exists but its agent key can't be read, so this install can't reuse it and a fresh key would not match the Control Plane.)", namespace),
+			fmt.Errorf("demo runner %q found but %s env is empty", demoRunnerDeploymentName, demoRunnerAPIKeyEnvVar),
+		)
+	}
+
+	if cpExists {
+		return "", false, NewCLIError(
+			TKErrInvalidInstallConfig,
+			"Testkube Control Plane already installed without a matching demo runner",
+			fmt.Sprintf("To fix: recreate the cluster, or delete the %q namespace, then run 'testkube init demo' once. (The Control Plane already bootstrapped a runner whose key can't be recovered, so installing a fresh key here would be rejected.)", namespace),
+			fmt.Errorf("control plane %q present without demo runner %q", demoControlPlaneDeploymentName, demoRunnerDeploymentName),
+		)
+	}
+
+	return "", true, nil
+}
+
+func readDemoRunnerSecretKey(namespace string) (string, *CLIError) {
+	kubectlPath, cliErr := lookupKubectlPath()
+	if cliErr != nil {
+		return "", cliErr
+	}
+	jsonpath := fmt.Sprintf(`jsonpath={.spec.template.spec.containers[*].env[?(@.name=="%s")].value}`, demoRunnerAPIKeyEnvVar)
+	out, cliErr := runKubectlCommand(kubectlPath, []string{"get", "deployment", demoRunnerDeploymentName, "--namespace", namespace, "-o", jsonpath})
+	if cliErr != nil {
+		return "", cliErr
+	}
+	return strings.TrimSpace(out), nil
 }
 
 func HelmUpgradeOrInstallTestkubeOnPremDemoRunner(options HelmOptions, runnerSecretKey string) *CLIError {
@@ -154,7 +242,7 @@ func demoRunnerHelmOptions(namespace, runnerSecretKey string, dryRun bool) HelmG
 		Namespace:      namespace,
 		Args:           []string{"--wait"},
 		Values: map[string]interface{}{
-			"fullnameOverride":  "testkube-demo-runner",
+			"fullnameOverride":  demoRunnerDeploymentName,
 			"runner.id":         demoRunnerID,
 			"runner.name":       demoRunnerName,
 			"runner.orgId":      demoRunnerOrgID,

--- a/cmd/kubectl-testkube/commands/common/helper.go
+++ b/cmd/kubectl-testkube/commands/common/helper.go
@@ -26,6 +26,7 @@ import (
 	tkhttp "github.com/kubeshop/testkube/pkg/http"
 	"github.com/kubeshop/testkube/pkg/process"
 	"github.com/kubeshop/testkube/pkg/ui"
+	"github.com/kubeshop/testkube/pkg/utils"
 )
 
 type HelmOptions struct {
@@ -84,7 +85,7 @@ func ShowOperatorDeprecationWarning(manager string, noCRDs bool) {
 	ui.NL()
 }
 
-func HelmUpgradeOrInstallTestkubeOnPremDemo(options HelmOptions) *CLIError {
+func HelmUpgradeOrInstallTestkubeOnPremDemo(options HelmOptions, runnerSecretKey string) *CLIError {
 	helmPath, cliErr := lookupHelmPath()
 	if cliErr != nil {
 		return cliErr
@@ -93,6 +94,11 @@ func HelmUpgradeOrInstallTestkubeOnPremDemo(options HelmOptions) *CLIError {
 	if err := updateHelmRepo(helmPath, options.DryRun, true); err != nil {
 		return err
 	}
+
+	if options.SetOptions == nil {
+		options.SetOptions = make(map[string]string)
+	}
+	options.SetOptions[demoRunnerBootstrapSecretKeyPath] = runnerSecretKey
 
 	// For default setup, change the Agent host to a cluster service endpoint,
 	// so it will be possible to install runners in different namespaces.
@@ -120,6 +126,45 @@ func HelmUpgradeOrInstallTestkubeOnPremDemo(options HelmOptions) *CLIError {
 	ui.Debug("Helm install testkube output", output)
 	return nil
 
+}
+
+const (
+	demoRunnerName                   = "demo-runner"
+	demoRunnerID                     = "tkcrun_demo-runner"
+	demoRunnerOrgID                  = "tkcorg_demo"
+	demoRunnerEnvID                  = "tkcenv_my-first-environment"
+	demoRunnerBootstrapSecretKeyPath = "testkube-cloud-api.api.features.bootstrapConfig.config.organizations[0].runners[0].secret_key"
+)
+
+func GenerateDemoAgentSecretKey() string {
+	return "tkckey_agent_" + utils.RandAlphanum(32)
+}
+
+func HelmUpgradeOrInstallTestkubeOnPremDemoRunner(options HelmOptions, runnerSecretKey string) *CLIError {
+	return HelmUpgradeOrInstallGeneric(demoRunnerHelmOptions(options.Namespace, runnerSecretKey, options.DryRun))
+}
+
+func demoRunnerHelmOptions(namespace, runnerSecretKey string, dryRun bool) HelmGenericOptions {
+	return HelmGenericOptions{
+		DryRun:         dryRun,
+		RegistryURL:    "https://kubeshop.github.io/helm-charts",
+		RepositoryName: "kubeshop",
+		ChartName:      "testkube-runner",
+		ReleaseName:    "testkube-" + demoRunnerName,
+		Namespace:      namespace,
+		Args:           []string{"--wait"},
+		Values: map[string]interface{}{
+			"fullnameOverride":  "testkube-demo-runner",
+			"runner.id":         demoRunnerID,
+			"runner.name":       demoRunnerName,
+			"runner.orgId":      demoRunnerOrgID,
+			"runner.envId":      demoRunnerEnvID,
+			"runner.secret":     runnerSecretKey,
+			"cloud.url":         fmt.Sprintf("testkube-enterprise-api.%s.svc.cluster.local:8089", namespace),
+			"cloud.tls.enabled": false,
+			"listener.enabled":  true,
+		},
+	}
 }
 
 func HelmUpgradeOrInstallTestkubeAgent(options HelmOptions, cfg config.Data, isMigration bool) *CLIError {

--- a/cmd/kubectl-testkube/commands/init.go
+++ b/cmd/kubectl-testkube/commands/init.go
@@ -21,7 +21,7 @@ const (
 	defaultNamespace       = "testkube"
 	standaloneAgentProfile = "standalone-agent"
 	demoProfile            = "demo"
-	demoValuesUrl          = "https://raw.githubusercontent.com/kubeshop/testkube-cloud-charts/main/charts/testkube-enterprise/profiles/values.demo.yaml"
+	demoValuesUrl          = "https://raw.githubusercontent.com/kubeshop/testkube-cloud-charts/main/charts/testkube-enterprise/profiles/values.demo.v2.yaml"
 	agentProfile           = "agent"
 
 	standaloneInstallationName = "Testkube OSS"
@@ -245,11 +245,26 @@ func NewInitCmdDemo() *cobra.Command {
 			spinner = ui.NewSpinner("Running Helm command...")
 			options.SetOptions = setOptions
 			options.ArgOptions = argOptions
-			cliErr = common.HelmUpgradeOrInstallTestkubeOnPremDemo(options)
+
+			runnerSecretKey := common.GenerateDemoAgentSecretKey()
+
+			cliErr = common.HelmUpgradeOrInstallTestkubeOnPremDemo(options, runnerSecretKey)
 			if cliErr != nil {
 				spinner.Fail("Failed to install Testkube On-Prem Demo")
 				if cfg.TelemetryEnabled {
 					cliErr.AddTelemetry(cmd, "installing", "install_failed", license)
+					_, _ = handleCLIErrorTelemetry(common.Version, cliErr)
+				}
+				common.HandleCLIError(cliErr)
+			}
+			spinner.Success()
+
+			spinner = ui.NewSpinner("Installing Testkube Runner...")
+			cliErr = common.HelmUpgradeOrInstallTestkubeOnPremDemoRunner(options, runnerSecretKey)
+			if cliErr != nil {
+				spinner.Fail("Failed to install Testkube Runner")
+				if cfg.TelemetryEnabled {
+					cliErr.AddTelemetry(cmd, "installing runner", "install_runner_failed", license)
 					_, _ = handleCLIErrorTelemetry(common.Version, cliErr)
 				}
 				common.HandleCLIError(cliErr)

--- a/cmd/kubectl-testkube/commands/init.go
+++ b/cmd/kubectl-testkube/commands/init.go
@@ -246,7 +246,15 @@ func NewInitCmdDemo() *cobra.Command {
 			options.SetOptions = setOptions
 			options.ArgOptions = argOptions
 
-			runnerSecretKey := common.GenerateDemoAgentSecretKey()
+			runnerSecretKey, cliErr := common.ResolveDemoAgentSecretKey(options.Namespace, options.DryRun)
+			if cliErr != nil {
+				spinner.Fail("Failed to install Testkube On-Prem Demo")
+				if cfg.TelemetryEnabled {
+					cliErr.AddTelemetry(cmd, "resolving agent key", "install_failed", license)
+					_, _ = handleCLIErrorTelemetry(common.Version, cliErr)
+				}
+				common.HandleCLIError(cliErr)
+			}
 
 			cliErr = common.HelmUpgradeOrInstallTestkubeOnPremDemo(options, runnerSecretKey)
 			if cliErr != nil {


### PR DESCRIPTION
## Pull request description 
Rework `testkube init demo` for the new architecture: install the control plane and a separate runner, generate a fresh agent secret per install (given to both sides so the runner connects automatically), with the listener capability enabled. Requires the matching `values.demo.v2.yaml` in testkube-cloud-charts.


## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [ ] tested locally
- [ ] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Breaking changes

-

## Changes
- `init demo` now installs control plane + separate runner (new architecture); 
- Per-install generated agent secret key; no secret baked into the binary.
- Points `demoValuesUrl` at the new `values.demo.v2.yaml` profile.

## Fixes

-