### PR TITLE
fix(datefilter): evaluate end date bound when start date is invalid

### DIFF
--- a/pkg/datefilter/filter.go
+++ b/pkg/datefilter/filter.go
@@ -55,14 +55,11 @@ func NewDateFilter(startDate string, endDate string) DateFilter {
 // IsPassing reports whether date falls within the filter's configured range.
 // Both the start and end bounds are inclusive.
 func (dFilter DateFilter) IsPassing(date time.Time) bool {
-	if !dFilter.IsStartValid {
-		return true
-	}
-	if dFilter.Start.After(date) {
+	if dFilter.IsStartValid && dFilter.Start.After(date) {
 		return false
 	}
-	if !dFilter.IsEndValid {
-		return true
+	if dFilter.IsEndValid && dFilter.End.Before(date) {
+		return false
 	}
-	return !dFilter.End.Before(date)
+	return true
 }

--- a/pkg/datefilter/filter_test.go
+++ b/pkg/datefilter/filter_test.go
@@ -160,3 +160,10 @@ func TestNewDateFilterRFC3339FractionalSeconds(t *testing.T) {
 	// Must NOT have been advanced to 23:59
 	assertion.Equal(0, dFilter.End.Second())
 }
+
+func TestIsPassingDateFilterWhenInvalidStartAndValidEnd(t *testing.T) {
+	assertion := require.New(t)
+	dFilter := NewDateFilter("", "2024-01-31")
+	assertion.True(dFilter.IsPassing(time.Date(2024, 1, 15, 10, 0, 0, 0, time.UTC)), "Date before end date should pass")
+	assertion.False(dFilter.IsPassing(time.Date(2024, 2, 5, 10, 0, 0, 0, time.UTC)), "Date after end date should fail even when start date is invalid")
+}


### PR DESCRIPTION
This PR fixes a bug in DateFilter.IsPassing where an empty or invalid start date caused the filter to return true immediately without evaluating whether the date passed the end date bound.