### PR TITLE
feat(runner): apply the reason the control plane sends with an abort or cancel

### DIFF
--- a/pkg/proto/testkube/testworkflow/execution/v1/execution_state_transition.pb.go
+++ b/pkg/proto/testkube/testworkflow/execution/v1/execution_state_transition.pb.go
@@ -27,7 +27,13 @@ type ExecutionStateTransition struct {
 	// execution_id is the unique identifier of the execution to be transitioned.
 	ExecutionId *string `protobuf:"bytes,1,opt,name=execution_id,json=executionId" json:"execution_id,omitempty"`
 	// transition_to is the state the execution should be transitioned into.
-	TransitionTo  *ExecutionState `protobuf:"varint,2,opt,name=transition_to,json=transitionTo,enum=testkube.testworkflow.execution.v1.ExecutionState" json:"transition_to,omitempty"`
+	TransitionTo *ExecutionState `protobuf:"varint,2,opt,name=transition_to,json=transitionTo,enum=testkube.testworkflow.execution.v1.ExecutionState" json:"transition_to,omitempty"`
+	// reason is the cause of an abort or a cancel, as free text, for example
+	// "the execution ran for too long". The runner writes it into the job
+	// annotation next to the actor, so the execution result names who stopped
+	// the execution and why. Empty when the Control Plane has no cause to give,
+	// and for every other transition.
+	Reason        *string `protobuf:"bytes,3,opt,name=reason" json:"reason,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -76,14 +82,22 @@ func (x *ExecutionStateTransition) GetTransitionTo() ExecutionState {
 	return ExecutionState_EXECUTION_STATE_UNSPECIFIED
 }
 
+func (x *ExecutionStateTransition) GetReason() string {
+	if x != nil && x.Reason != nil {
+		return *x.Reason
+	}
+	return ""
+}
+
 var File_testkube_testworkflow_execution_v1_execution_state_transition_proto protoreflect.FileDescriptor
 
 const file_testkube_testworkflow_execution_v1_execution_state_transition_proto_rawDesc = "" +
 	"\n" +
-	"Ctestkube/testworkflow/execution/v1/execution_state_transition.proto\x12\"testkube.testworkflow.execution.v1\x1a8testkube/testworkflow/execution/v1/execution_state.proto\"\x96\x01\n" +
+	"Ctestkube/testworkflow/execution/v1/execution_state_transition.proto\x12\"testkube.testworkflow.execution.v1\x1a8testkube/testworkflow/execution/v1/execution_state.proto\"\xae\x01\n" +
 	"\x18ExecutionStateTransition\x12!\n" +
 	"\fexecution_id\x18\x01 \x01(\tR\vexecutionId\x12W\n" +
-	"\rtransition_to\x18\x02 \x01(\x0e22.testkube.testworkflow.execution.v1.ExecutionStateR\ftransitionToB\xc9\x02\n" +
+	"\rtransition_to\x18\x02 \x01(\x0e22.testkube.testworkflow.execution.v1.ExecutionStateR\ftransitionTo\x12\x16\n" +
+	"\x06reason\x18\x03 \x01(\tR\x06reasonB\xc9\x02\n" +
 	"&com.testkube.testworkflow.execution.v1B\x1dExecutionStateTransitionProtoP\x01ZUgithub.com/kubeshop/testkube/pkg/proto/testkube/testworkflow/execution/v1;executionv1\xa2\x02\x03TTE\xaa\x02\"Testkube.Testworkflow.Execution.V1\xca\x02\"Testkube\\Testworkflow\\Execution\\V1\xe2\x02.Testkube\\Testworkflow\\Execution\\V1\\GPBMetadata\xea\x02%Testkube::Testworkflow::Execution::V1b\beditionsp\xe8\a"
 
 var (

--- a/pkg/runner/agent.go
+++ b/pkg/runner/agent.go
@@ -298,7 +298,7 @@ func (a *agentLoop) loopRunnerRequests(ctx context.Context) error {
 				}
 			case cloud.RunnerRequestType_CANCEL:
 				a.logger.Infow("received cancel request for execution", "environmentId", req.EnvironmentID(), "executionId", req.ExecutionID())
-				originalError := a.runner.Cancel(req.ExecutionID())
+				originalError := a.runner.Cancel(req.ExecutionID(), "")
 				if originalError != nil {
 					err := req.SendError(originalError)
 					if err != nil {
@@ -312,7 +312,7 @@ func (a *agentLoop) loopRunnerRequests(ctx context.Context) error {
 				}
 			case cloud.RunnerRequestType_ABORT:
 				a.logger.Infow("received abort request for execution", "environmentId", req.EnvironmentID(), "executionId", req.ExecutionID())
-				originalError := a.runner.Abort(req.ExecutionID())
+				originalError := a.runner.Abort(req.ExecutionID(), "")
 				if originalError != nil {
 					err := req.SendError(originalError)
 					if err != nil {

--- a/pkg/runner/grpc/client.go
+++ b/pkg/runner/grpc/client.go
@@ -37,8 +37,8 @@ type runner interface {
 	Execute(request executionworkertypes.ExecuteRequest) (*executionworkertypes.ExecuteResult, error)
 	Pause(executionId string) error
 	Resume(executionId string) error
-	Abort(executionId string) error
-	Cancel(executionId string) error
+	Abort(executionId string, reason string) error
+	Cancel(executionId string, reason string) error
 }
 
 type workflowStore interface {
@@ -205,7 +205,7 @@ func (c Client) executeResponse(ctx context.Context, response *executionv1.GetEx
 			})
 		case executionv1.ExecutionState_EXECUTION_STATE_CANCELLED:
 			wg.Go(func() {
-				err := c.runner.Cancel(transition.GetExecutionId())
+				err := c.runner.Cancel(transition.GetExecutionId(), transition.GetReason())
 				switch {
 				case errors.Is(err, registry.ErrResourceNotFound):
 					// Mission failed successfully!
@@ -219,7 +219,7 @@ func (c Client) executeResponse(ctx context.Context, response *executionv1.GetEx
 			})
 		case executionv1.ExecutionState_EXECUTION_STATE_ABORTED:
 			wg.Go(func() {
-				err := c.runner.Abort(transition.GetExecutionId())
+				err := c.runner.Abort(transition.GetExecutionId(), transition.GetReason())
 				switch {
 				case errors.Is(err, registry.ErrResourceNotFound):
 					// Mission failed successfully!

--- a/pkg/runner/grpc/client_stop_test.go
+++ b/pkg/runner/grpc/client_stop_test.go
@@ -1,0 +1,88 @@
+package grpc
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+	"google.golang.org/protobuf/proto"
+
+	executionv1 "github.com/kubeshop/testkube/pkg/proto/testkube/testworkflow/execution/v1"
+	"github.com/kubeshop/testkube/pkg/testworkflows/executionworker/executionworkertypes"
+)
+
+// stopRecorder records the reason each stop request carries.
+type stopRecorder struct {
+	mu       sync.Mutex
+	aborted  map[string]string
+	canceled map[string]string
+}
+
+func (r *stopRecorder) Execute(executionworkertypes.ExecuteRequest) (*executionworkertypes.ExecuteResult, error) {
+	return nil, nil
+}
+func (r *stopRecorder) Pause(string) error  { return nil }
+func (r *stopRecorder) Resume(string) error { return nil }
+func (r *stopRecorder) Abort(id, reason string) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.aborted[id] = reason
+	return nil
+}
+func (r *stopRecorder) Cancel(id, reason string) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.canceled[id] = reason
+	return nil
+}
+
+func TestClient_executeResponse_PassesStopReason(t *testing.T) {
+	tests := []struct {
+		name         string
+		to           executionv1.ExecutionState
+		reason       *string
+		wantAborted  map[string]string
+		wantCanceled map[string]string
+	}{
+		{
+			name:         "abort with a cause",
+			to:           executionv1.ExecutionState_EXECUTION_STATE_ABORTED,
+			reason:       proto.String("the execution ran for too long"),
+			wantAborted:  map[string]string{"exec-1": "the execution ran for too long"},
+			wantCanceled: map[string]string{},
+		},
+		{
+			name:         "cancel with a cause",
+			to:           executionv1.ExecutionState_EXECUTION_STATE_CANCELLED,
+			reason:       proto.String("all executions of the workflow were canceled"),
+			wantAborted:  map[string]string{},
+			wantCanceled: map[string]string{"exec-1": "all executions of the workflow were canceled"},
+		},
+		{
+			name:         "cancel from a control plane that sends no reason",
+			to:           executionv1.ExecutionState_EXECUTION_STATE_CANCELLED,
+			reason:       nil,
+			wantAborted:  map[string]string{},
+			wantCanceled: map[string]string{"exec-1": ""},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			recorder := &stopRecorder{aborted: map[string]string{}, canceled: map[string]string{}}
+			c := Client{runner: recorder, logger: zap.NewNop().Sugar()}
+
+			c.executeResponse(context.Background(), &executionv1.GetExecutionUpdatesResponse{
+				Update: []*executionv1.ExecutionStateTransition{{
+					ExecutionId:  proto.String("exec-1"),
+					TransitionTo: tt.to.Enum(),
+					Reason:       tt.reason,
+				}},
+			})
+
+			require.Equal(t, tt.wantAborted, recorder.aborted)
+			require.Equal(t, tt.wantCanceled, recorder.canceled)
+		})
+	}
+}

--- a/pkg/runner/mock_runner.go
+++ b/pkg/runner/mock_runner.go
@@ -42,31 +42,31 @@ func (m *MockRunner) EXPECT() *MockRunnerMockRecorder {
 }
 
 // Abort mocks base method.
-func (m *MockRunner) Abort(id string) error {
+func (m *MockRunner) Abort(id, reason string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Abort", id)
+	ret := m.ctrl.Call(m, "Abort", id, reason)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // Abort indicates an expected call of Abort.
-func (mr *MockRunnerMockRecorder) Abort(id any) *gomock.Call {
+func (mr *MockRunnerMockRecorder) Abort(id, reason any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Abort", reflect.TypeOf((*MockRunner)(nil).Abort), id)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Abort", reflect.TypeOf((*MockRunner)(nil).Abort), id, reason)
 }
 
 // Cancel mocks base method.
-func (m *MockRunner) Cancel(id string) error {
+func (m *MockRunner) Cancel(id, reason string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Cancel", id)
+	ret := m.ctrl.Call(m, "Cancel", id, reason)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // Cancel indicates an expected call of Cancel.
-func (mr *MockRunnerMockRecorder) Cancel(id any) *gomock.Call {
+func (mr *MockRunnerMockRecorder) Cancel(id, reason any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Cancel", reflect.TypeOf((*MockRunner)(nil).Cancel), id)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Cancel", reflect.TypeOf((*MockRunner)(nil).Cancel), id, reason)
 }
 
 // Execute mocks base method.

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -68,8 +68,10 @@ type Runner interface {
 	Notifications(ctx context.Context, id string) executionworkertypes.NotificationsWatcher
 	Pause(id string) error
 	Resume(id string) error
-	Abort(id string) error
-	Cancel(id string) error
+	// Abort stops the execution and records the cause the control plane sent. The cause can be empty.
+	Abort(id string, reason string) error
+	// Cancel stops the execution and records the cause the control plane sent. The cause can be empty.
+	Cancel(id string, reason string) error
 }
 
 type runner struct {
@@ -653,16 +655,17 @@ func (r *runner) Resume(id string) error {
 }
 
 // Abort stops the execution on a request from the control plane.
-// The control plane does not send a cause yet, so the result names the actor only.
-func (r *runner) Abort(id string) error {
+func (r *runner) Abort(id string, reason string) error {
 	return r.worker.Abort(context.Background(), id, executionworkertypes.DestroyOptions{
-		Actor: executionworkertypes.AbortActorControlPlane,
+		Actor:  executionworkertypes.AbortActorControlPlane,
+		Reason: reason,
 	})
 }
 
 // Cancel stops the execution on a request from a user. The control plane relays the request.
-func (r *runner) Cancel(id string) error {
+func (r *runner) Cancel(id string, reason string) error {
 	return r.worker.Cancel(context.Background(), id, executionworkertypes.DestroyOptions{
-		Actor: executionworkertypes.AbortActorUser,
+		Actor:  executionworkertypes.AbortActorUser,
+		Reason: reason,
 	})
 }

--- a/proto/testkube/testworkflow/execution/v1/execution_state_transition.proto
+++ b/proto/testkube/testworkflow/execution/v1/execution_state_transition.proto
@@ -10,4 +10,10 @@ message ExecutionStateTransition {
   string execution_id = 1;
   // transition_to is the state the execution should be transitioned into.
   ExecutionState transition_to = 2;
+  // reason is the cause of an abort or a cancel, as free text, for example
+  // "the execution ran for too long". The runner writes it into the job
+  // annotation next to the actor, so the execution result names who stopped
+  // the execution and why. Empty when the Control Plane has no cause to give,
+  // and for every other transition.
+  string reason = 3;
 }


### PR DESCRIPTION
## Pull request description

Milestone 1 of [TKC-6811](https://linear.app/kubeshop/issue/TKC-6811/why-did-my-test-fail-milestone-1-every-abort-carries-a-reason), third PR. Stacked on #8224.

`ExecutionStateTransition` carries an execution id and a target state. When the control plane aborts or cancels an execution, the runner cannot know why, so the job annotation gets a fixed text.

The transition gets a `reason` field with the cause of the stop. The runner passes it to the worker, which writes it into the job annotation next to the actor. The result reads `by the control plane: <cause>`. Without a reason the result names the actor only, so an old control plane keeps working.

`Runner.Abort` and `Runner.Cancel` take the reason as a second argument. The agent request path passes an empty reason, because that request has no reason field. cloud-api #5537 fills the field.
