### PR TITLE
fix: retry transient failures on artifact upload and tarball transfer

### DIFF
--- a/cmd/testworkflow-toolkit/artifacts/cloud_uploader.go
+++ b/cmd/testworkflow-toolkit/artifacts/cloud_uploader.go
@@ -106,11 +106,13 @@ func (d *cloudUploader) putObject(url string, path string, file io.Reader, size 
 	var lastErr error
 	for attempt := 0; attempt < uploadRetryCount; attempt++ {
 		if attempt > 0 {
-			if !canRewind || file == nil {
-				return lastErr
-			}
-			if _, e := seeker.Seek(0, io.SeekStart); e != nil {
-				return errors.Wrapf(lastErr, "cannot rewind body for retry: %v", e)
+			if file != nil {
+				if !canRewind {
+					return lastErr
+				}
+				if _, e := seeker.Seek(0, io.SeekStart); e != nil {
+					return errors.Wrapf(lastErr, "cannot rewind body for retry: %v", e)
+				}
 			}
 			time.Sleep(time.Duration(attempt) * uploadRetryBaseDelay)
 		}

--- a/cmd/testworkflow-toolkit/artifacts/cloud_uploader.go
+++ b/cmd/testworkflow-toolkit/artifacts/cloud_uploader.go
@@ -17,6 +17,14 @@ import (
 	"github.com/kubeshop/testkube/pkg/ui"
 )
 
+const (
+	uploadRetryCount = 5
+)
+
+// uploadRetryBaseDelay is a var (not a const) so tests can shorten the wait
+// between attempts without paying the full production budget.
+var uploadRetryBaseDelay = 500 * time.Millisecond
+
 type CloudUploaderRequestEnhancer = func(req *http.Request, path string, size int64)
 
 func NewCloudUploader(
@@ -89,15 +97,44 @@ func (d *cloudUploader) getContentType(path string, size int64) string {
 }
 
 func (d *cloudUploader) putObject(url string, path string, file io.Reader, size int64) error {
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Minute)
-	defer cancel()
 	if size == 0 {
 		// http.Request won't send Content-Length: 0, if the body is non-nil
 		file = nil
 	}
+	seeker, canRewind := file.(io.Seeker)
+
+	var lastErr error
+	for attempt := 0; attempt < uploadRetryCount; attempt++ {
+		if attempt > 0 {
+			if !canRewind || file == nil {
+				return lastErr
+			}
+			if _, e := seeker.Seek(0, io.SeekStart); e != nil {
+				return errors.Wrapf(lastErr, "cannot rewind body for retry: %v", e)
+			}
+			time.Sleep(time.Duration(attempt) * uploadRetryBaseDelay)
+		}
+		retryable, err := d.putObjectOnce(url, path, file, size)
+		if err == nil {
+			return nil
+		}
+		lastErr = err
+		if !retryable {
+			return err
+		}
+	}
+	return lastErr
+}
+
+// putObjectOnce performs a single PUT attempt and reports whether the error is
+// worth retrying: transport errors, 5xx, and 429 are retryable; other 4xx are
+// terminal so we do not spam the signed URL with a request that will always fail.
+func (d *cloudUploader) putObjectOnce(url string, path string, file io.Reader, size int64) (retryable bool, err error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Minute)
+	defer cancel()
 	req, err := http.NewRequestWithContext(ctx, http.MethodPut, url, file)
 	if err != nil {
-		return err
+		return false, err
 	}
 	for _, r := range d.reqEnhancers {
 		r(req, path, size)
@@ -111,14 +148,18 @@ func (d *cloudUploader) putObject(url string, path string, file io.Reader, size 
 	client := &http.Client{Transport: tr}
 	res, err := client.Do(req)
 	if err != nil {
-		return err
+		return true, err
 	}
 	defer res.Body.Close()
-	if res.StatusCode != http.StatusOK {
-		b, _ := io.ReadAll(res.Body)
-		return errors.Errorf("failed saving file: status code: %d / message: %s", res.StatusCode, string(b))
+	if res.StatusCode == http.StatusOK {
+		return false, nil
 	}
-	return nil
+	b, _ := io.ReadAll(res.Body)
+	statusErr := errors.Errorf("failed saving file: status code: %d / message: %s", res.StatusCode, string(b))
+	if res.StatusCode >= 500 || res.StatusCode == http.StatusTooManyRequests {
+		return true, statusErr
+	}
+	return false, statusErr
 }
 
 func (d *cloudUploader) upload(path string, file io.Reader, size int64) {

--- a/cmd/testworkflow-toolkit/artifacts/cloud_uploader.go
+++ b/cmd/testworkflow-toolkit/artifacts/cloud_uploader.go
@@ -21,8 +21,6 @@ const (
 	uploadRetryCount = 5
 )
 
-// uploadRetryBaseDelay is a var (not a const) so tests can shorten the wait
-// between attempts without paying the full production budget.
 var uploadRetryBaseDelay = 500 * time.Millisecond
 
 type CloudUploaderRequestEnhancer = func(req *http.Request, path string, size int64)
@@ -128,9 +126,6 @@ func (d *cloudUploader) putObject(url string, path string, file io.Reader, size 
 	return lastErr
 }
 
-// putObjectOnce performs a single PUT attempt and reports whether the error is
-// worth retrying: transport errors, 5xx, and 429 are retryable; other 4xx are
-// terminal so we do not spam the signed URL with a request that will always fail.
 func (d *cloudUploader) putObjectOnce(url string, path string, file io.Reader, size int64) (retryable bool, err error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Minute)
 	defer cancel()

--- a/cmd/testworkflow-toolkit/artifacts/cloud_uploader_retry_test.go
+++ b/cmd/testworkflow-toolkit/artifacts/cloud_uploader_retry_test.go
@@ -1,0 +1,80 @@
+package artifacts
+
+import (
+	"bytes"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func withShortUploadBackoff(t *testing.T) {
+	t.Helper()
+	old := uploadRetryBaseDelay
+	uploadRetryBaseDelay = time.Millisecond
+	t.Cleanup(func() { uploadRetryBaseDelay = old })
+}
+
+// A brief 5xx blip on the signed URL should be retried transparently: the
+// body is a *bytes.Reader (io.Seeker), so putObject rewinds and replays.
+func TestCloudUploader_putObject_RetriesOn5xxThenSucceeds(t *testing.T) {
+	withShortUploadBackoff(t)
+	var calls int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n := atomic.AddInt32(&calls, 1)
+		if n < 3 {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	u := &cloudUploader{}
+	body := bytes.NewReader([]byte("hello"))
+	err := u.putObject(server.URL, "artifact.txt", body, int64(body.Len()))
+
+	assert.NoError(t, err)
+	assert.Equal(t, int32(3), atomic.LoadInt32(&calls))
+}
+
+// 4xx signals a caller / URL problem; retrying spams the signed URL with a
+// request that will keep failing. Loop must short-circuit after one attempt.
+func TestCloudUploader_putObject_DoesNotRetryOn4xx(t *testing.T) {
+	withShortUploadBackoff(t)
+	var calls int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		atomic.AddInt32(&calls, 1)
+		w.WriteHeader(http.StatusForbidden)
+	}))
+	defer server.Close()
+
+	u := &cloudUploader{}
+	body := bytes.NewReader([]byte("hello"))
+	err := u.putObject(server.URL, "artifact.txt", body, int64(body.Len()))
+
+	assert.Error(t, err)
+	assert.Equal(t, int32(1), atomic.LoadInt32(&calls))
+}
+
+// Exhausting the retry budget must surface an error so the caller sets the
+// error flag on the uploader (visible as "failed" in the artifact summary).
+func TestCloudUploader_putObject_GivesUpAfterRetryBudget(t *testing.T) {
+	withShortUploadBackoff(t)
+	var calls int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		atomic.AddInt32(&calls, 1)
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}))
+	defer server.Close()
+
+	u := &cloudUploader{}
+	body := bytes.NewReader([]byte("hello"))
+	err := u.putObject(server.URL, "artifact.txt", body, int64(body.Len()))
+
+	assert.Error(t, err)
+	assert.Equal(t, int32(uploadRetryCount), atomic.LoadInt32(&calls))
+}

--- a/cmd/testworkflow-toolkit/artifacts/cloud_uploader_retry_test.go
+++ b/cmd/testworkflow-toolkit/artifacts/cloud_uploader_retry_test.go
@@ -60,6 +60,29 @@ func TestCloudUploader_putObject_DoesNotRetryOn4xx(t *testing.T) {
 	assert.Equal(t, int32(1), atomic.LoadInt32(&calls))
 }
 
+// A zero-byte artifact has no body to rewind, so the retry loop must not
+// short-circuit on it. Empty PUTs are inherently replayable; 5xx blips should
+// still be recovered.
+func TestCloudUploader_putObject_RetriesZeroByteBodyOn5xx(t *testing.T) {
+	withShortUploadBackoff(t)
+	var calls int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		n := atomic.AddInt32(&calls, 1)
+		if n < 3 {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	u := &cloudUploader{}
+	err := u.putObject(server.URL, "empty.txt", bytes.NewReader(nil), 0)
+
+	assert.NoError(t, err)
+	assert.Equal(t, int32(3), atomic.LoadInt32(&calls))
+}
+
 // Exhausting the retry budget must surface an error so the caller sets the
 // error flag on the uploader (visible as "failed" in the artifact summary).
 func TestCloudUploader_putObject_GivesUpAfterRetryBudget(t *testing.T) {

--- a/cmd/testworkflow-toolkit/artifacts/cloud_uploader_retry_test.go
+++ b/cmd/testworkflow-toolkit/artifacts/cloud_uploader_retry_test.go
@@ -18,8 +18,6 @@ func withShortUploadBackoff(t *testing.T) {
 	t.Cleanup(func() { uploadRetryBaseDelay = old })
 }
 
-// A brief 5xx blip on the signed URL should be retried transparently: the
-// body is a *bytes.Reader (io.Seeker), so putObject rewinds and replays.
 func TestCloudUploader_putObject_RetriesOn5xxThenSucceeds(t *testing.T) {
 	withShortUploadBackoff(t)
 	var calls int32
@@ -41,8 +39,6 @@ func TestCloudUploader_putObject_RetriesOn5xxThenSucceeds(t *testing.T) {
 	assert.Equal(t, int32(3), atomic.LoadInt32(&calls))
 }
 
-// 4xx signals a caller / URL problem; retrying spams the signed URL with a
-// request that will keep failing. Loop must short-circuit after one attempt.
 func TestCloudUploader_putObject_DoesNotRetryOn4xx(t *testing.T) {
 	withShortUploadBackoff(t)
 	var calls int32
@@ -60,9 +56,6 @@ func TestCloudUploader_putObject_DoesNotRetryOn4xx(t *testing.T) {
 	assert.Equal(t, int32(1), atomic.LoadInt32(&calls))
 }
 
-// A zero-byte artifact has no body to rewind, so the retry loop must not
-// short-circuit on it. Empty PUTs are inherently replayable; 5xx blips should
-// still be recovered.
 func TestCloudUploader_putObject_RetriesZeroByteBodyOn5xx(t *testing.T) {
 	withShortUploadBackoff(t)
 	var calls int32
@@ -83,8 +76,6 @@ func TestCloudUploader_putObject_RetriesZeroByteBodyOn5xx(t *testing.T) {
 	assert.Equal(t, int32(3), atomic.LoadInt32(&calls))
 }
 
-// Exhausting the retry budget must surface an error so the caller sets the
-// error flag on the uploader (visible as "failed" in the artifact summary).
 func TestCloudUploader_putObject_GivesUpAfterRetryBudget(t *testing.T) {
 	withShortUploadBackoff(t)
 	var calls int32

--- a/cmd/testworkflow-toolkit/commands/transfer.go
+++ b/cmd/testworkflow-toolkit/commands/transfer.go
@@ -18,8 +18,6 @@ const (
 	transferRetryCount = 3
 )
 
-// transferRetryBaseDelay is a var (not a const) so tests can shorten the wait
-// between attempts without paying the full production budget.
 var transferRetryBaseDelay = 500 * time.Millisecond
 
 func NewTransferCmd() *cobra.Command {
@@ -91,9 +89,6 @@ func ProcessTransferPair(pair string, output io.Writer) int {
 	return 1
 }
 
-// sendTarballOnce runs a single pack-and-send attempt and reports whether the
-// error is worth retrying. Transport errors, 5xx, and 429 are retryable; other
-// 4xx and local packing failures are terminal.
 func sendTarballOnce(dirPath string, patterns []string, url string) (retryable bool, err error) {
 	errChan := make(chan error, 1)
 	reader, writer := io.Pipe()

--- a/cmd/testworkflow-toolkit/commands/transfer.go
+++ b/cmd/testworkflow-toolkit/commands/transfer.go
@@ -7,11 +7,20 @@ import (
 	"net/http"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/spf13/cobra"
 
 	"github.com/kubeshop/testkube/cmd/testworkflow-toolkit/common"
 )
+
+const (
+	transferRetryCount = 3
+)
+
+// transferRetryBaseDelay is a var (not a const) so tests can shorten the wait
+// between attempts without paying the full production budget.
+var transferRetryBaseDelay = 500 * time.Millisecond
 
 func NewTransferCmd() *cobra.Command {
 	cmd := &cobra.Command{
@@ -62,46 +71,58 @@ func ProcessTransferPair(pair string, output io.Writer) int {
 	}
 	fmt.Fprintf(output, "Packing and sending %s to %s...\n", dirPath, url)
 
-	// Create a channel to capture errors from goroutine
-	errChan := make(chan error, 1)
+	var lastErr error
+	for attempt := 0; attempt < transferRetryCount; attempt++ {
+		if attempt > 0 {
+			time.Sleep(time.Duration(attempt) * transferRetryBaseDelay)
+			fmt.Fprintf(output, "retrying tarball transfer (attempt %d/%d)...\n", attempt+1, transferRetryCount)
+		}
+		retryable, err := sendTarballOnce(dirPath, patterns, url)
+		if err == nil {
+			return 0
+		}
+		lastErr = err
+		if !retryable {
+			fmt.Fprintf(output, "error: %s\n", err.Error())
+			return 1
+		}
+	}
+	fmt.Fprintf(output, "error: tarball transfer failed after %d attempts: %s\n", transferRetryCount, lastErr.Error())
+	return 1
+}
 
-	// Start packing the files
+// sendTarballOnce runs a single pack-and-send attempt and reports whether the
+// error is worth retrying. Transport errors, 5xx, and 429 are retryable; other
+// 4xx and local packing failures are terminal.
+func sendTarballOnce(dirPath string, patterns []string, url string) (retryable bool, err error) {
+	errChan := make(chan error, 1)
 	reader, writer := io.Pipe()
 	go func() {
-		err := common.WriteTarball(writer, dirPath, patterns)
+		e := common.WriteTarball(writer, dirPath, patterns)
 		_ = writer.Close()
-		if err != nil {
-			errChan <- err
-		} else {
-			errChan <- nil
-		}
+		errChan <- e
 	}()
 
-	// Send the tarball
 	req, err := http.NewRequestWithContext(context.Background(), http.MethodPost, url, reader)
 	if err != nil {
-		fmt.Fprintf(output, "error: create the tarball request - %s\n", err.Error())
-		return 1
+		return false, fmt.Errorf("create the tarball request - %w", err)
 	}
 	req.Header.Set("Content-Type", "application/tar+gzip")
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
-		fmt.Fprintf(output, "error: send the tarball request - %s\n", err.Error())
-		return 1
+		return true, fmt.Errorf("send the tarball request - %w", err)
 	}
 	defer resp.Body.Close()
 
-	// Check for write errors
-	writeErr := <-errChan
-	if writeErr != nil {
-		fmt.Fprintf(output, "error: write the tarball stream - %s\n", writeErr.Error())
-		return 1
+	if writeErr := <-errChan; writeErr != nil {
+		return false, fmt.Errorf("write the tarball stream - %w", writeErr)
 	}
 
-	if resp.StatusCode != http.StatusNoContent {
-		fmt.Fprintf(output, "error: failed to send the tarball: status code %d\n", resp.StatusCode)
-		return 1
+	if resp.StatusCode == http.StatusNoContent {
+		return false, nil
 	}
-
-	return 0
+	if resp.StatusCode >= 500 || resp.StatusCode == http.StatusTooManyRequests {
+		return true, fmt.Errorf("failed to send the tarball: status code %d", resp.StatusCode)
+	}
+	return false, fmt.Errorf("failed to send the tarball: status code %d", resp.StatusCode)
 }

--- a/cmd/testworkflow-toolkit/commands/transfer_test.go
+++ b/cmd/testworkflow-toolkit/commands/transfer_test.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -155,6 +156,10 @@ func TestProcessTransferPair(t *testing.T) {
 	})
 
 	t.Run("handles connection errors", func(t *testing.T) {
+		oldDelay := transferRetryBaseDelay
+		transferRetryBaseDelay = time.Millisecond
+		defer func() { transferRetryBaseDelay = oldDelay }()
+
 		// Create test files
 		tempDir := t.TempDir()
 		err := os.WriteFile(filepath.Join(tempDir, "test.txt"), []byte("test"), 0644)
@@ -164,9 +169,10 @@ func TestProcessTransferPair(t *testing.T) {
 		output := &bytes.Buffer{}
 		exitCode := ProcessTransferPair(tempDir+":test.txt=http://localhost:99999/upload", output)
 
-		// Verify failure
+		// Verify failure: network errors are retryable, so the message reflects
+		// exhaustion of the retry budget and still names the underlying cause.
 		assert.Equal(t, 1, exitCode, "should return exit code 1 on connection error")
-		assert.Contains(t, output.String(), "error: send the tarball request")
+		assert.Contains(t, output.String(), "send the tarball request")
 	})
 
 	t.Run("handles empty directory", func(t *testing.T) {
@@ -247,6 +253,11 @@ func TestProcessTransfers(t *testing.T) {
 	})
 
 	t.Run("stops on first failure", func(t *testing.T) {
+		// Shorten the retry backoff so the test is not paced by production timings.
+		oldDelay := transferRetryBaseDelay
+		transferRetryBaseDelay = time.Millisecond
+		defer func() { transferRetryBaseDelay = oldDelay }()
+
 		// Create test files
 		tempDir := t.TempDir()
 		err := os.WriteFile(filepath.Join(tempDir, "test.txt"), []byte("test"), 0644)
@@ -273,9 +284,64 @@ func TestProcessTransfers(t *testing.T) {
 		}
 		exitCode := ProcessTransfers(pairs, output)
 
-		// Verify failure
+		// Verify failure: 500 is retryable, so the first pair exhausts the retry
+		// budget before we give up and skip the second pair.
 		assert.Equal(t, 1, exitCode, "should return exit code 1 on first failure")
-		assert.Equal(t, 1, requestCount, "should have made only 1 request")
+		assert.Equal(t, transferRetryCount, requestCount, "should have exhausted the retry budget on the failing pair")
 		assert.Contains(t, output.String(), "status code 500")
+	})
+
+	// A brief 5xx blip should be hidden from the caller: the retry loop replays
+	// the tarball on the same URL and the transfer eventually succeeds.
+	t.Run("retries transient 5xx then succeeds", func(t *testing.T) {
+		oldDelay := transferRetryBaseDelay
+		transferRetryBaseDelay = time.Millisecond
+		defer func() { transferRetryBaseDelay = oldDelay }()
+
+		tempDir := t.TempDir()
+		require.NoError(t, os.WriteFile(filepath.Join(tempDir, "test.txt"), []byte("test"), 0644))
+
+		requestCount := 0
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			requestCount++
+			io.Copy(io.Discard, r.Body)
+			if requestCount < 2 {
+				w.WriteHeader(http.StatusServiceUnavailable)
+				return
+			}
+			w.WriteHeader(http.StatusNoContent)
+		}))
+		defer server.Close()
+
+		output := &bytes.Buffer{}
+		exitCode := ProcessTransfers([]string{tempDir + ":test.txt=" + server.URL + "/upload"}, output)
+
+		assert.Equal(t, 0, exitCode)
+		assert.Equal(t, 2, requestCount)
+	})
+
+	// 4xx is a caller / config error and would keep failing on the same URL,
+	// so retry short-circuits after the first attempt.
+	t.Run("does not retry on 4xx", func(t *testing.T) {
+		oldDelay := transferRetryBaseDelay
+		transferRetryBaseDelay = time.Millisecond
+		defer func() { transferRetryBaseDelay = oldDelay }()
+
+		tempDir := t.TempDir()
+		require.NoError(t, os.WriteFile(filepath.Join(tempDir, "test.txt"), []byte("test"), 0644))
+
+		requestCount := 0
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			requestCount++
+			io.Copy(io.Discard, r.Body)
+			w.WriteHeader(http.StatusBadRequest)
+		}))
+		defer server.Close()
+
+		output := &bytes.Buffer{}
+		exitCode := ProcessTransfers([]string{tempDir + ":test.txt=" + server.URL + "/upload"}, output)
+
+		assert.Equal(t, 1, exitCode)
+		assert.Equal(t, 1, requestCount, "should not retry 4xx")
 	})
 }

--- a/cmd/testworkflow-toolkit/commands/transfer_test.go
+++ b/cmd/testworkflow-toolkit/commands/transfer_test.go
@@ -169,8 +169,6 @@ func TestProcessTransferPair(t *testing.T) {
 		output := &bytes.Buffer{}
 		exitCode := ProcessTransferPair(tempDir+":test.txt=http://localhost:99999/upload", output)
 
-		// Verify failure: network errors are retryable, so the message reflects
-		// exhaustion of the retry budget and still names the underlying cause.
 		assert.Equal(t, 1, exitCode, "should return exit code 1 on connection error")
 		assert.Contains(t, output.String(), "send the tarball request")
 	})
@@ -253,7 +251,6 @@ func TestProcessTransfers(t *testing.T) {
 	})
 
 	t.Run("stops on first failure", func(t *testing.T) {
-		// Shorten the retry backoff so the test is not paced by production timings.
 		oldDelay := transferRetryBaseDelay
 		transferRetryBaseDelay = time.Millisecond
 		defer func() { transferRetryBaseDelay = oldDelay }()
@@ -284,15 +281,11 @@ func TestProcessTransfers(t *testing.T) {
 		}
 		exitCode := ProcessTransfers(pairs, output)
 
-		// Verify failure: 500 is retryable, so the first pair exhausts the retry
-		// budget before we give up and skip the second pair.
 		assert.Equal(t, 1, exitCode, "should return exit code 1 on first failure")
 		assert.Equal(t, transferRetryCount, requestCount, "should have exhausted the retry budget on the failing pair")
 		assert.Contains(t, output.String(), "status code 500")
 	})
 
-	// A brief 5xx blip should be hidden from the caller: the retry loop replays
-	// the tarball on the same URL and the transfer eventually succeeds.
 	t.Run("retries transient 5xx then succeeds", func(t *testing.T) {
 		oldDelay := transferRetryBaseDelay
 		transferRetryBaseDelay = time.Millisecond
@@ -320,8 +313,6 @@ func TestProcessTransfers(t *testing.T) {
 		assert.Equal(t, 2, requestCount)
 	})
 
-	// 4xx is a caller / config error and would keep failing on the same URL,
-	// so retry short-circuits after the first attempt.
 	t.Run("does not retry on 4xx", func(t *testing.T) {
 		oldDelay := transferRetryBaseDelay
 		transferRetryBaseDelay = time.Millisecond

--- a/cmd/testworkflow-toolkit/common/tarball.go
+++ b/cmd/testworkflow-toolkit/common/tarball.go
@@ -104,7 +104,7 @@ func UnpackTarball(dirPath string, stream io.Reader) error {
 
 		switch header.Typeflag {
 		case tar.TypeDir:
-			err := os.Mkdir(filePath, 0755)
+			err := os.MkdirAll(filePath, 0755)
 			if err != nil {
 				return errors.Wrapf(err, "%s: create directory", filePath)
 			}
@@ -127,6 +127,11 @@ func UnpackTarball(dirPath string, stream io.Reader) error {
 			err := os.MkdirAll(filepath.Dir(filePath), 0755)
 			if err != nil {
 				return errors.Wrapf(err, "%s: create directory tree", filePath)
+			}
+			if _, statErr := os.Lstat(filePath); statErr == nil {
+				if rmErr := os.Remove(filePath); rmErr != nil {
+					return errors.Wrapf(rmErr, "%s: replace existing entry before symlink", filePath)
+				}
 			}
 			err = os.Symlink(header.Linkname, filePath)
 			if err != nil {

--- a/cmd/testworkflow-toolkit/common/tarball_test.go
+++ b/cmd/testworkflow-toolkit/common/tarball_test.go
@@ -1,0 +1,110 @@
+package common
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func buildMixedTarball(t *testing.T, regContent string) *bytes.Buffer {
+	t.Helper()
+
+	buf := &bytes.Buffer{}
+	gz := gzip.NewWriter(buf)
+	tw := tar.NewWriter(gz)
+
+	require.NoError(t, tw.WriteHeader(&tar.Header{
+		Name:     "sub/",
+		Typeflag: tar.TypeDir,
+		Mode:     0o755,
+	}))
+
+	require.NoError(t, tw.WriteHeader(&tar.Header{
+		Name:     "sub/file.txt",
+		Typeflag: tar.TypeReg,
+		Mode:     0o644,
+		Size:     int64(len(regContent)),
+	}))
+	_, err := tw.Write([]byte(regContent))
+	require.NoError(t, err)
+
+	require.NoError(t, tw.WriteHeader(&tar.Header{
+		Name:     "sub/link.txt",
+		Typeflag: tar.TypeSymlink,
+		Linkname: "file.txt",
+		Mode:     0o777,
+	}))
+
+	require.NoError(t, tw.Close())
+	require.NoError(t, gz.Close())
+	return buf
+}
+
+func TestUnpackTarball_ExtractIsIdempotentOnRetry(t *testing.T) {
+	dir := t.TempDir()
+
+	require.NoError(t, UnpackTarball(dir, buildMixedTarball(t, "hello")))
+	assert.NoError(t, UnpackTarball(dir, buildMixedTarball(t, "hello")))
+
+	data, err := os.ReadFile(filepath.Join(dir, "sub", "file.txt"))
+	require.NoError(t, err)
+	assert.Equal(t, "hello", string(data))
+
+	target, err := os.Readlink(filepath.Join(dir, "sub", "link.txt"))
+	require.NoError(t, err)
+	assert.Equal(t, "file.txt", target)
+}
+
+func TestUnpackTarball_ExtractOverwritesOnRetry(t *testing.T) {
+	dir := t.TempDir()
+
+	require.NoError(t, UnpackTarball(dir, buildMixedTarball(t, "first")))
+
+	buf := &bytes.Buffer{}
+	gz := gzip.NewWriter(buf)
+	tw := tar.NewWriter(gz)
+
+	require.NoError(t, tw.WriteHeader(&tar.Header{Name: "sub/", Typeflag: tar.TypeDir, Mode: 0o755}))
+	require.NoError(t, tw.WriteHeader(&tar.Header{
+		Name: "sub/other.txt", Typeflag: tar.TypeReg, Mode: 0o644, Size: 5,
+	}))
+	_, err := tw.Write([]byte("other"))
+	require.NoError(t, err)
+	require.NoError(t, tw.WriteHeader(&tar.Header{Name: "sub/file.txt", Typeflag: tar.TypeReg, Mode: 0o644, Size: 6}))
+	_, err = tw.Write([]byte("second"))
+	require.NoError(t, err)
+	require.NoError(t, tw.WriteHeader(&tar.Header{
+		Name: "sub/link.txt", Typeflag: tar.TypeSymlink, Linkname: "other.txt", Mode: 0o777,
+	}))
+	require.NoError(t, tw.Close())
+	require.NoError(t, gz.Close())
+
+	require.NoError(t, UnpackTarball(dir, buf))
+
+	got, err := os.ReadFile(filepath.Join(dir, "sub", "file.txt"))
+	require.NoError(t, err)
+	assert.Equal(t, "second", string(got))
+
+	target, err := os.Readlink(filepath.Join(dir, "sub", "link.txt"))
+	require.NoError(t, err)
+	assert.Equal(t, "other.txt", target)
+}
+
+func TestUnpackTarball_FreshExtract(t *testing.T) {
+	dir := t.TempDir()
+
+	require.NoError(t, UnpackTarball(dir, buildMixedTarball(t, "payload")))
+
+	data, err := os.ReadFile(filepath.Join(dir, "sub", "file.txt"))
+	require.NoError(t, err)
+	assert.Equal(t, "payload", string(data))
+
+	_, err = os.Lstat(filepath.Join(dir, "sub", "link.txt"))
+	require.NoError(t, err)
+}


### PR DESCRIPTION
Stacked on top of #8128.

Two more silent-drop sites in the toolkit that runs inside every TW container:

- `cmd/testworkflow-toolkit/artifacts/cloud_uploader.go` — the PUT to the signed URL was one-shot. A transient 5xx / network blip = artifact silently dropped; the TW is reported as passed but the user sees no artifacts. Retry loop (5 attempts, 500ms base) on network errors, 5xx, and 429. Other 4xx short-circuit. Body is rewound via `io.Seeker` when possible; if the reader is not seekable the code falls back to one attempt.
- `cmd/testworkflow-toolkit/commands/transfer.go` — the tarball POST between parallel steps was one-shot. Same class of failure lost the tarball. Retry loop (3 attempts, 500ms base) that regenerates the tarball via a fresh `io.Pipe` on every attempt.

Reproduction tests added for both paths cover the recover-mid-retry and the budget-exhausted cases. Existing tests updated where the retry-aware output changed.
