### PR TITLE
fix(quality-loop): mask parent workflow name on child running context

### DIFF
--- a/pkg/api/v1/testkube/model_test_workflow_running_context_actor_type_child_context.go
+++ b/pkg/api/v1/testkube/model_test_workflow_running_context_actor_type_child_context.go
@@ -9,3 +9,11 @@ func (t TestWorkflowRunningContextActorType) ChildRunningContextType() cloud.Run
 	}
 	return cloud.RunningContextType_EXECUTION
 }
+
+func (t TestWorkflowRunningContextActorType) ChildRunningContextName(parentName string) string {
+	switch t {
+	case QUALITYLOOP_TestWorkflowRunningContextActorType:
+		return "Git Integration"
+	}
+	return parentName
+}

--- a/pkg/api/v1/testkube/model_test_workflow_running_context_actor_type_child_context_test.go
+++ b/pkg/api/v1/testkube/model_test_workflow_running_context_actor_type_child_context_test.go
@@ -47,3 +47,43 @@ func TestTestWorkflowRunningContextActorType_ChildRunningContextType(t *testing.
 		})
 	}
 }
+
+func TestTestWorkflowRunningContextActorType_ChildRunningContextName(t *testing.T) {
+	tests := []struct {
+		name       string
+		actor      TestWorkflowRunningContextActorType
+		parentName string
+		wanted     string
+	}{
+		{
+			name:       "QUALITYLOOP parent hides internal workflow name",
+			actor:      QUALITYLOOP_TestWorkflowRunningContextActorType,
+			parentName: "ql-parent-kubeshop-testkube-cloud-api",
+			wanted:     "Git Integration",
+		},
+		{
+			name:       "USER parent keeps original workflow name",
+			actor:      USER_TestWorkflowRunningContextActorType,
+			parentName: "user-authored-suite",
+			wanted:     "user-authored-suite",
+		},
+		{
+			name:       "TESTWORKFLOW parent keeps original workflow name",
+			actor:      TESTWORKFLOW_TestWorkflowRunningContextActorType,
+			parentName: "composite-suite",
+			wanted:     "composite-suite",
+		},
+		{
+			name:       "empty actor type keeps original workflow name",
+			actor:      "",
+			parentName: "some-workflow",
+			wanted:     "some-workflow",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.wanted, tt.actor.ChildRunningContextName(tt.parentName))
+		})
+	}
+}

--- a/pkg/controlplaneclient/execution_self.go
+++ b/pkg/controlplaneclient/execution_self.go
@@ -52,7 +52,7 @@ func (c *client) SaveExecutionArtifactGetPresignedURL(ctx context.Context, envir
 func (c *client) ScheduleExecution(ctx context.Context, environmentId string, request *cloud.ScheduleRequest) ExecutionsReader {
 	if c.opts.ExecutionID != "" {
 		request.RunningContext = &cloud.RunningContext{
-			Name: c.opts.WorkflowName,
+			Name: c.opts.ParentActorType.ChildRunningContextName(c.opts.WorkflowName),
 			Id:   c.opts.ExecutionID,
 			Type: c.opts.ParentActorType.ChildRunningContextType(),
 		}

--- a/pkg/controlplaneclient/execution_self_test.go
+++ b/pkg/controlplaneclient/execution_self_test.go
@@ -1,0 +1,36 @@
+package controlplaneclient
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/kubeshop/testkube/pkg/api/v1/testkube"
+)
+
+func TestChildRunningContextName_MasksQualityLoopParent(t *testing.T) {
+	t.Parallel()
+
+	got := childRunningContextName(
+		testkube.QUALITYLOOP_TestWorkflowRunningContextActorType,
+		"ql-parent-kubeshop-testkube-cloud-api",
+	)
+	assert.Equal(t, "Git Integration", got,
+		"internal ql-parent-* name must not leak into the child's RunningContext.Name")
+}
+
+func TestChildRunningContextName_PreservesNonQualityLoopParents(t *testing.T) {
+	t.Parallel()
+
+	cases := []testkube.TestWorkflowRunningContextActorType{
+		testkube.TESTWORKFLOW_TestWorkflowRunningContextActorType,
+		testkube.CRON_TestWorkflowRunningContextActorType,
+		testkube.USER_TestWorkflowRunningContextActorType,
+		testkube.TESTTRIGGER_TestWorkflowRunningContextActorType,
+	}
+	for _, parentActor := range cases {
+		got := childRunningContextName(parentActor, "user-authored-suite")
+		assert.Equal(t, "user-authored-suite", got,
+			"non-quality-loop parents keep exposing the parent workflow name")
+	}
+}


### PR DESCRIPTION
child executions scheduled from inside a QL parent were carrying the internal parent CR name (ql-parent-*) on running_context.actor.name, which the dashboard renders as "Triggered by ...". mask it with "Git Integration" for QUALITYLOOP parents; other actor types keep the current behavior since user-authored composites rely on the parent name being visible. parent<->child linkage is on actor.executionId, unchanged.