### PR TITLE
fix(tw-init): cherry-pick resource-usage chart fix to release/2-13

### DIFF
--- a/cmd/testworkflow-init/data/state.go
+++ b/cmd/testworkflow-init/data/state.go
@@ -172,6 +172,13 @@ func (s *state) SetCurrentStatus(expression string) {
 	s.CurrentStatus = expression
 }
 
+func SetContainerResources(cr testworkflowconfig.ContainerResourceConfig) {
+	stateMu.Lock()
+	defer stateMu.Unlock()
+
+	currentState.ContainerResources = cr
+}
+
 var currentState = &state{
 	Output: map[string]string{},
 	Steps:  map[string]*StepData{},

--- a/cmd/testworkflow-init/data/state.go
+++ b/cmd/testworkflow-init/data/state.go
@@ -173,6 +173,13 @@ func (s *state) SetCurrentStatus(expression string) {
 }
 
 func SetContainerResources(cr testworkflowconfig.ContainerResourceConfig) {
+	// Trigger the load-once so readState (which populates currentState from disk)
+	// runs before this write. Without this, a caller that invokes the setter
+	// before any GetState() call writes into the initial empty currentState,
+	// and a later GetState() call overwrites those fields with the on-disk
+	// contents.
+	_ = GetState()
+
 	stateMu.Lock()
 	defer stateMu.Unlock()
 

--- a/cmd/testworkflow-init/runner/state_manager.go
+++ b/cmd/testworkflow-init/runner/state_manager.go
@@ -9,6 +9,8 @@ import (
 	"github.com/kubeshop/testkube/cmd/testworkflow-init/constants"
 	"github.com/kubeshop/testkube/cmd/testworkflow-init/data"
 	"github.com/kubeshop/testkube/cmd/testworkflow-init/orchestration"
+	"github.com/kubeshop/testkube/pkg/testworkflows/testworkflowconfig"
+	"github.com/kubeshop/testkube/pkg/testworkflows/testworkflowprocessor/action/actiontypes/lite"
 )
 
 type StateManager interface {
@@ -120,15 +122,27 @@ func (sm *stateManager) LoadInitialState() error {
 	signature := orchestration.Setup.GetSignature()
 	containerResources := orchestration.Setup.GetContainerResources()
 
-	if actionGroups != nil {
+	shouldInitState := actionGroups != nil
+	if shouldInitState {
 		sm.stdoutUnsafe.Print("Initializing state...")
-		state := data.GetState()
-		state.Actions = actionGroups
-		state.InternalConfig = internalConfig
-		state.Signature = signature
-		state.ContainerResources = containerResources
+		sm.initState(actionGroups, internalConfig, signature, containerResources)
 		sm.stdoutUnsafe.Print(" done\n")
+	} else {
+		data.SetContainerResources(containerResources)
 	}
 
 	return nil
+}
+
+func (sm *stateManager) initState(
+	actionGroups [][]lite.LiteAction,
+	internalConfig testworkflowconfig.InternalConfig,
+	signature []testworkflowconfig.SignatureConfig,
+	containerResources testworkflowconfig.ContainerResourceConfig,
+) {
+	state := data.GetState()
+	state.Actions = actionGroups
+	state.InternalConfig = internalConfig
+	state.Signature = signature
+	state.ContainerResources = containerResources
 }


### PR DESCRIPTION
Cherry-picks https://github.com/kubeshop/testkube/pull/8172 and https://github.com/kubeshop/testkube/pull/8179 onto release/2-13 so the fix ships in the next 2.13.x release. Together they make the Resource Usage chart plot each step's own request/limit lines instead of the init helper's namespace defaults.

Linear: https://linear.app/kubeshop/issue/TKC-6710