### PR TITLE
feat(executionworker): name the actor and reason on every abort and cancel

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -78,6 +78,7 @@ Testkube uses [Test Workflows](https://docs.testkube.io/articles/test-workflows)
 - Core TestWorkflow executor (`testworkflowexecutor/`)
 - TestWorkflow processing and step execution
 - Result aggregation and status management
+- Execution worker (`executionworker/`): applies the workflow to Kubernetes, watches the job and pod, and stops executions. When a caller aborts or cancels an execution, it passes an actor and an optional cause in `DestroyOptions`, and the worker writes them into the job annotations `testkube.io/termination-actor` and `testkube.io/termination-reason`. The result reader renders them as one sentence, so the stored error message names the component that stopped the execution and, when there is one, the cause.
 
 ### 4. Storage Layer
 

--- a/cmd/tcl/testworkflow-toolkit/commands/parallel.go
+++ b/cmd/tcl/testworkflow-toolkit/commands/parallel.go
@@ -713,6 +713,7 @@ func (e *WorkerExecutor) handleWorkerCleanup(ctx context.Context, worker WorkerS
 	if cancelled {
 		err = spawn.ParallelExecutionWorker(e.cfg).Abort(cleanupCtx, cfg.Resource.Id, executionworkertypes.DestroyOptions{
 			Namespace: worker.Namespace,
+			Actor:     executionworkertypes.AbortActorFailFast,
 		})
 		if err == nil {
 			log("aborted")
@@ -820,6 +821,8 @@ func (o *ResumeOrchestrator) resumeAllWorkers(ctx context.Context) {
 			default:
 				_ = spawn.ParallelExecutionWorker(o.cfg).Abort(ctx, err.Id, executionworkertypes.DestroyOptions{
 					Namespace: o.namespaces[index],
+					Actor:     executionworkertypes.AbortActorRunner,
+					Reason:    "the parallel worker could not be resumed: " + err.Error.Error(),
 				})
 			}
 		}

--- a/internal/app/api/v1/testworkflowexecutions.go
+++ b/internal/app/api/v1/testworkflowexecutions.go
@@ -570,6 +570,7 @@ func (s *TestkubeAPI) abortTestWorkflowExecutionHandlerPro() fiber.Handler {
 		// Abort the Test Workflow
 		err = s.ExecutionWorkerClient.Abort(ctx, execution.Id, executionworkertypes.DestroyOptions{
 			Namespace: execution.Namespace,
+			Actor:     executionworkertypes.AbortActorAPI,
 		})
 		if err != nil {
 			return s.ClientError(c, "aborting test workflow execution", err)
@@ -800,6 +801,8 @@ func (s *TestkubeAPI) abortAllTestWorkflowExecutionsHandlerPro() fiber.Handler {
 		for _, execution := range executions {
 			err = s.ExecutionWorkerClient.Abort(ctx, execution.Id, executionworkertypes.DestroyOptions{
 				Namespace: execution.Namespace,
+				Actor:     executionworkertypes.AbortActorAPI,
+				Reason:    "all executions of the workflow were aborted",
 			})
 			if err != nil {
 				return s.ClientError(c, errPrefix, err)

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -615,7 +615,8 @@ func (r *runner) abortExecution(ctx context.Context, environmentID, executionID 
 	if execution.Result == nil {
 		return errors.New("execution result is nil")
 	}
-	execution.Result.Fatal(errors.New("execution is stuck in running state"), true, time.Now())
+	const stuckReason = "execution is stuck in running state"
+	execution.Result.Fatal(errors.New(stuckReason), true, time.Now())
 	err = retry(AbortExecutionRetryCount, delay, func(_ int) error {
 		return r.client.UpdateExecutionResult(ctx, environmentID, executionID, execution.Result)
 	})
@@ -631,7 +632,10 @@ func (r *runner) abortExecution(ctx context.Context, environmentID, executionID 
 	}
 
 	err = retry(AbortExecutionRetryCount, delay, func(_ int) error {
-		return r.Abort(executionID)
+		return r.worker.Abort(context.Background(), executionID, executionworkertypes.DestroyOptions{
+			Actor:  executionworkertypes.AbortActorRunner,
+			Reason: stuckReason,
+		})
 	})
 	if err != nil {
 		return errors.Wrapf(err, "failed to destroy execution '%s'", executionID)
@@ -648,10 +652,17 @@ func (r *runner) Resume(id string) error {
 	return r.worker.Resume(context.Background(), id, executionworkertypes.ControlOptions{})
 }
 
+// Abort stops the execution on a request from the control plane.
+// The control plane does not send a cause yet, so the result names the actor only.
 func (r *runner) Abort(id string) error {
-	return r.worker.Abort(context.Background(), id, executionworkertypes.DestroyOptions{})
+	return r.worker.Abort(context.Background(), id, executionworkertypes.DestroyOptions{
+		Actor: executionworkertypes.AbortActorControlPlane,
+	})
 }
 
+// Cancel stops the execution on a request from a user. The control plane relays the request.
 func (r *runner) Cancel(id string) error {
-	return r.worker.Cancel(context.Background(), id, executionworkertypes.DestroyOptions{})
+	return r.worker.Cancel(context.Background(), id, executionworkertypes.DestroyOptions{
+		Actor: executionworkertypes.AbortActorUser,
+	})
 }

--- a/pkg/testworkflows/executionworker/controller/watchers/commons.go
+++ b/pkg/testworkflows/executionworker/controller/watchers/commons.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/kubeshop/testkube/pkg/testworkflows/executionworker/executionworkertypes"
 	constants2 "github.com/kubeshop/testkube/pkg/testworkflows/testworkflowprocessor/constants"
 
 	batchv1 "k8s.io/api/batch/v1"
@@ -302,16 +303,25 @@ func GetJobError(job *batchv1.Job) string {
 			}
 		}
 	}
-	var msg string
-	if job.DeletionTimestamp != nil {
-		msg = "Job has been aborted"
-	}
+	// The worker annotates a stop with the actor and an optional cause. A deleted
+	// job without the annotation is a stop by an unknown party.
 	if job.Annotations != nil {
-		if terminationReason, ok := job.Annotations["testkube.io/termination-reason"]; ok && terminationReason != "" {
-			msg = terminationReason
+		actor := executionworkertypes.AbortActor(job.Annotations[constants2.AnnotationTerminationActor])
+		reason := job.Annotations[constants2.AnnotationTerminationReason]
+		if actor != "" || reason != "" {
+			if reason == "" {
+				return actor.Sentence()
+			}
+			if actor == "" {
+				return reason
+			}
+			return actor.Sentence() + ": " + reason
 		}
 	}
-	return msg
+	if job.DeletionTimestamp != nil {
+		return executionworkertypes.AbortActorSystem.Sentence()
+	}
+	return ""
 }
 
 func GetTerminationCode(job *batchv1.Job) string {

--- a/pkg/testworkflows/executionworker/controller/watchers/commons_test.go
+++ b/pkg/testworkflows/executionworker/controller/watchers/commons_test.go
@@ -1,0 +1,60 @@
+package watchers
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	batchv1 "k8s.io/api/batch/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/kubeshop/testkube/pkg/testworkflows/executionworker/executionworkertypes"
+	"github.com/kubeshop/testkube/pkg/testworkflows/testworkflowprocessor/constants"
+)
+
+func TestGetJobError(t *testing.T) {
+	deleted := metav1.NewTime(time.Now())
+	tests := []struct {
+		name string
+		job  *batchv1.Job
+		want string
+	}{
+		{
+			name: "actor and cause",
+			job: &batchv1.Job{ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{
+				constants.AnnotationTerminationActor:  string(executionworkertypes.AbortActorRunner),
+				constants.AnnotationTerminationReason: "execution is stuck in running state",
+			}}},
+			want: "by the runner: execution is stuck in running state",
+		},
+		{
+			name: "actor without a cause",
+			job: &batchv1.Job{ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{
+				constants.AnnotationTerminationActor: string(executionworkertypes.AbortActorUser),
+			}}},
+			want: "by the user",
+		},
+		{
+			name: "cause without an actor, as an older worker writes it",
+			job: &batchv1.Job{ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{
+				constants.AnnotationTerminationReason: "Job has been aborted by the system",
+			}}},
+			want: "Job has been aborted by the system",
+		},
+		{
+			name: "deleted job with no annotation",
+			job:  &batchv1.Job{ObjectMeta: metav1.ObjectMeta{DeletionTimestamp: &deleted}},
+			want: "by the system",
+		},
+		{
+			name: "job that still runs",
+			job:  &batchv1.Job{},
+			want: "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, GetJobError(tt.job))
+		})
+	}
+}

--- a/pkg/testworkflows/executionworker/executionworkertypes/interface.go
+++ b/pkg/testworkflows/executionworker/executionworkertypes/interface.go
@@ -176,9 +176,64 @@ type ControlOptions struct {
 	Namespace string
 }
 
+// AbortActor identifies the component that requested an abort or a cancel.
+type AbortActor string
+
+const (
+	// AbortActorUser is a person who cancels through the API, the CLI, or the dashboard.
+	AbortActorUser AbortActor = "user"
+	// AbortActorControlPlane is the control plane, for example a queue or execution timeout.
+	AbortActorControlPlane AbortActor = "control-plane"
+	// AbortActorTrigger is the trigger cleanup that stops executions of a deleted trigger.
+	AbortActorTrigger AbortActor = "trigger"
+	// AbortActorFailFast is a parallel step that stops its workers after the first failure.
+	AbortActorFailFast AbortActor = "fail-fast"
+	// AbortActorRunner is the runner itself, for example the check for stuck executions.
+	AbortActorRunner AbortActor = "runner"
+	// AbortActorAPI is the standalone agent API abort endpoint.
+	AbortActorAPI AbortActor = "api"
+	// AbortActorSystem is the fallback when the caller does not identify itself.
+	AbortActorSystem AbortActor = "system"
+)
+
 type DestroyOptions struct {
 	// Namespace where it has been deployed.
 	Namespace string
+	// Actor identifies the component that requested the stop. The worker writes it
+	// and the reason into the job annotations, so the result names who stopped it.
+	Actor AbortActor
+	// Reason is a short human-readable cause for the stop.
+	Reason string
+}
+
+// TerminationActor returns the actor for the job annotation, or the default when the
+// caller did not set one.
+func (o DestroyOptions) TerminationActor(defaultActor AbortActor) AbortActor {
+	if o.Actor == "" {
+		return defaultActor
+	}
+	return o.Actor
+}
+
+// Sentence returns the words the result reader uses for the actor after
+// "The execution has been aborted". The reason, when set, follows them.
+func (a AbortActor) Sentence() string {
+	switch a {
+	case AbortActorUser:
+		return "by the user"
+	case AbortActorControlPlane:
+		return "by the control plane"
+	case AbortActorTrigger:
+		return "because its trigger was deleted"
+	case AbortActorFailFast:
+		return "because another parallel worker failed"
+	case AbortActorRunner:
+		return "by the runner"
+	case AbortActorAPI:
+		return "through the API"
+	default:
+		return "by the system"
+	}
 }
 
 type StatusNotification struct {

--- a/pkg/testworkflows/executionworker/executionworkertypes/interface_test.go
+++ b/pkg/testworkflows/executionworker/executionworkertypes/interface_test.go
@@ -1,0 +1,56 @@
+package executionworkertypes
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDestroyOptions_TerminationActor(t *testing.T) {
+	tests := []struct {
+		name         string
+		options      DestroyOptions
+		defaultActor AbortActor
+		want         AbortActor
+	}{
+		{
+			name:         "actor set",
+			options:      DestroyOptions{Actor: AbortActorTrigger},
+			defaultActor: AbortActorSystem,
+			want:         AbortActorTrigger,
+		},
+		{
+			name:         "no actor uses the default",
+			options:      DestroyOptions{},
+			defaultActor: AbortActorUser,
+			want:         AbortActorUser,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, tt.options.TerminationActor(tt.defaultActor))
+		})
+	}
+}
+
+func TestAbortActor_Sentence(t *testing.T) {
+	tests := []struct {
+		name  string
+		actor AbortActor
+		want  string
+	}{
+		{name: "user", actor: AbortActorUser, want: "by the user"},
+		{name: "control plane", actor: AbortActorControlPlane, want: "by the control plane"},
+		{name: "trigger", actor: AbortActorTrigger, want: "because its trigger was deleted"},
+		{name: "fail-fast", actor: AbortActorFailFast, want: "because another parallel worker failed"},
+		{name: "runner", actor: AbortActorRunner, want: "by the runner"},
+		{name: "api", actor: AbortActorAPI, want: "through the API"},
+		{name: "system", actor: AbortActorSystem, want: "by the system"},
+		{name: "unknown value falls back to the system", actor: AbortActor("later-added"), want: "by the system"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, tt.actor.Sentence())
+		})
+	}
+}

--- a/pkg/testworkflows/executionworker/kubernetesworker/worker.go
+++ b/pkg/testworkflows/executionworker/kubernetesworker/worker.go
@@ -554,7 +554,7 @@ func (w *worker) Abort(ctx context.Context, id string, options executionworkerty
 			return err
 		}
 	}
-	if err := w.patchTerminationAnnotations(ctx, id, options.Namespace, testkube.ABORTED_TestWorkflowStatus, "Job has been aborted by the system"); err != nil {
+	if err := w.patchTerminationAnnotations(ctx, id, options.Namespace, testkube.ABORTED_TestWorkflowStatus, options.TerminationActor(executionworkertypes.AbortActorSystem), options.Reason); err != nil {
 		return errors.Wrapf(err, "failed to patch job %s/%s with termination code & reason", options.Namespace, id)
 	}
 	// It may safely destroy all the resources - the trace should be still readable.
@@ -568,17 +568,18 @@ func (w *worker) Cancel(ctx context.Context, id string, options executionworkert
 			return err
 		}
 	}
-	if err := w.patchTerminationAnnotations(ctx, id, options.Namespace, testkube.CANCELED_TestWorkflowStatus, "Job has been canceled by a user"); err != nil {
+	if err := w.patchTerminationAnnotations(ctx, id, options.Namespace, testkube.CANCELED_TestWorkflowStatus, options.TerminationActor(executionworkertypes.AbortActorUser), options.Reason); err != nil {
 		return errors.Wrapf(err, "failed to patch job %s/%s with termination code & reason", options.Namespace, id)
 	}
 	return w.Destroy(ctx, id, options)
 }
 
-func (w *worker) patchTerminationAnnotations(ctx context.Context, id string, namespace string, status testkube.TestWorkflowStatus, reason string) error {
+func (w *worker) patchTerminationAnnotations(ctx context.Context, id string, namespace string, status testkube.TestWorkflowStatus, actor executionworkertypes.AbortActor, reason string) error {
 	patch := map[string]interface{}{
 		"metadata": map[string]any{
 			"annotations": map[string]string{
 				constants.AnnotationTerminationCode:   string(status),
+				constants.AnnotationTerminationActor:  string(actor),
 				constants.AnnotationTerminationReason: reason,
 			},
 		},

--- a/pkg/testworkflows/testworkflowprocessor/constants/constants.go
+++ b/pkg/testworkflows/testworkflowprocessor/constants/constants.go
@@ -36,6 +36,7 @@ const (
 	RootOperationName               = "root"
 	AnnotationTerminationCode       = "testkube.io/termination-code"
 	AnnotationTerminationReason     = "testkube.io/termination-reason"
+	AnnotationTerminationActor      = "testkube.io/termination-actor"
 )
 
 var (

--- a/pkg/triggers/scraper.go
+++ b/pkg/triggers/scraper.go
@@ -85,6 +85,7 @@ func (s *Service) abortRunningTestWorkflowExecutions(ctx context.Context, status
 			// Obtain the controller
 			err = s.executionWorkerClient.Abort(ctx, execution.Id, executionworkertypes.DestroyOptions{
 				Namespace: s.testkubeNamespace,
+				Actor:     executionworkertypes.AbortActorTrigger,
 			})
 			if err != nil {
 				s.logger.Errorf("trigger service: execution scraper component: error aborting test workflow execution: %v", err)


### PR DESCRIPTION
## Pull request description

Milestone 1 of [TKC-6811](https://linear.app/kubeshop/issue/TKC-6811/why-did-my-test-fail-milestone-1-every-abort-carries-a-reason), first PR.

Every abort that is not a user cancel writes "Job has been aborted by the system" into the job annotation. The trigger cleanup, fail-fast, the stuck-execution check, the API, and the control plane all read the same. That one text is 35 % of aborted executions in production telemetry.

`DestroyOptions` gets `Actor` and `Reason`. Each caller sets its actor, and adds a reason only when the actor alone does not explain the stop. The worker writes them into `testkube.io/termination-actor` and `testkube.io/termination-reason`. The job watcher renders the actor as a short phrase and appends the reason after a colon.

| Caller | Text in the result |
| --- | --- |
| Control plane abort, relayed by the runner | `by the control plane` |
| Control plane cancel, relayed by the runner | `by the user` |
| Runner check for stuck executions | `by the runner: execution is stuck in running state` |
| Trigger cleanup | `because its trigger was deleted` |
| Parallel step fail-fast | `because another parallel worker failed` |
| Parallel worker that cannot resume | `by the runner: the parallel worker could not be resumed: <error>` |
| Standalone API abort | `through the API` |
| Standalone API abort of all executions of a workflow | `through the API: all executions of the workflow were aborted` |
| A caller that sets nothing, or a job deleted outside Testkube | `by the system` |

A job with a reason and no actor, from an older worker, keeps its text. The control plane sends no reason with its transition yet. #8225 adds it. The `Runner` interface keeps `Abort(id)` and `Cancel(id)`.

Not changed here: the control plane sends the cancel transition twice. The second one logs `failed to patch job ... not found` after the first one deleted the job.
