### PR TITLE
fix(triggers): retry transient gRPC failures on cloud trigger List

### DIFF
--- a/pkg/controlplaneclient/testtriggers.go
+++ b/pkg/controlplaneclient/testtriggers.go
@@ -62,7 +62,7 @@ func (c *client) ListTestTriggers(ctx context.Context, environmentId string, opt
 		Selector:   options.Selector,
 		Namespace:  namespace,
 	}
-	res, err := call(ctx, c.metadata().SetEnvironmentID(environmentId).GRPC(), c.client.ListTestTriggers, req)
+	res, err := callWithRetry(ctx, c.metadata().SetEnvironmentID(environmentId).GRPC(), c.client.ListTestTriggers, req)
 	if err != nil {
 		return channels.NewError[*testkube.TestTrigger](err)
 	}

--- a/pkg/controlplaneclient/utils.go
+++ b/pkg/controlplaneclient/utils.go
@@ -36,6 +36,59 @@ func call[Request any, Response any](ctx context.Context, md metadata.MD, fn fun
 	return fn(metadata.NewOutgoingContext(ctx, md), req, grpcOpts...)
 }
 
+// callRetryCount and callRetryBaseDelay bound the retry loop that wraps
+// transient-error-prone gRPC calls (see callWithRetry). The window is small
+// on purpose: the caller of a periodic poll (e.g. the trigger watcher) will
+// re-invoke on the next tick, so absorbing a short blip here beats logging
+// an error and waiting for the next tick. Exported to var so tests can shrink
+// the sleep.
+var (
+	callRetryCount     = 3
+	callRetryBaseDelay = 250 * time.Millisecond
+)
+
+// callWithRetry wraps call with a bounded retry loop that reacts only to
+// transient gRPC codes (Unavailable, DeadlineExceeded, ResourceExhausted).
+// Any other error short-circuits so the caller sees, for example, a
+// PermissionDenied without the retry loop swallowing time. Respects context
+// cancellation during backoff.
+func callWithRetry[Request any, Response any](
+	ctx context.Context,
+	md metadata.MD,
+	fn func(context.Context, Request, ...grpc.CallOption) (Response, error),
+	req Request,
+) (Response, error) {
+	var (
+		v       Response
+		lastErr error
+	)
+	for attempt := 0; attempt < callRetryCount; attempt++ {
+		if attempt > 0 {
+			select {
+			case <-ctx.Done():
+				return v, ctx.Err()
+			case <-time.After(time.Duration(attempt) * callRetryBaseDelay):
+			}
+		}
+		v, lastErr = call(ctx, md, fn, req)
+		if lastErr == nil {
+			return v, nil
+		}
+		if !isRetryableGrpcCode(getGrpcErrorCode(lastErr)) {
+			return v, lastErr
+		}
+	}
+	return v, lastErr
+}
+
+func isRetryableGrpcCode(code codes.Code) bool {
+	switch code {
+	case codes.Unavailable, codes.DeadlineExceeded, codes.ResourceExhausted:
+		return true
+	}
+	return false
+}
+
 // TODO: add timeout?
 func watch[Response any](ctx context.Context, md metadata.MD, fn func(context.Context, ...grpc.CallOption) (Response, error)) (Response, error) {
 	if ctx.Err() != nil {

--- a/pkg/controlplaneclient/utils_test.go
+++ b/pkg/controlplaneclient/utils_test.go
@@ -1,0 +1,132 @@
+package controlplaneclient
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
+)
+
+func withShortCallBackoff(t *testing.T) {
+	t.Helper()
+	old := callRetryBaseDelay
+	callRetryBaseDelay = time.Millisecond
+	t.Cleanup(func() { callRetryBaseDelay = old })
+}
+
+// Reproduces the log Sheng reported at pkg/triggers/watcher.go:314 -
+// gRPC "no healthy upstream" during a control-plane restart. Without the
+// retry, the very next tick (5s later) has to eat the error; with the retry
+// we absorb the blip inside the current call and the tick sees a valid list.
+func TestCallWithRetry_RetriesOnUnavailableThenSucceeds(t *testing.T) {
+	withShortCallBackoff(t)
+
+	var calls int32
+	fn := func(_ context.Context, _ struct{}, _ ...grpc.CallOption) (string, error) {
+		n := atomic.AddInt32(&calls, 1)
+		if n < 3 {
+			return "", status.Error(codes.Unavailable, "no healthy upstream")
+		}
+		return "OK", nil
+	}
+
+	res, err := callWithRetry(context.Background(), metadata.MD{}, fn, struct{}{})
+
+	assert.NoError(t, err)
+	assert.Equal(t, "OK", res)
+	assert.Equal(t, int32(3), atomic.LoadInt32(&calls))
+}
+
+// DeadlineExceeded is transient in the same way Unavailable is: the caller
+// eventually reconnects. Retry so the caller does not see a spurious error.
+func TestCallWithRetry_RetriesOnDeadlineExceeded(t *testing.T) {
+	withShortCallBackoff(t)
+
+	var calls int32
+	fn := func(_ context.Context, _ struct{}, _ ...grpc.CallOption) (string, error) {
+		n := atomic.AddInt32(&calls, 1)
+		if n < 2 {
+			return "", status.Error(codes.DeadlineExceeded, "deadline exceeded")
+		}
+		return "OK", nil
+	}
+
+	res, err := callWithRetry(context.Background(), metadata.MD{}, fn, struct{}{})
+
+	assert.NoError(t, err)
+	assert.Equal(t, "OK", res)
+	assert.Equal(t, int32(2), atomic.LoadInt32(&calls))
+}
+
+// Non-transient codes should exit immediately: retrying a PermissionDenied
+// wastes time and hides the real problem from the caller.
+func TestCallWithRetry_ShortCircuitsOnNonTransient(t *testing.T) {
+	withShortCallBackoff(t)
+
+	var calls int32
+	fn := func(_ context.Context, _ struct{}, _ ...grpc.CallOption) (string, error) {
+		atomic.AddInt32(&calls, 1)
+		return "", status.Error(codes.PermissionDenied, "no perms")
+	}
+
+	_, err := callWithRetry(context.Background(), metadata.MD{}, fn, struct{}{})
+
+	assert.Error(t, err)
+	assert.Equal(t, codes.PermissionDenied, status.Code(err))
+	assert.Equal(t, int32(1), atomic.LoadInt32(&calls))
+}
+
+// If the outage exceeds our budget the caller must see the error so the
+// tick logic can decide what to do next (log at warning, re-poll in 5s).
+// The propagated error must keep the gRPC code so upstream callers can
+// still classify it.
+func TestCallWithRetry_GivesUpAfterBudgetAndKeepsCode(t *testing.T) {
+	withShortCallBackoff(t)
+
+	var calls int32
+	fn := func(_ context.Context, _ struct{}, _ ...grpc.CallOption) (string, error) {
+		atomic.AddInt32(&calls, 1)
+		return "", status.Error(codes.Unavailable, "no healthy upstream")
+	}
+
+	_, err := callWithRetry(context.Background(), metadata.MD{}, fn, struct{}{})
+
+	assert.Error(t, err)
+	assert.Equal(t, codes.Unavailable, status.Code(err))
+	assert.Equal(t, int32(callRetryCount), atomic.LoadInt32(&calls))
+}
+
+// A canceled context during backoff must abort immediately, not wait out
+// the retry delay. This keeps the poll responsive to shutdown.
+func TestCallWithRetry_RespectsContextCancellationDuringBackoff(t *testing.T) {
+	old := callRetryBaseDelay
+	callRetryBaseDelay = 500 * time.Millisecond
+	t.Cleanup(func() { callRetryBaseDelay = old })
+
+	var calls int32
+	fn := func(_ context.Context, _ struct{}, _ ...grpc.CallOption) (string, error) {
+		atomic.AddInt32(&calls, 1)
+		return "", status.Error(codes.Unavailable, "no healthy upstream")
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(50 * time.Millisecond)
+		cancel()
+	}()
+
+	start := time.Now()
+	_, err := callWithRetry(ctx, metadata.MD{}, fn, struct{}{})
+	elapsed := time.Since(start)
+
+	assert.Error(t, err)
+	assert.ErrorIs(t, err, context.Canceled)
+	assert.Less(t, elapsed, 400*time.Millisecond, "must not wait out the full backoff after cancel")
+	assert.LessOrEqual(t, atomic.LoadInt32(&calls), int32(2))
+}

--- a/pkg/controlplaneclient/workflowtriggers.go
+++ b/pkg/controlplaneclient/workflowtriggers.go
@@ -57,7 +57,7 @@ func (c *client) ListWorkflowTriggers(ctx context.Context, environmentId string,
 		Selector:   options.Selector,
 		Namespace:  namespace,
 	}
-	res, err := call(ctx, c.metadata().SetEnvironmentID(environmentId).GRPC(), c.client.ListWorkflowTriggers, req)
+	res, err := callWithRetry(ctx, c.metadata().SetEnvironmentID(environmentId).GRPC(), c.client.ListWorkflowTriggers, req)
 	if err != nil {
 		return channels.NewError[*testkube.WorkflowTrigger](err)
 	}


### PR DESCRIPTION
Ref: https://linear.app/kubeshop/issue/TKC-6551/toyota-improve-resilience-and-logging-for-transient-infra-failures-in

Sheng flagged `pkg/triggers/watcher.go:314` firing `rpc error: code = Unavailable desc = no healthy upstream` during control-plane restarts. The gRPC List for cloud trigger definitions had no retry, so a transient blip surfaced as a Warnf and the trigger poll had to wait 5s for the next tick to resync.

Adds a `callWithRetry` helper next to the existing `call` helper. Bounded 3 attempts, 250ms base linear backoff, respects ctx cancel during backoff. Retries only on transient gRPC codes (Unavailable, DeadlineExceeded, ResourceExhausted); anything else short-circuits so a PermissionDenied is not delayed.

Applied to the two sites Sheng cited: `ListWorkflowTriggers` and `ListTestTriggers`. Other read calls (Get*, List*) can adopt the helper in a follow-up; writes need idempotency review first.

Tests use a fake fn that returns the exact `codes.Unavailable, "no healthy upstream"` status to reproduce the log, plus coverage for DeadlineExceeded, non-transient short-circuit, budget exhaustion (code preserved), and ctx cancel during backoff.