### PR TITLE
feat(runner): send the reason and message with a declined execution

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -79,6 +79,7 @@ Testkube uses [Test Workflows](https://docs.testkube.io/articles/test-workflows)
 - TestWorkflow processing and step execution
 - Result aggregation and status management
 - Execution worker (`executionworker/`): applies the workflow to Kubernetes, watches the job and pod, and stops executions. When a caller aborts or cancels an execution, it passes an actor and an optional cause in `DestroyOptions`, and the worker writes them into the job annotations `testkube.io/termination-actor` and `testkube.io/termination-reason`. The result reader renders them as one sentence, so the stored error message names the component that stopped the execution and, when there is one, the cause.
+- Runner gRPC client (`pkg/runner/grpc/`): receives execution starts from the control plane. When the runner cannot start an execution, the client maps the error to a reason token in `start_reason.go` and declines the execution with the token and the error text, so the control plane stores the cause on the execution.
 
 ### 4. Storage Layer
 

--- a/pkg/proto/testkube/testworkflow/execution/v1/decline_execution_request.pb.go
+++ b/pkg/proto/testkube/testworkflow/execution/v1/decline_execution_request.pb.go
@@ -26,7 +26,16 @@ const (
 type DeclineExecutionRequest struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// execution_id is the unique identifier of the execution that has failed.
-	ExecutionId   *string `protobuf:"bytes,1,opt,name=execution_id,json=executionId" json:"execution_id,omitempty"`
+	ExecutionId *string `protobuf:"bytes,1,opt,name=execution_id,json=executionId" json:"execution_id,omitempty"`
+	// reason is a short fixed token that names why the runner could not start
+	// the execution, for example "image-pull-failed" or "job-create-failed".
+	// The Control Plane stores it on the execution result so a user can read
+	// the cause without the runner log.
+	Reason *string `protobuf:"bytes,2,opt,name=reason" json:"reason,omitempty"`
+	// message is the human-readable error from the runner. It can contain image
+	// names and registry hosts, so the Control Plane must not send it outside
+	// the deployment.
+	Message       *string `protobuf:"bytes,3,opt,name=message" json:"message,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -68,13 +77,29 @@ func (x *DeclineExecutionRequest) GetExecutionId() string {
 	return ""
 }
 
+func (x *DeclineExecutionRequest) GetReason() string {
+	if x != nil && x.Reason != nil {
+		return *x.Reason
+	}
+	return ""
+}
+
+func (x *DeclineExecutionRequest) GetMessage() string {
+	if x != nil && x.Message != nil {
+		return *x.Message
+	}
+	return ""
+}
+
 var File_testkube_testworkflow_execution_v1_decline_execution_request_proto protoreflect.FileDescriptor
 
 const file_testkube_testworkflow_execution_v1_decline_execution_request_proto_rawDesc = "" +
 	"\n" +
-	"Btestkube/testworkflow/execution/v1/decline_execution_request.proto\x12\"testkube.testworkflow.execution.v1\"<\n" +
+	"Btestkube/testworkflow/execution/v1/decline_execution_request.proto\x12\"testkube.testworkflow.execution.v1\"n\n" +
 	"\x17DeclineExecutionRequest\x12!\n" +
-	"\fexecution_id\x18\x01 \x01(\tR\vexecutionIdB\xc8\x02\n" +
+	"\fexecution_id\x18\x01 \x01(\tR\vexecutionId\x12\x16\n" +
+	"\x06reason\x18\x02 \x01(\tR\x06reason\x12\x18\n" +
+	"\amessage\x18\x03 \x01(\tR\amessageB\xc8\x02\n" +
 	"&com.testkube.testworkflow.execution.v1B\x1cDeclineExecutionRequestProtoP\x01ZUgithub.com/kubeshop/testkube/pkg/proto/testkube/testworkflow/execution/v1;executionv1\xa2\x02\x03TTE\xaa\x02\"Testkube.Testworkflow.Execution.V1\xca\x02\"Testkube\\Testworkflow\\Execution\\V1\xe2\x02.Testkube\\Testworkflow\\Execution\\V1\\GPBMetadata\xea\x02%Testkube::Testworkflow::Execution::V1b\beditionsp\xe8\a"
 
 var (

--- a/pkg/runner/grpc/client.go
+++ b/pkg/runner/grpc/client.go
@@ -15,6 +15,7 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/oauth"
 	"google.golang.org/grpc/metadata"
+	"google.golang.org/protobuf/proto"
 
 	testworkflowsv1 "github.com/kubeshop/testkube/api/testworkflows/v1"
 	"github.com/kubeshop/testkube/pkg/api/v1/testkube"
@@ -277,8 +278,13 @@ func (c Client) executeResponse(ctx context.Context, response *executionv1.GetEx
 				ControlPlane: c.ControlPlaneConfig,
 			})
 			if err != nil {
+				reason := startErrorReason(err)
 				c.logger.Errorw("Failed to start execution.",
 					"executionId", start.GetExecutionId(),
+					"organizationId", c.OrganizationId,
+					"environmentId", start.GetEnvironmentId(),
+					"workflowName", start.GetWorkflowName(),
+					"reason", reason,
 					"error", err)
 				// Execute with our own call timeout context to prevent stalling out.
 				callCtx, cancel := context.WithTimeout(ctx, c.callTimeout)
@@ -287,9 +293,12 @@ func (c Client) executeResponse(ctx context.Context, response *executionv1.GetEx
 					"organization-id", c.OrganizationId,
 					"environment-id", start.GetEnvironmentId())
 				// Report the error to the control plane to prevent getting the execution on
-				// subsequent calls.
+				// subsequent calls. The reason and message let the control plane store the
+				// cause on the execution, so the user does not need the runner log.
 				_, callErr := c.client.DeclineExecution(callCtx, &executionv1.DeclineExecutionRequest{
 					ExecutionId: start.ExecutionId,
+					Reason:      proto.String(reason),
+					Message:     proto.String(err.Error()),
 				}, c.callOpts...)
 				cancel()
 				if callErr != nil {

--- a/pkg/runner/grpc/start_reason.go
+++ b/pkg/runner/grpc/start_reason.go
@@ -1,0 +1,39 @@
+package grpc
+
+import "strings"
+
+// The runner sends one of these tokens to the control plane with a decline. The
+// values are stable, because filters and telemetry use them. The error text goes
+// in the message.
+const (
+	StartReasonImagePullFailed   = "image-pull-failed"
+	StartReasonDefinitionInvalid = "definition-invalid"
+	StartReasonResourceFailed    = "resource-create-failed"
+	StartReasonJobCreateFailed   = "job-create-failed"
+	StartReasonUnknown           = "start-failed"
+)
+
+// startErrorReason maps a start error to a reason token. The worker wraps each
+// start error in a fixed text per phase, and that text selects the token. The
+// checks run in this order because the processing text contains the image error,
+// and the deploy text contains the secret, config map, and volume claim errors.
+// The function returns the first token that matches.
+func startErrorReason(err error) string {
+	msg := err.Error()
+	switch {
+	case strings.Contains(msg, "resolving image error"):
+		return StartReasonImagePullFailed
+	case strings.Contains(msg, "failed to process test workflow"):
+		return StartReasonDefinitionInvalid
+	case strings.Contains(msg, "failed to deploy secrets"),
+		strings.Contains(msg, "failed to deploy config maps"),
+		strings.Contains(msg, "failed to deploy pvcs"):
+		return StartReasonResourceFailed
+	case strings.Contains(msg, "failed to deploy"),
+		strings.Contains(msg, "admission webhook"),
+		strings.Contains(msg, "is invalid"):
+		return StartReasonJobCreateFailed
+	default:
+		return StartReasonUnknown
+	}
+}

--- a/pkg/runner/grpc/start_reason_test.go
+++ b/pkg/runner/grpc/start_reason_test.go
@@ -1,0 +1,57 @@
+package grpc
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestStartErrorReason(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want string
+	}{
+		{
+			name: "image inspection error inside the processing wrap",
+			err:  errors.New("failed to process test workflow: resolving image error: cypress/nope:1: inspecting image: UNAUTHORIZED"),
+			want: StartReasonImagePullFailed,
+		},
+		{
+			name: "expression or template error at processing",
+			err:  errors.New("failed to process test workflow: unknown template"),
+			want: StartReasonDefinitionInvalid,
+		},
+		{
+			name: "kubernetes rejected the job",
+			err:  errors.New("failed to deploy test workflow: Job.batch \"x\" is invalid: spec.template: ..."),
+			want: StartReasonJobCreateFailed,
+		},
+		{
+			name: "kubernetes rejected a secret before the job",
+			err:  errors.New("failed to deploy test workflow: failed to deploy secrets: secrets \"x\" is forbidden"),
+			want: StartReasonResourceFailed,
+		},
+		{
+			name: "kubernetes rejected a volume claim before the job",
+			err:  errors.New("failed to deploy test workflow: failed to deploy pvcs: quota exceeded"),
+			want: StartReasonResourceFailed,
+		},
+		{
+			name: "admission webhook denied the job",
+			err:  errors.New("admission webhook \"policy.example\" denied the request: no securityContext"),
+			want: StartReasonJobCreateFailed,
+		},
+		{
+			name: "anything else",
+			err:  errors.New("namespace foo not supported"),
+			want: StartReasonUnknown,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, startErrorReason(tt.err))
+		})
+	}
+}

--- a/proto/testkube/testworkflow/execution/v1/decline_execution_request.proto
+++ b/proto/testkube/testworkflow/execution/v1/decline_execution_request.proto
@@ -7,4 +7,13 @@ package testkube.testworkflow.execution.v1;
 message DeclineExecutionRequest {
   // execution_id is the unique identifier of the execution that has failed.
   string execution_id = 1;
+  // reason is a short fixed token that names why the runner could not start
+  // the execution, for example "image-pull-failed" or "job-create-failed".
+  // The Control Plane stores it on the execution result so a user can read
+  // the cause without the runner log.
+  string reason = 2;
+  // message is the human-readable error from the runner. It can contain image
+  // names and registry hosts, so the Control Plane must not send it outside
+  // the deployment.
+  string message = 3;
 }


### PR DESCRIPTION
## Pull request description

Milestone 1 of [TKC-6811](https://linear.app/kubeshop/issue/TKC-6811/why-did-my-test-fail-milestone-1-every-abort-carries-a-reason), second PR. Stacked on #8222.

When the runner cannot start an execution, it sends `DeclineExecutionRequest` with the execution id only. The control plane marks the execution `aborted` with no message. The cause exists only in the runner pod log.

`DeclineExecutionRequest` gets `reason`, a fixed token the control plane can store and filter on, and `message`, the runner error text. The runner log line for the failed start also names the organization, the environment, and the workflow.

| Runner error | Reason token |
| --- | --- |
| image inspection failed | `image-pull-failed` |
| the workflow could not be processed | `definition-invalid` |
| a secret, config map, or volume claim could not be created | `resource-create-failed` |
| Kubernetes rejected the Job, or an admission webhook denied it | `job-create-failed` |
| anything else | `start-failed` |

The checks run in that order, because the worker wraps the image error inside the processing text and the resource errors inside the deploy text.

Both fields are additive. A control plane that does not read them keeps its behaviour. cloud-api #5537 stores them.
