### PR TITLE
fix: retry TestWorkflow cleanup and webhook delivery on transient failures

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,6 +39,11 @@
 - Regenerate SQL code when query files change via `make generate-sqlc`.
 - Refresh mocks for new or updated interfaces using `make generate-mocks`.
 
+## Transient-failure retries
+
+- `pkg/runner/runner.go` runs `worker.Destroy` (cleanup of the execution's Secrets/Pods after the workflow ends) through the shared `retry()` helper via `destroyResources`. Bounded by `CleanupResourcesRetryCount` and `CleanupResourcesRetryDelay`; a brief `kube-apiserver` blip during teardown should not leave orphan resources in the customer namespace.
+- `pkg/event/kind/webhook/listener.go` retries the outbound `HttpClient.Do` for `sendRetryCount` attempts with a linear `sendRetryBaseDelay`. Retryable outcomes: network errors, `5xx`, and `429`. Other `4xx` short-circuit so a bad URL / auth failure is not spammed at the subscriber. Every attempt for a single event carries the same `Idempotency-Key: {event.Id}` header so subscribers can dedupe replays.
+
 ## Telemetry and cluster detection
 
 - `pkg/telemetry/` contains all telemetry event construction, sending, and cluster identification logic.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,7 +42,7 @@
 ## Transient-failure retries
 
 - `pkg/runner/runner.go` runs `worker.Destroy` (cleanup of the execution's Secrets/Pods after the workflow ends) through the shared `retry()` helper via `destroyResources`. Bounded by `CleanupResourcesRetryCount` and `CleanupResourcesRetryDelay`; a brief `kube-apiserver` blip during teardown should not leave orphan resources in the customer namespace.
-- `pkg/event/kind/webhook/listener.go` retries the outbound `HttpClient.Do` for `sendRetryCount` attempts with a linear `sendRetryBaseDelay`. Retryable outcomes: network errors, `5xx`, and `429`. Other `4xx` short-circuit so a bad URL / auth failure is not spammed at the subscriber. Every attempt for a single event carries the same `Idempotency-Key: {event.Id}` header so subscribers can dedupe replays.
+- `pkg/event/kind/webhook/listener.go` retries the outbound `HttpClient.Do` for `sendRetryCount` attempts with a linear `sendRetryBaseDelay`. Retryable outcomes: network errors, `5xx`, and `429`. Other `4xx` short-circuit so a bad URL / auth failure is not spammed at the subscriber. Delivery is intentionally at-least-once (subscribers own dedupe, matching Stripe/GitHub/Slack convention).
 
 ## Telemetry and cluster detection
 

--- a/pkg/event/kind/webhook/listener.go
+++ b/pkg/event/kind/webhook/listener.go
@@ -405,6 +405,11 @@ func (l *WebhookListener) Notify(event testkube.Event) (result testkube.EventRes
 	var respBody []byte
 	var sendErr error
 	for attempt := 0; attempt < l.sendRetryCount; attempt++ {
+		// Reset per-attempt state so a later transport failure does not pair with
+		// the previous attempt's response body or status code in logs and telemetry.
+		respBody = nil
+		statusCode = 0
+
 		if attempt > 0 {
 			time.Sleep(time.Duration(attempt) * l.sendRetryBaseDelay)
 		}
@@ -417,6 +422,8 @@ func (l *WebhookListener) Notify(event testkube.Event) (result testkube.EventRes
 			return
 		}
 		req.Header.Set("Content-Type", "application/json")
+		// Subscribers can dedupe replays: same event -> same key across all attempts.
+		req.Header.Set("Idempotency-Key", event.Id)
 		for k, v := range processedHeaders {
 			req.Header.Set(k, v)
 		}

--- a/pkg/event/kind/webhook/listener.go
+++ b/pkg/event/kind/webhook/listener.go
@@ -31,6 +31,11 @@ import (
 
 var _ common.Listener = (*WebhookListener)(nil)
 
+const (
+	webhookSendRetryCount     = 5
+	webhookSendRetryBaseDelay = 500 * time.Millisecond
+)
+
 func NewWebhookListener(
 	name, uri, selector string,
 	events []testkube.EventType,
@@ -54,6 +59,8 @@ func NewWebhookListener(
 		disabled:           disabled,
 		config:             config,
 		parameters:         parameters,
+		sendRetryCount:     webhookSendRetryCount,
+		sendRetryBaseDelay: webhookSendRetryBaseDelay,
 	}
 
 	for _, opt := range opts {
@@ -81,6 +88,9 @@ type WebhookListener struct {
 	grpcClient cloud.TestKubeCloudAPIClient
 	apiKey     string
 	agentID    string
+
+	sendRetryCount     int
+	sendRetryBaseDelay time.Duration
 
 	// Optional fields
 	testWorkflowResultsRepository testworkflow.Repository
@@ -373,14 +383,9 @@ func (l *WebhookListener) Notify(event testkube.Event) (result testkube.EventRes
 		return
 	}
 
-	request, err := http.NewRequestWithContext(context.Background(), http.MethodPost, string(uri), body)
-	if err != nil {
-		log.Errorw("webhook request creating error", "error", err)
-		result = testkube.NewFailedEventResult(event.Id, err)
-		return
-	}
+	bodyBytes := body.Bytes()
 
-	request.Header.Set("Content-Type", "application/json")
+	processedHeaders := make(map[string]string, len(l.headers))
 	for key, value := range l.headers {
 		values := []*string{&key, &value}
 		for i := range values {
@@ -394,31 +399,70 @@ func (l *WebhookListener) Notify(event testkube.Event) (result testkube.EventRes
 			*values[i] = string(data)
 		}
 
-		request.Header.Set(key, value)
+		processedHeaders[key] = value
 	}
 
-	var resp *http.Response
-	resp, err = l.HttpClient.Do(request)
-	if err != nil {
-		log.Errorw("webhook send error", "error", err)
-		result = testkube.NewFailedEventResult(event.Id, err)
+	var respBody []byte
+	var sendErr error
+	for attempt := 0; attempt < l.sendRetryCount; attempt++ {
+		if attempt > 0 {
+			time.Sleep(time.Duration(attempt) * l.sendRetryBaseDelay)
+		}
+
+		var req *http.Request
+		req, err = http.NewRequestWithContext(context.Background(), http.MethodPost, string(uri), bytes.NewReader(bodyBytes))
+		if err != nil {
+			log.Errorw("webhook request creating error", "error", err)
+			result = testkube.NewFailedEventResult(event.Id, err)
+			return
+		}
+		req.Header.Set("Content-Type", "application/json")
+		for k, v := range processedHeaders {
+			req.Header.Set(k, v)
+		}
+
+		var resp *http.Response
+		resp, sendErr = l.HttpClient.Do(req)
+		if sendErr != nil {
+			if attempt < l.sendRetryCount-1 {
+				log.Warnw("webhook send transient error, retrying", "attempt", attempt, "error", sendErr)
+			}
+			continue
+		}
+
+		respBody, sendErr = io.ReadAll(resp.Body)
+		resp.Body.Close()
+		if sendErr != nil {
+			if attempt < l.sendRetryCount-1 {
+				log.Warnw("webhook read response transient error, retrying", "attempt", attempt, "error", sendErr)
+			}
+			continue
+		}
+
+		statusCode = resp.StatusCode
+		if statusCode >= 500 || statusCode == http.StatusTooManyRequests {
+			sendErr = fmt.Errorf("webhook response with retryable status code: %d", statusCode)
+			if attempt < l.sendRetryCount-1 {
+				log.Warnw("webhook returned retryable status, retrying", "attempt", attempt, "status", statusCode)
+			}
+			continue
+		}
+
+		sendErr = nil
+		break
+	}
+
+	responseStr := string(respBody)
+	if sendErr != nil {
+		err = sendErr
+		log.Errorw("webhook send error after retries", "error", err, "status", statusCode, "response", responseStr)
+		result = testkube.NewFailedEventResult(event.Id, err).WithResult(responseStr)
 		return
 	}
-	defer resp.Body.Close()
 
-	var data []byte
-	data, err = io.ReadAll(resp.Body)
-	if err != nil {
-		log.Errorw("webhook read response error", "error", err)
-		result = testkube.NewFailedEventResult(event.Id, err)
-		return
-	}
-
-	responseStr := string(data)
-	statusCode = resp.StatusCode
-	if resp.StatusCode >= 400 {
-		err = fmt.Errorf("webhook response with bad status code: %d", resp.StatusCode)
-		log.Errorw("webhook send error", "error", err, "status", resp.StatusCode, "response", responseStr)
+	if statusCode >= 400 {
+		err = fmt.Errorf("webhook response with bad status code: %d", statusCode)
+		log.Errorw("webhook send error", "error", err, "status", statusCode, "response", responseStr)
 		result = testkube.NewFailedEventResult(event.Id, err).WithResult(responseStr)
 		return
 	}

--- a/pkg/event/kind/webhook/listener.go
+++ b/pkg/event/kind/webhook/listener.go
@@ -385,6 +385,9 @@ func (l *WebhookListener) Notify(event testkube.Event) (result testkube.EventRes
 
 	bodyBytes := body.Bytes()
 
+	// Webhook delivery is at-least-once by design: on network errors, 5xx, and 429 the
+	// same payload may reach the subscriber more than once. This matches the industry
+	// convention (Stripe, GitHub, Slack) where dedupe is the subscriber's responsibility.
 	processedHeaders := make(map[string]string, len(l.headers))
 	for key, value := range l.headers {
 		values := []*string{&key, &value}
@@ -422,8 +425,6 @@ func (l *WebhookListener) Notify(event testkube.Event) (result testkube.EventRes
 			return
 		}
 		req.Header.Set("Content-Type", "application/json")
-		// Subscribers can dedupe replays: same event -> same key across all attempts.
-		req.Header.Set("Idempotency-Key", event.Id)
 		for k, v := range processedHeaders {
 			req.Header.Set(k, v)
 		}

--- a/pkg/event/kind/webhook/listener_retry_test.go
+++ b/pkg/event/kind/webhook/listener_retry_test.go
@@ -3,7 +3,6 @@ package webhook
 import (
 	"net/http"
 	"net/http/httptest"
-	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -110,43 +109,6 @@ func TestWebhookListener_Notify_DoesNotRetryOn4xx(t *testing.T) {
 
 	assert.NotEqual(t, "", r.Error())
 	assert.Equal(t, int32(1), atomic.LoadInt32(&callCount))
-}
-
-// Every attempt for a single event must carry the same Idempotency-Key so the
-// subscriber can dedupe replays coming out of the retry loop.
-func TestWebhookListener_Notify_SendsStableIdempotencyKeyAcrossRetries(t *testing.T) {
-	var keys []string
-	var mu sync.Mutex
-	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		mu.Lock()
-		keys = append(keys, r.Header.Get("Idempotency-Key"))
-		mu.Unlock()
-		w.WriteHeader(http.StatusServiceUnavailable)
-	})
-	svr := httptest.NewServer(handler)
-	defer svr.Close()
-
-	mockCtrl := gomock.NewController(t)
-	defer mockCtrl.Finish()
-	repo := cloudwebhook.NewMockWebhookRepository(mockCtrl)
-	repo.EXPECT().CollectExecutionResult(gomock.Any(), gomock.Any(), "l1", gomock.Any(), http.StatusServiceUnavailable).AnyTimes()
-
-	l := NewWebhookListener("l1", svr.URL, "", testEventTypes, "", "", nil, false, nil, nil,
-		listenerWithMetrics(v1.NewMetrics()),
-		listenerWithWebhookResultsRepository(repo))
-	l.sendRetryBaseDelay = time.Millisecond
-
-	event := testkube.Event{
-		Id:                    "event-idem-1",
-		Type_:                 testkube.EventStartTestWorkflow,
-		TestWorkflowExecution: exampleExecution(),
-	}
-	_ = l.Notify(event)
-
-	assert.Len(t, keys, webhookSendRetryCount)
-	for _, k := range keys {
-		assert.Equal(t, "event-idem-1", k)
-	}
 }
 
 // 429 is treated as retryable: rate limiters usually clear within a short delay,

--- a/pkg/event/kind/webhook/listener_retry_test.go
+++ b/pkg/event/kind/webhook/listener_retry_test.go
@@ -1,0 +1,145 @@
+package webhook
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/mock/gomock"
+
+	v1 "github.com/kubeshop/testkube/internal/app/api/metrics"
+	"github.com/kubeshop/testkube/pkg/api/v1/testkube"
+	cloudwebhook "github.com/kubeshop/testkube/pkg/cloud/data/webhook"
+)
+
+// The subscriber's endpoint is briefly unhealthy (Sheng's scenario: transient
+// infra hiccup). It returns 503 twice, then 200; the retry loop hides the two
+// failures and reports success to the caller.
+func TestWebhookListener_Notify_RetriesOn5xxThenSucceeds(t *testing.T) {
+	var callCount int32
+	handler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		n := atomic.AddInt32(&callCount, 1)
+		if n <= 2 {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	})
+	svr := httptest.NewServer(handler)
+	defer svr.Close()
+
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+	repo := cloudwebhook.NewMockWebhookRepository(mockCtrl)
+	repo.EXPECT().CollectExecutionResult(gomock.Any(), gomock.Any(), "l1", "", http.StatusOK).AnyTimes()
+
+	l := NewWebhookListener("l1", svr.URL, "", testEventTypes, "", "", nil, false, nil, nil,
+		listenerWithMetrics(v1.NewMetrics()),
+		listenerWithWebhookResultsRepository(repo))
+	l.sendRetryBaseDelay = time.Millisecond
+
+	r := l.Notify(testkube.Event{
+		Type_:                 testkube.EventStartTestWorkflow,
+		TestWorkflowExecution: exampleExecution(),
+	})
+
+	assert.Equal(t, "", r.Error())
+	assert.Equal(t, int32(3), atomic.LoadInt32(&callCount))
+}
+
+// The subscriber stays down for the whole retry budget. The loop exhausts every
+// attempt and only then reports failure, so the payload is not lost silently.
+func TestWebhookListener_Notify_GivesUpAfter5xxRetryBudget(t *testing.T) {
+	var callCount int32
+	handler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		atomic.AddInt32(&callCount, 1)
+		w.WriteHeader(http.StatusServiceUnavailable)
+	})
+	svr := httptest.NewServer(handler)
+	defer svr.Close()
+
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+	repo := cloudwebhook.NewMockWebhookRepository(mockCtrl)
+	repo.EXPECT().CollectExecutionResult(gomock.Any(), gomock.Any(), "l1", gomock.Any(), http.StatusServiceUnavailable).AnyTimes()
+
+	l := NewWebhookListener("l1", svr.URL, "", testEventTypes, "", "", nil, false, nil, nil,
+		listenerWithMetrics(v1.NewMetrics()),
+		listenerWithWebhookResultsRepository(repo))
+	l.sendRetryBaseDelay = time.Millisecond
+
+	r := l.Notify(testkube.Event{
+		Type_:                 testkube.EventStartTestWorkflow,
+		TestWorkflowExecution: exampleExecution(),
+	})
+
+	assert.NotEqual(t, "", r.Error())
+	assert.Equal(t, int32(webhookSendRetryCount), atomic.LoadInt32(&callCount))
+}
+
+// 4xx is a client-side error the subscriber will not resolve by retrying (bad
+// URL, unauthorized, wrong payload shape). Retrying would just spam the endpoint,
+// so the loop exits after the first attempt.
+func TestWebhookListener_Notify_DoesNotRetryOn4xx(t *testing.T) {
+	var callCount int32
+	handler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		atomic.AddInt32(&callCount, 1)
+		w.WriteHeader(http.StatusNotFound)
+	})
+	svr := httptest.NewServer(handler)
+	defer svr.Close()
+
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+	repo := cloudwebhook.NewMockWebhookRepository(mockCtrl)
+	repo.EXPECT().CollectExecutionResult(gomock.Any(), gomock.Any(), "l1", gomock.Any(), http.StatusNotFound).AnyTimes()
+
+	l := NewWebhookListener("l1", svr.URL, "", testEventTypes, "", "", nil, false, nil, nil,
+		listenerWithMetrics(v1.NewMetrics()),
+		listenerWithWebhookResultsRepository(repo))
+	l.sendRetryBaseDelay = time.Millisecond
+
+	r := l.Notify(testkube.Event{
+		Type_:                 testkube.EventStartTestWorkflow,
+		TestWorkflowExecution: exampleExecution(),
+	})
+
+	assert.NotEqual(t, "", r.Error())
+	assert.Equal(t, int32(1), atomic.LoadInt32(&callCount))
+}
+
+// 429 is treated as retryable: rate limiters usually clear within a short delay,
+// and the alternative (drop the event) is what Sheng flagged as unacceptable.
+func TestWebhookListener_Notify_RetriesOn429ThenSucceeds(t *testing.T) {
+	var callCount int32
+	handler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		if atomic.AddInt32(&callCount, 1) == 1 {
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	})
+	svr := httptest.NewServer(handler)
+	defer svr.Close()
+
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+	repo := cloudwebhook.NewMockWebhookRepository(mockCtrl)
+	repo.EXPECT().CollectExecutionResult(gomock.Any(), gomock.Any(), "l1", "", http.StatusOK).AnyTimes()
+
+	l := NewWebhookListener("l1", svr.URL, "", testEventTypes, "", "", nil, false, nil, nil,
+		listenerWithMetrics(v1.NewMetrics()),
+		listenerWithWebhookResultsRepository(repo))
+	l.sendRetryBaseDelay = time.Millisecond
+
+	r := l.Notify(testkube.Event{
+		Type_:                 testkube.EventStartTestWorkflow,
+		TestWorkflowExecution: exampleExecution(),
+	})
+
+	assert.Equal(t, "", r.Error())
+	assert.Equal(t, int32(2), atomic.LoadInt32(&callCount))
+}

--- a/pkg/event/kind/webhook/listener_retry_test.go
+++ b/pkg/event/kind/webhook/listener_retry_test.go
@@ -3,6 +3,7 @@ package webhook
 import (
 	"net/http"
 	"net/http/httptest"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -109,6 +110,43 @@ func TestWebhookListener_Notify_DoesNotRetryOn4xx(t *testing.T) {
 
 	assert.NotEqual(t, "", r.Error())
 	assert.Equal(t, int32(1), atomic.LoadInt32(&callCount))
+}
+
+// Every attempt for a single event must carry the same Idempotency-Key so the
+// subscriber can dedupe replays coming out of the retry loop.
+func TestWebhookListener_Notify_SendsStableIdempotencyKeyAcrossRetries(t *testing.T) {
+	var keys []string
+	var mu sync.Mutex
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		keys = append(keys, r.Header.Get("Idempotency-Key"))
+		mu.Unlock()
+		w.WriteHeader(http.StatusServiceUnavailable)
+	})
+	svr := httptest.NewServer(handler)
+	defer svr.Close()
+
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+	repo := cloudwebhook.NewMockWebhookRepository(mockCtrl)
+	repo.EXPECT().CollectExecutionResult(gomock.Any(), gomock.Any(), "l1", gomock.Any(), http.StatusServiceUnavailable).AnyTimes()
+
+	l := NewWebhookListener("l1", svr.URL, "", testEventTypes, "", "", nil, false, nil, nil,
+		listenerWithMetrics(v1.NewMetrics()),
+		listenerWithWebhookResultsRepository(repo))
+	l.sendRetryBaseDelay = time.Millisecond
+
+	event := testkube.Event{
+		Id:                    "event-idem-1",
+		Type_:                 testkube.EventStartTestWorkflow,
+		TestWorkflowExecution: exampleExecution(),
+	}
+	_ = l.Notify(event)
+
+	assert.Len(t, keys, webhookSendRetryCount)
+	for _, k := range keys {
+		assert.Equal(t, "event-idem-1", k)
+	}
 }
 
 // 429 is treated as retryable: rate limiters usually clear within a short delay,

--- a/pkg/event/kind/webhook/listener_test.go
+++ b/pkg/event/kind/webhook/listener_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/mock/gomock"
@@ -65,6 +66,7 @@ func TestWebhookListener_Notify(t *testing.T) {
 		mockWebhookRepository := cloudwebhook.NewMockWebhookRepository(mockCtrl)
 		mockWebhookRepository.EXPECT().CollectExecutionResult(gomock.Any(), gomock.Any(), "l1", gomock.Any(), http.StatusBadGateway).AnyTimes()
 		l := NewWebhookListener("l1", svr.URL, "", testEventTypes, "", "", nil, false, nil, nil, listenerWithMetrics(v1.NewMetrics()), listenerWithWebhookResultsRepository(mockWebhookRepository))
+		l.sendRetryBaseDelay = time.Millisecond
 
 		// when
 		r := l.Notify(testkube.Event{
@@ -85,6 +87,7 @@ func TestWebhookListener_Notify(t *testing.T) {
 		mockWebhookRepository := cloudwebhook.NewMockWebhookRepository(mockCtrl)
 		mockWebhookRepository.EXPECT().CollectExecutionResult(gomock.Any(), gomock.Any(), "l1", gomock.Any(), 0).AnyTimes()
 		s := NewWebhookListener("l1", "http://baduri.badbadbad", "", testEventTypes, "", "", nil, false, nil, nil, listenerWithMetrics(v1.NewMetrics()), listenerWithWebhookResultsRepository(mockWebhookRepository))
+		s.sendRetryBaseDelay = time.Millisecond
 
 		// when
 		r := s.Notify(testkube.Event{

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -43,6 +43,9 @@ const (
 	MonitorRetryCount = 10
 	MonitorRetryDelay = 500 * time.Millisecond
 
+	CleanupResourcesRetryCount = 5
+	CleanupResourcesRetryDelay = 500 * time.Millisecond
+
 	RecoverLogsRetryOnFailureDelay = 300 * time.Millisecond
 	RecoverLogsRetryMaxAttempts    = 5
 
@@ -80,6 +83,9 @@ type runner struct {
 
 	watching sync.Map
 	sf       singleflight.Group
+
+	// cleanupRetryDelay overrides the wait between Destroy retries; zero falls back to CleanupResourcesRetryDelay.
+	cleanupRetryDelay time.Duration
 }
 
 func New(
@@ -309,13 +315,21 @@ func (r *runner) monitor(ctx context.Context, organizationId string, environment
 	execution.Result = lastResult
 	r.observeExecutionMetrics(execution)
 
-	err = r.worker.Destroy(context.Background(), execution.Id, executionworkertypes.DestroyOptions{})
-	if err != nil {
-		// TODO: what to do on error?
-		logger.Errorw("failed to cleanup TestWorkflow resources", "error", err)
+	if err := r.destroyResources(context.Background(), execution.Id); err != nil {
+		logger.Errorw("failed to cleanup TestWorkflow resources after retries", "error", err)
 	}
 
 	return nil
+}
+
+func (r *runner) destroyResources(ctx context.Context, executionID string) error {
+	delay := r.cleanupRetryDelay
+	if delay == 0 {
+		delay = CleanupResourcesRetryDelay
+	}
+	return retry(CleanupResourcesRetryCount, delay, func(int) error {
+		return r.worker.Destroy(ctx, executionID, executionworkertypes.DestroyOptions{})
+	})
 }
 
 func (r *runner) recoverServiceLogs(ctx context.Context, saver ExecutionSaver, environmentId string, execution *testkube.TestWorkflowExecution, svc commands.ServiceInfo) error {

--- a/pkg/runner/runner_destroy_test.go
+++ b/pkg/runner/runner_destroy_test.go
@@ -1,0 +1,60 @@
+package runner
+
+import (
+	"context"
+	stderrors "errors"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/mock/gomock"
+
+	"github.com/kubeshop/testkube/pkg/testworkflows/executionworker/executionworkertypes"
+)
+
+// A cluster hiccup during cleanup fails Destroy for a few attempts, then it succeeds.
+// The retry helper hides the transient failures from the caller.
+func TestDestroyResources_RetriesTransientFailuresThenSucceeds(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	const transientFailures = 2
+	var calls int32
+	worker := executionworkertypes.NewMockWorker(ctrl)
+	worker.EXPECT().
+		Destroy(gomock.Any(), "exec-1", gomock.Any()).
+		DoAndReturn(func(context.Context, string, executionworkertypes.DestroyOptions) error {
+			if atomic.AddInt32(&calls, 1) <= transientFailures {
+				return stderrors.New("kube-apiserver unavailable")
+			}
+			return nil
+		}).
+		Times(transientFailures + 1)
+
+	r := &runner{worker: worker, cleanupRetryDelay: time.Millisecond}
+
+	err := r.destroyResources(context.Background(), "exec-1")
+
+	assert.NoError(t, err)
+}
+
+// The k8s API stays unreachable for the whole retry budget; the helper eventually
+// gives up and surfaces the last error so the caller can log it.
+func TestDestroyResources_GivesUpAfterRetryBudget(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	wantErr := stderrors.New("kube-apiserver unavailable")
+	worker := executionworkertypes.NewMockWorker(ctrl)
+	worker.EXPECT().
+		Destroy(gomock.Any(), "exec-1", gomock.Any()).
+		Return(wantErr).
+		Times(CleanupResourcesRetryCount)
+
+	r := &runner{worker: worker, cleanupRetryDelay: time.Millisecond}
+
+	err := r.destroyResources(context.Background(), "exec-1")
+
+	assert.ErrorIs(t, err, wantErr)
+}


### PR DESCRIPTION
Fixes two "one shot + log.Error on failure" sites that drop work on a transient failure:

- `pkg/runner/runner.go` cleanup (`worker.Destroy`) leaves Secrets orphan on a `kube-apiserver` blip.
- `pkg/event/kind/webhook/listener.go` webhook delivery drops the event if the subscriber is briefly unhealthy.

Both wrapped in a bounded retry (5 attempts, 500ms base). Webhook retries only network / 5xx / 429; 4xx short-circuits so a bad URL is not spammed.

Refs TKC-6551.
