### PR TITLE
fix: replace App Engine logger with testkube logger in k8sclient

### DIFF
--- a/pkg/k8sclient/k8sclient.go
+++ b/pkg/k8sclient/k8sclient.go
@@ -11,7 +11,6 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
-	"google.golang.org/appengine/v2/log"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/transport/spdy"
 
@@ -27,6 +26,7 @@ import (
 	"k8s.io/client-go/tools/portforward"
 
 	"github.com/kubeshop/testkube/pkg/executor"
+	"github.com/kubeshop/testkube/pkg/log"
 )
 
 const (
@@ -370,7 +370,7 @@ func PortForward(ctx context.Context, namespace, serviceName string, servicePort
 			}
 		}()
 		if err = forwarder.ForwardPorts(); err != nil {
-			log.Errorf(ctx, "port forwarding failed: %v", err)
+			log.DefaultLogger.Errorw("port forwarding failed", "error", err)
 		}
 	}()
 	<-readyChan


### PR DESCRIPTION
Fixes #8105

pkg/k8sclient imported google.golang.org/appengine/v2/log for a single error log in the port-forward helper, pulling the App Engine SDK into the CLI and agent for no benefit and diverging from the zap-based logging used across the codebase. This switches that call to pkg/log's DefaultLogger.

go build, go vet and package tests green.