### PR TITLE
fix(webhooks): skip silent-webhook executions in previous-state lookup

### DIFF
--- a/pkg/cloud/data/testworkflow/execution.go
+++ b/pkg/cloud/data/testworkflow/execution.go
@@ -181,8 +181,12 @@ func (r *CloudRepository) GetTestWorkflowMetrics(ctx context.Context, name strin
 }
 
 // GetPreviousFinishedState gets previous finished execution state by test
-func (r *CloudRepository) GetPreviousFinishedState(ctx context.Context, workflowName string, date time.Time) (testkube.TestWorkflowStatus, error) {
-	req := ExecutionGetPreviousFinishedStateRequest{WorkflowName: workflowName, Date: date}
+func (r *CloudRepository) GetPreviousFinishedState(ctx context.Context, workflowName string, date time.Time, opts testworkflow2.GetPreviousFinishedStateOptions) (testkube.TestWorkflowStatus, error) {
+	req := ExecutionGetPreviousFinishedStateRequest{
+		WorkflowName:                workflowName,
+		Date:                        date,
+		SkipSilentWebhookExecutions: opts.SkipSilentWebhookExecutions,
+	}
 	response, err := r.executor.Execute(ctx, CmdTestWorkflowExecutionGetPreviousFinishedState, req)
 	if err != nil {
 		return "", err

--- a/pkg/cloud/data/testworkflow/execution_models.go
+++ b/pkg/cloud/data/testworkflow/execution_models.go
@@ -89,8 +89,9 @@ type ExecutionGetExecutionsSummaryResponse struct {
 }
 
 type ExecutionGetPreviousFinishedStateRequest struct {
-	WorkflowName string
-	Date         time.Time
+	WorkflowName                string
+	Date                        time.Time
+	SkipSilentWebhookExecutions bool
 }
 
 type ExecutionGetPreviousFinishedStateResponse struct {

--- a/pkg/controlplane/agent_grpc_call.go
+++ b/pkg/controlplane/agent_grpc_call.go
@@ -84,7 +84,9 @@ func CreateCommands(storageBucket string, storageClient domainstorage.Client, te
 			return
 		}),
 		cloudtestworkflow.CmdTestWorkflowExecutionGetPreviousFinishedState: Handler(func(ctx context.Context, data cloudtestworkflow.ExecutionGetPreviousFinishedStateRequest) (r cloudtestworkflow.ExecutionGetPreviousFinishedStateResponse, err error) {
-			r.Result, err = testWorkflowResultsRepository.GetPreviousFinishedState(ctx, data.WorkflowName, data.Date)
+			r.Result, err = testWorkflowResultsRepository.GetPreviousFinishedState(ctx, data.WorkflowName, data.Date, testworkflow.GetPreviousFinishedStateOptions{
+				SkipSilentWebhookExecutions: data.SkipSilentWebhookExecutions,
+			})
 			return
 		}),
 		cloudtestworkflow.CmdTestWorkflowExecutionInsert: Handler(func(ctx context.Context, data cloudtestworkflow.ExecutionInsertRequest) (r cloudtestworkflow.ExecutionInsertResponse, err error) {

--- a/pkg/database/postgres/queries/executions.sql
+++ b/pkg/database/postgres/queries/executions.sql
@@ -975,6 +975,7 @@ WHERE e.workflow_name = @workflow_name::text AND (e.organization_id = @organizat
     AND r.finished_at < @date
     AND r.status IN ('passed', 'failed', 'skipped', 'aborted', 'canceled', 'timeout')
     AND (e.silent_mode IS NULL OR (e.silent_mode->>'webhooks')::boolean IS NOT TRUE)
+    AND e.disable_webhooks IS NOT TRUE
 ORDER BY r.finished_at DESC
 LIMIT 1;
 

--- a/pkg/database/postgres/queries/executions.sql
+++ b/pkg/database/postgres/queries/executions.sql
@@ -974,6 +974,7 @@ LEFT JOIN test_workflow_results r ON e.id = r.execution_id
 WHERE e.workflow_name = @workflow_name::text AND (e.organization_id = @organization_id AND e.environment_id = @environment_id)
     AND r.finished_at < @date
     AND r.status IN ('passed', 'failed', 'skipped', 'aborted', 'canceled', 'timeout')
+    AND (e.silent_mode IS NULL OR (e.silent_mode->>'webhooks')::boolean IS NOT TRUE)
 ORDER BY r.finished_at DESC
 LIMIT 1;
 

--- a/pkg/database/postgres/queries/executions.sql
+++ b/pkg/database/postgres/queries/executions.sql
@@ -974,8 +974,13 @@ LEFT JOIN test_workflow_results r ON e.id = r.execution_id
 WHERE e.workflow_name = @workflow_name::text AND (e.organization_id = @organization_id AND e.environment_id = @environment_id)
     AND r.finished_at < @date
     AND r.status IN ('passed', 'failed', 'skipped', 'aborted', 'canceled', 'timeout')
-    AND (e.silent_mode IS NULL OR (e.silent_mode->>'webhooks')::boolean IS NOT TRUE)
-    AND e.disable_webhooks IS NOT TRUE
+    AND (
+        NOT @skip_silent_webhook_executions::boolean
+        OR (
+            (e.silent_mode IS NULL OR (e.silent_mode->>'webhooks')::boolean IS NOT TRUE)
+            AND e.disable_webhooks IS NOT TRUE
+        )
+    )
 ORDER BY r.finished_at DESC
 LIMIT 1;
 

--- a/pkg/database/postgres/sqlc/executions.sql.go
+++ b/pkg/database/postgres/sqlc/executions.sql.go
@@ -1481,6 +1481,7 @@ LEFT JOIN test_workflow_results r ON e.id = r.execution_id
 WHERE e.workflow_name = $1::text AND (e.organization_id = $2 AND e.environment_id = $3)
     AND r.finished_at < $4
     AND r.status IN ('passed', 'failed', 'skipped', 'aborted', 'canceled', 'timeout')
+    AND (e.silent_mode IS NULL OR (e.silent_mode->>'webhooks')::boolean IS NOT TRUE)
 ORDER BY r.finished_at DESC
 LIMIT 1
 `

--- a/pkg/database/postgres/sqlc/executions.sql.go
+++ b/pkg/database/postgres/sqlc/executions.sql.go
@@ -1481,17 +1481,23 @@ LEFT JOIN test_workflow_results r ON e.id = r.execution_id
 WHERE e.workflow_name = $1::text AND (e.organization_id = $2 AND e.environment_id = $3)
     AND r.finished_at < $4
     AND r.status IN ('passed', 'failed', 'skipped', 'aborted', 'canceled', 'timeout')
-    AND (e.silent_mode IS NULL OR (e.silent_mode->>'webhooks')::boolean IS NOT TRUE)
-    AND e.disable_webhooks IS NOT TRUE
+    AND (
+        NOT $5::boolean
+        OR (
+            (e.silent_mode IS NULL OR (e.silent_mode->>'webhooks')::boolean IS NOT TRUE)
+            AND e.disable_webhooks IS NOT TRUE
+        )
+    )
 ORDER BY r.finished_at DESC
 LIMIT 1
 `
 
 type GetPreviousFinishedStateParams struct {
-	WorkflowName   string             `db:"workflow_name" json:"workflow_name"`
-	OrganizationID string             `db:"organization_id" json:"organization_id"`
-	EnvironmentID  string             `db:"environment_id" json:"environment_id"`
-	Date           pgtype.Timestamptz `db:"date" json:"date"`
+	WorkflowName                string             `db:"workflow_name" json:"workflow_name"`
+	OrganizationID              string             `db:"organization_id" json:"organization_id"`
+	EnvironmentID               string             `db:"environment_id" json:"environment_id"`
+	Date                        pgtype.Timestamptz `db:"date" json:"date"`
+	SkipSilentWebhookExecutions bool               `db:"skip_silent_webhook_executions" json:"skip_silent_webhook_executions"`
 }
 
 func (q *Queries) GetPreviousFinishedState(ctx context.Context, arg GetPreviousFinishedStateParams) (pgtype.Text, error) {
@@ -1500,6 +1506,7 @@ func (q *Queries) GetPreviousFinishedState(ctx context.Context, arg GetPreviousF
 		arg.OrganizationID,
 		arg.EnvironmentID,
 		arg.Date,
+		arg.SkipSilentWebhookExecutions,
 	)
 	var status pgtype.Text
 	err := row.Scan(&status)

--- a/pkg/database/postgres/sqlc/executions.sql.go
+++ b/pkg/database/postgres/sqlc/executions.sql.go
@@ -1482,6 +1482,7 @@ WHERE e.workflow_name = $1::text AND (e.organization_id = $2 AND e.environment_i
     AND r.finished_at < $4
     AND r.status IN ('passed', 'failed', 'skipped', 'aborted', 'canceled', 'timeout')
     AND (e.silent_mode IS NULL OR (e.silent_mode->>'webhooks')::boolean IS NOT TRUE)
+    AND e.disable_webhooks IS NOT TRUE
 ORDER BY r.finished_at DESC
 LIMIT 1
 `

--- a/pkg/event/kind/webhook/listener.go
+++ b/pkg/event/kind/webhook/listener.go
@@ -574,7 +574,9 @@ func (l *WebhookListener) hasBecomeState(event testkube.Event) (bool, error) {
 			log.Warn("unable to determine become state, testworkflow execution results queries not supported")
 			return false, nil
 		}
-		prevStatus, err := l.testWorkflowResultsRepository.GetPreviousFinishedState(context.Background(), event.TestWorkflowExecution.Workflow.Name, event.TestWorkflowExecution.StatusAt)
+		prevStatus, err := l.testWorkflowResultsRepository.GetPreviousFinishedState(context.Background(), event.TestWorkflowExecution.Workflow.Name, event.TestWorkflowExecution.StatusAt, testworkflow.GetPreviousFinishedStateOptions{
+			SkipSilentWebhookExecutions: true,
+		})
 		if err != nil {
 			return false, err
 		}

--- a/pkg/event/kind/webhook/listener_test.go
+++ b/pkg/event/kind/webhook/listener_test.go
@@ -190,7 +190,7 @@ func TestWebhookListener_Notify(t *testing.T) {
 		// Mock repository to return previous status as PASSED
 		mockTestWorkflowRepo := testworkflow.NewMockRepository(mockCtrl)
 		mockTestWorkflowRepo.EXPECT().
-			GetPreviousFinishedState(gomock.Any(), "test-workflow", gomock.Any()).
+			GetPreviousFinishedState(gomock.Any(), "test-workflow", gomock.Any(), testworkflow.GetPreviousFinishedStateOptions{SkipSilentWebhookExecutions: true}).
 			Return(testkube.PASSED_TestWorkflowStatus, nil).
 			Times(1)
 
@@ -239,7 +239,7 @@ func TestWebhookListener_Notify(t *testing.T) {
 		// Mock repository to return previous status as FAILED
 		mockTestWorkflowRepo := testworkflow.NewMockRepository(mockCtrl)
 		mockTestWorkflowRepo.EXPECT().
-			GetPreviousFinishedState(gomock.Any(), "test-workflow", gomock.Any()).
+			GetPreviousFinishedState(gomock.Any(), "test-workflow", gomock.Any(), testworkflow.GetPreviousFinishedStateOptions{SkipSilentWebhookExecutions: true}).
 			Return(testkube.FAILED_TestWorkflowStatus, nil).
 			Times(1)
 

--- a/pkg/repository/testworkflow/interface.go
+++ b/pkg/repository/testworkflow/interface.go
@@ -20,6 +20,10 @@ type LabelSelector struct {
 	Or []Label
 }
 
+type GetPreviousFinishedStateOptions struct {
+	SkipSilentWebhookExecutions bool
+}
+
 // LatestSortBy defines the sorting criteria for getting the latest execution
 type LatestSortBy string
 
@@ -122,7 +126,7 @@ type Repository interface {
 	// GetExecutionsSummary gets executions summary using a filter, use filter with no data for all
 	GetExecutionsSummary(ctx context.Context, filter Filter) ([]testkube.TestWorkflowExecutionSummary, error)
 	// GetPreviousFinishedState gets previous finished execution state by test
-	GetPreviousFinishedState(ctx context.Context, testName string, date time.Time) (testkube.TestWorkflowStatus, error)
+	GetPreviousFinishedState(ctx context.Context, testName string, date time.Time, opts GetPreviousFinishedStateOptions) (testkube.TestWorkflowStatus, error)
 	// Insert inserts new execution result
 	Insert(ctx context.Context, result testkube.TestWorkflowExecution) error
 	// Update updates execution

--- a/pkg/repository/testworkflow/mock_repository.go
+++ b/pkg/repository/testworkflow/mock_repository.go
@@ -300,18 +300,18 @@ func (mr *MockRepositoryMockRecorder) GetNextExecutionNumber(ctx, name any) *gom
 }
 
 // GetPreviousFinishedState mocks base method.
-func (m *MockRepository) GetPreviousFinishedState(ctx context.Context, testName string, date time.Time) (testkube.TestWorkflowStatus, error) {
+func (m *MockRepository) GetPreviousFinishedState(ctx context.Context, testName string, date time.Time, opts GetPreviousFinishedStateOptions) (testkube.TestWorkflowStatus, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetPreviousFinishedState", ctx, testName, date)
+	ret := m.ctrl.Call(m, "GetPreviousFinishedState", ctx, testName, date, opts)
 	ret0, _ := ret[0].(testkube.TestWorkflowStatus)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetPreviousFinishedState indicates an expected call of GetPreviousFinishedState.
-func (mr *MockRepositoryMockRecorder) GetPreviousFinishedState(ctx, testName, date any) *gomock.Call {
+func (mr *MockRepositoryMockRecorder) GetPreviousFinishedState(ctx, testName, date, opts any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPreviousFinishedState", reflect.TypeOf((*MockRepository)(nil).GetPreviousFinishedState), ctx, testName, date)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPreviousFinishedState", reflect.TypeOf((*MockRepository)(nil).GetPreviousFinishedState), ctx, testName, date, opts)
 }
 
 // GetRunning mocks base method.

--- a/pkg/repository/testworkflow/mongo/mongo.go
+++ b/pkg/repository/testworkflow/mongo/mongo.go
@@ -854,6 +854,7 @@ func (r *MongoRepository) GetPreviousFinishedState(ctx context.Context, testWork
 		{Key: "workflow.name", Value: testWorkflowName},
 		{Key: "result.finishedat", Value: bson.M{"$lt": date}},
 		{Key: "result.status", Value: bson.M{"$in": []string{"passed", "failed", "skipped", "aborted", "canceled", "timeout"}}},
+		{Key: "silentmode.webhooks", Value: bson.M{"$ne": true}},
 	}
 
 	var result testkube.TestWorkflowExecution

--- a/pkg/repository/testworkflow/mongo/mongo.go
+++ b/pkg/repository/testworkflow/mongo/mongo.go
@@ -848,18 +848,22 @@ func (r *MongoRepository) GetTestWorkflowMetrics(ctx context.Context, name strin
 }
 
 // GetPreviousFinishedState gets previous finished execution state by test workflow
-func (r *MongoRepository) GetPreviousFinishedState(ctx context.Context, testWorkflowName string, date time.Time) (testkube.TestWorkflowStatus, error) {
-	opts := options.FindOne().SetProjection(bson.M{"result.status": 1}).SetSort(bson.D{{Key: "result.finishedat", Value: -1}})
+func (r *MongoRepository) GetPreviousFinishedState(ctx context.Context, testWorkflowName string, date time.Time, opts testworkflow.GetPreviousFinishedStateOptions) (testkube.TestWorkflowStatus, error) {
+	findOpts := options.FindOne().SetProjection(bson.M{"result.status": 1}).SetSort(bson.D{{Key: "result.finishedat", Value: -1}})
 	filter := bson.D{
 		{Key: "workflow.name", Value: testWorkflowName},
 		{Key: "result.finishedat", Value: bson.M{"$lt": date}},
 		{Key: "result.status", Value: bson.M{"$in": []string{"passed", "failed", "skipped", "aborted", "canceled", "timeout"}}},
-		{Key: "silentmode.webhooks", Value: bson.M{"$ne": true}},
-		{Key: "disablewebhooks", Value: bson.M{"$ne": true}},
+	}
+	if opts.SkipSilentWebhookExecutions {
+		filter = append(filter,
+			bson.E{Key: "silentmode.webhooks", Value: bson.M{"$ne": true}},
+			bson.E{Key: "disablewebhooks", Value: bson.M{"$ne": true}},
+		)
 	}
 
 	var result testkube.TestWorkflowExecution
-	err := r.Coll.FindOne(ctx, filter, opts).Decode(&result)
+	err := r.Coll.FindOne(ctx, filter, findOpts).Decode(&result)
 	if err != nil && err == mongo.ErrNoDocuments {
 		return "", nil
 	}

--- a/pkg/repository/testworkflow/mongo/mongo.go
+++ b/pkg/repository/testworkflow/mongo/mongo.go
@@ -855,6 +855,7 @@ func (r *MongoRepository) GetPreviousFinishedState(ctx context.Context, testWork
 		{Key: "result.finishedat", Value: bson.M{"$lt": date}},
 		{Key: "result.status", Value: bson.M{"$in": []string{"passed", "failed", "skipped", "aborted", "canceled", "timeout"}}},
 		{Key: "silentmode.webhooks", Value: bson.M{"$ne": true}},
+		{Key: "disablewebhooks", Value: bson.M{"$ne": true}},
 	}
 
 	var result testkube.TestWorkflowExecution

--- a/pkg/repository/testworkflow/postgres/postgres.go
+++ b/pkg/repository/testworkflow/postgres/postgres.go
@@ -1795,12 +1795,13 @@ func (r *PostgresRepository) GetTestWorkflowMetrics(ctx context.Context, name st
 }
 
 // GetPreviousFinishedState gets previous finished state
-func (r *PostgresRepository) GetPreviousFinishedState(ctx context.Context, testWorkflowName string, date time.Time) (testkube.TestWorkflowStatus, error) {
+func (r *PostgresRepository) GetPreviousFinishedState(ctx context.Context, testWorkflowName string, date time.Time, opts testworkflow.GetPreviousFinishedStateOptions) (testkube.TestWorkflowStatus, error) {
 	status, err := r.queries.GetPreviousFinishedState(ctx, sqlc.GetPreviousFinishedStateParams{
-		WorkflowName:   testWorkflowName,
-		Date:           toPgTimestamp(date),
-		OrganizationID: r.organizationID,
-		EnvironmentID:  r.environmentID,
+		WorkflowName:                testWorkflowName,
+		Date:                        toPgTimestamp(date),
+		OrganizationID:              r.organizationID,
+		EnvironmentID:               r.environmentID,
+		SkipSilentWebhookExecutions: opts.SkipSilentWebhookExecutions,
 	})
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {

--- a/pkg/repository/testworkflow/testsuite/filter.go
+++ b/pkg/repository/testworkflow/testsuite/filter.go
@@ -263,3 +263,61 @@ func testGetPreviousFinishedState(t *testing.T, repo testworkflow.Repository) {
 	require.NoError(t, err)
 	assert.Equal(t, testkube.FAILED_TestWorkflowStatus, status)
 }
+
+func testGetPreviousFinishedStateSkipsSilentWebhookExecutions(t *testing.T, repo testworkflow.Repository) {
+	ctx := context.Background()
+	wfName := "prev-state-silent-skip"
+
+	failedResult := &testkube.TestWorkflowResult{
+		Status:          fixtures.Ptr(testkube.FAILED_TestWorkflowStatus),
+		PredictedStatus: fixtures.Ptr(testkube.FAILED_TestWorkflowStatus),
+		FinishedAt:      time.Now().Add(-2 * time.Minute),
+	}
+	failed := fixtures.NewExecution(wfName,
+		fixtures.WithResult(failedResult),
+		fixtures.WithNumber(1),
+	)
+	failed.StatusAt = failedResult.FinishedAt
+	require.NoError(t, repo.Insert(ctx, failed))
+
+	silentAbortedResult := &testkube.TestWorkflowResult{
+		Status:          fixtures.Ptr(testkube.ABORTED_TestWorkflowStatus),
+		PredictedStatus: fixtures.Ptr(testkube.ABORTED_TestWorkflowStatus),
+		FinishedAt:      time.Now().Add(-time.Minute),
+	}
+	silentAborted := fixtures.NewExecution(wfName,
+		fixtures.WithResult(silentAbortedResult),
+		fixtures.WithNumber(2),
+		fixtures.WithSilentMode(testkube.SilentMode{Webhooks: true}),
+	)
+	silentAborted.StatusAt = silentAbortedResult.FinishedAt
+	require.NoError(t, repo.Insert(ctx, silentAborted))
+
+	status, err := repo.GetPreviousFinishedState(ctx, wfName, time.Now().Add(time.Hour))
+	require.NoError(t, err)
+	assert.Equal(t, testkube.FAILED_TestWorkflowStatus, status,
+		"silent-webhooks execution must not be treated as previous finished state")
+}
+
+func testGetPreviousFinishedStateReturnsEmptyWhenOnlySilent(t *testing.T, repo testworkflow.Repository) {
+	ctx := context.Background()
+	wfName := "prev-state-only-silent"
+
+	silentResult := &testkube.TestWorkflowResult{
+		Status:          fixtures.Ptr(testkube.FAILED_TestWorkflowStatus),
+		PredictedStatus: fixtures.Ptr(testkube.FAILED_TestWorkflowStatus),
+		FinishedAt:      time.Now().Add(-time.Minute),
+	}
+	silent := fixtures.NewExecution(wfName,
+		fixtures.WithResult(silentResult),
+		fixtures.WithNumber(1),
+		fixtures.WithSilentMode(testkube.SilentMode{Webhooks: true}),
+	)
+	silent.StatusAt = silentResult.FinishedAt
+	require.NoError(t, repo.Insert(ctx, silent))
+
+	status, err := repo.GetPreviousFinishedState(ctx, wfName, time.Now().Add(time.Hour))
+	require.NoError(t, err)
+	assert.Equal(t, testkube.TestWorkflowStatus(""), status,
+		"only silent-webhooks executions in history must resolve to empty previous state")
+}

--- a/pkg/repository/testworkflow/testsuite/filter.go
+++ b/pkg/repository/testworkflow/testsuite/filter.go
@@ -299,6 +299,41 @@ func testGetPreviousFinishedStateSkipsSilentWebhookExecutions(t *testing.T, repo
 		"silent-webhooks execution must not be treated as previous finished state")
 }
 
+func testGetPreviousFinishedStateSkipsLegacyDisableWebhooksExecutions(t *testing.T, repo testworkflow.Repository) {
+	ctx := context.Background()
+	wfName := "prev-state-legacy-skip"
+
+	failedResult := &testkube.TestWorkflowResult{
+		Status:          fixtures.Ptr(testkube.FAILED_TestWorkflowStatus),
+		PredictedStatus: fixtures.Ptr(testkube.FAILED_TestWorkflowStatus),
+		FinishedAt:      time.Now().Add(-2 * time.Minute),
+	}
+	failed := fixtures.NewExecution(wfName,
+		fixtures.WithResult(failedResult),
+		fixtures.WithNumber(1),
+	)
+	failed.StatusAt = failedResult.FinishedAt
+	require.NoError(t, repo.Insert(ctx, failed))
+
+	legacySilentAbortedResult := &testkube.TestWorkflowResult{
+		Status:          fixtures.Ptr(testkube.ABORTED_TestWorkflowStatus),
+		PredictedStatus: fixtures.Ptr(testkube.ABORTED_TestWorkflowStatus),
+		FinishedAt:      time.Now().Add(-time.Minute),
+	}
+	legacySilentAborted := fixtures.NewExecution(wfName,
+		fixtures.WithResult(legacySilentAbortedResult),
+		fixtures.WithNumber(2),
+		fixtures.WithDisableWebhooks(true),
+	)
+	legacySilentAborted.StatusAt = legacySilentAbortedResult.FinishedAt
+	require.NoError(t, repo.Insert(ctx, legacySilentAborted))
+
+	status, err := repo.GetPreviousFinishedState(ctx, wfName, time.Now().Add(time.Hour))
+	require.NoError(t, err)
+	assert.Equal(t, testkube.FAILED_TestWorkflowStatus, status,
+		"legacy DisableWebhooks execution must not be treated as previous finished state")
+}
+
 func testGetPreviousFinishedStateReturnsEmptyWhenOnlySilent(t *testing.T, repo testworkflow.Repository) {
 	ctx := context.Background()
 	wfName := "prev-state-only-silent"

--- a/pkg/repository/testworkflow/testsuite/filter.go
+++ b/pkg/repository/testworkflow/testsuite/filter.go
@@ -259,7 +259,7 @@ func testGetPreviousFinishedState(t *testing.T, repo testworkflow.Repository) {
 	err := repo.Insert(ctx, exec)
 	require.NoError(t, err)
 
-	status, err := repo.GetPreviousFinishedState(ctx, wfName, time.Now().Add(time.Hour))
+	status, err := repo.GetPreviousFinishedState(ctx, wfName, time.Now().Add(time.Hour), testworkflow.GetPreviousFinishedStateOptions{})
 	require.NoError(t, err)
 	assert.Equal(t, testkube.FAILED_TestWorkflowStatus, status)
 }
@@ -293,7 +293,7 @@ func testGetPreviousFinishedStateSkipsSilentWebhookExecutions(t *testing.T, repo
 	silentAborted.StatusAt = silentAbortedResult.FinishedAt
 	require.NoError(t, repo.Insert(ctx, silentAborted))
 
-	status, err := repo.GetPreviousFinishedState(ctx, wfName, time.Now().Add(time.Hour))
+	status, err := repo.GetPreviousFinishedState(ctx, wfName, time.Now().Add(time.Hour), testworkflow.GetPreviousFinishedStateOptions{SkipSilentWebhookExecutions: true})
 	require.NoError(t, err)
 	assert.Equal(t, testkube.FAILED_TestWorkflowStatus, status,
 		"silent-webhooks execution must not be treated as previous finished state")
@@ -328,7 +328,7 @@ func testGetPreviousFinishedStateSkipsLegacyDisableWebhooksExecutions(t *testing
 	legacySilentAborted.StatusAt = legacySilentAbortedResult.FinishedAt
 	require.NoError(t, repo.Insert(ctx, legacySilentAborted))
 
-	status, err := repo.GetPreviousFinishedState(ctx, wfName, time.Now().Add(time.Hour))
+	status, err := repo.GetPreviousFinishedState(ctx, wfName, time.Now().Add(time.Hour), testworkflow.GetPreviousFinishedStateOptions{SkipSilentWebhookExecutions: true})
 	require.NoError(t, err)
 	assert.Equal(t, testkube.FAILED_TestWorkflowStatus, status,
 		"legacy DisableWebhooks execution must not be treated as previous finished state")
@@ -351,8 +351,13 @@ func testGetPreviousFinishedStateReturnsEmptyWhenOnlySilent(t *testing.T, repo t
 	silent.StatusAt = silentResult.FinishedAt
 	require.NoError(t, repo.Insert(ctx, silent))
 
-	status, err := repo.GetPreviousFinishedState(ctx, wfName, time.Now().Add(time.Hour))
+	status, err := repo.GetPreviousFinishedState(ctx, wfName, time.Now().Add(time.Hour), testworkflow.GetPreviousFinishedStateOptions{SkipSilentWebhookExecutions: true})
 	require.NoError(t, err)
 	assert.Equal(t, testkube.TestWorkflowStatus(""), status,
 		"only silent-webhooks executions in history must resolve to empty previous state")
+
+	rawStatus, err := repo.GetPreviousFinishedState(ctx, wfName, time.Now().Add(time.Hour), testworkflow.GetPreviousFinishedStateOptions{})
+	require.NoError(t, err)
+	assert.Equal(t, testkube.FAILED_TestWorkflowStatus, rawStatus,
+		"raw mode must include silent-webhooks executions")
 }

--- a/pkg/repository/testworkflow/testsuite/suite.go
+++ b/pkg/repository/testworkflow/testsuite/suite.go
@@ -31,6 +31,9 @@ func RunRepositoryTests(t *testing.T, repo testworkflow.Repository) {
 	t.Run("GetPreviousFinishedStateSkipsSilentWebhookExecutions", func(t *testing.T) {
 		testGetPreviousFinishedStateSkipsSilentWebhookExecutions(t, repo)
 	})
+	t.Run("GetPreviousFinishedStateSkipsLegacyDisableWebhooksExecutions", func(t *testing.T) {
+		testGetPreviousFinishedStateSkipsLegacyDisableWebhooksExecutions(t, repo)
+	})
 	t.Run("GetPreviousFinishedStateReturnsEmptyWhenOnlySilent", func(t *testing.T) {
 		testGetPreviousFinishedStateReturnsEmptyWhenOnlySilent(t, repo)
 	})

--- a/pkg/repository/testworkflow/testsuite/suite.go
+++ b/pkg/repository/testworkflow/testsuite/suite.go
@@ -28,6 +28,12 @@ func RunRepositoryTests(t *testing.T, repo testworkflow.Repository) {
 	t.Run("Count", func(t *testing.T) { testCount(t, repo) })
 	t.Run("GetExecutionsTotals", func(t *testing.T) { testGetExecutionsTotals(t, repo) })
 	t.Run("GetPreviousFinishedState", func(t *testing.T) { testGetPreviousFinishedState(t, repo) })
+	t.Run("GetPreviousFinishedStateSkipsSilentWebhookExecutions", func(t *testing.T) {
+		testGetPreviousFinishedStateSkipsSilentWebhookExecutions(t, repo)
+	})
+	t.Run("GetPreviousFinishedStateReturnsEmptyWhenOnlySilent", func(t *testing.T) {
+		testGetPreviousFinishedStateReturnsEmptyWhenOnlySilent(t, repo)
+	})
 	t.Run("GetRunning", func(t *testing.T) { testGetRunning(t, repo) })
 	t.Run("GetFinished", func(t *testing.T) { testGetFinished(t, repo) })
 	t.Run("GetUnassigned", func(t *testing.T) { testGetUnassigned(t, repo) })

--- a/pkg/test/fixtures/testworkflow.go
+++ b/pkg/test/fixtures/testworkflow.go
@@ -109,6 +109,12 @@ func WithSilentMode(mode testkube.SilentMode) ExecutionOption {
 	}
 }
 
+func WithDisableWebhooks(disabled bool) ExecutionOption {
+	return func(e *testkube.TestWorkflowExecution) {
+		e.DisableWebhooks = disabled
+	}
+}
+
 func NewExecution(name string, opts ...ExecutionOption) testkube.TestWorkflowExecution {
 	e := testkube.TestWorkflowExecution{
 		Id:   fmt.Sprintf("exec-%s-%d", name, time.Now().UnixNano()),

--- a/pkg/test/fixtures/testworkflow.go
+++ b/pkg/test/fixtures/testworkflow.go
@@ -103,6 +103,12 @@ func WithInitialization(init *testkube.TestWorkflowStepResult) ExecutionOption {
 	}
 }
 
+func WithSilentMode(mode testkube.SilentMode) ExecutionOption {
+	return func(e *testkube.TestWorkflowExecution) {
+		e.SilentMode = &mode
+	}
+}
+
 func NewExecution(name string, opts ...ExecutionOption) testkube.TestWorkflowExecution {
 	e := testkube.TestWorkflowExecution{
 		Id:   fmt.Sprintf("exec-%s-%d", name, time.Now().UnixNano()),


### PR DESCRIPTION
Ref: [TKC-6495](https://linear.app/kubeshop/issue/TKC-6495/become-testworkflow-up-is-triggered-after-failed-silent-execuiton)

## Problem

`GetPreviousFinishedState` did not filter out executions with `SilentMode.Webhooks=true`, so a silent failed run in the workflow's history was being treated as the "previous state" for the next non-silent run. The next non-silent passed execution then triggered a spurious `become-testworkflow-up` webhook

Confirmed on the .dev postgres for the `cloud-ui-e2e-12874` alert on 2026-08-11: the alerted execution was preceded by a fully-silent failed run 42 seconds earlier; without that silent row, the query would have returned `passed` and no become-up would have fired

## Fix

Add a silent-mode filter to `GetPreviousFinishedState` in both backends, targeting the `webhooks` aspect specifically. This mirrors what the webhook listener already checks in `pkg/event/kind/webhook/listener.go` when deciding whether to dispatch a webhook for the current execution

## Test plan

- [x] Postgres integration suite passes with fix, `GetPreviousFinishedStateSkipsSilentWebhookExecutions` fails without fix
- [x] Mongo integration suite passes with fix, same test fails without fix
- [x] Full `pkg/repository/testworkflow/{postgres,mongo}` suites green
- [x] `go build ./...` and `make generate-sqlc` clean