### PR TITLE
fix(ci): bump mcp-publisher to v1.8.1 for OIDC audience compatibility

### DIFF
--- a/.github/workflows/new-build.yaml
+++ b/.github/workflows/new-build.yaml
@@ -271,7 +271,7 @@ jobs:
 
       - name: Install mcp-publisher
         env:
-          MCP_PUBLISHER_VERSION: v1.5.0
+          MCP_PUBLISHER_VERSION: v1.8.1
         run: |
           curl -L "https://github.com/modelcontextprotocol/registry/releases/download/${MCP_PUBLISHER_VERSION}/mcp-publisher_linux_amd64.tar.gz" | tar xz
           chmod +x mcp-publisher

--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,18 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:recommended"
+  ],
+  "customManagers": [
+    {
+      "customType": "regex",
+      "managerFilePatterns": [
+        ".github/workflows/new-build.yaml"
+      ],
+      "matchStrings": [
+        "MCP_PUBLISHER_VERSION:\\s*(?<currentValue>v\\S+)"
+      ],
+      "datasourceTemplate": "github-releases",
+      "depNameTemplate": "modelcontextprotocol/registry"
+    }
   ]
 }


### PR DESCRIPTION
Bumps `mcp-publisher` from v1.5.0 to v1.8.1 to fix the "Publish to MCP Registry" job, which fails at OIDC auth with `invalid audience: expected https://registry.modelcontextprotocol.io, got [mcp-registry]`.

The registry now binds the OIDC token audience to the registry URL. The pinned v1.5.0 sends a hardcoded `mcp-registry` audience; v1.7.9+ derives it from the registry URL, so the version bump is the fix.

Also adds a Renovate custom manager so `MCP_PUBLISHER_VERSION` is tracked as a dependency and won't silently fall behind again.

Supersedes #7777. Closes TKC-6713.

Failed run: https://github.com/kubeshop/testkube/actions/runs/33058034352