### PR TITLE
fix(tw-init): propagate current container resources into shared state for step containers

### DIFF
--- a/cmd/testworkflow-init/data/state.go
+++ b/cmd/testworkflow-init/data/state.go
@@ -187,6 +187,13 @@ func (s *state) SetCurrentStatus(expression string) {
 	s.CurrentStatus = expression
 }
 
+func SetContainerResources(cr testworkflowconfig.ContainerResourceConfig) {
+	stateMu.Lock()
+	defer stateMu.Unlock()
+
+	currentState.ContainerResources = cr
+}
+
 var currentState = &state{
 	Output: map[string]string{},
 	Steps:  map[string]*StepData{},

--- a/cmd/testworkflow-init/runner/state_manager.go
+++ b/cmd/testworkflow-init/runner/state_manager.go
@@ -9,6 +9,8 @@ import (
 	"github.com/kubeshop/testkube/cmd/testworkflow-init/constants"
 	"github.com/kubeshop/testkube/cmd/testworkflow-init/data"
 	"github.com/kubeshop/testkube/cmd/testworkflow-init/orchestration"
+	"github.com/kubeshop/testkube/pkg/testworkflows/testworkflowconfig"
+	"github.com/kubeshop/testkube/pkg/testworkflows/testworkflowprocessor/action/actiontypes/lite"
 )
 
 type StateManager interface {
@@ -120,21 +122,27 @@ func (sm *stateManager) LoadInitialState() error {
 	signature := orchestration.Setup.GetSignature()
 	containerResources := orchestration.Setup.GetContainerResources()
 
-	if actionGroups != nil {
+	shouldInitState := actionGroups != nil
+	if shouldInitState {
 		sm.stdoutUnsafe.Print("Initializing state...")
-		state := data.GetState()
-		state.Actions = actionGroups
-		state.InternalConfig = internalConfig
-		state.Signature = signature
-		state.ContainerResources = containerResources
+		sm.initState(actionGroups, internalConfig, signature, containerResources)
 		sm.stdoutUnsafe.Print(" done\n")
 	} else {
-		// ContainerResources reflects the current container's downward-api values.
-		// Step containers do not receive the actions env var so the block above is
-		// skipped for them; without this write they would inherit the init helper's
-		// stale (namespace-default or zero) resources for the entire metrics run.
-		data.GetState().ContainerResources = containerResources
+		data.SetContainerResources(containerResources)
 	}
 
 	return nil
+}
+
+func (sm *stateManager) initState(
+	actionGroups [][]lite.LiteAction,
+	internalConfig testworkflowconfig.InternalConfig,
+	signature []testworkflowconfig.SignatureConfig,
+	containerResources testworkflowconfig.ContainerResourceConfig,
+) {
+	state := data.GetState()
+	state.Actions = actionGroups
+	state.InternalConfig = internalConfig
+	state.Signature = signature
+	state.ContainerResources = containerResources
 }

--- a/cmd/testworkflow-init/runner/state_manager.go
+++ b/cmd/testworkflow-init/runner/state_manager.go
@@ -128,6 +128,12 @@ func (sm *stateManager) LoadInitialState() error {
 		state.Signature = signature
 		state.ContainerResources = containerResources
 		sm.stdoutUnsafe.Print(" done\n")
+	} else {
+		// ContainerResources reflects the current container's downward-api values.
+		// Step containers do not receive the actions env var so the block above is
+		// skipped for them; without this write they would inherit the init helper's
+		// stale (namespace-default or zero) resources for the entire metrics run.
+		data.GetState().ContainerResources = containerResources
 	}
 
 	return nil


### PR DESCRIPTION
Propagate current container resources into shared state for step containers so the CPU and memory charts show the request/limit lines properly.

Linear: https://linear.app/kubeshop/issue/TKC-6710


## How it looks now
<img width="862" height="458" alt="image" src="https://github.com/user-attachments/assets/09677a96-9c01-476b-8f07-f3e6590a866b" />


## How it should look
<img width="1794" height="458" alt="image" src="https://github.com/user-attachments/assets/cdb6ee1a-be35-492d-b632-fe6a214e245b" />
