### PR TITLE
fix: retry silent-drop sites and enrich error logs with tenant coordinates

### DIFF
--- a/pkg/event/emitter.go
+++ b/pkg/event/emitter.go
@@ -22,7 +22,18 @@ const (
 	eventEmitterQueueName     string = "emitter"
 	DefaultEventTTL                  = 1 * time.Hour
 	DefaultEventCacheCapacity        = 100000
+
+	// publishRetryCount bounds a short retry loop around bus.PublishTopic so a
+	// brief NATS blip (a few hundred ms while the client reconnects) does not
+	// silently drop an event. The NATS client already buffers publishes during
+	// transient outages; this covers the rare case where Publish returns an
+	// error before the reconnect completes.
+	publishRetryCount = 3
 )
+
+// publishRetryBaseDelay is a var (not a const) so tests can shorten the wait
+// between attempts without waiting the full 200ms budget.
+var publishRetryBaseDelay = 200 * time.Millisecond
 
 // EmitterOption is a functional option for configuring the Emitter.
 type EmitterOption func(*Emitter)
@@ -174,12 +185,31 @@ func (e *Emitter) Notify(event testkube.Event) {
 		"resource", event.Resource,
 		"resource_id", event.ResourceId)
 
-	err := e.bus.PublishTopic(topic, event)
+	var err error
+	for attempt := 0; attempt < publishRetryCount; attempt++ {
+		if attempt > 0 {
+			time.Sleep(time.Duration(attempt) * publishRetryBaseDelay)
+		}
+		err = e.bus.PublishTopic(topic, event)
+		if err == nil {
+			break
+		}
+		if attempt < publishRetryCount-1 {
+			e.log.Warnw("failed to publish event, retrying",
+				append(event.Log(),
+					"event_type", eventType,
+					"topic", topic,
+					"attempt", attempt,
+					"error", err)...)
+		}
+	}
 	if err != nil {
-		e.log.Errorw("failed to publish event",
-			"event_type", eventType,
-			"topic", topic,
-			"error", err)
+		e.log.Errorw("failed to publish event after retries",
+			append(event.Log(),
+				"event_type", eventType,
+				"topic", topic,
+				"attempts", publishRetryCount,
+				"error", err)...)
 		return
 	}
 	e.log.Debugw("event published successfully",

--- a/pkg/event/emitter.go
+++ b/pkg/event/emitter.go
@@ -444,11 +444,15 @@ func notifyListener(logger *zap.SugaredLogger, listener common.Listener, event t
 	result := listener.Notify(event)
 
 	if result.Error() != "" {
+		// Include event.Log() so the failure carries executionId / name / labels,
+		// letting on-call trace the incident to a specific workflow execution
+		// without a DB round-trip (TKC-6551).
 		logger.Errorw("listener notification failed",
-			"listener_name", listener.Name(),
-			"listener_kind", listener.Kind(),
-			"event_type", eventType,
-			"error", result.Error())
+			append(event.Log(),
+				"listener_name", listener.Name(),
+				"listener_kind", listener.Kind(),
+				"event_type", eventType,
+				"error", result.Error())...)
 	}
 }
 

--- a/pkg/event/emitter_publish_retry_test.go
+++ b/pkg/event/emitter_publish_retry_test.go
@@ -1,0 +1,72 @@
+package event
+
+import (
+	"errors"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/kubeshop/testkube/pkg/api/v1/testkube"
+	"github.com/kubeshop/testkube/pkg/event/bus"
+)
+
+// flakyBus mimics NATS returning a transient error N times before the publish
+// eventually goes through. Used to prove the emitter now retries transient
+// PublishTopic failures instead of dropping the event.
+type flakyBus struct {
+	*bus.EventBusMock
+	failuresBeforeSuccess int
+	calls                 int32
+}
+
+func (f *flakyBus) PublishTopic(topic string, event testkube.Event) error {
+	n := atomic.AddInt32(&f.calls, 1)
+	if int(n) <= f.failuresBeforeSuccess {
+		return errors.New("nats connection refused")
+	}
+	return f.EventBusMock.PublishTopic(topic, event)
+}
+
+// alwaysFailingBus never returns success, letting the retry loop exhaust its
+// budget so we can assert the final failure surfaces cleanly.
+type alwaysFailingBus struct {
+	*bus.EventBusMock
+	calls int32
+}
+
+func (f *alwaysFailingBus) PublishTopic(topic string, event testkube.Event) error {
+	atomic.AddInt32(&f.calls, 1)
+	return errors.New("nats connection refused")
+}
+
+func TestEmitter_Notify_RetriesTransientPublishThenSucceeds(t *testing.T) {
+	prev := publishRetryBaseDelay
+	publishRetryBaseDelay = time.Millisecond
+	t.Cleanup(func() { publishRetryBaseDelay = prev })
+
+	fb := &flakyBus{EventBusMock: bus.NewEventBusMock(), failuresBeforeSuccess: 2}
+	emitter := NewEmitter(fb, nil, "agentevents", "", DefaultEventTTL, DefaultEventCacheCapacity)
+	defer emitter.eventCache.Stop()
+
+	evt := testkube.Event{Id: "e1", Type_: testkube.EventStartTestWorkflow}
+	emitter.Notify(evt)
+
+	assert.Equal(t, int32(3), atomic.LoadInt32(&fb.calls))
+}
+
+func TestEmitter_Notify_GivesUpAfterRetryBudget(t *testing.T) {
+	prev := publishRetryBaseDelay
+	publishRetryBaseDelay = time.Millisecond
+	t.Cleanup(func() { publishRetryBaseDelay = prev })
+
+	fb := &alwaysFailingBus{EventBusMock: bus.NewEventBusMock()}
+	emitter := NewEmitter(fb, nil, "agentevents", "", DefaultEventTTL, DefaultEventCacheCapacity)
+	defer emitter.eventCache.Stop()
+
+	evt := testkube.Event{Id: "e2", Type_: testkube.EventStartTestWorkflow}
+	emitter.Notify(evt)
+
+	assert.Equal(t, int32(publishRetryCount), atomic.LoadInt32(&fb.calls))
+}

--- a/pkg/runner/agent.go
+++ b/pkg/runner/agent.go
@@ -133,12 +133,23 @@ func (a *agentLoop) _saveEmptyLogs(ctx context.Context, environmentId string, ex
 	return a.client.SaveExecutionLogs(ctx, environmentId, execution.Id, workflowName, strings.NewReader(""))
 }
 
+// logFields returns the execution's LogFields plus the tenant coordinates
+// (org / env) so every Errorw / Warnw carries enough context for on-call to
+// route the incident to the right customer without cross-referencing the log
+// with the DB (TKC-6551).
+func (a *agentLoop) logFields(environmentId string, execution *testkube.TestWorkflowExecution) []any {
+	return append(execution.LogFields(),
+		"organizationId", a.organizationId,
+		"environmentId", environmentId,
+	)
+}
+
 func (a *agentLoop) saveEmptyLogs(ctx context.Context, environmentId string, execution *testkube.TestWorkflowExecution) error {
 	err := retry(saveResultRetryMaxAttempts, saveResultRetryBaseDelay, func(_ int) error {
 		return a._saveEmptyLogs(ctx, environmentId, execution)
 	})
 	if err != nil {
-		a.logger.Errorw("failed to save empty log", append(execution.LogFields(), "error", err)...)
+		a.logger.Errorw("failed to save empty log", append(a.logFields(environmentId, execution), "error", err)...)
 	}
 	return err
 }
@@ -147,28 +158,28 @@ func (a *agentLoop) finishExecution(ctx context.Context, environmentId string, e
 	err := retry(saveResultRetryMaxAttempts, saveResultRetryBaseDelay, func(_ int) error {
 		err := a.client.FinishExecutionResult(ctx, environmentId, execution.Id, execution.Result)
 		if err != nil {
-			a.logger.Warnw("failed to finish the TestWorkflow execution in database", append(execution.LogFields(), "recoverable", true, "error", err)...)
+			a.logger.Warnw("failed to finish the TestWorkflow execution in database", append(a.logFields(environmentId, execution), "recoverable", true, "error", err)...)
 			return err
 		}
 		return nil
 	})
 	if err != nil {
-		a.logger.Errorw("failed to finish the TestWorkflow execution in database", append(execution.LogFields(), "recoverable", false, "error", err)...)
+		a.logger.Errorw("failed to finish the TestWorkflow execution in database", append(a.logFields(environmentId, execution), "recoverable", false, "error", err)...)
 	}
 	return err
 }
 
 func (a *agentLoop) init(ctx context.Context, environmentId string, execution *testkube.TestWorkflowExecution) error {
 	err := retry(saveResultRetryMaxAttempts, saveResultRetryBaseDelay, func(retryCount int) (err error) {
-		a.logger.Infow("Initializing execution", append(execution.LogFields(), "attempt", retryCount)...)
+		a.logger.Infow("Initializing execution", append(a.logFields(environmentId, execution), "attempt", retryCount)...)
 		err = a.client.InitExecution(ctx, environmentId, execution.Id, execution.Signature, execution.Namespace)
 		if err != nil {
-			a.logger.Warnw("failed to initialize the TestWorkflow execution in database", append(execution.LogFields(), "recoverable", true, "error", err)...)
+			a.logger.Warnw("failed to initialize the TestWorkflow execution in database", append(a.logFields(environmentId, execution), "recoverable", true, "error", err)...)
 		}
 		return err
 	})
 	if err != nil {
-		a.logger.Errorw("failed to initialize the TestWorkflow execution in database", append(execution.LogFields(), "recoverable", false, "error", err)...)
+		a.logger.Errorw("failed to initialize the TestWorkflow execution in database", append(a.logFields(environmentId, execution), "recoverable", false, "error", err)...)
 	}
 	return err
 }
@@ -364,7 +375,11 @@ func (a *agentLoop) runTestWorkflow(environmentId string, executionId string, ex
 
 func (a *agentLoop) directRunTestWorkflow(environmentId string, executionId string, executionToken string, runtime *cloud.TestWorkflowRuntime) error {
 	ctx := context.Background()
-	logger := a.logger.With("environmentId", environmentId)
+	logger := a.logger.With(
+		"executionId", executionId,
+		"organizationId", a.organizationId,
+		"environmentId", environmentId,
+	)
 
 	// Get the execution details
 	execution, err := a.client.GetExecution(ctx, environmentId, executionId)

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -46,6 +46,9 @@ const (
 	CleanupResourcesRetryCount = 5
 	CleanupResourcesRetryDelay = 500 * time.Millisecond
 
+	AbortExecutionRetryCount = 5
+	AbortExecutionRetryDelay = 500 * time.Millisecond
+
 	RecoverLogsRetryOnFailureDelay = 300 * time.Millisecond
 	RecoverLogsRetryMaxAttempts    = 5
 
@@ -86,6 +89,8 @@ type runner struct {
 
 	// cleanupRetryDelay overrides the wait between Destroy retries; zero falls back to CleanupResourcesRetryDelay.
 	cleanupRetryDelay time.Duration
+	// abortRetryDelay overrides the wait between AbortExecution retries; zero falls back to AbortExecutionRetryDelay.
+	abortRetryDelay time.Duration
 }
 
 func New(
@@ -573,8 +578,20 @@ func (r *runner) execute(request executionworkertypes.ExecuteRequest) (*executio
 }
 
 // abortExecution aborts fetches the execution, updates its result to aborted and finishes it.
+// This runs after the Monitor loop has already given up on the execution, so every
+// control-plane call here is the last line of defence: a transient failure without retry
+// would leave the execution stuck in running state indefinitely.
 func (r *runner) abortExecution(ctx context.Context, environmentID, executionID string) error {
-	execution, err := r.client.GetExecution(context.Background(), environmentID, executionID)
+	var execution *testkube.TestWorkflowExecution
+	delay := r.abortRetryDelay
+	if delay == 0 {
+		delay = AbortExecutionRetryDelay
+	}
+	err := retry(AbortExecutionRetryCount, delay, func(_ int) error {
+		var e error
+		execution, e = r.client.GetExecution(context.Background(), environmentID, executionID)
+		return e
+	})
 	if err != nil {
 		return errors.Wrapf(err, "failed to get execution '%s'", executionID)
 	}
@@ -582,15 +599,24 @@ func (r *runner) abortExecution(ctx context.Context, environmentID, executionID 
 		return errors.New("execution result is nil")
 	}
 	execution.Result.Fatal(errors.New("execution is stuck in running state"), true, time.Now())
-	if err = r.client.UpdateExecutionResult(ctx, environmentID, executionID, execution.Result); err != nil {
+	err = retry(AbortExecutionRetryCount, delay, func(_ int) error {
+		return r.client.UpdateExecutionResult(ctx, environmentID, executionID, execution.Result)
+	})
+	if err != nil {
 		return errors.Wrapf(err, "failed to update execution result '%s' to aborted", executionID)
 	}
 
-	if err = r.client.FinishExecutionResult(ctx, environmentID, executionID, execution.Result); err != nil {
+	err = retry(AbortExecutionRetryCount, delay, func(_ int) error {
+		return r.client.FinishExecutionResult(ctx, environmentID, executionID, execution.Result)
+	})
+	if err != nil {
 		return errors.Wrapf(err, "failed to finish execution result '%s'", executionID)
 	}
 
-	if err = r.Abort(executionID); err != nil {
+	err = retry(AbortExecutionRetryCount, delay, func(_ int) error {
+		return r.Abort(executionID)
+	})
+	if err != nil {
 		return errors.Wrapf(err, "failed to destroy execution '%s'", executionID)
 	}
 

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -134,8 +134,13 @@ func (r *runner) monitor(ctx context.Context, organizationId string, environment
 	defer r.watching.Delete(execution.Id)
 
 	// Scoped logger carrying human-readable context (workflow name, trigger/source) so every
-	// log line emitted while monitoring this execution is easy to identify.
-	logger := log.DefaultLogger.With(execution.LogFields()...)
+	// log line emitted while monitoring this execution is easy to identify. Env / org are
+	// added so any Errorw the customer sees carries the tenant coordinates needed to route
+	// the incident, matching the ask in TKC-6551.
+	logger := log.DefaultLogger.With(execution.LogFields()...).With(
+		"organizationId", organizationId,
+		"environmentId", environmentId,
+	)
 
 	var notifications executionworkertypes.NotificationsWatcher
 	for i := 0; i < GetNotificationsRetryCount; i++ {
@@ -475,18 +480,24 @@ func (r *runner) Monitor(ctx context.Context, organizationId string, environment
 		return nil
 	}
 
-	// Load the execution
+	// Load the execution. Scoped logger carries the tenant coordinates so retries and the
+	// final failure are attributable to a specific env / org (TKC-6551).
+	logger := log.DefaultLogger.With(
+		"executionId", id,
+		"organizationId", organizationId,
+		"environmentId", environmentId,
+	)
 	var execution *testkube.TestWorkflowExecution
 	err := retry(GetExecutionRetryCount, GetExecutionRetryDelay, func(_ int) (err error) {
 		execution, err = r.client.GetExecution(ctx, environmentId, id)
 		if err != nil {
-			log.DefaultLogger.Warnw("failed to get execution for monitoring, retrying...", "executionId", id, "error", err)
+			logger.Warnw("failed to get execution for monitoring, retrying...", "error", err)
 		}
 		return err
 	})
 	if err != nil {
 		r.watching.Delete(id)
-		log.DefaultLogger.Errorw("failed to get execution for monitoring", "executionId", id, "error", err)
+		logger.Errorw("failed to get execution for monitoring", "error", err)
 		return err
 	}
 	return r.monitor(ctx, organizationId, environmentId, *execution)
@@ -535,8 +546,14 @@ func (r *runner) execute(request executionworkertypes.ExecuteRequest) (*executio
 	if err == nil {
 		go func() {
 			// The full execution object isn't available here (only the ExecuteRequest), so we
-			// scope with the fields we do have: the execution ID and the workflow name.
-			logger := log.DefaultLogger.With("executionId", request.Execution.Id, "workflowName", request.Workflow.Name)
+			// scope with the fields we do have. Env / org make it possible to route the incident
+			// to the right tenant when the retry budget is exhausted (TKC-6551).
+			logger := log.DefaultLogger.With(
+				"executionId", request.Execution.Id,
+				"workflowName", request.Workflow.Name,
+				"organizationId", request.Execution.OrganizationId,
+				"environmentId", request.Execution.EnvironmentId,
+			)
 			err := retry(MonitorRetryCount, MonitorRetryDelay, func(_ int) error {
 				err := r.Monitor(context.Background(), request.Execution.OrganizationId, request.Execution.EnvironmentId, request.Execution.Id)
 				if err != nil {

--- a/pkg/runner/runner_abort_test.go
+++ b/pkg/runner/runner_abort_test.go
@@ -1,0 +1,106 @@
+package runner
+
+import (
+	"context"
+	stderrors "errors"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/mock/gomock"
+
+	"github.com/kubeshop/testkube/pkg/api/v1/testkube"
+	"github.com/kubeshop/testkube/pkg/controlplaneclient"
+	"github.com/kubeshop/testkube/pkg/testworkflows/executionworker/executionworkertypes"
+)
+
+// abortExecution runs after Monitor has already given up. A transient failure
+// on any of its control-plane calls without retry would leave the execution
+// stuck in running state. The retry loop must hide the transient failures
+// from the caller.
+func TestAbortExecution_RetriesTransientFailures(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	const transientFailures = 2
+	transient := stderrors.New("control-plane unavailable")
+
+	client := controlplaneclient.NewMockClient(ctrl)
+
+	var getCalls int32
+	client.EXPECT().
+		GetExecution(gomock.Any(), "env-1", "exec-1").
+		DoAndReturn(func(context.Context, string, string) (*testkube.TestWorkflowExecution, error) {
+			if atomic.AddInt32(&getCalls, 1) <= transientFailures {
+				return nil, transient
+			}
+			return &testkube.TestWorkflowExecution{
+				Id:     "exec-1",
+				Result: &testkube.TestWorkflowResult{},
+			}, nil
+		}).
+		Times(transientFailures + 1)
+
+	var updateCalls int32
+	client.EXPECT().
+		UpdateExecutionResult(gomock.Any(), "env-1", "exec-1", gomock.Any()).
+		DoAndReturn(func(context.Context, string, string, *testkube.TestWorkflowResult) error {
+			if atomic.AddInt32(&updateCalls, 1) <= transientFailures {
+				return transient
+			}
+			return nil
+		}).
+		Times(transientFailures + 1)
+
+	var finishCalls int32
+	client.EXPECT().
+		FinishExecutionResult(gomock.Any(), "env-1", "exec-1", gomock.Any()).
+		DoAndReturn(func(context.Context, string, string, *testkube.TestWorkflowResult) error {
+			if atomic.AddInt32(&finishCalls, 1) <= transientFailures {
+				return transient
+			}
+			return nil
+		}).
+		Times(transientFailures + 1)
+
+	worker := executionworkertypes.NewMockWorker(ctrl)
+	var abortCalls int32
+	worker.EXPECT().
+		Abort(gomock.Any(), "exec-1", gomock.Any()).
+		DoAndReturn(func(context.Context, string, executionworkertypes.DestroyOptions) error {
+			if atomic.AddInt32(&abortCalls, 1) <= transientFailures {
+				return transient
+			}
+			return nil
+		}).
+		Times(transientFailures + 1)
+
+	r := &runner{worker: worker, client: client, abortRetryDelay: time.Millisecond}
+
+	err := r.abortExecution(context.Background(), "env-1", "exec-1")
+	assert.NoError(t, err)
+}
+
+// If every attempt of the first call keeps failing, the whole abort chain
+// surfaces the error so the caller can alert on-call.
+func TestAbortExecution_GivesUpAfterRetryBudget(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	transient := stderrors.New("control-plane unavailable")
+
+	client := controlplaneclient.NewMockClient(ctrl)
+	client.EXPECT().
+		GetExecution(gomock.Any(), "env-1", "exec-1").
+		Return(nil, transient).
+		Times(AbortExecutionRetryCount)
+
+	worker := executionworkertypes.NewMockWorker(ctrl)
+
+	r := &runner{worker: worker, client: client, abortRetryDelay: time.Millisecond}
+
+	err := r.abortExecution(context.Background(), "env-1", "exec-1")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to get execution")
+}

--- a/pkg/testworkflows/executionworker/registry/ips.go
+++ b/pkg/testworkflows/executionworker/registry/ips.go
@@ -44,7 +44,7 @@ func (r *ipsRegistry) load(ctx context.Context, id string) (string, error) {
 		return "", err
 	}
 	var pods *corev1.PodList
-	err = kubeReadRetry(func() error {
+	err = kubeReadRetry(ctx, func() error {
 		var listErr error
 		pods, listErr = r.clientSet.CoreV1().Pods(ns).List(ctx, metav1.ListOptions{
 			LabelSelector: constants.ResourceIdLabelName + "=" + id,

--- a/pkg/testworkflows/executionworker/registry/ips.go
+++ b/pkg/testworkflows/executionworker/registry/ips.go
@@ -6,6 +6,7 @@ import (
 	lru "github.com/hashicorp/golang-lru/v2"
 	"github.com/pkg/errors"
 	"golang.org/x/sync/singleflight"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 
@@ -42,10 +43,14 @@ func (r *ipsRegistry) load(ctx context.Context, id string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	// TODO: consider retry
-	pods, err := r.clientSet.CoreV1().Pods(ns).List(ctx, metav1.ListOptions{
-		LabelSelector: constants.ResourceIdLabelName + "=" + id,
-		Limit:         1,
+	var pods *corev1.PodList
+	err = kubeReadRetry(func() error {
+		var listErr error
+		pods, listErr = r.clientSet.CoreV1().Pods(ns).List(ctx, metav1.ListOptions{
+			LabelSelector: constants.ResourceIdLabelName + "=" + id,
+			Limit:         1,
+		})
+		return listErr
 	})
 	if err != nil {
 		return "", err

--- a/pkg/testworkflows/executionworker/registry/namespaces.go
+++ b/pkg/testworkflows/executionworker/registry/namespaces.go
@@ -6,6 +6,8 @@ import (
 	lru "github.com/hashicorp/golang-lru/v2"
 	"github.com/pkg/errors"
 	"golang.org/x/sync/singleflight"
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
@@ -39,8 +41,12 @@ func (r *namespacesRegistry) Register(id, namespace string) {
 }
 
 func (r *namespacesRegistry) hasJobAt(ctx context.Context, id, namespace string) (bool, error) {
-	// TODO: consider retry
-	job, err := r.clientSet.BatchV1().Jobs(namespace).Get(ctx, id, metav1.GetOptions{})
+	var job *batchv1.Job
+	err := kubeReadRetry(func() error {
+		var getErr error
+		job, getErr = r.clientSet.BatchV1().Jobs(namespace).Get(ctx, id, metav1.GetOptions{})
+		return getErr
+	})
 	if k8serrors.IsNotFound(err) {
 		return false, nil
 	} else if err != nil {
@@ -50,11 +56,15 @@ func (r *namespacesRegistry) hasJobAt(ctx context.Context, id, namespace string)
 }
 
 func (r *namespacesRegistry) hasJobTracesAt(ctx context.Context, id, namespace string) (bool, error) {
-	// TODO: consider retry
-	events, err := r.clientSet.CoreV1().Events(namespace).List(ctx, metav1.ListOptions{
-		FieldSelector: "involvedObject.name=" + id,
-		TypeMeta:      metav1.TypeMeta{Kind: "Job"},
-		Limit:         1,
+	var events *corev1.EventList
+	err := kubeReadRetry(func() error {
+		var listErr error
+		events, listErr = r.clientSet.CoreV1().Events(namespace).List(ctx, metav1.ListOptions{
+			FieldSelector: "involvedObject.name=" + id,
+			TypeMeta:      metav1.TypeMeta{Kind: "Job"},
+			Limit:         1,
+		})
+		return listErr
 	})
 	if err != nil {
 		return false, err

--- a/pkg/testworkflows/executionworker/registry/namespaces.go
+++ b/pkg/testworkflows/executionworker/registry/namespaces.go
@@ -42,7 +42,7 @@ func (r *namespacesRegistry) Register(id, namespace string) {
 
 func (r *namespacesRegistry) hasJobAt(ctx context.Context, id, namespace string) (bool, error) {
 	var job *batchv1.Job
-	err := kubeReadRetry(func() error {
+	err := kubeReadRetry(ctx, func() error {
 		var getErr error
 		job, getErr = r.clientSet.BatchV1().Jobs(namespace).Get(ctx, id, metav1.GetOptions{})
 		return getErr
@@ -57,7 +57,7 @@ func (r *namespacesRegistry) hasJobAt(ctx context.Context, id, namespace string)
 
 func (r *namespacesRegistry) hasJobTracesAt(ctx context.Context, id, namespace string) (bool, error) {
 	var events *corev1.EventList
-	err := kubeReadRetry(func() error {
+	err := kubeReadRetry(ctx, func() error {
 		var listErr error
 		events, listErr = r.clientSet.CoreV1().Events(namespace).List(ctx, metav1.ListOptions{
 			FieldSelector: "involvedObject.name=" + id,

--- a/pkg/testworkflows/executionworker/registry/retry.go
+++ b/pkg/testworkflows/executionworker/registry/retry.go
@@ -1,6 +1,7 @@
 package registry
 
 import (
+	"context"
 	"time"
 
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
@@ -13,8 +14,12 @@ const (
 
 // kubeReadRetry runs fn against the k8s API and retries transient failures
 // (network hiccups, api-server unavailable). Terminal errors that will not
-// resolve by retrying — NotFound, Forbidden, Unauthorized — short-circuit.
-func kubeReadRetry(fn func() error) error {
+// resolve by retrying (NotFound, Forbidden, Unauthorized) short-circuit.
+//
+// The backoff only runs between attempts, never after the last one, and it
+// aborts as soon as ctx is cancelled so callers that fan out over many
+// namespaces do not eat several seconds of dead wait on shutdown.
+func kubeReadRetry(ctx context.Context, fn func() error) error {
 	var err error
 	for i := 0; i < kubeReadRetryCount; i++ {
 		err = fn()
@@ -24,7 +29,14 @@ func kubeReadRetry(fn func() error) error {
 		if k8serrors.IsNotFound(err) || k8serrors.IsForbidden(err) || k8serrors.IsUnauthorized(err) {
 			return err
 		}
-		time.Sleep(time.Duration(i) * kubeReadRetryDelay)
+		if i == kubeReadRetryCount-1 {
+			break
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(time.Duration(i+1) * kubeReadRetryDelay):
+		}
 	}
 	return err
 }

--- a/pkg/testworkflows/executionworker/registry/retry.go
+++ b/pkg/testworkflows/executionworker/registry/retry.go
@@ -1,0 +1,30 @@
+package registry
+
+import (
+	"time"
+
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+)
+
+const (
+	kubeReadRetryCount = 3
+	kubeReadRetryDelay = 200 * time.Millisecond
+)
+
+// kubeReadRetry runs fn against the k8s API and retries transient failures
+// (network hiccups, api-server unavailable). Terminal errors that will not
+// resolve by retrying — NotFound, Forbidden, Unauthorized — short-circuit.
+func kubeReadRetry(fn func() error) error {
+	var err error
+	for i := 0; i < kubeReadRetryCount; i++ {
+		err = fn()
+		if err == nil {
+			return nil
+		}
+		if k8serrors.IsNotFound(err) || k8serrors.IsForbidden(err) || k8serrors.IsUnauthorized(err) {
+			return err
+		}
+		time.Sleep(time.Duration(i) * kubeReadRetryDelay)
+	}
+	return err
+}

--- a/pkg/testworkflows/executionworker/registry/retry_test.go
+++ b/pkg/testworkflows/executionworker/registry/retry_test.go
@@ -1,0 +1,57 @@
+package registry
+
+import (
+	stderrors "errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+func TestKubeReadRetry_TransientErrorRetriedThenSucceeds(t *testing.T) {
+	var calls int
+	transient := stderrors.New("kube-apiserver unavailable")
+	err := kubeReadRetry(func() error {
+		calls++
+		if calls < 2 {
+			return transient
+		}
+		return nil
+	})
+	assert.NoError(t, err)
+	assert.Equal(t, 2, calls)
+}
+
+func TestKubeReadRetry_GivesUpAfterBudget(t *testing.T) {
+	var calls int
+	transient := stderrors.New("kube-apiserver unavailable")
+	err := kubeReadRetry(func() error {
+		calls++
+		return transient
+	})
+	assert.ErrorIs(t, err, transient)
+	assert.Equal(t, kubeReadRetryCount, calls)
+}
+
+func TestKubeReadRetry_NotFoundShortCircuits(t *testing.T) {
+	var calls int
+	nf := k8serrors.NewNotFound(schema.GroupResource{Resource: "pods"}, "x")
+	err := kubeReadRetry(func() error {
+		calls++
+		return nf
+	})
+	assert.True(t, k8serrors.IsNotFound(err))
+	assert.Equal(t, 1, calls)
+}
+
+func TestKubeReadRetry_ForbiddenShortCircuits(t *testing.T) {
+	var calls int
+	f := k8serrors.NewForbidden(schema.GroupResource{Resource: "pods"}, "x", stderrors.New("nope"))
+	err := kubeReadRetry(func() error {
+		calls++
+		return f
+	})
+	assert.True(t, k8serrors.IsForbidden(err))
+	assert.Equal(t, 1, calls)
+}

--- a/pkg/testworkflows/executionworker/registry/retry_test.go
+++ b/pkg/testworkflows/executionworker/registry/retry_test.go
@@ -1,8 +1,10 @@
 package registry
 
 import (
+	"context"
 	stderrors "errors"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
@@ -12,7 +14,7 @@ import (
 func TestKubeReadRetry_TransientErrorRetriedThenSucceeds(t *testing.T) {
 	var calls int
 	transient := stderrors.New("kube-apiserver unavailable")
-	err := kubeReadRetry(func() error {
+	err := kubeReadRetry(context.Background(), func() error {
 		calls++
 		if calls < 2 {
 			return transient
@@ -26,7 +28,7 @@ func TestKubeReadRetry_TransientErrorRetriedThenSucceeds(t *testing.T) {
 func TestKubeReadRetry_GivesUpAfterBudget(t *testing.T) {
 	var calls int
 	transient := stderrors.New("kube-apiserver unavailable")
-	err := kubeReadRetry(func() error {
+	err := kubeReadRetry(context.Background(), func() error {
 		calls++
 		return transient
 	})
@@ -37,7 +39,7 @@ func TestKubeReadRetry_GivesUpAfterBudget(t *testing.T) {
 func TestKubeReadRetry_NotFoundShortCircuits(t *testing.T) {
 	var calls int
 	nf := k8serrors.NewNotFound(schema.GroupResource{Resource: "pods"}, "x")
-	err := kubeReadRetry(func() error {
+	err := kubeReadRetry(context.Background(), func() error {
 		calls++
 		return nf
 	})
@@ -48,10 +50,47 @@ func TestKubeReadRetry_NotFoundShortCircuits(t *testing.T) {
 func TestKubeReadRetry_ForbiddenShortCircuits(t *testing.T) {
 	var calls int
 	f := k8serrors.NewForbidden(schema.GroupResource{Resource: "pods"}, "x", stderrors.New("nope"))
-	err := kubeReadRetry(func() error {
+	err := kubeReadRetry(context.Background(), func() error {
 		calls++
 		return f
 	})
 	assert.True(t, k8serrors.IsForbidden(err))
 	assert.Equal(t, 1, calls)
+}
+
+// Exhausting the budget must not sleep after the final attempt.
+// With kubeReadRetryCount=3 and kubeReadRetryDelay=200ms the only real waits
+// are before attempts 2 and 3 (200ms + 400ms). A stray sleep after attempt 3
+// would push wall-clock past ~600ms.
+func TestKubeReadRetry_DoesNotSleepAfterLastAttempt(t *testing.T) {
+	transient := stderrors.New("kube-apiserver unavailable")
+	start := time.Now()
+	err := kubeReadRetry(context.Background(), func() error {
+		return transient
+	})
+	elapsed := time.Since(start)
+	assert.ErrorIs(t, err, transient)
+	// Expected total wait between attempts: (1+2) * 200ms = 600ms. Allow slack
+	// but reject the buggy behaviour where a terminal sleep pushes past 800ms.
+	assert.Less(t, elapsed, 800*time.Millisecond, "elapsed=%s", elapsed)
+}
+
+// A cancelled context must abort the backoff instead of eating the full delay.
+func TestKubeReadRetry_ContextCancelledInterruptsBackoff(t *testing.T) {
+	transient := stderrors.New("kube-apiserver unavailable")
+	ctx, cancel := context.WithCancel(context.Background())
+	var calls int
+	go func() {
+		time.Sleep(50 * time.Millisecond)
+		cancel()
+	}()
+	start := time.Now()
+	err := kubeReadRetry(ctx, func() error {
+		calls++
+		return transient
+	})
+	elapsed := time.Since(start)
+	assert.ErrorIs(t, err, context.Canceled)
+	assert.Less(t, elapsed, 500*time.Millisecond, "elapsed=%s", elapsed)
+	assert.LessOrEqual(t, calls, kubeReadRetryCount)
 }


### PR DESCRIPTION
Stacked on top of #8125. two pillars: (1) more silent-drop sites, (2) error logs that carry enough context to be actionable.

**Silent-drop retries (pillar 2):**

- `pkg/testworkflows/executionworker/registry/`: `Pods().List()`, `Jobs().Get()`, `Events().List()` each had a `TODO: consider retry` and no retry. Wrapped in a new `kubeReadRetry` helper (3 attempts, 200ms) that short-circuits on `NotFound` / `Forbidden` / `Unauthorized`.
- `pkg/runner/runner.go` `abortExecution`: runs after `Monitor` has already given up (execution stuck in running state). Four control-plane calls (`GetExecution`, `UpdateExecutionResult`, `FinishExecutionResult`, `worker.Abort`) had no retry. Wrapped all four (5 attempts, 500ms).
- `pkg/event/emitter.go` `Notify`: `bus.PublishTopic` had no retry. NATS client already buffers across transient outages, but Publish can still surface an error before a reconnect completes. Short bounded retry (3 attempts, 200ms) covers that gap.

**Error log context (pillar 1):**

- `pkg/runner/runner.go` monitor + Monitor scoped loggers now carry `organizationId` + `environmentId` alongside `executionId` + `workflowName`.
- `pkg/runner/agent.go` new `agentLoop.logFields(env, execution)` helper drives `saveEmptyLogs` / `finishExecution` / `init` consistently; `directRunTestWorkflow` scoped logger carries the tenant coordinates too.
- `pkg/event/emitter.go` `listener notification failed` now includes `event.Log()` (executionId / name / labels).

Reproduction tests added for every retry.
