### PR TITLE
feat(executionworker): carry the stop reason as a token with words

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -78,7 +78,7 @@ Testkube uses [Test Workflows](https://docs.testkube.io/articles/test-workflows)
 - Core TestWorkflow executor (`testworkflowexecutor/`)
 - TestWorkflow processing and step execution
 - Result aggregation and status management
-- Execution worker (`executionworker/`): applies the workflow to Kubernetes, watches the job and pod, and stops executions. When a caller aborts or cancels an execution, it passes an actor and an optional cause in `DestroyOptions`, and the worker writes them into the job annotations `testkube.io/termination-actor` and `testkube.io/termination-reason`. The result reader renders them as one sentence, so the stored error message names the component that stopped the execution and, when there is one, the cause.
+- Execution worker (`executionworker/`): applies the workflow to Kubernetes, watches the job and pod, and stops executions. When a caller aborts or cancels an execution, it passes an actor, a reason token, and an optional detail in `DestroyOptions`, and the worker writes them into the job annotations `testkube.io/termination-actor`, `testkube.io/termination-reason`, and `testkube.io/termination-detail`. The result reader renders the words for the actor and the token, so the stored error message names the component that stopped the execution and, when there is one, the cause.
 - Runner gRPC client (`pkg/runner/grpc/`): receives execution starts from the control plane. When the runner cannot start an execution, the client reads the reason token from the `StartError` in the error chain and declines the execution with the token and the error text, so the control plane stores the cause on the execution.
 
 ### 4. Storage Layer

--- a/cmd/tcl/testworkflow-toolkit/commands/parallel.go
+++ b/cmd/tcl/testworkflow-toolkit/commands/parallel.go
@@ -822,7 +822,8 @@ func (o *ResumeOrchestrator) resumeAllWorkers(ctx context.Context) {
 				_ = spawn.ParallelExecutionWorker(o.cfg).Abort(ctx, err.Id, executionworkertypes.DestroyOptions{
 					Namespace: o.namespaces[index],
 					Actor:     testkube.StopActorRunner,
-					Reason:    "the parallel worker could not be resumed: " + err.Error.Error(),
+					Reason:    testkube.StopReasonWorkerResumeFailed,
+					Detail:    err.Error.Error(),
 				})
 			}
 		}

--- a/internal/app/api/v1/testworkflowexecutions.go
+++ b/internal/app/api/v1/testworkflowexecutions.go
@@ -802,7 +802,7 @@ func (s *TestkubeAPI) abortAllTestWorkflowExecutionsHandlerPro() fiber.Handler {
 			err = s.ExecutionWorkerClient.Abort(ctx, execution.Id, executionworkertypes.DestroyOptions{
 				Namespace: execution.Namespace,
 				Actor:     testkube.StopActorAPI,
-				Reason:    "all executions of the workflow were aborted",
+				Reason:    testkube.StopReasonAbortAll,
 			})
 			if err != nil {
 				return s.ClientError(c, errPrefix, err)

--- a/pkg/api/v1/testkube/stop_reason.go
+++ b/pkg/api/v1/testkube/stop_reason.go
@@ -1,0 +1,45 @@
+package testkube
+
+// StopReason is the token for the cause of an abort or a cancel. The control plane
+// stores it, sends it with the stop transition, and the runner writes it into the
+// job annotations. The values are stable, because filters and telemetry use them.
+type StopReason string
+
+const (
+	StopReasonAbortAll           StopReason = "abort-all"
+	StopReasonSuperseded         StopReason = "superseded"
+	StopReasonQueueTimeout       StopReason = "queue-timeout"
+	StopReasonQueuedTooLong      StopReason = "queued-too-long"
+	StopReasonTransitionTimeout  StopReason = "transition-timeout"
+	StopReasonStopNotConfirmed   StopReason = "stop-not-confirmed"
+	StopReasonExecutionTimeout   StopReason = "execution-timeout"
+	StopReasonExecutionStuck     StopReason = "execution-stuck"
+	StopReasonWorkerResumeFailed StopReason = "worker-resume-failed"
+)
+
+// Sentence returns the words for the reason in a message for people. It returns an
+// empty string for a value it does not know, so a reader can keep the raw token.
+func (r StopReason) Sentence() string {
+	switch r {
+	case StopReasonAbortAll:
+		return "all executions of the workflow were stopped"
+	case StopReasonSuperseded:
+		return "a newer commit superseded this run"
+	case StopReasonQueueTimeout:
+		return "the execution exceeded the queue timeout of the workflow"
+	case StopReasonQueuedTooLong:
+		return "the execution stayed queued for too long"
+	case StopReasonTransitionTimeout:
+		return "the execution stayed in a transitional state for too long"
+	case StopReasonStopNotConfirmed:
+		return "the runner did not confirm the stop in time"
+	case StopReasonExecutionTimeout:
+		return "the execution ran for too long"
+	case StopReasonExecutionStuck:
+		return "the execution is stuck in the running state"
+	case StopReasonWorkerResumeFailed:
+		return "the parallel worker could not be resumed"
+	default:
+		return ""
+	}
+}

--- a/pkg/api/v1/testkube/stop_reason_test.go
+++ b/pkg/api/v1/testkube/stop_reason_test.go
@@ -1,0 +1,31 @@
+package testkube
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestStopReason_Sentence(t *testing.T) {
+	tests := []struct {
+		name   string
+		reason StopReason
+		want   string
+	}{
+		{name: "abort all", reason: StopReasonAbortAll, want: "all executions of the workflow were stopped"},
+		{name: "superseded", reason: StopReasonSuperseded, want: "a newer commit superseded this run"},
+		{name: "queue timeout", reason: StopReasonQueueTimeout, want: "the execution exceeded the queue timeout of the workflow"},
+		{name: "queued too long", reason: StopReasonQueuedTooLong, want: "the execution stayed queued for too long"},
+		{name: "transition timeout", reason: StopReasonTransitionTimeout, want: "the execution stayed in a transitional state for too long"},
+		{name: "stop not confirmed", reason: StopReasonStopNotConfirmed, want: "the runner did not confirm the stop in time"},
+		{name: "execution timeout", reason: StopReasonExecutionTimeout, want: "the execution ran for too long"},
+		{name: "execution stuck", reason: StopReasonExecutionStuck, want: "the execution is stuck in the running state"},
+		{name: "worker resume failed", reason: StopReasonWorkerResumeFailed, want: "the parallel worker could not be resumed"},
+		{name: "token from a newer control plane has no words yet", reason: StopReason("later-added"), want: ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, tt.reason.Sentence())
+		})
+	}
+}

--- a/pkg/proto/testkube/testworkflow/execution/v1/execution_state_transition.pb.go
+++ b/pkg/proto/testkube/testworkflow/execution/v1/execution_state_transition.pb.go
@@ -28,9 +28,9 @@ type ExecutionStateTransition struct {
 	ExecutionId *string `protobuf:"bytes,1,opt,name=execution_id,json=executionId" json:"execution_id,omitempty"`
 	// transition_to is the state the execution should be transitioned into.
 	TransitionTo *ExecutionState `protobuf:"varint,2,opt,name=transition_to,json=transitionTo,enum=testkube.testworkflow.execution.v1.ExecutionState" json:"transition_to,omitempty"`
-	// reason is the cause of an abort or a cancel, as free text, for example
-	// "the execution ran for too long". The runner writes it into the job
-	// annotation next to the actor, so the execution result names who stopped
+	// reason is the token for the cause of an abort or a cancel, for example
+	// "execution-timeout". The runner writes it into the job annotation next to
+	// the actor and renders its words, so the execution result names who stopped
 	// the execution and why. Empty when the Control Plane has no cause to give,
 	// and for every other transition.
 	Reason        *string `protobuf:"bytes,3,opt,name=reason" json:"reason,omitempty"`

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -617,8 +617,7 @@ func (r *runner) abortExecution(ctx context.Context, environmentID, executionID 
 	if execution.Result == nil {
 		return errors.New("execution result is nil")
 	}
-	const stuckReason = "execution is stuck in running state"
-	execution.Result.Fatal(errors.New(stuckReason), true, time.Now())
+	execution.Result.Fatal(errors.New(testkube.StopReasonExecutionStuck.Sentence()), true, time.Now())
 	err = retry(AbortExecutionRetryCount, delay, func(_ int) error {
 		return r.client.UpdateExecutionResult(ctx, environmentID, executionID, execution.Result)
 	})
@@ -636,7 +635,7 @@ func (r *runner) abortExecution(ctx context.Context, environmentID, executionID 
 	err = retry(AbortExecutionRetryCount, delay, func(_ int) error {
 		return r.worker.Abort(context.Background(), executionID, executionworkertypes.DestroyOptions{
 			Actor:  testkube.StopActorRunner,
-			Reason: stuckReason,
+			Reason: testkube.StopReasonExecutionStuck,
 		})
 	})
 	if err != nil {
@@ -658,7 +657,7 @@ func (r *runner) Resume(id string) error {
 func (r *runner) Abort(id string, reason string) error {
 	return r.worker.Abort(context.Background(), id, executionworkertypes.DestroyOptions{
 		Actor:  testkube.StopActorControlPlane,
-		Reason: reason,
+		Reason: testkube.StopReason(reason),
 	})
 }
 
@@ -666,6 +665,6 @@ func (r *runner) Abort(id string, reason string) error {
 func (r *runner) Cancel(id string, reason string) error {
 	return r.worker.Cancel(context.Background(), id, executionworkertypes.DestroyOptions{
 		Actor:  testkube.StopActorUser,
-		Reason: reason,
+		Reason: testkube.StopReason(reason),
 	})
 }

--- a/pkg/testworkflows/executionworker/controller/watchers/commons.go
+++ b/pkg/testworkflows/executionworker/controller/watchers/commons.go
@@ -302,19 +302,30 @@ func GetJobError(job *batchv1.Job) string {
 			}
 		}
 	}
-	// The worker annotates a stop with the actor and an optional cause. A deleted
-	// job without the annotation is a stop by an unknown party.
+	// The worker annotates a stop with the actor, a reason token, and an optional
+	// detail. A reason without words, from an older worker or a newer control plane,
+	// shows as its raw text. A deleted job without the annotation is a stop by an
+	// unknown party.
 	if job.Annotations != nil {
 		actor := testkube.StopActor(job.Annotations[constants2.AnnotationTerminationActor])
-		reason := job.Annotations[constants2.AnnotationTerminationReason]
+		reason := testkube.StopReason(job.Annotations[constants2.AnnotationTerminationReason])
+		detail := job.Annotations[constants2.AnnotationTerminationDetail]
 		if actor != "" || reason != "" {
-			if reason == "" {
-				return actor.Sentence()
+			var parts []string
+			if actor != "" {
+				parts = append(parts, actor.Sentence())
 			}
-			if actor == "" {
-				return reason
+			if reason != "" {
+				words := reason.Sentence()
+				if words == "" {
+					words = string(reason)
+				}
+				parts = append(parts, words)
 			}
-			return actor.Sentence() + ": " + reason
+			if detail != "" {
+				parts = append(parts, detail)
+			}
+			return strings.Join(parts, ": ")
 		}
 	}
 	if job.DeletionTimestamp != nil {

--- a/pkg/testworkflows/executionworker/controller/watchers/commons_test.go
+++ b/pkg/testworkflows/executionworker/controller/watchers/commons_test.go
@@ -20,22 +20,39 @@ func TestGetJobError(t *testing.T) {
 		want string
 	}{
 		{
-			name: "actor and cause",
+			name: "actor and reason token",
 			job: &batchv1.Job{ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{
 				constants.AnnotationTerminationActor:  string(testkube.StopActorRunner),
-				constants.AnnotationTerminationReason: "execution is stuck in running state",
+				constants.AnnotationTerminationReason: string(testkube.StopReasonExecutionStuck),
 			}}},
-			want: "by the runner: execution is stuck in running state",
+			want: "by the runner: the execution is stuck in the running state",
 		},
 		{
-			name: "actor without a cause",
+			name: "actor, reason token, and detail",
+			job: &batchv1.Job{ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{
+				constants.AnnotationTerminationActor:  string(testkube.StopActorRunner),
+				constants.AnnotationTerminationReason: string(testkube.StopReasonWorkerResumeFailed),
+				constants.AnnotationTerminationDetail: "pod not found",
+			}}},
+			want: "by the runner: the parallel worker could not be resumed: pod not found",
+		},
+		{
+			name: "actor without a reason",
 			job: &batchv1.Job{ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{
 				constants.AnnotationTerminationActor: string(testkube.StopActorUser),
 			}}},
 			want: "by the user",
 		},
 		{
-			name: "cause without an actor, as an older worker writes it",
+			name: "token without words yet keeps its raw text",
+			job: &batchv1.Job{ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{
+				constants.AnnotationTerminationActor:  string(testkube.StopActorControlPlane),
+				constants.AnnotationTerminationReason: "later-added",
+			}}},
+			want: "by the control plane: later-added",
+		},
+		{
+			name: "free text without an actor, as an older worker writes it",
 			job: &batchv1.Job{ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{
 				constants.AnnotationTerminationReason: "Job has been aborted by the system",
 			}}},

--- a/pkg/testworkflows/executionworker/executionworkertypes/interface.go
+++ b/pkg/testworkflows/executionworker/executionworkertypes/interface.go
@@ -182,8 +182,10 @@ type DestroyOptions struct {
 	// Actor identifies the component that requested the stop. The worker writes it
 	// and the reason into the job annotations, so the result names who stopped it.
 	Actor testkube.StopActor
-	// Reason is a short human-readable cause for the stop.
-	Reason string
+	// Reason is the token for the cause of the stop. The result shows its sentence.
+	Reason testkube.StopReason
+	// Detail is free text that follows the reason, for example the error of a failed step.
+	Detail string
 }
 
 // TerminationActor returns the actor for the job annotation, or the default when the

--- a/pkg/testworkflows/executionworker/kubernetesworker/worker.go
+++ b/pkg/testworkflows/executionworker/kubernetesworker/worker.go
@@ -554,7 +554,7 @@ func (w *worker) Abort(ctx context.Context, id string, options executionworkerty
 			return err
 		}
 	}
-	if err := w.patchTerminationAnnotations(ctx, id, options.Namespace, testkube.ABORTED_TestWorkflowStatus, options.TerminationActor(testkube.StopActorSystem), options.Reason); err != nil {
+	if err := w.patchTerminationAnnotations(ctx, id, options.Namespace, testkube.ABORTED_TestWorkflowStatus, options.TerminationActor(testkube.StopActorSystem), options.Reason, options.Detail); err != nil {
 		return errors.Wrapf(err, "failed to patch job %s/%s with termination code & reason", options.Namespace, id)
 	}
 	// It may safely destroy all the resources - the trace should be still readable.
@@ -568,19 +568,20 @@ func (w *worker) Cancel(ctx context.Context, id string, options executionworkert
 			return err
 		}
 	}
-	if err := w.patchTerminationAnnotations(ctx, id, options.Namespace, testkube.CANCELED_TestWorkflowStatus, options.TerminationActor(testkube.StopActorUser), options.Reason); err != nil {
+	if err := w.patchTerminationAnnotations(ctx, id, options.Namespace, testkube.CANCELED_TestWorkflowStatus, options.TerminationActor(testkube.StopActorUser), options.Reason, options.Detail); err != nil {
 		return errors.Wrapf(err, "failed to patch job %s/%s with termination code & reason", options.Namespace, id)
 	}
 	return w.Destroy(ctx, id, options)
 }
 
-func (w *worker) patchTerminationAnnotations(ctx context.Context, id string, namespace string, status testkube.TestWorkflowStatus, actor testkube.StopActor, reason string) error {
+func (w *worker) patchTerminationAnnotations(ctx context.Context, id string, namespace string, status testkube.TestWorkflowStatus, actor testkube.StopActor, reason testkube.StopReason, detail string) error {
 	patch := map[string]interface{}{
 		"metadata": map[string]any{
 			"annotations": map[string]string{
 				constants.AnnotationTerminationCode:   string(status),
 				constants.AnnotationTerminationActor:  string(actor),
-				constants.AnnotationTerminationReason: reason,
+				constants.AnnotationTerminationReason: string(reason),
+				constants.AnnotationTerminationDetail: detail,
 			},
 		},
 	}

--- a/pkg/testworkflows/testworkflowprocessor/constants/constants.go
+++ b/pkg/testworkflows/testworkflowprocessor/constants/constants.go
@@ -37,6 +37,7 @@ const (
 	AnnotationTerminationCode       = "testkube.io/termination-code"
 	AnnotationTerminationReason     = "testkube.io/termination-reason"
 	AnnotationTerminationActor      = "testkube.io/termination-actor"
+	AnnotationTerminationDetail     = "testkube.io/termination-detail"
 )
 
 var (

--- a/proto/testkube/testworkflow/execution/v1/execution_state_transition.proto
+++ b/proto/testkube/testworkflow/execution/v1/execution_state_transition.proto
@@ -10,9 +10,9 @@ message ExecutionStateTransition {
   string execution_id = 1;
   // transition_to is the state the execution should be transitioned into.
   ExecutionState transition_to = 2;
-  // reason is the cause of an abort or a cancel, as free text, for example
-  // "the execution ran for too long". The runner writes it into the job
-  // annotation next to the actor, so the execution result names who stopped
+  // reason is the token for the cause of an abort or a cancel, for example
+  // "execution-timeout". The runner writes it into the job annotation next to
+  // the actor and renders its words, so the execution result names who stopped
   // the execution and why. Empty when the Control Plane has no cause to give,
   // and for every other transition.
   string reason = 3;


### PR DESCRIPTION
## Pull request description

Follow-up to #8239 on [TKC-6811](https://linear.app/kubeshop/issue/TKC-6811/why-did-my-test-fail-milestone-1-every-abort-carries-a-reason), third of three. Stacked on the start-reason words.

The cause of an abort or a cancel travelled as free text. Filters, webhooks, and telemetry had no stable key, and the Milestone 3 classifier would have to match strings.

`StopReason` is the token for that cause, with `Sentence` for its words. `DestroyOptions.Reason` carries the token, and a new `Detail` carries free text such as the error of a worker that could not be resumed. The worker writes both into the job annotations. The watcher renders the words for the actor and the token. A token without words, from an older worker or a newer control plane, shows as its raw text. The stop transition carries the token. The texts a user sees do not change. The control plane switches to the tokens in kubeshop/testkube-cloud-api #5537 and #5538.

