### PR TITLE
feat(executionworker): add the words for each start-failure reason

### DIFF
--- a/pkg/api/v1/testkube/start_reason.go
+++ b/pkg/api/v1/testkube/start_reason.go
@@ -11,3 +11,23 @@ const (
 	StartReasonJobCreateFailed   StartReason = "job-create-failed"
 	StartReasonUnknown           StartReason = "start-failed"
 )
+
+// Sentence returns the words for the reason in a message for people, as the tail of
+// "Failed to run execution: ...". It returns an empty string for a value it does not
+// know, so a reader can keep the raw token.
+func (r StartReason) Sentence() string {
+	switch r {
+	case StartReasonImagePullFailed:
+		return "the image could not be pulled"
+	case StartReasonDefinitionInvalid:
+		return "the workflow definition is invalid"
+	case StartReasonResourceFailed:
+		return "a secret, config map, or volume claim could not be created"
+	case StartReasonJobCreateFailed:
+		return "the job could not be created"
+	case StartReasonUnknown:
+		return "the runner could not start the execution"
+	default:
+		return ""
+	}
+}

--- a/pkg/api/v1/testkube/start_reason_test.go
+++ b/pkg/api/v1/testkube/start_reason_test.go
@@ -1,0 +1,27 @@
+package testkube
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestStartReason_Sentence(t *testing.T) {
+	tests := []struct {
+		name   string
+		reason StartReason
+		want   string
+	}{
+		{name: "image pull", reason: StartReasonImagePullFailed, want: "the image could not be pulled"},
+		{name: "definition", reason: StartReasonDefinitionInvalid, want: "the workflow definition is invalid"},
+		{name: "resource", reason: StartReasonResourceFailed, want: "a secret, config map, or volume claim could not be created"},
+		{name: "job", reason: StartReasonJobCreateFailed, want: "the job could not be created"},
+		{name: "unknown phase", reason: StartReasonUnknown, want: "the runner could not start the execution"},
+		{name: "token from a newer runner has no words yet", reason: StartReason("later-added"), want: ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, tt.reason.Sentence())
+		})
+	}
+}


### PR DESCRIPTION
## Pull request description

Follow-up to #8239 on [TKC-6811](https://linear.app/kubeshop/issue/TKC-6811/why-did-my-test-fail-milestone-1-every-abort-carries-a-reason), second of three. Stacked on the move to the model package.

The control plane stores the start-failure token inside the message it shows to people, as `Failed to run execution (image-pull-failed)`. The token is a machine key and reads as one.

`StartReason.Sentence` gives the words for each token, in the shape of `StopActor.Sentence`, so one place defines the key and its words. It returns an empty string for a token it does not know. A reader then keeps the raw token, for example one from a newer runner. The control plane switches to it in kubeshop/testkube-cloud-api #5537.

