### PR TITLE
fix(js): regenerate package-lock.json for the inquirer bump

### DIFF
--- a/js/package-lock.json
+++ b/js/package-lock.json
@@ -350,13 +350,13 @@
       }
     },
     "node_modules/@inquirer/checkbox": {
-      "version": "5.2.4",
-      "resolved": "https://registry.npmjs.org/@inquirer/checkbox/-/checkbox-5.2.4.tgz",
-      "integrity": "sha512-oKT5RNeO9oKYizSyOxKb66IrKUsYVMQD2tnjllYW4wmSOe9WawfL3OE2p82JuvAyo+/nDIEem5P4Bm/ZIVYVew==",
+      "version": "5.2.5",
+      "resolved": "https://registry.npmjs.org/@inquirer/checkbox/-/checkbox-5.2.5.tgz",
+      "integrity": "sha512-bRt8J8m+Fot9CXv+zNQGXUq2ET0MggR1fPz7v6edN6MFYmsbfGnMmkmWZJEegMKqrAC8ej/o1sqisHZXZJMAfQ==",
       "license": "MIT",
       "dependencies": {
         "@inquirer/ansi": "^2.0.8",
-        "@inquirer/core": "^12.0.2",
+        "@inquirer/core": "^12.0.3",
         "@inquirer/figures": "^2.0.9",
         "@inquirer/type": "4.1.1"
       },
@@ -373,12 +373,12 @@
       }
     },
     "node_modules/@inquirer/confirm": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-6.3.1.tgz",
-      "integrity": "sha512-HvnOHal39DTenOVoRpIy8Z+n4YYfNa3Qhi/P8zFqn9/d1crpmQG0DPx34rwOeOFvotgKr9Vov/14OmKR/Iwfjw==",
+      "version": "6.3.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-6.3.2.tgz",
+      "integrity": "sha512-Xvr/0HggjddPtGppuqVmxhTw+Hr8PvsZ/k0HmOEaAqQEt80OITNkFWnsdNmyT0/eM4Ab+iJLx2R8rctlEyfSVg==",
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^12.0.2",
+        "@inquirer/core": "^12.0.3",
         "@inquirer/type": "4.1.1"
       },
       "engines": {
@@ -394,9 +394,9 @@
       }
     },
     "node_modules/@inquirer/core": {
-      "version": "12.0.2",
-      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-12.0.2.tgz",
-      "integrity": "sha512-9pBhkxE14uUlnHhs8lOt7qVPtS4caRY6CjADl8COejl9Mf7w8i6Uoe3DrljCqYtmYM3Iv2Q6EmPxx/oTYbvTAQ==",
+      "version": "12.0.3",
+      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-12.0.3.tgz",
+      "integrity": "sha512-wsSy0sznmXwkty+2PzZwx00Cazc/E0r0B7mAzdGROz2Ct+DFZXaK7WDjGZvgjRldxH5ZhFVfF2lgkYrqgOw2KA==",
       "license": "MIT",
       "dependencies": {
         "@inquirer/ansi": "^2.0.8",
@@ -420,12 +420,12 @@
       }
     },
     "node_modules/@inquirer/editor": {
-      "version": "5.3.2",
-      "resolved": "https://registry.npmjs.org/@inquirer/editor/-/editor-5.3.2.tgz",
-      "integrity": "sha512-7ruKO5d/wxhGHxdCQ3eyP/aBNrPTZ+Ju7ERtnAwuIsu0RSLs6kotlTRkOxHatbD6sDaEEdwsD82pzFiT9ESIyQ==",
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/@inquirer/editor/-/editor-5.3.3.tgz",
+      "integrity": "sha512-YsKkS2q63IiLtaDK/9nqzdComN97SDQrmKiyNggN+ceP4ty+Z6VwyTz3FpjeUWeW1Efss2xHFKCC9sx7hnrsxg==",
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^12.0.2",
+        "@inquirer/core": "^12.0.3",
         "@inquirer/external-editor": "^3.0.5",
         "@inquirer/type": "4.1.1"
       },
@@ -442,12 +442,12 @@
       }
     },
     "node_modules/@inquirer/expand": {
-      "version": "5.1.4",
-      "resolved": "https://registry.npmjs.org/@inquirer/expand/-/expand-5.1.4.tgz",
-      "integrity": "sha512-12o4aYnjWouoq0fyVhYIL+hwXAaga+kntA/wrijFmVvn2heinkdvkbEXRt1Ob/9IOJ285US5tntjfI/Ukt2YkA==",
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@inquirer/expand/-/expand-5.1.5.tgz",
+      "integrity": "sha512-uHuXLmXW+TtIfT/9vSBotypAkqn1n34Ul+CLGPos/xANyO4Ff5xZzkYhbKR4NEcfVK4a9mHQOpwVZzluSHFRGw==",
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^12.0.2",
+        "@inquirer/core": "^12.0.3",
         "@inquirer/type": "4.1.1"
       },
       "engines": {
@@ -493,12 +493,12 @@
       }
     },
     "node_modules/@inquirer/input": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@inquirer/input/-/input-5.1.5.tgz",
-      "integrity": "sha512-2MkYYFD1Owt1eRBwHhsLSutysRodWasA4DVpl42KJKGmzwBTXRYAIXujisrt0UW0UohUlMjNjLfMDbw4emRbfw==",
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/@inquirer/input/-/input-5.1.6.tgz",
+      "integrity": "sha512-HtcJhB2QFVXbLuJ5S3syhNbTUVxYvwqV4VRBDkQceBloC9bmTViUoRFP5PbSaDZb3HzfPmpuU/gG4ybVBz4FHA==",
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^12.0.2",
+        "@inquirer/core": "^12.0.3",
         "@inquirer/type": "4.1.1"
       },
       "engines": {
@@ -514,12 +514,12 @@
       }
     },
     "node_modules/@inquirer/number": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/@inquirer/number/-/number-4.2.2.tgz",
-      "integrity": "sha512-tjW1gMIQsFb/9Ie11i8SpuPARBdyCVfC5XOeVugWovrdm8CpjzN+A1CBX5QwCCN2mtNmpgDDCnuLCCT94cQ5zA==",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/@inquirer/number/-/number-4.2.3.tgz",
+      "integrity": "sha512-6Yuwh1NGSbu1Lo4N1EWjXs1jKRntLg/ZCwhmeorEHde90v1XxAozdbd4Iu30eOQLW+6h1hp2O9ujNfLSbTPJnA==",
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^12.0.2",
+        "@inquirer/core": "^12.0.3",
         "@inquirer/type": "4.1.1"
       },
       "engines": {
@@ -535,13 +535,13 @@
       }
     },
     "node_modules/@inquirer/password": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/@inquirer/password/-/password-5.2.1.tgz",
-      "integrity": "sha512-InA6nJxMCXPavPBiTKYHIsYiWz/mkIsk1rkI6pKp5w18gVawqrZOj7eSzSmPJa3j0pVxXm6RlrFP1BE9YeOixA==",
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/password/-/password-5.2.2.tgz",
+      "integrity": "sha512-W9zYdyzogK+6110mqwaSJWCBu2yA5Q/OfnGSjjZB1bNpHlmUozXxTl0+QOZBNeVd6Qo81/qT75gW05gLAtITxw==",
       "license": "MIT",
       "dependencies": {
         "@inquirer/ansi": "^2.0.8",
-        "@inquirer/core": "^12.0.2",
+        "@inquirer/core": "^12.0.3",
         "@inquirer/type": "4.1.1"
       },
       "engines": {
@@ -557,21 +557,21 @@
       }
     },
     "node_modules/@inquirer/prompts": {
-      "version": "8.7.1",
-      "resolved": "https://registry.npmjs.org/@inquirer/prompts/-/prompts-8.7.1.tgz",
-      "integrity": "sha512-xJIKWyrFNUKj3R5VEub/iKodG9Sh/MbCeApZUbATJgHTw8YoAJ2gOT78HlvO6NMFiRvjm6ySM7aiAew/zVY0Sw==",
+      "version": "8.7.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/prompts/-/prompts-8.7.2.tgz",
+      "integrity": "sha512-QoRB4wFIjgH5iOhSjoIKMkTvSHDuV+O3OITlIqAYO0oK5x364GJILXiMBvlPiE+klg7Xx9tq5XVqQHcGUDYYPA==",
       "license": "MIT",
       "dependencies": {
-        "@inquirer/checkbox": "^5.2.4",
-        "@inquirer/confirm": "^6.3.1",
-        "@inquirer/editor": "^5.3.2",
-        "@inquirer/expand": "^5.1.4",
-        "@inquirer/input": "^5.1.5",
-        "@inquirer/number": "^4.2.2",
-        "@inquirer/password": "^5.2.1",
-        "@inquirer/rawlist": "^5.3.4",
-        "@inquirer/search": "^4.3.2",
-        "@inquirer/select": "^5.2.4"
+        "@inquirer/checkbox": "^5.2.5",
+        "@inquirer/confirm": "^6.3.2",
+        "@inquirer/editor": "^5.3.3",
+        "@inquirer/expand": "^5.1.5",
+        "@inquirer/input": "^5.1.6",
+        "@inquirer/number": "^4.2.3",
+        "@inquirer/password": "^5.2.2",
+        "@inquirer/rawlist": "^5.3.5",
+        "@inquirer/search": "^4.3.3",
+        "@inquirer/select": "^5.2.5"
       },
       "engines": {
         "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
@@ -586,12 +586,12 @@
       }
     },
     "node_modules/@inquirer/rawlist": {
-      "version": "5.3.4",
-      "resolved": "https://registry.npmjs.org/@inquirer/rawlist/-/rawlist-5.3.4.tgz",
-      "integrity": "sha512-c4fDwOpQsjJDHjXdHJE1/xXH6w9/BAiyu3QKzH9Ww5Xm1q37mzyUNa20L7qdtM1ECi4e+oUEKjhK8hR37OMAMQ==",
+      "version": "5.3.5",
+      "resolved": "https://registry.npmjs.org/@inquirer/rawlist/-/rawlist-5.3.5.tgz",
+      "integrity": "sha512-1oHky1ONfCOwNrnkQGDE1oaSij/3fI6HFMSf2H/WsGO2lEyDX9My82iggITSy9ddSZ8yk8j9v41OI0fVoSIoaA==",
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^12.0.2",
+        "@inquirer/core": "^12.0.3",
         "@inquirer/type": "4.1.1"
       },
       "engines": {
@@ -607,12 +607,12 @@
       }
     },
     "node_modules/@inquirer/search": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/@inquirer/search/-/search-4.3.2.tgz",
-      "integrity": "sha512-YIaEhWmfkdHEWOKwhF/oJar35FFTTrAdzNbJDo9lSsRT6E/obRPx9oVm4rkTMtlcJSqGYttNtLbcHQef9Qw2yw==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@inquirer/search/-/search-4.3.3.tgz",
+      "integrity": "sha512-fyuIU1Nbpvwlikjg3gXwJFDI11+EFjqQ7P+iByfmivIKQ1vmaykNrD/vy5unHuUqUpsOsnvJ25//tPF7E/RBRA==",
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^12.0.2",
+        "@inquirer/core": "^12.0.3",
         "@inquirer/figures": "^2.0.9",
         "@inquirer/type": "4.1.1"
       },
@@ -629,13 +629,13 @@
       }
     },
     "node_modules/@inquirer/select": {
-      "version": "5.2.4",
-      "resolved": "https://registry.npmjs.org/@inquirer/select/-/select-5.2.4.tgz",
-      "integrity": "sha512-L9ubNaJdoBsiom/AfPKq0QLHTkhhCFCtszzdVidGremrlJjPZfGlmvp+IULKIbnYjtVFWnvb4mhiEdNTZ12ugA==",
+      "version": "5.2.5",
+      "resolved": "https://registry.npmjs.org/@inquirer/select/-/select-5.2.5.tgz",
+      "integrity": "sha512-9kc15hr8r/kI+3DO/xLog5nOzTz1jqsHXa6JBFzmQKhkoJ8Slda1I1L/uD8ZSZ9tF1yp79wwXe7mclvX1rqR2Q==",
       "license": "MIT",
       "dependencies": {
         "@inquirer/ansi": "^2.0.8",
-        "@inquirer/core": "^12.0.2",
+        "@inquirer/core": "^12.0.3",
         "@inquirer/figures": "^2.0.9",
         "@inquirer/type": "4.1.1"
       },
@@ -1425,6 +1425,8 @@
     },
     "node_modules/cli-width": {
       "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-4.1.0.tgz",
+      "integrity": "sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ==",
       "license": "ISC",
       "engines": {
         "node": ">= 12"
@@ -1662,14 +1664,14 @@
       }
     },
     "node_modules/inquirer": {
-      "version": "14.2.1",
-      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-14.2.1.tgz",
-      "integrity": "sha512-jLO8986l0/jW+K2Y5BHAhrD6ztnm8MHQgnTI5BwKV6can/LN6xYBcLbtUSvDt1jXNTASwCZszZk0ZBUT5YmH6Q==",
+      "version": "14.2.2",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-14.2.2.tgz",
+      "integrity": "sha512-WGerZIIb7mTtaFFskkD/P0europ8xBWf1OXACMiugzKPSmVzoqhcPSuSUzbzMch/t3rf1ncBT3v/0WU73cLqJQ==",
       "license": "MIT",
       "dependencies": {
         "@inquirer/ansi": "^2.0.8",
-        "@inquirer/core": "^12.0.2",
-        "@inquirer/prompts": "^8.7.1",
+        "@inquirer/core": "^12.0.3",
+        "@inquirer/prompts": "^8.7.2",
         "@inquirer/type": "4.1.1",
         "mute-stream": "^3.0.0",
         "run-async": "^4.0.6"
@@ -2593,7 +2595,7 @@
         "chalk": "6.0.0",
         "execa": "10.0.1",
         "fs-extra": "11.4.0",
-        "inquirer": "14.2.1",
+        "inquirer": "14.2.2",
         "log-symbols": "7.0.1",
         "ora": "9.4.1",
         "semver": "7.8.5",


### PR DESCRIPTION
`npm ci` fails anywhere in js/ on main:

  npm error code EUSAGE
  npm error `npm ci` can only install packages when your package.json and
  npm error package-lock.json or npm-shrinkwrap.json are in sync.
  npm error Invalid: lock file's inquirer@14.2.1 does not satisfy inquirer@14.2.2
  ... and twelve more across the @inquirer/* family

#8220 bumped js/scripts/tk-release/package.json to inquirer 14.2.2 and changed nothing else - one file, one line. The root lock covers that workspace through the scripts/* glob, so it still declared 14.2.1 there and resolved the whole @inquirer/* family to the older versions; the string 14.2.2 did not appear in it at all. Its predecessor #8204 did the same bump correctly, with 192 lines of lockfile alongside the manifest line.

Regenerated with `npm install --package-lock-only`, which touches only what the manifest requires: the thirteen packages npm listed, plus resolved and integrity fields that were missing from cli-width's entry.

Verified in both directions rather than just the fixed one - `npm ci --dry-run` reproduces EUSAGE with the lock as it stands on main, and installs 170 packages cleanly with this change - because a dry run that skipped the sync check would have looked like a pass either way.

This is not specific to any one job. Any CI step or developer running `npm ci` in js/ hits it; it surfaced through a TestWorkflow that installs the js workspace.

## Pull request description 



## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [ ] tested locally
- [ ] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Breaking changes

-

## Changes

-

## Fixes

-