### PR TITLE
docs: call the stop and start reasons codes, not tokens

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -78,8 +78,8 @@ Testkube uses [Test Workflows](https://docs.testkube.io/articles/test-workflows)
 - Core TestWorkflow executor (`testworkflowexecutor/`)
 - TestWorkflow processing and step execution
 - Result aggregation and status management
-- Execution worker (`executionworker/`): applies the workflow to Kubernetes, watches the job and pod, and stops executions. When a caller aborts or cancels an execution, it passes an actor, a reason token, and an optional detail in `DestroyOptions`, and the worker writes them into the job annotations `testkube.io/termination-actor`, `testkube.io/termination-reason`, and `testkube.io/termination-detail`. The result reader renders the words for the actor and the token, so the stored error message names the component that stopped the execution and, when there is one, the cause.
-- Runner gRPC client (`pkg/runner/grpc/`): receives execution starts from the control plane. When the runner cannot start an execution, the client reads the reason token from the `StartError` in the error chain and declines the execution with the token and the error text, so the control plane stores the cause on the execution.
+- Execution worker (`executionworker/`): applies the workflow to Kubernetes, watches the job and pod, and stops executions. When a caller aborts or cancels an execution, it passes an actor code, a reason code, and an optional detail in `DestroyOptions`, and the worker writes them into the job annotations `testkube.io/termination-actor`, `testkube.io/termination-reason`, and `testkube.io/termination-detail`. The result reader renders the words for both codes, so the stored error message names the component that stopped the execution and, when there is one, the cause.
+- Runner gRPC client (`pkg/runner/grpc/`): receives execution starts from the control plane. When the runner cannot start an execution, the client reads the reason code from the `StartError` in the error chain and declines the execution with the code and the error text, so the control plane stores the cause on the execution.
 
 ### 4. Storage Layer
 
@@ -126,7 +126,7 @@ Testkube exposes REST APIs for interacting with core resources and functionality
 - Defines the complete REST API contract
 - Used for client code generation and documentation
 - Generated models: [`pkg/api/v1/testkube/`](pkg/api/v1/testkube/)
-- The stop actor and the reason tokens, with their words, live in the same package as hand-written files, so the worker, the runner, and the control plane share one definition
+- The actor codes and the reason codes, with their words, live in the same package as hand-written files, so the worker, the runner, and the control plane share one definition
 
 **Framework**: Uses [Fiber](https://gofiber.io/) web framework for HTTP routing and middleware
 

--- a/pkg/api/v1/testkube/start_reason.go
+++ b/pkg/api/v1/testkube/start_reason.go
@@ -1,6 +1,6 @@
 package testkube
 
-// StartReason is the token the runner sends to the control plane when it declines
+// StartReason is the code the runner sends to the control plane when it declines
 // an execution. The values are stable, because filters and telemetry use them.
 type StartReason string
 
@@ -14,7 +14,7 @@ const (
 
 // Sentence returns the words for the reason in a message for people, as the tail of
 // "Failed to run execution: ...". It returns an empty string for a value it does not
-// know, so a reader can keep the raw token.
+// know, so a reader can keep the raw code.
 func (r StartReason) Sentence() string {
 	switch r {
 	case StartReasonImagePullFailed:

--- a/pkg/api/v1/testkube/stop_reason.go
+++ b/pkg/api/v1/testkube/stop_reason.go
@@ -1,6 +1,6 @@
 package testkube
 
-// StopReason is the token for the cause of an abort or a cancel. The control plane
+// StopReason is the code for the cause of an abort or a cancel. The control plane
 // stores it, sends it with the stop transition, and the runner writes it into the
 // job annotations. The values are stable, because filters and telemetry use them.
 type StopReason string
@@ -18,7 +18,7 @@ const (
 )
 
 // Sentence returns the words for the reason in a message for people. It returns an
-// empty string for a value it does not know, so a reader can keep the raw token.
+// empty string for a value it does not know, so a reader can keep the raw code.
 func (r StopReason) Sentence() string {
 	switch r {
 	case StopReasonAbortAll:

--- a/pkg/proto/testkube/testworkflow/execution/v1/decline_execution_request.pb.go
+++ b/pkg/proto/testkube/testworkflow/execution/v1/decline_execution_request.pb.go
@@ -27,7 +27,7 @@ type DeclineExecutionRequest struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// execution_id is the unique identifier of the execution that has failed.
 	ExecutionId *string `protobuf:"bytes,1,opt,name=execution_id,json=executionId" json:"execution_id,omitempty"`
-	// reason is a short fixed token that names why the runner could not start
+	// reason is a short fixed code that names why the runner could not start
 	// the execution, for example "image-pull-failed" or "job-create-failed".
 	// The Control Plane stores it on the execution result so a user can read
 	// the cause without the runner log.

--- a/pkg/proto/testkube/testworkflow/execution/v1/execution_state_transition.pb.go
+++ b/pkg/proto/testkube/testworkflow/execution/v1/execution_state_transition.pb.go
@@ -28,13 +28,13 @@ type ExecutionStateTransition struct {
 	ExecutionId *string `protobuf:"bytes,1,opt,name=execution_id,json=executionId" json:"execution_id,omitempty"`
 	// transition_to is the state the execution should be transitioned into.
 	TransitionTo *ExecutionState `protobuf:"varint,2,opt,name=transition_to,json=transitionTo,enum=testkube.testworkflow.execution.v1.ExecutionState" json:"transition_to,omitempty"`
-	// reason is the token for the cause of an abort or a cancel, for example
+	// reason is the code for the cause of an abort or a cancel, for example
 	// "execution-timeout". The runner writes it into the job annotation next to
 	// the actor and renders its words, so the execution result names who stopped
 	// the execution and why. Empty when the Control Plane has no cause to give,
 	// and for every other transition.
 	Reason *string `protobuf:"bytes,3,opt,name=reason" json:"reason,omitempty"`
-	// actor is the token for the component that decided an abort or a cancel, for
+	// actor is the code for the component that decided an abort or a cancel, for
 	// example "quality-loop". The runner writes it into the job annotation and renders
 	// its words in front of the reason. Empty when the Control Plane does not name the
 	// actor, and the runner then names the user for a cancel and the Control Plane for

--- a/pkg/testworkflows/executionworker/executionworkertypes/interface.go
+++ b/pkg/testworkflows/executionworker/executionworkertypes/interface.go
@@ -182,7 +182,7 @@ type DestroyOptions struct {
 	// Actor identifies the component that requested the stop. The worker writes it
 	// and the reason into the job annotations, so the result names who stopped it.
 	Actor testkube.StopActor
-	// Reason is the token for the cause of the stop. The result shows its sentence.
+	// Reason is the code for the cause of the stop. The result shows its sentence.
 	Reason testkube.StopReason
 	// Detail is free text that follows the reason, for example the error of a failed step.
 	Detail string

--- a/proto/testkube/testworkflow/execution/v1/decline_execution_request.proto
+++ b/proto/testkube/testworkflow/execution/v1/decline_execution_request.proto
@@ -7,7 +7,7 @@ package testkube.testworkflow.execution.v1;
 message DeclineExecutionRequest {
   // execution_id is the unique identifier of the execution that has failed.
   string execution_id = 1;
-  // reason is a short fixed token that names why the runner could not start
+  // reason is a short fixed code that names why the runner could not start
   // the execution, for example "image-pull-failed" or "job-create-failed".
   // The Control Plane stores it on the execution result so a user can read
   // the cause without the runner log.

--- a/proto/testkube/testworkflow/execution/v1/execution_state_transition.proto
+++ b/proto/testkube/testworkflow/execution/v1/execution_state_transition.proto
@@ -10,13 +10,13 @@ message ExecutionStateTransition {
   string execution_id = 1;
   // transition_to is the state the execution should be transitioned into.
   ExecutionState transition_to = 2;
-  // reason is the token for the cause of an abort or a cancel, for example
+  // reason is the code for the cause of an abort or a cancel, for example
   // "execution-timeout". The runner writes it into the job annotation next to
   // the actor and renders its words, so the execution result names who stopped
   // the execution and why. Empty when the Control Plane has no cause to give,
   // and for every other transition.
   string reason = 3;
-  // actor is the token for the component that decided an abort or a cancel, for
+  // actor is the code for the component that decided an abort or a cancel, for
   // example "quality-loop". The runner writes it into the job annotation and renders
   // its words in front of the reason. Empty when the Control Plane does not name the
   // actor, and the runner then names the user for a cancel and the Control Plane for


### PR DESCRIPTION
## Pull request description

The start and stop reasons, and the stop actor, are fixed string values. The comments on the Go types, the two proto messages, and ARCHITECTURE.md called these values tokens. In this codebase a token is a credential, so the word misleads a reader.

The comments now call them codes. A code is a fixed string that the runner maps to a sentence. The generated proto files carry the new comments. No behavior changes.
