### PR TITLE
feat(TKC-6504): Add warn message

### DIFF
--- a/cmd/kubectl-testkube/commands/init.go
+++ b/cmd/kubectl-testkube/commands/init.go
@@ -206,10 +206,11 @@ func NewInitCmdDemo() *cobra.Command {
 				common.HandleCLIError(cliErr)
 			}
 			sendTelemetry(cmd, cfg, license, "license validated")
-
+			
 			ui.NL()
 			ui.Warn("Installation is about to start and may take a several minutes:")
 			ui.NL()
+			ui.Warn("- This install typically works best in a local cluster.")
 			ui.Warn("- Testkube will be installed in the " + kubecontext + " context.")
 			ui.Warn("- Testkube services will be applied to the " + namespace + " namespace.")
 			ui.Warn("- Testkube CRDs and cluster roles will be applied to your cluster.")

--- a/cmd/kubectl-testkube/commands/init.go
+++ b/cmd/kubectl-testkube/commands/init.go
@@ -206,7 +206,7 @@ func NewInitCmdDemo() *cobra.Command {
 				common.HandleCLIError(cliErr)
 			}
 			sendTelemetry(cmd, cfg, license, "license validated")
-			
+
 			ui.NL()
 			ui.Warn("Installation is about to start and may take a several minutes:")
 			ui.NL()


### PR DESCRIPTION
## Pull request description 
Adds an info line to `testkube init demo` output letting users know the demo works best in a local cluster.


## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [x] tested locally
- [ ] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Breaking changes

-

## Changes

-

## Fixes

-