### PR TITLE
fix: support multiple kubeconfig files in KUBECONFIG env var

### DIFF
--- a/pkg/k8sclient/k8sclient.go
+++ b/pkg/k8sclient/k8sclient.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"os"
 	"path"
+	"path/filepath"
 	"time"
 
 	"github.com/pkg/errors"
@@ -76,7 +77,11 @@ func GetK8sClientConfig() (*rest.Config, error) {
 	}
 
 	if cfg, exists := os.LookupEnv("KUBECONFIG"); exists {
-		config, err = clientcmd.BuildConfigFromFlags("", cfg)
+		// KUBECONFIG may hold a list of files (colon-separated on Unix, semicolon on
+		// Windows); merge them with kubectl's own precedence semantics instead of
+		// treating the whole value as a single path.
+		loadingRules := &clientcmd.ClientConfigLoadingRules{Precedence: filepath.SplitList(cfg)}
+		config, err = clientcmd.NewNonInteractiveDeferredLoadingClientConfig(loadingRules, &clientcmd.ConfigOverrides{}).ClientConfig()
 	} else if k8sConfigExists {
 		config, err = clientcmd.BuildConfigFromFlags("", cubeConfigPath)
 	} else {

--- a/pkg/k8sclient/k8sclient.go
+++ b/pkg/k8sclient/k8sclient.go
@@ -76,7 +76,7 @@ func GetK8sClientConfig() (*rest.Config, error) {
 		k8sConfigExists = true
 	}
 
-	if cfg, exists := os.LookupEnv("KUBECONFIG"); exists {
+	if cfg, exists := os.LookupEnv("KUBECONFIG"); exists && cfg != "" {
 		// KUBECONFIG may hold a list of files (colon-separated on Unix, semicolon on
 		// Windows); merge them with kubectl's own precedence semantics instead of
 		// treating the whole value as a single path.

--- a/pkg/k8sclient/k8sclient_test.go
+++ b/pkg/k8sclient/k8sclient_test.go
@@ -2,11 +2,67 @@ package k8sclient
 
 import (
 	"context"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"k8s.io/client-go/kubernetes/fake"
 )
+
+func writeKubeconfig(t *testing.T, name, server string) string {
+	t.Helper()
+	content := `apiVersion: v1
+kind: Config
+clusters:
+- cluster:
+    server: ` + server + `
+  name: ` + name + `
+contexts:
+- context:
+    cluster: ` + name + `
+    user: ` + name + `
+  name: ` + name + `
+current-context: ` + name + `
+users:
+- name: ` + name + `
+  user:
+    token: ` + name + `-token
+`
+	p := filepath.Join(t.TempDir(), name+".yaml")
+	if err := os.WriteFile(p, []byte(content), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return p
+}
+
+func TestGetK8sClientConfigMultipleKubeconfigFiles(t *testing.T) {
+	one := writeKubeconfig(t, "cluster-one", "https://one.example.com")
+	two := writeKubeconfig(t, "cluster-two", "https://two.example.com")
+	sep := string(os.PathListSeparator)
+
+	// Multiple files must merge instead of being treated as one path
+	// (https://github.com/kubeshop/testkube/issues/657); the first file's
+	// current-context wins, matching kubectl precedence.
+	t.Setenv("KUBECONFIG", one+sep+two)
+	config, err := GetK8sClientConfig()
+	assert.NoError(t, err)
+	assert.Equal(t, "https://one.example.com", config.Host)
+
+	t.Setenv("KUBECONFIG", two+sep+one)
+	config, err = GetK8sClientConfig()
+	assert.NoError(t, err)
+	assert.Equal(t, "https://two.example.com", config.Host)
+}
+
+func TestGetK8sClientConfigSingleKubeconfigFile(t *testing.T) {
+	one := writeKubeconfig(t, "cluster-one", "https://one.example.com")
+
+	t.Setenv("KUBECONFIG", one)
+	config, err := GetK8sClientConfig()
+	assert.NoError(t, err)
+	assert.Equal(t, "https://one.example.com", config.Host)
+}
 
 func TestGetClusterVersion(t *testing.T) {
 	client := fake.NewClientset()

--- a/pkg/k8sclient/k8sclient_test.go
+++ b/pkg/k8sclient/k8sclient_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"k8s.io/client-go/kubernetes/fake"
 )
 
@@ -94,4 +95,20 @@ func TestGetPodLogs(t *testing.T) {
 	logs, err := GetPodLogs(context.Background(), client, "testkube", "selector")
 	assert.NoError(t, err)
 	assert.Equal(t, []string([]string{}), logs)
+}
+
+func TestGetK8sClientConfigEmptyKubeconfigEnvFallsBackToDefault(t *testing.T) {
+	home := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(home, ".kube"), 0o700))
+	def := writeKubeconfig(t, "cluster-default", "https://default.example.com")
+	content, err := os.ReadFile(def)
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(filepath.Join(home, ".kube", "config"), content, 0o600))
+
+	t.Setenv("HOME", home)
+	// A set-but-empty KUBECONFIG must behave like an unset one instead of erroring.
+	t.Setenv("KUBECONFIG", "")
+	config, err := GetK8sClientConfig()
+	assert.NoError(t, err)
+	assert.Equal(t, "https://default.example.com", config.Host)
 }


### PR DESCRIPTION
Fixes #657

Problem: GetK8sClientConfig() passes the entire KUBECONFIG value to BuildConfigFromFlags as if it were a single file path. When the variable holds a list (colon-separated on Unix, semicolon on Windows), this fails with stat /a/config:/b/config: no such file or directory. Since this helper is also used by the api-server, telemetry, and agent utils, anything running with a multi-cluster KUBECONFIG hits it, not just the CLI.

Fix: split the value with filepath.SplitList and load it through clientcmd's loading rules, which merge the files with kubectl's own precedence semantics: the first file's current-context wins, and entries defined in later files stay reachable. This also answers the open question in the issue thread about which path to use — all of them, same as kubectl.

Single-file KUBECONFIG, ~/.kube/config fallback, and in-cluster config behavior are unchanged.

Testing: added tests covering the multi-file merge in both list orders (asserting first-file precedence — the case that previously errored) and single-file regression. go test ./pkg/k8sclient/ green, gofmt/go vet clean.

