### PR TITLE
fix(tw-init): trigger state load before SetContainerResources overwrites

### DIFF
--- a/cmd/testworkflow-init/data/state.go
+++ b/cmd/testworkflow-init/data/state.go
@@ -190,8 +190,9 @@ func (s *state) SetCurrentStatus(expression string) {
 func SetContainerResources(cr testworkflowconfig.ContainerResourceConfig) {
 	// Trigger the load-once so readState (which populates currentState from disk)
 	// runs before this write. Without this, a caller that invokes the setter
-	// before any GetState() writes into the initial empty currentState, and a
-	// later GetState() call overwrites those fields with the on-disk contents.
+	// before any GetState() call writes into the initial empty currentState,
+	// and a later GetState() call overwrites those fields with the on-disk
+	// contents.
 	_ = GetState()
 
 	stateMu.Lock()

--- a/cmd/testworkflow-init/data/state.go
+++ b/cmd/testworkflow-init/data/state.go
@@ -188,6 +188,12 @@ func (s *state) SetCurrentStatus(expression string) {
 }
 
 func SetContainerResources(cr testworkflowconfig.ContainerResourceConfig) {
+	// Trigger the load-once so readState (which populates currentState from disk)
+	// runs before this write. Without this, a caller that invokes the setter
+	// before any GetState() writes into the initial empty currentState, and a
+	// later GetState() call overwrites those fields with the on-disk contents.
+	_ = GetState()
+
 	stateMu.Lock()
 	defer stateMu.Unlock()
 


### PR DESCRIPTION
Follow-up to https://github.com/kubeshop/testkube/pull/8172. The setter introduced in the previous refactor writes to `currentState` directly, but if it runs before any `GetState()` call, `readState()` (triggered by the next `GetState()` from the runner) reassigns fields on the in-memory state from disk, silently overwriting the just-written ContainerResources. Add a `GetState()` call at the top of the setter to force the load-once first, so the write lands on the state that will actually be used.

Verified end-to-end on k3d: aggregated /metrics response returns distinct per-step requests/limits (100m/200m for step-a, 500m/1000m for step-b, matching the yaml).

Linear: https://linear.app/kubeshop/issue/TKC-6710