### PR TITLE
refactor(executionworker): move the stop actor and start reason tokens to the model package

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -126,6 +126,7 @@ Testkube exposes REST APIs for interacting with core resources and functionality
 - Defines the complete REST API contract
 - Used for client code generation and documentation
 - Generated models: [`pkg/api/v1/testkube/`](pkg/api/v1/testkube/)
+- The stop actor and the reason tokens, with their words, live in the same package as hand-written files, so the worker, the runner, and the control plane share one definition
 
 **Framework**: Uses [Fiber](https://gofiber.io/) web framework for HTTP routing and middleware
 

--- a/cmd/tcl/testworkflow-toolkit/commands/parallel.go
+++ b/cmd/tcl/testworkflow-toolkit/commands/parallel.go
@@ -713,7 +713,7 @@ func (e *WorkerExecutor) handleWorkerCleanup(ctx context.Context, worker WorkerS
 	if cancelled {
 		err = spawn.ParallelExecutionWorker(e.cfg).Abort(cleanupCtx, cfg.Resource.Id, executionworkertypes.DestroyOptions{
 			Namespace: worker.Namespace,
-			Actor:     executionworkertypes.AbortActorFailFast,
+			Actor:     testkube.StopActorFailFast,
 		})
 		if err == nil {
 			log("aborted")
@@ -821,7 +821,7 @@ func (o *ResumeOrchestrator) resumeAllWorkers(ctx context.Context) {
 			default:
 				_ = spawn.ParallelExecutionWorker(o.cfg).Abort(ctx, err.Id, executionworkertypes.DestroyOptions{
 					Namespace: o.namespaces[index],
-					Actor:     executionworkertypes.AbortActorRunner,
+					Actor:     testkube.StopActorRunner,
 					Reason:    "the parallel worker could not be resumed: " + err.Error.Error(),
 				})
 			}

--- a/internal/app/api/v1/testworkflowexecutions.go
+++ b/internal/app/api/v1/testworkflowexecutions.go
@@ -570,7 +570,7 @@ func (s *TestkubeAPI) abortTestWorkflowExecutionHandlerPro() fiber.Handler {
 		// Abort the Test Workflow
 		err = s.ExecutionWorkerClient.Abort(ctx, execution.Id, executionworkertypes.DestroyOptions{
 			Namespace: execution.Namespace,
-			Actor:     executionworkertypes.AbortActorAPI,
+			Actor:     testkube.StopActorAPI,
 		})
 		if err != nil {
 			return s.ClientError(c, "aborting test workflow execution", err)
@@ -801,7 +801,7 @@ func (s *TestkubeAPI) abortAllTestWorkflowExecutionsHandlerPro() fiber.Handler {
 		for _, execution := range executions {
 			err = s.ExecutionWorkerClient.Abort(ctx, execution.Id, executionworkertypes.DestroyOptions{
 				Namespace: execution.Namespace,
-				Actor:     executionworkertypes.AbortActorAPI,
+				Actor:     testkube.StopActorAPI,
 				Reason:    "all executions of the workflow were aborted",
 			})
 			if err != nil {

--- a/pkg/api/v1/testkube/start_reason.go
+++ b/pkg/api/v1/testkube/start_reason.go
@@ -1,0 +1,13 @@
+package testkube
+
+// StartReason is the token the runner sends to the control plane when it declines
+// an execution. The values are stable, because filters and telemetry use them.
+type StartReason string
+
+const (
+	StartReasonImagePullFailed   StartReason = "image-pull-failed"
+	StartReasonDefinitionInvalid StartReason = "definition-invalid"
+	StartReasonResourceFailed    StartReason = "resource-create-failed"
+	StartReasonJobCreateFailed   StartReason = "job-create-failed"
+	StartReasonUnknown           StartReason = "start-failed"
+)

--- a/pkg/api/v1/testkube/stop_actor.go
+++ b/pkg/api/v1/testkube/stop_actor.go
@@ -1,0 +1,43 @@
+package testkube
+
+// StopActor identifies the component that requested an abort or a cancel. The worker
+// writes it into the job annotations, so the execution result names who stopped it.
+type StopActor string
+
+const (
+	// StopActorUser is a person who cancels through the API, the CLI, or the dashboard.
+	StopActorUser StopActor = "user"
+	// StopActorControlPlane is the control plane, for example a queue or execution timeout.
+	StopActorControlPlane StopActor = "control-plane"
+	// StopActorTrigger is the trigger cleanup that stops executions of a deleted trigger.
+	StopActorTrigger StopActor = "trigger"
+	// StopActorFailFast is a parallel step that stops its workers after the first failure.
+	StopActorFailFast StopActor = "fail-fast"
+	// StopActorRunner is the runner itself, for example the check for stuck executions.
+	StopActorRunner StopActor = "runner"
+	// StopActorAPI is the standalone agent API abort endpoint.
+	StopActorAPI StopActor = "api"
+	// StopActorSystem is the fallback when the caller does not identify itself.
+	StopActorSystem StopActor = "system"
+)
+
+// Sentence returns the words the result reader uses for the actor after
+// "The execution has been aborted". The reason, when set, follows them.
+func (a StopActor) Sentence() string {
+	switch a {
+	case StopActorUser:
+		return "by the user"
+	case StopActorControlPlane:
+		return "by the control plane"
+	case StopActorTrigger:
+		return "because its trigger was deleted"
+	case StopActorFailFast:
+		return "because another parallel worker failed"
+	case StopActorRunner:
+		return "by the runner"
+	case StopActorAPI:
+		return "through the API"
+	default:
+		return "by the system"
+	}
+}

--- a/pkg/api/v1/testkube/stop_actor_test.go
+++ b/pkg/api/v1/testkube/stop_actor_test.go
@@ -1,0 +1,29 @@
+package testkube
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestStopActor_Sentence(t *testing.T) {
+	tests := []struct {
+		name  string
+		actor StopActor
+		want  string
+	}{
+		{name: "user", actor: StopActorUser, want: "by the user"},
+		{name: "control plane", actor: StopActorControlPlane, want: "by the control plane"},
+		{name: "trigger", actor: StopActorTrigger, want: "because its trigger was deleted"},
+		{name: "fail-fast", actor: StopActorFailFast, want: "because another parallel worker failed"},
+		{name: "runner", actor: StopActorRunner, want: "by the runner"},
+		{name: "api", actor: StopActorAPI, want: "through the API"},
+		{name: "system", actor: StopActorSystem, want: "by the system"},
+		{name: "unknown value falls back to the system", actor: StopActor("later-added"), want: "by the system"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, tt.actor.Sentence())
+		})
+	}
+}

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -635,7 +635,7 @@ func (r *runner) abortExecution(ctx context.Context, environmentID, executionID 
 
 	err = retry(AbortExecutionRetryCount, delay, func(_ int) error {
 		return r.worker.Abort(context.Background(), executionID, executionworkertypes.DestroyOptions{
-			Actor:  executionworkertypes.AbortActorRunner,
+			Actor:  testkube.StopActorRunner,
 			Reason: stuckReason,
 		})
 	})
@@ -657,7 +657,7 @@ func (r *runner) Resume(id string) error {
 // Abort stops the execution on a request from the control plane.
 func (r *runner) Abort(id string, reason string) error {
 	return r.worker.Abort(context.Background(), id, executionworkertypes.DestroyOptions{
-		Actor:  executionworkertypes.AbortActorControlPlane,
+		Actor:  testkube.StopActorControlPlane,
 		Reason: reason,
 	})
 }
@@ -665,7 +665,7 @@ func (r *runner) Abort(id string, reason string) error {
 // Cancel stops the execution on a request from a user. The control plane relays the request.
 func (r *runner) Cancel(id string, reason string) error {
 	return r.worker.Cancel(context.Background(), id, executionworkertypes.DestroyOptions{
-		Actor:  executionworkertypes.AbortActorUser,
+		Actor:  testkube.StopActorUser,
 		Reason: reason,
 	})
 }

--- a/pkg/testworkflows/executionworker/controller/watchers/commons.go
+++ b/pkg/testworkflows/executionworker/controller/watchers/commons.go
@@ -9,7 +9,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/kubeshop/testkube/pkg/testworkflows/executionworker/executionworkertypes"
 	constants2 "github.com/kubeshop/testkube/pkg/testworkflows/testworkflowprocessor/constants"
 
 	batchv1 "k8s.io/api/batch/v1"
@@ -306,7 +305,7 @@ func GetJobError(job *batchv1.Job) string {
 	// The worker annotates a stop with the actor and an optional cause. A deleted
 	// job without the annotation is a stop by an unknown party.
 	if job.Annotations != nil {
-		actor := executionworkertypes.AbortActor(job.Annotations[constants2.AnnotationTerminationActor])
+		actor := testkube.StopActor(job.Annotations[constants2.AnnotationTerminationActor])
 		reason := job.Annotations[constants2.AnnotationTerminationReason]
 		if actor != "" || reason != "" {
 			if reason == "" {
@@ -319,7 +318,7 @@ func GetJobError(job *batchv1.Job) string {
 		}
 	}
 	if job.DeletionTimestamp != nil {
-		return executionworkertypes.AbortActorSystem.Sentence()
+		return testkube.StopActorSystem.Sentence()
 	}
 	return ""
 }

--- a/pkg/testworkflows/executionworker/controller/watchers/commons_test.go
+++ b/pkg/testworkflows/executionworker/controller/watchers/commons_test.go
@@ -8,7 +8,7 @@ import (
 	batchv1 "k8s.io/api/batch/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/kubeshop/testkube/pkg/testworkflows/executionworker/executionworkertypes"
+	"github.com/kubeshop/testkube/pkg/api/v1/testkube"
 	"github.com/kubeshop/testkube/pkg/testworkflows/testworkflowprocessor/constants"
 )
 
@@ -22,7 +22,7 @@ func TestGetJobError(t *testing.T) {
 		{
 			name: "actor and cause",
 			job: &batchv1.Job{ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{
-				constants.AnnotationTerminationActor:  string(executionworkertypes.AbortActorRunner),
+				constants.AnnotationTerminationActor:  string(testkube.StopActorRunner),
 				constants.AnnotationTerminationReason: "execution is stuck in running state",
 			}}},
 			want: "by the runner: execution is stuck in running state",
@@ -30,7 +30,7 @@ func TestGetJobError(t *testing.T) {
 		{
 			name: "actor without a cause",
 			job: &batchv1.Job{ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{
-				constants.AnnotationTerminationActor: string(executionworkertypes.AbortActorUser),
+				constants.AnnotationTerminationActor: string(testkube.StopActorUser),
 			}}},
 			want: "by the user",
 		},

--- a/pkg/testworkflows/executionworker/executionworkertypes/interface.go
+++ b/pkg/testworkflows/executionworker/executionworkertypes/interface.go
@@ -176,64 +176,23 @@ type ControlOptions struct {
 	Namespace string
 }
 
-// AbortActor identifies the component that requested an abort or a cancel.
-type AbortActor string
-
-const (
-	// AbortActorUser is a person who cancels through the API, the CLI, or the dashboard.
-	AbortActorUser AbortActor = "user"
-	// AbortActorControlPlane is the control plane, for example a queue or execution timeout.
-	AbortActorControlPlane AbortActor = "control-plane"
-	// AbortActorTrigger is the trigger cleanup that stops executions of a deleted trigger.
-	AbortActorTrigger AbortActor = "trigger"
-	// AbortActorFailFast is a parallel step that stops its workers after the first failure.
-	AbortActorFailFast AbortActor = "fail-fast"
-	// AbortActorRunner is the runner itself, for example the check for stuck executions.
-	AbortActorRunner AbortActor = "runner"
-	// AbortActorAPI is the standalone agent API abort endpoint.
-	AbortActorAPI AbortActor = "api"
-	// AbortActorSystem is the fallback when the caller does not identify itself.
-	AbortActorSystem AbortActor = "system"
-)
-
 type DestroyOptions struct {
 	// Namespace where it has been deployed.
 	Namespace string
 	// Actor identifies the component that requested the stop. The worker writes it
 	// and the reason into the job annotations, so the result names who stopped it.
-	Actor AbortActor
+	Actor testkube.StopActor
 	// Reason is a short human-readable cause for the stop.
 	Reason string
 }
 
 // TerminationActor returns the actor for the job annotation, or the default when the
 // caller did not set one.
-func (o DestroyOptions) TerminationActor(defaultActor AbortActor) AbortActor {
+func (o DestroyOptions) TerminationActor(defaultActor testkube.StopActor) testkube.StopActor {
 	if o.Actor == "" {
 		return defaultActor
 	}
 	return o.Actor
-}
-
-// Sentence returns the words the result reader uses for the actor after
-// "The execution has been aborted". The reason, when set, follows them.
-func (a AbortActor) Sentence() string {
-	switch a {
-	case AbortActorUser:
-		return "by the user"
-	case AbortActorControlPlane:
-		return "by the control plane"
-	case AbortActorTrigger:
-		return "because its trigger was deleted"
-	case AbortActorFailFast:
-		return "because another parallel worker failed"
-	case AbortActorRunner:
-		return "by the runner"
-	case AbortActorAPI:
-		return "through the API"
-	default:
-		return "by the system"
-	}
 }
 
 type StatusNotification struct {

--- a/pkg/testworkflows/executionworker/executionworkertypes/interface_test.go
+++ b/pkg/testworkflows/executionworker/executionworkertypes/interface_test.go
@@ -4,53 +4,33 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+
+	"github.com/kubeshop/testkube/pkg/api/v1/testkube"
 )
 
 func TestDestroyOptions_TerminationActor(t *testing.T) {
 	tests := []struct {
 		name         string
 		options      DestroyOptions
-		defaultActor AbortActor
-		want         AbortActor
+		defaultActor testkube.StopActor
+		want         testkube.StopActor
 	}{
 		{
 			name:         "actor set",
-			options:      DestroyOptions{Actor: AbortActorTrigger},
-			defaultActor: AbortActorSystem,
-			want:         AbortActorTrigger,
+			options:      DestroyOptions{Actor: testkube.StopActorTrigger},
+			defaultActor: testkube.StopActorSystem,
+			want:         testkube.StopActorTrigger,
 		},
 		{
 			name:         "no actor uses the default",
 			options:      DestroyOptions{},
-			defaultActor: AbortActorUser,
-			want:         AbortActorUser,
+			defaultActor: testkube.StopActorUser,
+			want:         testkube.StopActorUser,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			assert.Equal(t, tt.want, tt.options.TerminationActor(tt.defaultActor))
-		})
-	}
-}
-
-func TestAbortActor_Sentence(t *testing.T) {
-	tests := []struct {
-		name  string
-		actor AbortActor
-		want  string
-	}{
-		{name: "user", actor: AbortActorUser, want: "by the user"},
-		{name: "control plane", actor: AbortActorControlPlane, want: "by the control plane"},
-		{name: "trigger", actor: AbortActorTrigger, want: "because its trigger was deleted"},
-		{name: "fail-fast", actor: AbortActorFailFast, want: "because another parallel worker failed"},
-		{name: "runner", actor: AbortActorRunner, want: "by the runner"},
-		{name: "api", actor: AbortActorAPI, want: "through the API"},
-		{name: "system", actor: AbortActorSystem, want: "by the system"},
-		{name: "unknown value falls back to the system", actor: AbortActor("later-added"), want: "by the system"},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			assert.Equal(t, tt.want, tt.actor.Sentence())
 		})
 	}
 }

--- a/pkg/testworkflows/executionworker/executionworkertypes/start_error.go
+++ b/pkg/testworkflows/executionworker/executionworkertypes/start_error.go
@@ -1,22 +1,14 @@
 package executionworkertypes
 
-import "errors"
+import (
+	"errors"
 
-// StartReason is the token the runner sends to the control plane when it declines
-// an execution. The values are stable, because filters and telemetry use them.
-type StartReason string
-
-const (
-	StartReasonImagePullFailed   StartReason = "image-pull-failed"
-	StartReasonDefinitionInvalid StartReason = "definition-invalid"
-	StartReasonResourceFailed    StartReason = "resource-create-failed"
-	StartReasonJobCreateFailed   StartReason = "job-create-failed"
-	StartReasonUnknown           StartReason = "start-failed"
+	"github.com/kubeshop/testkube/pkg/api/v1/testkube"
 )
 
 // StartError is an error from one phase of an execution start. Reason names that phase.
 type StartError struct {
-	Reason StartReason
+	Reason testkube.StartReason
 	Err    error
 }
 
@@ -26,7 +18,7 @@ func (e *StartError) Unwrap() error { return e.Err }
 
 // WithStartReason marks err with the reason of the phase that failed. An inner phase
 // names a more specific reason, so an error that already carries one keeps it.
-func WithStartReason(err error, reason StartReason) error {
+func WithStartReason(err error, reason testkube.StartReason) error {
 	if err == nil {
 		return nil
 	}
@@ -38,10 +30,10 @@ func WithStartReason(err error, reason StartReason) error {
 }
 
 // StartReasonOf returns the reason in the error chain, or StartReasonUnknown.
-func StartReasonOf(err error) StartReason {
+func StartReasonOf(err error) testkube.StartReason {
 	var startErr *StartError
 	if errors.As(err, &startErr) {
 		return startErr.Reason
 	}
-	return StartReasonUnknown
+	return testkube.StartReasonUnknown
 }

--- a/pkg/testworkflows/executionworker/executionworkertypes/start_error_test.go
+++ b/pkg/testworkflows/executionworker/executionworkertypes/start_error_test.go
@@ -7,36 +7,38 @@ import (
 
 	pkgerrors "github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/kubeshop/testkube/pkg/api/v1/testkube"
 )
 
 func TestStartReasonOf(t *testing.T) {
 	tests := []struct {
 		name string
 		err  error
-		want StartReason
+		want testkube.StartReason
 	}{
 		{
 			name: "reason of the failed phase",
-			err:  WithStartReason(errors.New("job is invalid"), StartReasonJobCreateFailed),
-			want: StartReasonJobCreateFailed,
+			err:  WithStartReason(errors.New("job is invalid"), testkube.StartReasonJobCreateFailed),
+			want: testkube.StartReasonJobCreateFailed,
 		},
 		{
 			name: "inner phase keeps its reason when an outer phase wraps it",
 			err: WithStartReason(
-				pkgerrors.Wrap(WithStartReason(errors.New("unauthorized"), StartReasonImagePullFailed), "failed to process test workflow"),
-				StartReasonDefinitionInvalid,
+				pkgerrors.Wrap(WithStartReason(errors.New("unauthorized"), testkube.StartReasonImagePullFailed), "failed to process test workflow"),
+				testkube.StartReasonDefinitionInvalid,
 			),
-			want: StartReasonImagePullFailed,
+			want: testkube.StartReasonImagePullFailed,
 		},
 		{
 			name: "reason survives a plain wrap",
-			err:  fmt.Errorf("start: %w", WithStartReason(errors.New("quota exceeded"), StartReasonResourceFailed)),
-			want: StartReasonResourceFailed,
+			err:  fmt.Errorf("start: %w", WithStartReason(errors.New("quota exceeded"), testkube.StartReasonResourceFailed)),
+			want: testkube.StartReasonResourceFailed,
 		},
 		{
 			name: "error without a reason",
 			err:  errors.New("namespace foo not supported"),
-			want: StartReasonUnknown,
+			want: testkube.StartReasonUnknown,
 		},
 	}
 	for _, tt := range tests {
@@ -47,5 +49,5 @@ func TestStartReasonOf(t *testing.T) {
 }
 
 func TestWithStartReason_Nil(t *testing.T) {
-	assert.NoError(t, WithStartReason(nil, StartReasonJobCreateFailed))
+	assert.NoError(t, WithStartReason(nil, testkube.StartReasonJobCreateFailed))
 }

--- a/pkg/testworkflows/executionworker/kubernetesworker/worker.go
+++ b/pkg/testworkflows/executionworker/kubernetesworker/worker.go
@@ -162,7 +162,7 @@ func (w *worker) Execute(ctx context.Context, request executionworkertypes.Execu
 		Runtime:                runtimeOptions,
 	})
 	if err != nil {
-		return nil, executionworkertypes.WithStartReason(errors.Wrap(err, "failed to process test workflow"), executionworkertypes.StartReasonDefinitionInvalid)
+		return nil, executionworkertypes.WithStartReason(errors.Wrap(err, "failed to process test workflow"), testkube.StartReasonDefinitionInvalid)
 	}
 
 	// Annotate the group ID
@@ -181,7 +181,7 @@ func (w *worker) Execute(ctx context.Context, request executionworkertypes.Execu
 	// Deploy required resources
 	err = bundle.Deploy(ctx, w.clientSet, cfg.Worker.Namespace)
 	if err != nil {
-		return nil, executionworkertypes.WithStartReason(errors.Wrap(err, "failed to deploy test workflow"), executionworkertypes.StartReasonJobCreateFailed)
+		return nil, executionworkertypes.WithStartReason(errors.Wrap(err, "failed to deploy test workflow"), testkube.StartReasonJobCreateFailed)
 	}
 
 	return &executionworkertypes.ExecuteResult{
@@ -228,7 +228,7 @@ func (w *worker) Service(ctx context.Context, request executionworkertypes.Servi
 		Runtime:                runtimeOptions,
 	})
 	if err != nil {
-		return nil, executionworkertypes.WithStartReason(errors.Wrap(err, "failed to process test workflow"), executionworkertypes.StartReasonDefinitionInvalid)
+		return nil, executionworkertypes.WithStartReason(errors.Wrap(err, "failed to process test workflow"), testkube.StartReasonDefinitionInvalid)
 	}
 
 	// Apply the service setup
@@ -256,7 +256,7 @@ func (w *worker) Service(ctx context.Context, request executionworkertypes.Servi
 	// Deploy required resources
 	err = bundle.Deploy(ctx, w.clientSet, cfg.Worker.Namespace)
 	if err != nil {
-		return nil, executionworkertypes.WithStartReason(errors.Wrap(err, "failed to deploy test workflow"), executionworkertypes.StartReasonJobCreateFailed)
+		return nil, executionworkertypes.WithStartReason(errors.Wrap(err, "failed to deploy test workflow"), testkube.StartReasonJobCreateFailed)
 	}
 
 	return &executionworkertypes.ServiceResult{
@@ -554,7 +554,7 @@ func (w *worker) Abort(ctx context.Context, id string, options executionworkerty
 			return err
 		}
 	}
-	if err := w.patchTerminationAnnotations(ctx, id, options.Namespace, testkube.ABORTED_TestWorkflowStatus, options.TerminationActor(executionworkertypes.AbortActorSystem), options.Reason); err != nil {
+	if err := w.patchTerminationAnnotations(ctx, id, options.Namespace, testkube.ABORTED_TestWorkflowStatus, options.TerminationActor(testkube.StopActorSystem), options.Reason); err != nil {
 		return errors.Wrapf(err, "failed to patch job %s/%s with termination code & reason", options.Namespace, id)
 	}
 	// It may safely destroy all the resources - the trace should be still readable.
@@ -568,13 +568,13 @@ func (w *worker) Cancel(ctx context.Context, id string, options executionworkert
 			return err
 		}
 	}
-	if err := w.patchTerminationAnnotations(ctx, id, options.Namespace, testkube.CANCELED_TestWorkflowStatus, options.TerminationActor(executionworkertypes.AbortActorUser), options.Reason); err != nil {
+	if err := w.patchTerminationAnnotations(ctx, id, options.Namespace, testkube.CANCELED_TestWorkflowStatus, options.TerminationActor(testkube.StopActorUser), options.Reason); err != nil {
 		return errors.Wrapf(err, "failed to patch job %s/%s with termination code & reason", options.Namespace, id)
 	}
 	return w.Destroy(ctx, id, options)
 }
 
-func (w *worker) patchTerminationAnnotations(ctx context.Context, id string, namespace string, status testkube.TestWorkflowStatus, actor executionworkertypes.AbortActor, reason string) error {
+func (w *worker) patchTerminationAnnotations(ctx context.Context, id string, namespace string, status testkube.TestWorkflowStatus, actor testkube.StopActor, reason string) error {
 	patch := map[string]interface{}{
 		"metadata": map[string]any{
 			"annotations": map[string]string{

--- a/pkg/testworkflows/testworkflowprocessor/bundle.go
+++ b/pkg/testworkflows/testworkflowprocessor/bundle.go
@@ -11,6 +11,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 
+	"github.com/kubeshop/testkube/pkg/api/v1/testkube"
 	"github.com/kubeshop/testkube/pkg/testworkflows/executionworker/executionworkertypes"
 	"github.com/kubeshop/testkube/pkg/testworkflows/testworkflowconfig"
 	"github.com/kubeshop/testkube/pkg/testworkflows/testworkflowprocessor/action/actiontypes"
@@ -85,19 +86,19 @@ func (b *Bundle) Deploy(ctx context.Context, clientSet kubernetes.Interface, nam
 	for _, item := range b.Secrets {
 		_, err = clientSet.CoreV1().Secrets(namespace).Create(ctx, &item, metav1.CreateOptions{})
 		if err != nil {
-			return executionworkertypes.WithStartReason(errors.Wrap(err, "failed to deploy secrets"), executionworkertypes.StartReasonResourceFailed)
+			return executionworkertypes.WithStartReason(errors.Wrap(err, "failed to deploy secrets"), testkube.StartReasonResourceFailed)
 		}
 	}
 	for _, item := range b.ConfigMaps {
 		_, err = clientSet.CoreV1().ConfigMaps(namespace).Create(ctx, &item, metav1.CreateOptions{})
 		if err != nil {
-			return executionworkertypes.WithStartReason(errors.Wrap(err, "failed to deploy config maps"), executionworkertypes.StartReasonResourceFailed)
+			return executionworkertypes.WithStartReason(errors.Wrap(err, "failed to deploy config maps"), testkube.StartReasonResourceFailed)
 		}
 	}
 	for _, item := range b.Pvcs {
 		_, err = clientSet.CoreV1().PersistentVolumeClaims(namespace).Create(ctx, &item, metav1.CreateOptions{})
 		if err != nil {
-			return executionworkertypes.WithStartReason(errors.Wrap(err, "failed to deploy pvcs"), executionworkertypes.StartReasonResourceFailed)
+			return executionworkertypes.WithStartReason(errors.Wrap(err, "failed to deploy pvcs"), testkube.StartReasonResourceFailed)
 		}
 	}
 

--- a/pkg/testworkflows/testworkflowprocessor/processor.go
+++ b/pkg/testworkflows/testworkflowprocessor/processor.go
@@ -16,6 +16,7 @@ import (
 
 	testworkflowsv1 "github.com/kubeshop/testkube/api/testworkflows/v1"
 	"github.com/kubeshop/testkube/internal/common"
+	"github.com/kubeshop/testkube/pkg/api/v1/testkube"
 	"github.com/kubeshop/testkube/pkg/expressions"
 	"github.com/kubeshop/testkube/pkg/imageinspector"
 	"github.com/kubeshop/testkube/pkg/testworkflows/executionworker/executionworkertypes"
@@ -350,7 +351,7 @@ func (p *processor) Bundle(ctx context.Context, workflow *testworkflowsv1.TestWo
 		}
 		imageNameResolutions[image] = p.inspector.ResolveName("", image)
 		if err != nil {
-			return nil, executionworkertypes.WithStartReason(fmt.Errorf("resolving image error: %s: %w", image, err), executionworkertypes.StartReasonImagePullFailed)
+			return nil, executionworkertypes.WithStartReason(fmt.Errorf("resolving image error: %s: %w", image, err), testkube.StartReasonImagePullFailed)
 		}
 	}
 	err = root.ApplyImages(images, imageNameResolutions)

--- a/pkg/triggers/scraper.go
+++ b/pkg/triggers/scraper.go
@@ -8,6 +8,7 @@ import (
 	"github.com/jackc/pgx/v5"
 	"go.mongodb.org/mongo-driver/v2/mongo"
 
+	"github.com/kubeshop/testkube/pkg/api/v1/testkube"
 	"github.com/kubeshop/testkube/pkg/testworkflows/executionworker/executionworkertypes"
 )
 
@@ -85,7 +86,7 @@ func (s *Service) abortRunningTestWorkflowExecutions(ctx context.Context, status
 			// Obtain the controller
 			err = s.executionWorkerClient.Abort(ctx, execution.Id, executionworkertypes.DestroyOptions{
 				Namespace: s.testkubeNamespace,
-				Actor:     executionworkertypes.AbortActorTrigger,
+				Actor:     testkube.StopActorTrigger,
 			})
 			if err != nil {
 				s.logger.Errorf("trigger service: execution scraper component: error aborting test workflow execution: %v", err)


### PR DESCRIPTION
## Pull request description

Follow-up to #8239 on [TKC-6811](https://linear.app/kubeshop/issue/TKC-6811/why-did-my-test-fail-milestone-1-every-abort-carries-a-reason), first of three.

The actor of a stop and the start-failure tokens lived in the execution worker's types. Milestone 3 puts the classifier next to the final-status functions in the model package. That package cannot import the worker types, because the worker types import it. The tokens are also the future values of `statusDetails.reason`, a model field.

`StopActor` and `StartReason` move to `pkg/api/v1/testkube`, next to the statuses. `StopActor` replaces `AbortActor`: cancels use it as much as aborts, and the name matches the two reason types. The annotation values on clusters do not change. `StartError` and its helpers stay with the worker types, because they wrap the errors of the worker's start phases. No behaviour changes.

