### PR TITLE
fix(templates): propagate step-level template Pod fields to workflow spec

### DIFF
--- a/pkg/testworkflows/testworkflowresolver/apply.go
+++ b/pkg/testworkflows/testworkflowresolver/apply.go
@@ -124,7 +124,7 @@ func InjectServiceTemplate(svc *testworkflowsv1.ServiceSpec, template *testworkf
 	return nil
 }
 
-func applyTemplatesToStep(step testworkflowsv1.Step, templates map[string]*testworkflowsv1.TestWorkflowTemplate,
+func applyTemplatesToStep(step testworkflowsv1.Step, spec *testworkflowsv1.TestWorkflowSpec, templates map[string]*testworkflowsv1.TestWorkflowTemplate,
 	externalize func(key, value string) (expressions.Expression, error)) (testworkflowsv1.Step, error) {
 	// Apply regular templates
 	for i := len(step.Use) - 1; i >= 0; i-- {
@@ -132,6 +132,13 @@ func applyTemplatesToStep(step testworkflowsv1.Step, templates map[string]*testw
 		tpl, err := getConfiguredTemplate(ref.Name, ref.Config, templates, externalize)
 		if err != nil {
 			return step, errors.Wrap(err, fmt.Sprintf(".use[%d]: resolving template", i))
+		}
+		// Pod is a workflow-scoped concern; a step-level template that carries pod
+		// fields (e.g. Volumes backing its Container.VolumeMounts) must have them
+		// applied to the enclosing spec, otherwise the resulting Job is rejected
+		// by the K8s API with "volume not found".
+		if spec != nil && tpl.Spec.Pod != nil {
+			spec.Pod = MergePodConfig(tpl.Spec.Pod, spec.Pod)
 		}
 		err = InjectStepTemplate(&step, tpl)
 		if err != nil {
@@ -145,6 +152,9 @@ func applyTemplatesToStep(step testworkflowsv1.Step, templates map[string]*testw
 		tpl, err := getConfiguredTemplate(step.Template.Name, step.Template.Config, templates, externalize)
 		if err != nil {
 			return step, errors.Wrap(err, ".template: resolving template")
+		}
+		if spec != nil && tpl.Spec.Pod != nil {
+			spec.Pod = MergePodConfig(tpl.Spec.Pod, spec.Pod)
 		}
 		isolate := testworkflowsv1.Step{}
 		err = InjectStepTemplate(&isolate, tpl)
@@ -227,13 +237,13 @@ func applyTemplatesToStep(step testworkflowsv1.Step, templates map[string]*testw
 	// Resolve templates in the sub-steps
 	var err error
 	for i := range step.Setup {
-		step.Setup[i], err = applyTemplatesToStep(step.Setup[i], templates, externalize)
+		step.Setup[i], err = applyTemplatesToStep(step.Setup[i], spec, templates, externalize)
 		if err != nil {
 			return step, errors.Wrap(err, fmt.Sprintf(".steps[%d]", i))
 		}
 	}
 	for i := range step.Steps {
-		step.Steps[i], err = applyTemplatesToStep(step.Steps[i], templates, externalize)
+		step.Steps[i], err = applyTemplatesToStep(step.Steps[i], spec, templates, externalize)
 		if err != nil {
 			return step, errors.Wrap(err, fmt.Sprintf(".steps[%d]", i))
 		}
@@ -318,19 +328,19 @@ func applyTemplatesToSpec(spec *testworkflowsv1.TestWorkflowSpec, templates map[
 
 	// Apply templates on the step level
 	for i := range spec.Setup {
-		spec.Setup[i], err = applyTemplatesToStep(spec.Setup[i], templates, externalize)
+		spec.Setup[i], err = applyTemplatesToStep(spec.Setup[i], spec, templates, externalize)
 		if err != nil {
 			return errors.Wrap(err, fmt.Sprintf("spec.setup[%d]", i))
 		}
 	}
 	for i := range spec.Steps {
-		spec.Steps[i], err = applyTemplatesToStep(spec.Steps[i], templates, externalize)
+		spec.Steps[i], err = applyTemplatesToStep(spec.Steps[i], spec, templates, externalize)
 		if err != nil {
 			return errors.Wrap(err, fmt.Sprintf("spec.steps[%d]", i))
 		}
 	}
 	for i := range spec.After {
-		spec.After[i], err = applyTemplatesToStep(spec.After[i], templates, externalize)
+		spec.After[i], err = applyTemplatesToStep(spec.After[i], spec, templates, externalize)
 		if err != nil {
 			return errors.Wrap(err, fmt.Sprintf("spec.after[%d]", i))
 		}

--- a/pkg/testworkflows/testworkflowresolver/apply.go
+++ b/pkg/testworkflows/testworkflowresolver/apply.go
@@ -134,6 +134,9 @@ func applyTemplatesToStep(step testworkflowsv1.Step, spec *testworkflowsv1.TestW
 			return step, errors.Wrap(err, fmt.Sprintf(".use[%d]: resolving template", i))
 		}
 		if spec != nil && tpl.Spec.Pod != nil {
+			if err := checkTemplatePodVolumeConflict(spec.Pod, tpl.Spec.Pod, ref.Name); err != nil {
+				return step, errors.Wrap(err, fmt.Sprintf(".use[%d]: injecting template", i))
+			}
 			spec.Pod = MergePodConfig(tpl.Spec.Pod, spec.Pod)
 			spec.Pod.Volumes = dedupeVolumesByName(spec.Pod.Volumes)
 		}
@@ -151,6 +154,9 @@ func applyTemplatesToStep(step testworkflowsv1.Step, spec *testworkflowsv1.TestW
 			return step, errors.Wrap(err, ".template: resolving template")
 		}
 		if spec != nil && tpl.Spec.Pod != nil {
+			if err := checkTemplatePodVolumeConflict(spec.Pod, tpl.Spec.Pod, step.Template.Name); err != nil {
+				return step, errors.Wrap(err, ".template: injecting template")
+			}
 			spec.Pod = MergePodConfig(tpl.Spec.Pod, spec.Pod)
 			spec.Pod.Volumes = dedupeVolumesByName(spec.Pod.Volumes)
 		}

--- a/pkg/testworkflows/testworkflowresolver/apply.go
+++ b/pkg/testworkflows/testworkflowresolver/apply.go
@@ -133,12 +133,9 @@ func applyTemplatesToStep(step testworkflowsv1.Step, spec *testworkflowsv1.TestW
 		if err != nil {
 			return step, errors.Wrap(err, fmt.Sprintf(".use[%d]: resolving template", i))
 		}
-		// Pod is a workflow-scoped concern; a step-level template that carries pod
-		// fields (e.g. Volumes backing its Container.VolumeMounts) must have them
-		// applied to the enclosing spec, otherwise the resulting Job is rejected
-		// by the K8s API with "volume not found".
 		if spec != nil && tpl.Spec.Pod != nil {
 			spec.Pod = MergePodConfig(tpl.Spec.Pod, spec.Pod)
+			spec.Pod.Volumes = dedupeVolumesByName(spec.Pod.Volumes)
 		}
 		err = InjectStepTemplate(&step, tpl)
 		if err != nil {

--- a/pkg/testworkflows/testworkflowresolver/apply.go
+++ b/pkg/testworkflows/testworkflowresolver/apply.go
@@ -152,6 +152,7 @@ func applyTemplatesToStep(step testworkflowsv1.Step, spec *testworkflowsv1.TestW
 		}
 		if spec != nil && tpl.Spec.Pod != nil {
 			spec.Pod = MergePodConfig(tpl.Spec.Pod, spec.Pod)
+			spec.Pod.Volumes = dedupeVolumesByName(spec.Pod.Volumes)
 		}
 		isolate := testworkflowsv1.Step{}
 		err = InjectStepTemplate(&isolate, tpl)

--- a/pkg/testworkflows/testworkflowresolver/apply_test.go
+++ b/pkg/testworkflows/testworkflowresolver/apply_test.go
@@ -373,12 +373,6 @@ func TestApplyTemplatesStepIgnorePod(t *testing.T) {
 	assert.Equal(t, want, s)
 }
 
-// TestApplyTemplatesStepPropagatesPodViaUse asserts that a step-level template
-// referenced via steps[].use[] contributes its Pod fields to the enclosing spec.
-// Regression guard: when the merger silently drops these fields, K8s API rejects
-// the resulting Job with `spec.template.spec.containers[0].volumeMounts[N].name:
-// Not found: "..."` because the container's volumeMounts survive the merge but
-// their backing pod.volumes do not.
 func TestApplyTemplatesStepPropagatesPodViaUse(t *testing.T) {
 	s := *basicStep.DeepCopy()
 	s.Use = []testworkflowsv1.TemplateRef{tplPodRef}
@@ -387,13 +381,11 @@ func TestApplyTemplatesStepPropagatesPodViaUse(t *testing.T) {
 	_, err := applyTemplatesToStep(s, spec, templates, nil)
 
 	assert.NoError(t, err)
-	if assert.NotNil(t, spec.Pod, "template Pod should have been merged into spec.Pod") {
+	if assert.NotNil(t, spec.Pod) {
 		assert.Equal(t, tplPod.Spec.Pod.Labels, spec.Pod.Labels)
 	}
 }
 
-// TestApplyTemplatesStepPropagatesPodViaTemplate covers the alternative
-// steps[].template.name syntax path, which shares the same silent-drop bug.
 func TestApplyTemplatesStepPropagatesPodViaTemplate(t *testing.T) {
 	s := *basicStep.DeepCopy()
 	s.Template = &tplPodRef
@@ -402,8 +394,37 @@ func TestApplyTemplatesStepPropagatesPodViaTemplate(t *testing.T) {
 	_, err := applyTemplatesToStep(s, spec, templates, nil)
 
 	assert.NoError(t, err)
-	if assert.NotNil(t, spec.Pod, "template Pod should have been merged into spec.Pod") {
+	if assert.NotNil(t, spec.Pod) {
 		assert.Equal(t, tplPod.Spec.Pod.Labels, spec.Pod.Labels)
+	}
+}
+
+func TestApplyTemplatesStepPropagatesPodDedupeVolumes(t *testing.T) {
+	tplWithVolumes := testworkflowsv1.TestWorkflowTemplate{
+		Spec: testworkflowsv1.TestWorkflowTemplateSpec{
+			TestWorkflowSpecBase: testworkflowsv1.TestWorkflowSpecBase{
+				Pod: &testworkflowsv1.PodConfig{
+					Volumes: []corev1.Volume{{Name: "cfg-vol"}},
+				},
+			},
+		},
+	}
+	tpls := map[string]*testworkflowsv1.TestWorkflowTemplate{"podVol": &tplWithVolumes}
+	ref := testworkflowsv1.TemplateRef{Name: "podVol"}
+
+	s := *basicStep.DeepCopy()
+	s.Use = []testworkflowsv1.TemplateRef{ref, ref}
+	spec := &testworkflowsv1.TestWorkflowSpec{}
+
+	_, err := applyTemplatesToStep(s, spec, tpls, nil)
+
+	assert.NoError(t, err)
+	if assert.NotNil(t, spec.Pod) {
+		names := make([]string, 0, len(spec.Pod.Volumes))
+		for _, v := range spec.Pod.Volumes {
+			names = append(names, v.Name)
+		}
+		assert.Equal(t, []string{"cfg-vol"}, names, "same template used twice must not duplicate pod.volumes")
 	}
 }
 

--- a/pkg/testworkflows/testworkflowresolver/apply_test.go
+++ b/pkg/testworkflows/testworkflowresolver/apply_test.go
@@ -353,7 +353,7 @@ func TestApplyTemplatesMergeMultipleConfigurable(t *testing.T) {
 func TestApplyTemplatesStepBasic(t *testing.T) {
 	s := *basicStep.DeepCopy()
 	s.Use = []testworkflowsv1.TemplateRef{tplEnvRef}
-	s, err := applyTemplatesToStep(s, templates, nil)
+	s, err := applyTemplatesToStep(s, nil, templates, nil)
 
 	want := *basicStep.DeepCopy()
 	want.Container.Env = append(tplEnv.Spec.Container.Env, want.Container.Env...)
@@ -365,7 +365,7 @@ func TestApplyTemplatesStepBasic(t *testing.T) {
 func TestApplyTemplatesStepIgnorePod(t *testing.T) {
 	s := *basicStep.DeepCopy()
 	s.Use = []testworkflowsv1.TemplateRef{tplPodRef}
-	s, err := applyTemplatesToStep(s, templates, nil)
+	s, err := applyTemplatesToStep(s, nil, templates, nil)
 
 	want := *basicStep.DeepCopy()
 
@@ -373,10 +373,44 @@ func TestApplyTemplatesStepIgnorePod(t *testing.T) {
 	assert.Equal(t, want, s)
 }
 
+// TestApplyTemplatesStepPropagatesPodViaUse asserts that a step-level template
+// referenced via steps[].use[] contributes its Pod fields to the enclosing spec.
+// Regression guard: when the merger silently drops these fields, K8s API rejects
+// the resulting Job with `spec.template.spec.containers[0].volumeMounts[N].name:
+// Not found: "..."` because the container's volumeMounts survive the merge but
+// their backing pod.volumes do not.
+func TestApplyTemplatesStepPropagatesPodViaUse(t *testing.T) {
+	s := *basicStep.DeepCopy()
+	s.Use = []testworkflowsv1.TemplateRef{tplPodRef}
+	spec := &testworkflowsv1.TestWorkflowSpec{}
+
+	_, err := applyTemplatesToStep(s, spec, templates, nil)
+
+	assert.NoError(t, err)
+	if assert.NotNil(t, spec.Pod, "template Pod should have been merged into spec.Pod") {
+		assert.Equal(t, tplPod.Spec.Pod.Labels, spec.Pod.Labels)
+	}
+}
+
+// TestApplyTemplatesStepPropagatesPodViaTemplate covers the alternative
+// steps[].template.name syntax path, which shares the same silent-drop bug.
+func TestApplyTemplatesStepPropagatesPodViaTemplate(t *testing.T) {
+	s := *basicStep.DeepCopy()
+	s.Template = &tplPodRef
+	spec := &testworkflowsv1.TestWorkflowSpec{}
+
+	_, err := applyTemplatesToStep(s, spec, templates, nil)
+
+	assert.NoError(t, err)
+	if assert.NotNil(t, spec.Pod, "template Pod should have been merged into spec.Pod") {
+		assert.Equal(t, tplPod.Spec.Pod.Labels, spec.Pod.Labels)
+	}
+}
+
 func TestApplyTemplatesStepBasicIsolatedIgnore(t *testing.T) {
 	s := *basicStep.DeepCopy()
 	s.Template = &tplEnvRef
-	s, err := applyTemplatesToStep(s, templates, nil)
+	s, err := applyTemplatesToStep(s, nil, templates, nil)
 
 	want := *basicStep.DeepCopy()
 
@@ -387,7 +421,7 @@ func TestApplyTemplatesStepBasicIsolatedIgnore(t *testing.T) {
 func TestApplyTemplatesStepBasicIsolated(t *testing.T) {
 	s := *basicStep.DeepCopy()
 	s.Template = &tplStepsRef
-	s, err := applyTemplatesToStep(s, templates, nil)
+	s, err := applyTemplatesToStep(s, nil, templates, nil)
 
 	want := *basicStep.DeepCopy()
 	want.Steps = append([]testworkflowsv1.Step{
@@ -403,7 +437,7 @@ func TestApplyTemplatesStepBasicIsolated(t *testing.T) {
 func TestApplyTemplatesStepBasicIsolatedWrapped(t *testing.T) {
 	s := *basicStep.DeepCopy()
 	s.Template = &tplStepsEnvRef
-	s, err := applyTemplatesToStep(s, templates, nil)
+	s, err := applyTemplatesToStep(s, nil, templates, nil)
 
 	want := *basicStep.DeepCopy()
 	want.Steps = append([]testworkflowsv1.Step{{
@@ -426,7 +460,7 @@ func TestApplyTemplatesStepBasicIsolatedWrapped(t *testing.T) {
 func TestApplyTemplatesStepBasicSteps(t *testing.T) {
 	s := *basicStep.DeepCopy()
 	s.Use = []testworkflowsv1.TemplateRef{tplStepsRef}
-	s, err := applyTemplatesToStep(s, templates, nil)
+	s, err := applyTemplatesToStep(s, nil, templates, nil)
 
 	want := *basicStep.DeepCopy()
 	want.Setup = []testworkflowsv1.Step{
@@ -445,7 +479,7 @@ func TestApplyTemplatesStepBasicSteps(t *testing.T) {
 func TestApplyTemplatesStepBasicMultipleSteps(t *testing.T) {
 	s := *basicStep.DeepCopy()
 	s.Use = []testworkflowsv1.TemplateRef{tplStepsRef, tplStepsConfigRef}
-	s, err := applyTemplatesToStep(s, templates, nil)
+	s, err := applyTemplatesToStep(s, nil, templates, nil)
 
 	want := *basicStep.DeepCopy()
 	want.Setup = []testworkflowsv1.Step{
@@ -470,7 +504,7 @@ func TestApplyTemplatesStepBasicMultipleSteps(t *testing.T) {
 func TestApplyTemplatesStepAdvancedIsolated(t *testing.T) {
 	s := *advancedStep.DeepCopy()
 	s.Template = &tplStepsRef
-	s, err := applyTemplatesToStep(s, templates, nil)
+	s, err := applyTemplatesToStep(s, nil, templates, nil)
 
 	want := *advancedStep.DeepCopy()
 	want.Steps = append([]testworkflowsv1.Step{
@@ -486,7 +520,7 @@ func TestApplyTemplatesStepAdvancedIsolated(t *testing.T) {
 func TestApplyTemplatesStepAdvancedIsolatedWrapped(t *testing.T) {
 	s := *advancedStep.DeepCopy()
 	s.Template = &tplStepsEnvRef
-	s, err := applyTemplatesToStep(s, templates, nil)
+	s, err := applyTemplatesToStep(s, nil, templates, nil)
 
 	want := *advancedStep.DeepCopy()
 	want.Steps = append([]testworkflowsv1.Step{{
@@ -512,7 +546,7 @@ func TestApplyTemplatesParallel(t *testing.T) {
 		Use:   []testworkflowsv1.TemplateRef{tplStepsEnvRef},
 		Steps: []testworkflowsv1.Step{basicStep},
 	}
-	s, err := applyTemplatesToStep(s, templates, nil)
+	s, err := applyTemplatesToStep(s, nil, templates, nil)
 
 	want := *advancedStep.DeepCopy()
 	want.Parallel = &testworkflowsv1.StepParallel{
@@ -540,7 +574,7 @@ func TestApplyTemplatesParallel(t *testing.T) {
 func TestApplyTemplatesStepAdvancedSteps(t *testing.T) {
 	s := *advancedStep.DeepCopy()
 	s.Use = []testworkflowsv1.TemplateRef{tplStepsRef}
-	s, err := applyTemplatesToStep(s, templates, nil)
+	s, err := applyTemplatesToStep(s, nil, templates, nil)
 
 	want := *advancedStep.DeepCopy()
 	want.Setup = []testworkflowsv1.Step{
@@ -559,7 +593,7 @@ func TestApplyTemplatesStepAdvancedSteps(t *testing.T) {
 func TestApplyTemplatesStepAdvancedMultipleSteps(t *testing.T) {
 	s := *advancedStep.DeepCopy()
 	s.Use = []testworkflowsv1.TemplateRef{tplStepsRef, tplStepsConfigRef}
-	s, err := applyTemplatesToStep(s, templates, nil)
+	s, err := applyTemplatesToStep(s, nil, templates, nil)
 
 	want := *advancedStep.DeepCopy()
 	want.Setup = []testworkflowsv1.Step{

--- a/pkg/testworkflows/testworkflowresolver/apply_test.go
+++ b/pkg/testworkflows/testworkflowresolver/apply_test.go
@@ -399,52 +399,68 @@ func TestApplyTemplatesStepPropagatesPodViaTemplate(t *testing.T) {
 	}
 }
 
-func TestApplyTemplatesStepPropagatesPodWorkflowVolumeWinsOverTemplate(t *testing.T) {
-	tplWithVolumes := testworkflowsv1.TestWorkflowTemplate{
-		Spec: testworkflowsv1.TestWorkflowTemplateSpec{
+func TestApplyTemplatesStepPropagatesPodErrorsOnVolumeSourceConflict(t *testing.T) {
+	mkTpl := func(cmName string) *testworkflowsv1.TestWorkflowTemplate {
+		return &testworkflowsv1.TestWorkflowTemplate{
+			Spec: testworkflowsv1.TestWorkflowTemplateSpec{
+				TestWorkflowSpecBase: testworkflowsv1.TestWorkflowSpecBase{
+					Pod: &testworkflowsv1.PodConfig{
+						Volumes: []corev1.Volume{{
+							Name: "cfg-vol",
+							VolumeSource: corev1.VolumeSource{
+								ConfigMap: &corev1.ConfigMapVolumeSource{
+									LocalObjectReference: corev1.LocalObjectReference{Name: cmName},
+								},
+							},
+						}},
+					},
+				},
+			},
+		}
+	}
+	mkWorkflowVol := func(cmName string) *testworkflowsv1.TestWorkflowSpec {
+		return &testworkflowsv1.TestWorkflowSpec{
 			TestWorkflowSpecBase: testworkflowsv1.TestWorkflowSpecBase{
 				Pod: &testworkflowsv1.PodConfig{
 					Volumes: []corev1.Volume{{
 						Name: "cfg-vol",
 						VolumeSource: corev1.VolumeSource{
 							ConfigMap: &corev1.ConfigMapVolumeSource{
-								LocalObjectReference: corev1.LocalObjectReference{Name: "from-template"},
+								LocalObjectReference: corev1.LocalObjectReference{Name: cmName},
 							},
 						},
 					}},
 				},
 			},
-		},
-	}
-	tpls := map[string]*testworkflowsv1.TestWorkflowTemplate{"podVol": &tplWithVolumes}
-	ref := testworkflowsv1.TemplateRef{Name: "podVol"}
-
-	spec := &testworkflowsv1.TestWorkflowSpec{
-		TestWorkflowSpecBase: testworkflowsv1.TestWorkflowSpecBase{
-			Pod: &testworkflowsv1.PodConfig{
-				Volumes: []corev1.Volume{{
-					Name: "cfg-vol",
-					VolumeSource: corev1.VolumeSource{
-						ConfigMap: &corev1.ConfigMapVolumeSource{
-							LocalObjectReference: corev1.LocalObjectReference{Name: "from-workflow"},
-						},
-					},
-				}},
-			},
-		},
-	}
-	s := *basicStep.DeepCopy()
-	s.Use = []testworkflowsv1.TemplateRef{ref}
-
-	_, err := applyTemplatesToStep(s, spec, tpls, nil)
-
-	assert.NoError(t, err)
-	if assert.Len(t, spec.Pod.Volumes, 1) {
-		got := spec.Pod.Volumes[0]
-		assert.Equal(t, "cfg-vol", got.Name)
-		if assert.NotNil(t, got.ConfigMap) {
-			assert.Equal(t, "from-workflow", got.ConfigMap.Name)
 		}
+	}
+
+	cases := map[string]func() (testworkflowsv1.Step, *testworkflowsv1.TestWorkflowSpec, map[string]*testworkflowsv1.TestWorkflowTemplate){
+		"workflow declares same name with different source": func() (testworkflowsv1.Step, *testworkflowsv1.TestWorkflowSpec, map[string]*testworkflowsv1.TestWorkflowTemplate) {
+			tpls := map[string]*testworkflowsv1.TestWorkflowTemplate{"tplA": mkTpl("from-template")}
+			s := *basicStep.DeepCopy()
+			s.Use = []testworkflowsv1.TemplateRef{{Name: "tplA"}}
+			return s, mkWorkflowVol("from-workflow"), tpls
+		},
+		"sibling templates disagree on source": func() (testworkflowsv1.Step, *testworkflowsv1.TestWorkflowSpec, map[string]*testworkflowsv1.TestWorkflowTemplate) {
+			tpls := map[string]*testworkflowsv1.TestWorkflowTemplate{
+				"tplA": mkTpl("from-A"),
+				"tplB": mkTpl("from-B"),
+			}
+			s := *basicStep.DeepCopy()
+			s.Use = []testworkflowsv1.TemplateRef{{Name: "tplA"}, {Name: "tplB"}}
+			return s, &testworkflowsv1.TestWorkflowSpec{}, tpls
+		},
+	}
+
+	for name, setup := range cases {
+		t.Run(name, func(t *testing.T) {
+			s, spec, tpls := setup()
+			_, err := applyTemplatesToStep(s, spec, tpls, nil)
+			if assert.Error(t, err) {
+				assert.Contains(t, err.Error(), "conflicts with an existing declaration")
+			}
+		})
 	}
 }
 

--- a/pkg/testworkflows/testworkflowresolver/apply_test.go
+++ b/pkg/testworkflows/testworkflowresolver/apply_test.go
@@ -399,6 +399,55 @@ func TestApplyTemplatesStepPropagatesPodViaTemplate(t *testing.T) {
 	}
 }
 
+func TestApplyTemplatesStepPropagatesPodWorkflowVolumeWinsOverTemplate(t *testing.T) {
+	tplWithVolumes := testworkflowsv1.TestWorkflowTemplate{
+		Spec: testworkflowsv1.TestWorkflowTemplateSpec{
+			TestWorkflowSpecBase: testworkflowsv1.TestWorkflowSpecBase{
+				Pod: &testworkflowsv1.PodConfig{
+					Volumes: []corev1.Volume{{
+						Name: "cfg-vol",
+						VolumeSource: corev1.VolumeSource{
+							ConfigMap: &corev1.ConfigMapVolumeSource{
+								LocalObjectReference: corev1.LocalObjectReference{Name: "from-template"},
+							},
+						},
+					}},
+				},
+			},
+		},
+	}
+	tpls := map[string]*testworkflowsv1.TestWorkflowTemplate{"podVol": &tplWithVolumes}
+	ref := testworkflowsv1.TemplateRef{Name: "podVol"}
+
+	spec := &testworkflowsv1.TestWorkflowSpec{
+		TestWorkflowSpecBase: testworkflowsv1.TestWorkflowSpecBase{
+			Pod: &testworkflowsv1.PodConfig{
+				Volumes: []corev1.Volume{{
+					Name: "cfg-vol",
+					VolumeSource: corev1.VolumeSource{
+						ConfigMap: &corev1.ConfigMapVolumeSource{
+							LocalObjectReference: corev1.LocalObjectReference{Name: "from-workflow"},
+						},
+					},
+				}},
+			},
+		},
+	}
+	s := *basicStep.DeepCopy()
+	s.Use = []testworkflowsv1.TemplateRef{ref}
+
+	_, err := applyTemplatesToStep(s, spec, tpls, nil)
+
+	assert.NoError(t, err)
+	if assert.Len(t, spec.Pod.Volumes, 1) {
+		got := spec.Pod.Volumes[0]
+		assert.Equal(t, "cfg-vol", got.Name)
+		if assert.NotNil(t, got.ConfigMap) {
+			assert.Equal(t, "from-workflow", got.ConfigMap.Name)
+		}
+	}
+}
+
 func TestApplyTemplatesStepPropagatesPodDedupeVolumes(t *testing.T) {
 	tplWithVolumes := testworkflowsv1.TestWorkflowTemplate{
 		Spec: testworkflowsv1.TestWorkflowTemplateSpec{

--- a/pkg/testworkflows/testworkflowresolver/apply_test.go
+++ b/pkg/testworkflows/testworkflowresolver/apply_test.go
@@ -412,19 +412,40 @@ func TestApplyTemplatesStepPropagatesPodDedupeVolumes(t *testing.T) {
 	tpls := map[string]*testworkflowsv1.TestWorkflowTemplate{"podVol": &tplWithVolumes}
 	ref := testworkflowsv1.TemplateRef{Name: "podVol"}
 
-	s := *basicStep.DeepCopy()
-	s.Use = []testworkflowsv1.TemplateRef{ref, ref}
-	spec := &testworkflowsv1.TestWorkflowSpec{}
+	cases := map[string]func() *testworkflowsv1.TestWorkflowSpec{
+		"repeated ref in one step's Use[]": func() *testworkflowsv1.TestWorkflowSpec {
+			spec := &testworkflowsv1.TestWorkflowSpec{}
+			s := *basicStep.DeepCopy()
+			s.Use = []testworkflowsv1.TemplateRef{ref, ref}
+			_, err := applyTemplatesToStep(s, spec, tpls, nil)
+			assert.NoError(t, err)
+			return spec
+		},
+		"sibling steps using same .template": func() *testworkflowsv1.TestWorkflowSpec {
+			spec := &testworkflowsv1.TestWorkflowSpec{}
+			s1 := *basicStep.DeepCopy()
+			s1.Template = &ref
+			s2 := *basicStep.DeepCopy()
+			s2.Template = &ref
+			_, err := applyTemplatesToStep(s1, spec, tpls, nil)
+			assert.NoError(t, err)
+			_, err = applyTemplatesToStep(s2, spec, tpls, nil)
+			assert.NoError(t, err)
+			return spec
+		},
+	}
 
-	_, err := applyTemplatesToStep(s, spec, tpls, nil)
-
-	assert.NoError(t, err)
-	if assert.NotNil(t, spec.Pod) {
-		names := make([]string, 0, len(spec.Pod.Volumes))
-		for _, v := range spec.Pod.Volumes {
-			names = append(names, v.Name)
-		}
-		assert.Equal(t, []string{"cfg-vol"}, names, "same template used twice must not duplicate pod.volumes")
+	for name, setup := range cases {
+		t.Run(name, func(t *testing.T) {
+			spec := setup()
+			if assert.NotNil(t, spec.Pod) {
+				names := make([]string, 0, len(spec.Pod.Volumes))
+				for _, v := range spec.Pod.Volumes {
+					names = append(names, v.Name)
+				}
+				assert.Equal(t, []string{"cfg-vol"}, names)
+			}
+		})
 	}
 }
 

--- a/pkg/testworkflows/testworkflowresolver/apply_test.go
+++ b/pkg/testworkflows/testworkflowresolver/apply_test.go
@@ -434,29 +434,37 @@ func TestApplyTemplatesStepPropagatesPodErrorsOnVolumeSourceConflict(t *testing.
 			},
 		}
 	}
+	mkStep := func(refs ...string) testworkflowsv1.Step {
+		s := *basicStep.DeepCopy()
+		for _, r := range refs {
+			s.Use = append(s.Use, testworkflowsv1.TemplateRef{Name: r})
+		}
+		return s
+	}
 
-	cases := map[string]func() (testworkflowsv1.Step, *testworkflowsv1.TestWorkflowSpec, map[string]*testworkflowsv1.TestWorkflowTemplate){
-		"workflow declares same name with different source": func() (testworkflowsv1.Step, *testworkflowsv1.TestWorkflowSpec, map[string]*testworkflowsv1.TestWorkflowTemplate) {
-			tpls := map[string]*testworkflowsv1.TestWorkflowTemplate{"tplA": mkTpl("from-template")}
-			s := *basicStep.DeepCopy()
-			s.Use = []testworkflowsv1.TemplateRef{{Name: "tplA"}}
-			return s, mkWorkflowVol("from-workflow"), tpls
+	tests := map[string]struct {
+		step testworkflowsv1.Step
+		spec *testworkflowsv1.TestWorkflowSpec
+		tpls map[string]*testworkflowsv1.TestWorkflowTemplate
+	}{
+		"workflow declares same name with different source": {
+			step: mkStep("tplA"),
+			spec: mkWorkflowVol("from-workflow"),
+			tpls: map[string]*testworkflowsv1.TestWorkflowTemplate{"tplA": mkTpl("from-template")},
 		},
-		"sibling templates disagree on source": func() (testworkflowsv1.Step, *testworkflowsv1.TestWorkflowSpec, map[string]*testworkflowsv1.TestWorkflowTemplate) {
-			tpls := map[string]*testworkflowsv1.TestWorkflowTemplate{
+		"sibling templates disagree on source": {
+			step: mkStep("tplA", "tplB"),
+			spec: &testworkflowsv1.TestWorkflowSpec{},
+			tpls: map[string]*testworkflowsv1.TestWorkflowTemplate{
 				"tplA": mkTpl("from-A"),
 				"tplB": mkTpl("from-B"),
-			}
-			s := *basicStep.DeepCopy()
-			s.Use = []testworkflowsv1.TemplateRef{{Name: "tplA"}, {Name: "tplB"}}
-			return s, &testworkflowsv1.TestWorkflowSpec{}, tpls
+			},
 		},
 	}
 
-	for name, setup := range cases {
+	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			s, spec, tpls := setup()
-			_, err := applyTemplatesToStep(s, spec, tpls, nil)
+			_, err := applyTemplatesToStep(tc.step, tc.spec, tc.tpls, nil)
 			if assert.Error(t, err) {
 				assert.Contains(t, err.Error(), "conflicts with an existing declaration")
 			}
@@ -477,32 +485,35 @@ func TestApplyTemplatesStepPropagatesPodDedupeVolumes(t *testing.T) {
 	tpls := map[string]*testworkflowsv1.TestWorkflowTemplate{"podVol": &tplWithVolumes}
 	ref := testworkflowsv1.TemplateRef{Name: "podVol"}
 
-	cases := map[string]func() *testworkflowsv1.TestWorkflowSpec{
-		"repeated ref in one step's Use[]": func() *testworkflowsv1.TestWorkflowSpec {
-			spec := &testworkflowsv1.TestWorkflowSpec{}
-			s := *basicStep.DeepCopy()
-			s.Use = []testworkflowsv1.TemplateRef{ref, ref}
-			_, err := applyTemplatesToStep(s, spec, tpls, nil)
-			assert.NoError(t, err)
-			return spec
+	mkStepUse := func(refs ...testworkflowsv1.TemplateRef) testworkflowsv1.Step {
+		s := *basicStep.DeepCopy()
+		s.Use = refs
+		return s
+	}
+	mkStepTemplate := func(r testworkflowsv1.TemplateRef) testworkflowsv1.Step {
+		s := *basicStep.DeepCopy()
+		s.Template = &r
+		return s
+	}
+
+	tests := map[string]struct {
+		steps []testworkflowsv1.Step
+	}{
+		"repeated ref in one step's Use[]": {
+			steps: []testworkflowsv1.Step{mkStepUse(ref, ref)},
 		},
-		"sibling steps using same .template": func() *testworkflowsv1.TestWorkflowSpec {
-			spec := &testworkflowsv1.TestWorkflowSpec{}
-			s1 := *basicStep.DeepCopy()
-			s1.Template = &ref
-			s2 := *basicStep.DeepCopy()
-			s2.Template = &ref
-			_, err := applyTemplatesToStep(s1, spec, tpls, nil)
-			assert.NoError(t, err)
-			_, err = applyTemplatesToStep(s2, spec, tpls, nil)
-			assert.NoError(t, err)
-			return spec
+		"sibling steps using same .template": {
+			steps: []testworkflowsv1.Step{mkStepTemplate(ref), mkStepTemplate(ref)},
 		},
 	}
 
-	for name, setup := range cases {
+	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			spec := setup()
+			spec := &testworkflowsv1.TestWorkflowSpec{}
+			for _, s := range tc.steps {
+				_, err := applyTemplatesToStep(s, spec, tpls, nil)
+				assert.NoError(t, err)
+			}
 			if assert.NotNil(t, spec.Pod) {
 				names := make([]string, 0, len(spec.Pod.Volumes))
 				for _, v := range spec.Pod.Volumes {

--- a/pkg/testworkflows/testworkflowresolver/merge.go
+++ b/pkg/testworkflows/testworkflowresolver/merge.go
@@ -17,6 +17,22 @@ import (
 	"github.com/kubeshop/testkube/internal/common"
 )
 
+func dedupeVolumesByName(vs []corev1.Volume) []corev1.Volume {
+	if len(vs) < 2 {
+		return vs
+	}
+	seen := make(map[string]struct{}, len(vs))
+	out := vs[:0]
+	for _, v := range vs {
+		if _, ok := seen[v.Name]; ok {
+			continue
+		}
+		seen[v.Name] = struct{}{}
+		out = append(out, v)
+	}
+	return out
+}
+
 func MergePodConfig(dst, include *testworkflowsv1.PodConfig) *testworkflowsv1.PodConfig {
 	if dst == nil {
 		return include

--- a/pkg/testworkflows/testworkflowresolver/merge.go
+++ b/pkg/testworkflows/testworkflowresolver/merge.go
@@ -17,17 +17,22 @@ import (
 	"github.com/kubeshop/testkube/internal/common"
 )
 
+// dedupeVolumesByName keeps the LAST entry per Name so a workflow-level
+// declaration wins over a template-provided one with the same name.
+// MergePodConfig prepends the template's Volumes before the enclosing spec's,
+// so the workflow copy trails and overrides the template copy in place.
 func dedupeVolumesByName(vs []corev1.Volume) []corev1.Volume {
 	if len(vs) < 2 {
 		return vs
 	}
-	seen := make(map[string]struct{}, len(vs))
-	out := vs[:0]
+	idx := make(map[string]int, len(vs))
+	out := make([]corev1.Volume, 0, len(vs))
 	for _, v := range vs {
-		if _, ok := seen[v.Name]; ok {
+		if i, ok := idx[v.Name]; ok {
+			out[i] = v
 			continue
 		}
-		seen[v.Name] = struct{}{}
+		idx[v.Name] = len(out)
 		out = append(out, v)
 	}
 	return out

--- a/pkg/testworkflows/testworkflowresolver/merge.go
+++ b/pkg/testworkflows/testworkflowresolver/merge.go
@@ -9,7 +9,9 @@
 package testworkflowresolver
 
 import (
+	"fmt"
 	"maps"
+	"reflect"
 
 	corev1 "k8s.io/api/core/v1"
 
@@ -17,10 +19,32 @@ import (
 	"github.com/kubeshop/testkube/internal/common"
 )
 
-// dedupeVolumesByName keeps the LAST entry per Name so a workflow-level
-// declaration wins over a template-provided one with the same name.
-// MergePodConfig prepends the template's Volumes before the enclosing spec's,
-// so the workflow copy trails and overrides the template copy in place.
+// checkTemplatePodVolumeConflict rejects a template that would introduce a
+// pod.volume whose Name already appears in the accumulator with a different
+// VolumeSource. Silent last-wins would let the loser template's container
+// mount the wrong ConfigMap/Secret/etc; a workflow-declared source would be
+// discarded by the merge order. Fail loudly instead so the author reconciles.
+func checkTemplatePodVolumeConflict(existing, incoming *testworkflowsv1.PodConfig, tplName string) error {
+	if existing == nil || incoming == nil {
+		return nil
+	}
+	existingByName := make(map[string]corev1.Volume, len(existing.Volumes))
+	for _, v := range existing.Volumes {
+		existingByName[v.Name] = v
+	}
+	for _, iv := range incoming.Volumes {
+		ev, ok := existingByName[iv.Name]
+		if !ok {
+			continue
+		}
+		if reflect.DeepEqual(ev.VolumeSource, iv.VolumeSource) {
+			continue
+		}
+		return fmt.Errorf("template %q declares pod.volume %q that conflicts with an existing declaration", tplName, iv.Name)
+	}
+	return nil
+}
+
 func dedupeVolumesByName(vs []corev1.Volume) []corev1.Volume {
 	if len(vs) < 2 {
 		return vs

--- a/pkg/testworkflows/testworkflowresolver/merge.go
+++ b/pkg/testworkflows/testworkflowresolver/merge.go
@@ -19,11 +19,6 @@ import (
 	"github.com/kubeshop/testkube/internal/common"
 )
 
-// checkTemplatePodVolumeConflict rejects a template that would introduce a
-// pod.volume whose Name already appears in the accumulator with a different
-// VolumeSource. Silent last-wins would let the loser template's container
-// mount the wrong ConfigMap/Secret/etc; a workflow-declared source would be
-// discarded by the merge order. Fail loudly instead so the author reconciles.
 func checkTemplatePodVolumeConflict(existing, incoming *testworkflowsv1.PodConfig, tplName string) error {
 	if existing == nil || incoming == nil {
 		return nil


### PR DESCRIPTION
Ref: https://linear.app/kubeshop/issue/TKC-6727/step-level-templates-silently-drop-podvolumes-k8s-rejects-job

Step-level templates (steps[].template, steps[].use[]) silently dropped Pod fields. When a template declared container.volumeMounts backed by pod.volumes, kube-apiserver rejected the Job with `volumeMounts[N].name: Not found`. Step has no Pod field (Pod is workflow-scoped), so the merger now propagates the template's Pod up to the enclosing workflow spec.

Reported by customer support.