### PR TITLE
feat: add ability to rerun with latest workflow

### DIFF
--- a/api/v1/testkube.yaml
+++ b/api/v1/testkube.yaml
@@ -4448,8 +4448,12 @@ paths:
       parameters:
         - $ref: "#/components/parameters/ID"
         - $ref: "#/components/parameters/executionID"
+        - $ref: "#/components/parameters/Latest"
       summary: Rerun test workflow execution
-      description: Rerun test workflow execution
+      description: |
+        Rerun test workflow execution using the previous execution's parameters.
+        By default the resolved workflow snapshot from the original execution is reused.
+        When `latest=true`, the current workflow definition is used instead while keeping the original parameter set.
       operationId: rerunTestWorkflowExecutionByTestWorkflow
       requestBody:
         description: test workflow running context
@@ -4817,8 +4821,12 @@ paths:
         - api
       parameters:
         - $ref: "#/components/parameters/executionID"
+        - $ref: "#/components/parameters/Latest"
       summary: Rerun test workflow execution
-      description: Rerun test workflow execution
+      description: |
+        Rerun test workflow execution using the previous execution's parameters.
+        By default the resolved workflow snapshot from the original execution is reused.
+        When `latest=true`, the current workflow definition is used instead while keeping the original parameter set.
       operationId: rerunTestWorkflowExecution
       requestBody:
         description: test workflow running context
@@ -12365,6 +12373,14 @@ components:
         type: boolean
         default: false
       description: should inline templates in the resolved workflow
+      required: false
+    Latest:
+      in: query
+      name: latest
+      schema:
+        type: boolean
+        default: false
+      description: when rerunning, use the latest workflow definition instead of the original resolved snapshot while keeping the original parameter set
       required: false
     All:
       in: query

--- a/cmd/kubectl-testkube/commands/testworkflows/rerun.go
+++ b/cmd/kubectl-testkube/commands/testworkflows/rerun.go
@@ -31,6 +31,7 @@ func NewReRunTestWorkflowExecutionCmd() *cobra.Command {
 		parallelStepName         string
 		serviceIndex             int
 		parallelStepIndex        int
+		latest                   bool
 	)
 
 	cmd := &cobra.Command{
@@ -77,7 +78,7 @@ func NewReRunTestWorkflowExecutionCmd() *cobra.Command {
 				name = execution.Workflow.Name
 			}
 
-			execution, err = client.ReRunTestWorkflowExecution(name, execution.Id, runningContext)
+			execution, err = client.ReRunTestWorkflowExecution(name, execution.Id, runningContext, latest)
 			if err != nil {
 				// User friendly Open Source operation error
 				errMessage := err.Error()
@@ -146,6 +147,7 @@ func NewReRunTestWorkflowExecutionCmd() *cobra.Command {
 	}
 
 	cmd.Flags().BoolVarP(&watchEnabled, "watch", "f", false, "watch for changes after start")
+	cmd.Flags().BoolVar(&latest, "latest", false, "use the latest workflow definition instead of the original resolved snapshot, keeping the original parameter set")
 	cmd.Flags().StringVar(&downloadDir, "download-dir", "artifacts", "download dir")
 	cmd.Flags().BoolVarP(&downloadArtifactsEnabled, "download-artifacts", "d", false, "download artifacts automatically")
 	cmd.Flags().StringVar(&format, "format", "folder", "data format for storing files, one of folder|archive")

--- a/internal/app/api/v1/testworkflows.go
+++ b/internal/app/api/v1/testworkflows.go
@@ -589,7 +589,8 @@ func (s *TestkubeAPI) ReRunTestWorkflowExecutionHandler() fiber.Handler {
 	return func(c *fiber.Ctx) (err error) {
 		ctx := c.Context()
 		executionID := c.Params("executionID")
-		s.Log.Debugw("rerunning test workflow execution", "id", executionID)
+		latest := c.QueryBool("latest")
+		s.Log.Debugw("rerunning test workflow execution", "id", executionID, "latest", latest)
 
 		errPrefix := "failed to rerun test workflow execution"
 
@@ -605,14 +606,36 @@ func (s *TestkubeAPI) ReRunTestWorkflowExecutionHandler() fiber.Handler {
 			return s.ClientError(c, errPrefix, err)
 		}
 
-		if execution.ResolvedWorkflow == nil {
-			return s.ClientError(c, errPrefix, errors.New("can't find resolved workflow spec"))
-		}
+		// By default reuse the resolved snapshot from the original execution.
+		// When latest=true, omit it so the scheduler loads and resolves the current workflow definition.
+		var resolvedWorkflow []byte
+		var workflow *testkube.TestWorkflow
+		if latest {
+			name := ""
+			if execution.Workflow != nil {
+				name = execution.Workflow.Name
+			}
+			if name == "" && execution.ResolvedWorkflow != nil {
+				name = execution.ResolvedWorkflow.Name
+			}
+			if name == "" {
+				return s.ClientError(c, errPrefix, errors.New("can't find workflow name"))
+			}
 
-		name := execution.ResolvedWorkflow.Name
-		workflow, err := json.Marshal(execution.ResolvedWorkflow)
-		if err != nil {
-			return s.ClientError(c, errPrefix, err)
+			workflow, err = s.TestWorkflowsClient.Get(ctx, s.getEnvironmentId(), name)
+			if err != nil {
+				return s.ClientError(c, errPrefix, err)
+			}
+		} else {
+			if execution.ResolvedWorkflow == nil {
+				return s.ClientError(c, errPrefix, errors.New("can't find resolved workflow spec"))
+			}
+			workflow = execution.ResolvedWorkflow
+
+			resolvedWorkflow, err = json.Marshal(workflow)
+			if err != nil {
+				return s.ClientError(c, errPrefix, err)
+			}
 		}
 
 		// Load the execution request
@@ -641,17 +664,15 @@ func (s *TestkubeAPI) ReRunTestWorkflowExecutionHandler() fiber.Handler {
 
 		// Check if workflow is silent and activate SilentMode accordingly
 		var silentMode *cloud.SilentMode
-		if execution.ResolvedWorkflow != nil {
-			// Check if workflow has silent set to true, and if so, activate SilentMode with all fields to true
-			// This overrides any SilentMode settings from the request (CLI flags)
-			if testworkflowutils.IsWorkflowSilent(execution.ResolvedWorkflow) {
-				silentMode = &cloud.SilentMode{
-					Webhooks: true,
-					Insights: true,
-					Health:   true,
-					Metrics:  true,
-					Cdevents: true,
-				}
+		// Check if workflow has silent set to true, and if so, activate SilentMode with all fields to true
+		// This overrides any SilentMode settings from the request (CLI flags)
+		if testworkflowutils.IsWorkflowSilent(workflow) {
+			silentMode = &cloud.SilentMode{
+				Webhooks: true,
+				Insights: true,
+				Health:   true,
+				Metrics:  true,
+				Cdevents: true,
 			}
 		}
 
@@ -681,7 +702,7 @@ func (s *TestkubeAPI) ReRunTestWorkflowExecutionHandler() fiber.Handler {
 			scheduleExecution.Targets = []*cloud.ExecutionTarget{target}
 		}
 
-		scheduleExecution.Selector = &cloud.ScheduleResourceSelector{Name: name}
+		scheduleExecution.Selector = &cloud.ScheduleResourceSelector{Name: workflow.Name}
 		scheduleExecution.Config = request.Config
 		if request.Runtime != nil && len(request.Runtime.Variables) > 0 {
 			scheduleExecution.Runtime = &cloud.TestWorkflowRuntime{
@@ -695,7 +716,7 @@ func (s *TestkubeAPI) ReRunTestWorkflowExecutionHandler() fiber.Handler {
 			RunningContext:     runningContext,
 			User:               user,
 			ExecutionReference: &executionID,
-			ResolvedWorkflow:   workflow,
+			ResolvedWorkflow:   resolvedWorkflow,
 			SilentMode:         silentMode,
 		})
 
@@ -703,7 +724,7 @@ func (s *TestkubeAPI) ReRunTestWorkflowExecutionHandler() fiber.Handler {
 			return s.InternalError(c, errPrefix, "execution error", err)
 		}
 
-		s.Log.Debugw("rerunning test workflow execution", "id", executionID)
+		s.Log.Debugw("rerunning test workflow execution", "id", executionID, "latest", latest)
 		if len(results) != 0 {
 			return c.JSON(results[0])
 		}

--- a/pkg/api/v1/client/interface.go
+++ b/pkg/api/v1/client/interface.go
@@ -139,7 +139,7 @@ type TestWorkflowExecutionAPI interface {
 	GetTestWorkflowExecutionArtifacts(executionID string) (artifacts testkube.Artifacts, err error)
 	DownloadTestWorkflowArtifact(executionID, fileName, destination string) (artifact string, err error)
 	DownloadTestWorkflowArtifactArchive(executionID, destination string, masks []string) (archive string, err error)
-	ReRunTestWorkflowExecution(workflow string, id string, runningContext *testkube.TestWorkflowRunningContext) (testkube.TestWorkflowExecution, error)
+	ReRunTestWorkflowExecution(workflow string, id string, runningContext *testkube.TestWorkflowRunningContext, latest bool) (testkube.TestWorkflowExecution, error)
 	UpdateTestWorkflowExecutionTags(executionID string, tags map[string]string) error
 	ValidateTestWorkflow(body []byte) error
 	ExportExecutions(destination string, since string) (fileName string, err error)

--- a/pkg/api/v1/client/testworkflow.go
+++ b/pkg/api/v1/client/testworkflow.go
@@ -328,8 +328,10 @@ func (c TestWorkflowClient) UpdateTestWorkflowExecutionTags(executionID string, 
 	return c.testWorkflowExecutionTransport.Validate(http.MethodPatch, uri, body, nil)
 }
 
-// ReRunTestWorkflowExecution reruns selected execution
-func (c TestWorkflowClient) ReRunTestWorkflowExecution(workflow, id string, runningContext *testkube.TestWorkflowRunningContext) (result testkube.TestWorkflowExecution, err error) {
+// ReRunTestWorkflowExecution reruns selected execution.
+// When latest is true, the current workflow definition is used instead of the original resolved snapshot,
+// while keeping the original parameter set.
+func (c TestWorkflowClient) ReRunTestWorkflowExecution(workflow, id string, runningContext *testkube.TestWorkflowRunningContext, latest bool) (result testkube.TestWorkflowExecution, err error) {
 	if workflow == "" {
 		return result, fmt.Errorf("test workflow name '%s' is not valid", workflow)
 	}
@@ -341,7 +343,12 @@ func (c TestWorkflowClient) ReRunTestWorkflowExecution(workflow, id string, runn
 		return result, err
 	}
 
-	return c.testWorkflowExecutionTransport.Execute(http.MethodPost, uri, body, nil)
+	params := map[string]string{}
+	if latest {
+		params["latest"] = "true"
+	}
+
+	return c.testWorkflowExecutionTransport.Execute(http.MethodPost, uri, body, params)
 }
 
 // ExportExecutions downloads the export archive from the server


### PR DESCRIPTION
Adds the ability to rerun an execution using the latest workflow configuration. The execution will still use the same params, but will load the workflow configuration during execution. Default behavior mimics the current behavior (using the snapshot workflow).