### PR TITLE
feat(runner): carry the stop actor on the execution state transition

### DIFF
--- a/pkg/api/v1/testkube/stop_actor.go
+++ b/pkg/api/v1/testkube/stop_actor.go
@@ -15,6 +15,9 @@ const (
 	StopActorFailFast StopActor = "fail-fast"
 	// StopActorRunner is the runner itself, for example the check for stuck executions.
 	StopActorRunner StopActor = "runner"
+	// StopActorQualityLoop is the quality loop in the control plane, which cancels a run
+	// that a newer commit superseded.
+	StopActorQualityLoop StopActor = "quality-loop"
 	// StopActorAPI is the standalone agent API abort endpoint.
 	StopActorAPI StopActor = "api"
 	// StopActorSystem is the fallback when the caller does not identify itself.
@@ -35,6 +38,8 @@ func (a StopActor) Sentence() string {
 		return "because another parallel worker failed"
 	case StopActorRunner:
 		return "by the runner"
+	case StopActorQualityLoop:
+		return "by the quality loop"
 	case StopActorAPI:
 		return "through the API"
 	default:

--- a/pkg/api/v1/testkube/stop_actor_test.go
+++ b/pkg/api/v1/testkube/stop_actor_test.go
@@ -17,6 +17,7 @@ func TestStopActor_Sentence(t *testing.T) {
 		{name: "trigger", actor: StopActorTrigger, want: "because its trigger was deleted"},
 		{name: "fail-fast", actor: StopActorFailFast, want: "because another parallel worker failed"},
 		{name: "runner", actor: StopActorRunner, want: "by the runner"},
+		{name: "quality loop", actor: StopActorQualityLoop, want: "by the quality loop"},
 		{name: "api", actor: StopActorAPI, want: "through the API"},
 		{name: "system", actor: StopActorSystem, want: "by the system"},
 		{name: "unknown value falls back to the system", actor: StopActor("later-added"), want: "by the system"},

--- a/pkg/proto/testkube/testworkflow/execution/v1/execution_state_transition.pb.go
+++ b/pkg/proto/testkube/testworkflow/execution/v1/execution_state_transition.pb.go
@@ -33,7 +33,13 @@ type ExecutionStateTransition struct {
 	// the actor and renders its words, so the execution result names who stopped
 	// the execution and why. Empty when the Control Plane has no cause to give,
 	// and for every other transition.
-	Reason        *string `protobuf:"bytes,3,opt,name=reason" json:"reason,omitempty"`
+	Reason *string `protobuf:"bytes,3,opt,name=reason" json:"reason,omitempty"`
+	// actor is the token for the component that decided an abort or a cancel, for
+	// example "quality-loop". The runner writes it into the job annotation and renders
+	// its words in front of the reason. Empty when the Control Plane does not name the
+	// actor, and the runner then names the user for a cancel and the Control Plane for
+	// an abort.
+	Actor         *string `protobuf:"bytes,4,opt,name=actor" json:"actor,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -89,15 +95,23 @@ func (x *ExecutionStateTransition) GetReason() string {
 	return ""
 }
 
+func (x *ExecutionStateTransition) GetActor() string {
+	if x != nil && x.Actor != nil {
+		return *x.Actor
+	}
+	return ""
+}
+
 var File_testkube_testworkflow_execution_v1_execution_state_transition_proto protoreflect.FileDescriptor
 
 const file_testkube_testworkflow_execution_v1_execution_state_transition_proto_rawDesc = "" +
 	"\n" +
-	"Ctestkube/testworkflow/execution/v1/execution_state_transition.proto\x12\"testkube.testworkflow.execution.v1\x1a8testkube/testworkflow/execution/v1/execution_state.proto\"\xae\x01\n" +
+	"Ctestkube/testworkflow/execution/v1/execution_state_transition.proto\x12\"testkube.testworkflow.execution.v1\x1a8testkube/testworkflow/execution/v1/execution_state.proto\"\xc4\x01\n" +
 	"\x18ExecutionStateTransition\x12!\n" +
 	"\fexecution_id\x18\x01 \x01(\tR\vexecutionId\x12W\n" +
 	"\rtransition_to\x18\x02 \x01(\x0e22.testkube.testworkflow.execution.v1.ExecutionStateR\ftransitionTo\x12\x16\n" +
-	"\x06reason\x18\x03 \x01(\tR\x06reasonB\xc9\x02\n" +
+	"\x06reason\x18\x03 \x01(\tR\x06reason\x12\x14\n" +
+	"\x05actor\x18\x04 \x01(\tR\x05actorB\xc9\x02\n" +
 	"&com.testkube.testworkflow.execution.v1B\x1dExecutionStateTransitionProtoP\x01ZUgithub.com/kubeshop/testkube/pkg/proto/testkube/testworkflow/execution/v1;executionv1\xa2\x02\x03TTE\xaa\x02\"Testkube.Testworkflow.Execution.V1\xca\x02\"Testkube\\Testworkflow\\Execution\\V1\xe2\x02.Testkube\\Testworkflow\\Execution\\V1\\GPBMetadata\xea\x02%Testkube::Testworkflow::Execution::V1b\beditionsp\xe8\a"
 
 var (

--- a/pkg/runner/agent.go
+++ b/pkg/runner/agent.go
@@ -298,7 +298,7 @@ func (a *agentLoop) loopRunnerRequests(ctx context.Context) error {
 				}
 			case cloud.RunnerRequestType_CANCEL:
 				a.logger.Infow("received cancel request for execution", "environmentId", req.EnvironmentID(), "executionId", req.ExecutionID())
-				originalError := a.runner.Cancel(req.ExecutionID(), "")
+				originalError := a.runner.Cancel(req.ExecutionID(), "", "")
 				if originalError != nil {
 					err := req.SendError(originalError)
 					if err != nil {
@@ -312,7 +312,7 @@ func (a *agentLoop) loopRunnerRequests(ctx context.Context) error {
 				}
 			case cloud.RunnerRequestType_ABORT:
 				a.logger.Infow("received abort request for execution", "environmentId", req.EnvironmentID(), "executionId", req.ExecutionID())
-				originalError := a.runner.Abort(req.ExecutionID(), "")
+				originalError := a.runner.Abort(req.ExecutionID(), "", "")
 				if originalError != nil {
 					err := req.SendError(originalError)
 					if err != nil {

--- a/pkg/runner/grpc/client.go
+++ b/pkg/runner/grpc/client.go
@@ -37,8 +37,8 @@ type runner interface {
 	Execute(request executionworkertypes.ExecuteRequest) (*executionworkertypes.ExecuteResult, error)
 	Pause(executionId string) error
 	Resume(executionId string) error
-	Abort(executionId string, reason string) error
-	Cancel(executionId string, reason string) error
+	Abort(executionId string, actor string, reason string) error
+	Cancel(executionId string, actor string, reason string) error
 }
 
 type workflowStore interface {
@@ -205,7 +205,7 @@ func (c Client) executeResponse(ctx context.Context, response *executionv1.GetEx
 			})
 		case executionv1.ExecutionState_EXECUTION_STATE_CANCELLED:
 			wg.Go(func() {
-				err := c.runner.Cancel(transition.GetExecutionId(), transition.GetReason())
+				err := c.runner.Cancel(transition.GetExecutionId(), transition.GetActor(), transition.GetReason())
 				switch {
 				case errors.Is(err, registry.ErrResourceNotFound):
 					// Mission failed successfully!
@@ -219,7 +219,7 @@ func (c Client) executeResponse(ctx context.Context, response *executionv1.GetEx
 			})
 		case executionv1.ExecutionState_EXECUTION_STATE_ABORTED:
 			wg.Go(func() {
-				err := c.runner.Abort(transition.GetExecutionId(), transition.GetReason())
+				err := c.runner.Abort(transition.GetExecutionId(), transition.GetActor(), transition.GetReason())
 				switch {
 				case errors.Is(err, registry.ErrResourceNotFound):
 					// Mission failed successfully!

--- a/pkg/runner/grpc/client_stop_test.go
+++ b/pkg/runner/grpc/client_stop_test.go
@@ -13,11 +13,16 @@ import (
 	"github.com/kubeshop/testkube/pkg/testworkflows/executionworker/executionworkertypes"
 )
 
-// stopRecorder records the reason each stop request carries.
+// stopRecorder records the actor and the reason each stop request carries.
 type stopRecorder struct {
 	mu       sync.Mutex
-	aborted  map[string]string
-	canceled map[string]string
+	aborted  map[string]stop
+	canceled map[string]stop
+}
+
+type stop struct {
+	actor  string
+	reason string
 }
 
 func (r *stopRecorder) Execute(executionworkertypes.ExecuteRequest) (*executionworkertypes.ExecuteResult, error) {
@@ -25,58 +30,60 @@ func (r *stopRecorder) Execute(executionworkertypes.ExecuteRequest) (*executionw
 }
 func (r *stopRecorder) Pause(string) error  { return nil }
 func (r *stopRecorder) Resume(string) error { return nil }
-func (r *stopRecorder) Abort(id, reason string) error {
+func (r *stopRecorder) Abort(id, actor, reason string) error {
 	r.mu.Lock()
 	defer r.mu.Unlock()
-	r.aborted[id] = reason
+	r.aborted[id] = stop{actor: actor, reason: reason}
 	return nil
 }
-func (r *stopRecorder) Cancel(id, reason string) error {
+func (r *stopRecorder) Cancel(id, actor, reason string) error {
 	r.mu.Lock()
 	defer r.mu.Unlock()
-	r.canceled[id] = reason
+	r.canceled[id] = stop{actor: actor, reason: reason}
 	return nil
 }
 
-func TestClient_executeResponse_PassesStopReason(t *testing.T) {
+func TestClient_executeResponse_PassesStopActorAndReason(t *testing.T) {
 	tests := []struct {
 		name         string
 		to           executionv1.ExecutionState
+		actor        *string
 		reason       *string
-		wantAborted  map[string]string
-		wantCanceled map[string]string
+		wantAborted  map[string]stop
+		wantCanceled map[string]stop
 	}{
 		{
 			name:         "abort with a cause",
 			to:           executionv1.ExecutionState_EXECUTION_STATE_ABORTED,
-			reason:       proto.String("the execution ran for too long"),
-			wantAborted:  map[string]string{"exec-1": "the execution ran for too long"},
-			wantCanceled: map[string]string{},
+			reason:       proto.String("execution-timeout"),
+			wantAborted:  map[string]stop{"exec-1": {reason: "execution-timeout"}},
+			wantCanceled: map[string]stop{},
 		},
 		{
-			name:         "cancel with a cause",
+			name:         "cancel with an actor and a cause",
 			to:           executionv1.ExecutionState_EXECUTION_STATE_CANCELLED,
-			reason:       proto.String("all executions of the workflow were canceled"),
-			wantAborted:  map[string]string{},
-			wantCanceled: map[string]string{"exec-1": "all executions of the workflow were canceled"},
+			actor:        proto.String("quality-loop"),
+			reason:       proto.String("superseded"),
+			wantAborted:  map[string]stop{},
+			wantCanceled: map[string]stop{"exec-1": {actor: "quality-loop", reason: "superseded"}},
 		},
 		{
-			name:         "cancel from a control plane that sends no reason",
+			name:         "cancel from a control plane that sends no actor and no reason",
 			to:           executionv1.ExecutionState_EXECUTION_STATE_CANCELLED,
-			reason:       nil,
-			wantAborted:  map[string]string{},
-			wantCanceled: map[string]string{"exec-1": ""},
+			wantAborted:  map[string]stop{},
+			wantCanceled: map[string]stop{"exec-1": {}},
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			recorder := &stopRecorder{aborted: map[string]string{}, canceled: map[string]string{}}
+			recorder := &stopRecorder{aborted: map[string]stop{}, canceled: map[string]stop{}}
 			c := Client{runner: recorder, logger: zap.NewNop().Sugar()}
 
 			c.executeResponse(context.Background(), &executionv1.GetExecutionUpdatesResponse{
 				Update: []*executionv1.ExecutionStateTransition{{
 					ExecutionId:  proto.String("exec-1"),
 					TransitionTo: tt.to.Enum(),
+					Actor:        tt.actor,
 					Reason:       tt.reason,
 				}},
 			})

--- a/pkg/runner/mock_runner.go
+++ b/pkg/runner/mock_runner.go
@@ -42,31 +42,31 @@ func (m *MockRunner) EXPECT() *MockRunnerMockRecorder {
 }
 
 // Abort mocks base method.
-func (m *MockRunner) Abort(id, reason string) error {
+func (m *MockRunner) Abort(id, actor, reason string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Abort", id, reason)
+	ret := m.ctrl.Call(m, "Abort", id, actor, reason)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // Abort indicates an expected call of Abort.
-func (mr *MockRunnerMockRecorder) Abort(id, reason any) *gomock.Call {
+func (mr *MockRunnerMockRecorder) Abort(id, actor, reason any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Abort", reflect.TypeOf((*MockRunner)(nil).Abort), id, reason)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Abort", reflect.TypeOf((*MockRunner)(nil).Abort), id, actor, reason)
 }
 
 // Cancel mocks base method.
-func (m *MockRunner) Cancel(id, reason string) error {
+func (m *MockRunner) Cancel(id, actor, reason string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Cancel", id, reason)
+	ret := m.ctrl.Call(m, "Cancel", id, actor, reason)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // Cancel indicates an expected call of Cancel.
-func (mr *MockRunnerMockRecorder) Cancel(id, reason any) *gomock.Call {
+func (mr *MockRunnerMockRecorder) Cancel(id, actor, reason any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Cancel", reflect.TypeOf((*MockRunner)(nil).Cancel), id, reason)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Cancel", reflect.TypeOf((*MockRunner)(nil).Cancel), id, actor, reason)
 }
 
 // Execute mocks base method.

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -68,10 +68,12 @@ type Runner interface {
 	Notifications(ctx context.Context, id string) executionworkertypes.NotificationsWatcher
 	Pause(id string) error
 	Resume(id string) error
-	// Abort stops the execution and records the cause the control plane sent. The cause can be empty.
-	Abort(id string, reason string) error
-	// Cancel stops the execution and records the cause the control plane sent. The cause can be empty.
-	Cancel(id string, reason string) error
+	// Abort stops the execution and records the actor and the cause the control plane
+	// sent. Both can be empty. An empty actor names the control plane.
+	Abort(id string, actor string, reason string) error
+	// Cancel stops the execution and records the actor and the cause the control plane
+	// sent. Both can be empty. An empty actor names the user.
+	Cancel(id string, actor string, reason string) error
 }
 
 type runner struct {
@@ -654,17 +656,27 @@ func (r *runner) Resume(id string) error {
 }
 
 // Abort stops the execution on a request from the control plane.
-func (r *runner) Abort(id string, reason string) error {
+func (r *runner) Abort(id string, actor string, reason string) error {
 	return r.worker.Abort(context.Background(), id, executionworkertypes.DestroyOptions{
-		Actor:  testkube.StopActorControlPlane,
+		Actor:  stopActor(actor, testkube.StopActorControlPlane),
 		Reason: testkube.StopReason(reason),
 	})
 }
 
-// Cancel stops the execution on a request from a user. The control plane relays the request.
-func (r *runner) Cancel(id string, reason string) error {
+// Cancel stops the execution on a request that the control plane relays, from a user
+// or from one of its own components.
+func (r *runner) Cancel(id string, actor string, reason string) error {
 	return r.worker.Cancel(context.Background(), id, executionworkertypes.DestroyOptions{
-		Actor:  testkube.StopActorUser,
+		Actor:  stopActor(actor, testkube.StopActorUser),
 		Reason: testkube.StopReason(reason),
 	})
+}
+
+// stopActor returns the actor the control plane named, or the default of the
+// transition when the control plane sent none.
+func stopActor(actor string, defaultActor testkube.StopActor) testkube.StopActor {
+	if actor == "" {
+		return defaultActor
+	}
+	return testkube.StopActor(actor)
 }

--- a/proto/testkube/testworkflow/execution/v1/execution_state_transition.proto
+++ b/proto/testkube/testworkflow/execution/v1/execution_state_transition.proto
@@ -16,4 +16,10 @@ message ExecutionStateTransition {
   // the execution and why. Empty when the Control Plane has no cause to give,
   // and for every other transition.
   string reason = 3;
+  // actor is the token for the component that decided an abort or a cancel, for
+  // example "quality-loop". The runner writes it into the job annotation and renders
+  // its words in front of the reason. Empty when the Control Plane does not name the
+  // actor, and the runner then names the user for a cancel and the Control Plane for
+  // an abort.
+  string actor = 4;
 }


### PR DESCRIPTION
## Pull request description

Follow-up to Milestone 1 of [TKC-6811](https://linear.app/kubeshop/issue/TKC-6811/why-did-my-test-fail-milestone-1-every-abort-carries-a-reason). The runner names the actor of a stop from the transition type. A cancel reads `by the user` and an abort reads `by the control plane`. A cancel that the quality loop decides therefore reads `by the user: a newer commit superseded this run`, which names the wrong actor.

The transition now carries an `actor` token next to `reason`. The runner writes it into the job annotation and renders its words in front of the cause. When the control plane sends no actor, the runner keeps the default of the transition type, so an older control plane sees no change. `StopActor` gains `quality-loop`, which reads `by the quality loop`.

The control-plane side stores the actor next to the stop reason and sends it with the transition. That change follows in testkube-cloud-api.
