### PR TITLE
fix(api): store plain-text error messages without terminal colour codes

### DIFF
--- a/pkg/api/v1/testkube/model_test_workflow_execution_extended.go
+++ b/pkg/api/v1/testkube/model_test_workflow_execution_extended.go
@@ -4,8 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/gookit/color"
-
 	"github.com/kubeshop/testkube/internal/common"
 	"github.com/kubeshop/testkube/pkg/utils"
 )
@@ -103,7 +101,8 @@ func (e *TestWorkflowExecution) InitializationError(header string, err error) {
 	e.Result.Initialization.FinishedAt = e.ScheduledAt
 	e.Result.Initialization.ErrorMessage = err.Error()
 	if header != "" {
-		e.Result.Initialization.ErrorMessage = fmt.Sprintf("%s\n%s", color.Bold.Render(header), e.Result.Initialization.ErrorMessage)
+		// The stored message must stay plain text. The API and telemetry read it without a terminal renderer.
+		e.Result.Initialization.ErrorMessage = fmt.Sprintf("%s\n%s", header, e.Result.Initialization.ErrorMessage)
 	}
 	for ref, step := range e.Result.Steps {
 		step.Status = common.Ptr(SKIPPED_TestWorkflowStepStatus)

--- a/pkg/api/v1/testkube/model_test_workflow_execution_extended_test.go
+++ b/pkg/api/v1/testkube/model_test_workflow_execution_extended_test.go
@@ -1,0 +1,45 @@
+package testkube
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTestWorkflowExecution_InitializationError(t *testing.T) {
+	tests := []struct {
+		name             string
+		header           string
+		err              error
+		wantErrorMessage string
+	}{
+		{
+			name:             "puts the plain header above the error",
+			header:           "Failed to run execution",
+			err:              errors.New("image not found"),
+			wantErrorMessage: "Failed to run execution\nimage not found",
+		},
+		{
+			name:             "stores only the error when the header is empty",
+			header:           "",
+			err:              errors.New("image not found"),
+			wantErrorMessage: "image not found",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			e := &TestWorkflowExecution{
+				Result: &TestWorkflowResult{
+					Initialization: &TestWorkflowStepResult{},
+					Steps:          map[string]TestWorkflowStepResult{},
+				},
+			}
+
+			e.InitializationError(tt.header, tt.err)
+
+			assert.Equal(t, tt.wantErrorMessage, e.Result.Initialization.ErrorMessage)
+		})
+	}
+}

--- a/pkg/api/v1/testkube/model_test_workflow_result_extended.go
+++ b/pkg/api/v1/testkube/model_test_workflow_result_extended.go
@@ -7,8 +7,6 @@ import (
 	"slices"
 	"time"
 
-	"github.com/gookit/color"
-
 	"github.com/kubeshop/testkube/cmd/testworkflow-init/constants"
 	"github.com/kubeshop/testkube/internal/common"
 )
@@ -526,6 +524,7 @@ func (r *TestWorkflowResult) HealTimestamps(sigSequence []TestWorkflowSignature,
 }
 
 func (r *TestWorkflowResult) HealAbortedOrCanceled(sigSequence []TestWorkflowSignature, errorStr, defaultErrorStr string, terminationCode string) {
+	// The stored message must stay plain text. The API and telemetry read it without a terminal renderer.
 	errorMessage := fmt.Sprintf("The execution has been %s. (%s)", terminationCode, errorStr)
 	if errorStr == "" {
 		errorMessage = fmt.Sprintf("The execution has been %s.", terminationCode)
@@ -562,9 +561,10 @@ func (r *TestWorkflowResult) HealAbortedOrCanceled(sigSequence []TestWorkflowSig
 		}
 		if aborted || canceled {
 			step.Status = common.Ptr(SKIPPED_TestWorkflowStepStatus)
-			step.ErrorMessage = fmt.Sprintf("The execution was aborted before. %s", color.FgDarkGray.Render("("+errorStr+")"))
 			if canceled {
-				step.ErrorMessage = fmt.Sprintf("The execution was canceled before. %s", color.FgDarkGray.Render("("+errorStr+")"))
+				step.ErrorMessage = fmt.Sprintf("The execution was canceled before. (%s)", errorStr)
+			} else {
+				step.ErrorMessage = fmt.Sprintf("The execution was aborted before. (%s)", errorStr)
 			}
 		} else {
 			if terminationCode == string(CANCELED_TestWorkflowStatus) {

--- a/pkg/api/v1/testkube/model_test_workflow_result_extended_test.go
+++ b/pkg/api/v1/testkube/model_test_workflow_result_extended_test.go
@@ -5,6 +5,8 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+
+	"github.com/kubeshop/testkube/internal/common"
 )
 
 func TestHealDuration(t *testing.T) {
@@ -117,6 +119,49 @@ func TestTestWorkflowResult_Fatal(t *testing.T) {
 			assert.Equal(t, ts, tt.result.QueuedAt)
 			assert.Equal(t, ts, tt.result.StartedAt)
 			assert.Equal(t, ts, tt.result.FinishedAt)
+		})
+	}
+}
+
+func TestTestWorkflowResult_HealAbortedOrCanceled(t *testing.T) {
+	tests := []struct {
+		name                   string
+		terminationCode        string
+		errorStr               string
+		wantRunningStepMessage string
+		wantQueuedStepMessage  string
+	}{
+		{
+			name:                   "stores plain text messages for an aborted execution",
+			terminationCode:        string(ABORTED_TestWorkflowStatus),
+			errorStr:               "trigger: deleted",
+			wantRunningStepMessage: "The execution has been aborted. (trigger: deleted)",
+			wantQueuedStepMessage:  "The execution was aborted before. (trigger: deleted)",
+		},
+		{
+			name:                   "stores plain text messages for a canceled execution",
+			terminationCode:        string(CANCELED_TestWorkflowStatus),
+			errorStr:               "user: stopped",
+			wantRunningStepMessage: "The execution has been canceled. (user: stopped)",
+			wantQueuedStepMessage:  "The execution was canceled before. (user: stopped)",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := &TestWorkflowResult{
+				Initialization: &TestWorkflowStepResult{Status: common.Ptr(PASSED_TestWorkflowStepStatus)},
+				Steps: map[string]TestWorkflowStepResult{
+					"running": {Status: common.Ptr(RUNNING_TestWorkflowStepStatus), StartedAt: time.Now()},
+					"queued":  {Status: common.Ptr(QUEUED_TestWorkflowStepStatus)},
+				},
+			}
+			sigSequence := []TestWorkflowSignature{{Ref: "running"}, {Ref: "queued"}}
+
+			r.HealAbortedOrCanceled(sigSequence, tt.errorStr, "Job has been aborted", tt.terminationCode)
+
+			assert.Equal(t, tt.wantRunningStepMessage, r.Steps["running"].ErrorMessage)
+			assert.Equal(t, tt.wantQueuedStepMessage, r.Steps["queued"].ErrorMessage)
 		})
 	}
 }


### PR DESCRIPTION
## Pull request description

Milestone 1 of [TKC-6811](https://linear.app/kubeshop/issue/TKC-6811/why-did-my-test-fail-milestone-1-every-abort-carries-a-reason). Independent of the other PRs in the milestone.

Two places write terminal colour codes into the stored `errorMessage`. `InitializationError` wraps the header in bold. `HealAbortedOrCanceled` wraps the reason in grey for every step after the first aborted one. The API, telemetry, and Mixpanel then show `[1m` and `[90m` inside the text.

Both write plain text now, with the same words. The stored message is data. The renderer that shows it decides on colour.
